### PR TITLE
add payload verification for fields expected to be hex strings

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -115,15 +115,15 @@ function generateSrpParams(doc, cb) {
 }
 
 function createSession(p, cb) {
-  var B = p.B.toString(16);
+  var B = p.B.toBuffer().toString('hex');
   kv.cache.set(
     p.sid + '/session',
     {
       uid: p.uid,
       srp: {
         s: p.s,
-        v: p.v.toString(16),
-        b: p.b.toString(16),
+        v: p.v.toBuffer().toString('hex'),
+        b: p.b.toBuffer().toString('hex'),
         B: B
       }
     },
@@ -193,7 +193,7 @@ exports.getToken2 = function (sessionId, tokenType, A, M1, cb) {
         alg
       );
       var M2 = srp.getM(A, bigint(p.B, 16), S);
-      if (M1 === M2.toString(16)) {
+      if (M1 === M2.toBuffer().toString('hex')) {
         K = srp.getK(S, alg);
         getUser(uid, next);
       }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -157,7 +157,7 @@ TestClient.prototype.createSRP = function (email, password, kB, cb) {
     {
       payload: {
         email: email,
-        verifier: verifier.toString(16),
+        verifier: verifier.toBuffer().toString('hex'),
         salt: salt.toString('hex'),
         wrapKb: kB,
         params: {
@@ -250,8 +250,8 @@ TestClient.prototype.getToken2 = function (tokenType, session, email, password, 
     {
       payload: {
         sessionId: json.sessionId,
-        A: A.toString(16),
-        M: M.toString(16)
+        A: A.toBuffer().toString('hex'),
+        M: M.toBuffer().toString('hex')
       }
     },
     function (res) {

--- a/test/integration/account.js
+++ b/test/integration/account.js
@@ -87,8 +87,8 @@ describe('user', function() {
     testClient.makeRequest('POST', '/finishLogin', {
       payload: {
         sessionId: session.sessionId,
-        A: 'bad',
-        M: 'bad'
+        A: 'bad1',
+        M: 'bad1'
       }
     }, function(res) {
       try {
@@ -117,8 +117,8 @@ describe('user', function() {
     testClient.makeRequest('POST', '/finishLogin', {
       payload: {
         sessionId: session.sessionId,
-        A: 'bad',
-        M: 'bad'
+        A: 'bad1',
+        M: 'bad1'
       }
     }, function(res) {
       try {
@@ -135,8 +135,8 @@ describe('user', function() {
     testClient.makeRequest('POST', '/finishLogin', {
       payload: {
         sessionId: 'bad sessionid',
-        A: 'bad',
-        M: 'bad'
+        A: 'bad1',
+        M: 'bad1'
       }
     }, function(res) {
       try {
@@ -234,8 +234,8 @@ describe('user', function() {
       testClient.makeRequest('POST', '/finishResetToken', {
         payload: {
           sessionId: session.sessionId,
-          A: 'bad',
-          M: 'bad'
+          A: 'bad1',
+          M: 'bad1'
         }
       }, function(res) {
         try {
@@ -265,8 +265,8 @@ describe('user', function() {
       testClient.makeRequest('POST', '/finishResetToken', {
         payload: {
           sessionId: session.sessionId,
-          A: 'bad',
-          M: 'bad'
+          A: 'bad1',
+          M: 'bad1'
         }
       }, function(res) {
         try {
@@ -283,8 +283,8 @@ describe('user', function() {
       testClient.makeRequest('POST', '/finishResetToken', {
         payload: {
           sessionId: 'bad sessionid',
-          A: 'bad',
-          M: 'bad'
+          A: 'bad1',
+          M: 'bad1'
         }
       }, function(res) {
         try {


### PR DESCRIPTION
This will ensure these fields are valid hex strings and can safely be converted to a `Buffer`.

Incidentally, this already found a bug, `bigint.toString(16)` doesn't pad, and sometimes outputs an unparseable hex string.
