### PR TITLE
use a relative path when loading plugins to avoid hapi's incorrect infer...

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ server.ext('onPreResponse', function (request, next) {
     next();
 });
 
-server.pack.require('good', {
+server.pack.require('./node_modules/good', {
     subscribers: {
       console: ['ops', 'request', 'log']
     },


### PR DESCRIPTION
...red path

Needed for #16.
