### PR TITLE
turn on hapi doc generation plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "bunyan": "0.21.3",
     "heka": "0.3.0",
     "node-statsd": "0.0.7",
-    "toobusy": "0.2.3"
+    "toobusy": "0.2.3",
+    "lout": "0.4.0"
   },
   "devDependencies": {
     "awsbox": "0.4.5",

--- a/routes/idp.js
+++ b/routes/idp.js
@@ -44,6 +44,8 @@ var routes = [
     method: 'POST',
     path: '/create',
     config: {
+      description: "Creates an account associated with an email address," +
+        " passing along SRP information and a wrapped key (used for class B data storage).",
       handler: create,
       validate: {
         payload: {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const path = require('path');
 const Hapi = require('hapi');
 const toobusy = require('toobusy');
 
@@ -77,6 +78,12 @@ module.exports = function (config, routes, log) {
       }
 
       next();
+  });
+
+  server.pack.require('lout', function(err){
+    if (err) {
+      console.log('Failed loading plugin: lout (doc generator)');
+    }
   });
 
   return server;


### PR DESCRIPTION
And begin adding descriptions to routes.

We should be able to change the doc templates but there's a bug with `lout` at the moment.

@dannycoates r?
