### PR TITLE
use the node v0.10 awsbox ami

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -1,4 +1,5 @@
 {
+  "ami": "ami-6f690106",
   "processes": [
     "index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "kvstore": "git://github.com/mozilla/node-kvstore.git#4b8c2f6763"
   },
   "devDependencies": {
-    "awsbox": "0.4.x",
+    "awsbox": "git://github.com/dannycoates/awsbox.git",
     "mocha": "1.9.x",
     "request": "2.21.x",
     "jshint": "0.9.1"

--- a/scripts/aws/post_create.sh
+++ b/scripts/aws/post_create.sh
@@ -6,3 +6,8 @@ sudo /sbin/service mysqld start
 echo "CREATE USER 'picl'@'localhost';" | mysql -u root
 echo "CREATE DATABASE picl;" | mysql -u root
 echo "GRANT ALL ON picl.* TO 'picl'@'localhost';" | mysql -u root
+
+echo "hacking iptables"
+# this is a workaround until someone figures
+# out why the iptables on this image don't stick
+sudo /home/app/scripts/setup_routes.sh


### PR DESCRIPTION
This uses my ami patch to awsbox. Once that gets merged we can switch back to the npm version. This also has an annoying `postcreate` hook workaround for iptables, that needs to get fixed.

Other than that this works as expected. It can get merged now or after awsbox gets updated.
