### PR TITLE
Fix running of tests against a live server.

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -137,7 +137,8 @@ TestClient.prototype._makeRequestViaHTTP = function(method, path, opts, cb) {
     body: body
   }, function (err, res, body) {
     if (err) return cb({statusCode: 599, error: err});
-    if (body && res.headers['content-type'] === 'application/json') {
+    var contentType = res.headers['content-type'].split(';')[0];
+    if (body && contentType === 'application/json') {
       res.result = JSON.parse(body);
     } else {
       res.result = body;

--- a/test/integration/account.js
+++ b/test/integration/account.js
@@ -9,7 +9,7 @@ require("jwcrypto/lib/algs/rs");
 
 var testClient = new helpers.TestClient();
 
-var TEST_EMAIL = 'foo@example.com';
+var TEST_EMAIL = crypto.randomBytes(16).toString('hex') + '@example.com';
 var TEST_PASSWORD = 'foo';
 var TEST_PASSWORD_NEW = 'I like pie.';
 var TEST_WRAPKB = crypto.randomBytes(32).toString('hex');


### PR DESCRIPTION
This requires using a different email address for each test, so that we
can be sure it doesn't already exist.  It also requires correct handling
of the "application/json; charset=utf8" content-type which seems to be
generated by the server.

@dannycoates r?
