### PR TITLE
Enabled CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,8 @@ module.exports = function (config, routes, log) {
         engines: {
           html: 'handlebars'
         }
-      }
+      },
+      cors: true
     }
   );
 


### PR DESCRIPTION
The client API requires CORS support on the server. Hence, enabling it.
