### PR TITLE
Add SSL support into the awsboxen ELB

### DIFF
--- a/.awsboxen.json
+++ b/.awsboxen.json
@@ -88,6 +88,13 @@
             "LoadBalancerPort" : "80",
             "InstancePort" : "80",
             "Protocol" : "HTTP"
+          },
+          {
+            "LoadBalancerPort" : "443",
+            "InstancePort" : "80",
+            "Protocol" : "HTTPS",
+            "InstanceProtocol" : "HTTP",
+            "SSLCertificateId": "arn:aws:iam::142069644989:server-certificate/profileinthecloud.net"
           }
         ],
         "HealthCheck" : {


### PR DESCRIPTION
I uploaded a wildcard ssl certificate for *.profileinthecloud.net out-of-band.  This PR updates the awsboxen config to use it.  @dannycoates r?
