### PR TITLE
Added config.dev.verified option

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -34,7 +34,7 @@ function main() {
   var mailer = new Mailer(config.smtp)
 
   // stored objects
-  var models = require('../models')(config.domain, dbs, mailer)
+  var models = require('../models')(config, dbs, mailer)
 
   // server public key
   var serverPublicKey = fs.readFileSync(config.publicKeyFile)

--- a/config/config.js
+++ b/config/config.js
@@ -203,6 +203,13 @@ module.exports = function (fs, path, url, convict) {
         default: '',
         env: 'SMTP_SENDER'
       }
+    },
+    dev: {
+      verified: {
+        doc: 'new Accounts should start already verified',
+        default: false,
+        env: 'DEV_VERIFIED'
+      }
     }
   })
 

--- a/models/account.js
+++ b/models/account.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (P, tokens, RecoveryMethod, db, domain) {
+module.exports = function (P, tokens, RecoveryMethod, db, config) {
 
+  var domain = config.domain
   var SessionToken = tokens.SessionToken
   var AccountResetToken = tokens.AccountResetToken
 
@@ -49,8 +50,11 @@ module.exports = function (P, tokens, RecoveryMethod, db, domain) {
             throw new Error("AccountExists")
           }
           var account = Account.hydrate(options)
+          if (config.dev.verified) {
+            account.verified = true
+          }
           return RecoveryMethod
-            .create(account.uid, account.email, true)
+            .create(account.uid, account.email, true, account.verified)
             .then(
               function (rm) {
                 account.recoveryMethodIds[rm.id] = true

--- a/models/index.js
+++ b/models/index.js
@@ -12,7 +12,7 @@ var uuid = require('uuid')
 var Bundle = require('../bundle')
 var srp = require('../srp')
 
-module.exports = function (domain, dbs, mailer) {
+module.exports = function (config, dbs, mailer) {
 
   var Token = require('./token')(inherits, Bundle)
 
@@ -49,7 +49,7 @@ module.exports = function (domain, dbs, mailer) {
     tokens,
     RecoveryMethod,
     dbs.store,
-    domain
+    config
   )
   var SrpSession = require('./srp_session')(
     P,

--- a/models/recovery_method.js
+++ b/models/recovery_method.js
@@ -12,14 +12,19 @@ module.exports = function (crypto, P, db, mailer) {
     this.code = null
   }
 
-  RecoveryMethod.create = function (uid, email, primary) {
+  RecoveryMethod.create = function (uid, email, primary, verified) {
     var rm = new RecoveryMethod()
     rm.id = email
     rm.uid = uid
     rm.primary = !!primary
-    rm.verified = false
+    rm.verified = verified || false
     rm.code = crypto.randomBytes(32).toString('hex')
-    return rm.sendCode().then(function () { return rm.save() })
+    if (!rm.verified) {
+      return rm.sendCode().then(function () { return rm.save() })
+    }
+    else {
+      return rm.save()
+    }
   }
 
   RecoveryMethod.hydrate = function (object) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "CONFIG_FILES=./test/config/test.json tap ./test",
+    "test": "tap ./test",
     "start": "scripts/start-local.sh"
   },
   "repository": "",

--- a/test/account_reset_token_tests.js
+++ b/test/account_reset_token_tests.js
@@ -16,8 +16,11 @@ var mailer = {
   sendCode: function () { return P(null) }
 }
 
-var DOMAIN = 'example.com'
-var models = require('../models')(DOMAIN, dbs, mailer)
+var config = {
+  domain: 'example.com',
+  dev: {}
+}
+var models = require('../models')(config, dbs, mailer)
 var AccountResetToken = models.tokens.AccountResetToken
 
 test(

--- a/test/account_tests.js
+++ b/test/account_tests.js
@@ -15,8 +15,11 @@ var mailer = {
   sendCode: function () { return P(null) }
 }
 
-var DOMAIN = 'example.com'
-var models = require('../models')(DOMAIN, dbs, mailer)
+var config = {
+  domain: 'example.com',
+  dev: {}
+}
+var models = require('../models')(config, dbs, mailer)
 var Account = models.Account
 var RecoveryMethod = models.RecoveryMethod
 var SessionToken = models.tokens.SessionToken
@@ -34,7 +37,7 @@ var a = {
 test(
   'Account.principal uses the given uid and adds the domain',
   function (t) {
-    t.equal(Account.principal('xyz'), 'xyz@' + DOMAIN)
+    t.equal(Account.principal('xyz'), 'xyz@' + config.domain)
     t.end()
   }
 )

--- a/test/key_fetch_token_tests.js
+++ b/test/key_fetch_token_tests.js
@@ -16,8 +16,11 @@ var mailer = {
   sendCode: function () { return P(null) }
 }
 
-var DOMAIN = 'example.com'
-var models = require('../models')(DOMAIN, dbs, mailer)
+var config = {
+  domain: 'example.com',
+  dev: {}
+}
+var models = require('../models')(config, dbs, mailer)
 var KeyFetchToken = models.tokens.KeyFetchToken
 
 test(

--- a/test/recovery_method_tests.js
+++ b/test/recovery_method_tests.js
@@ -19,8 +19,11 @@ var mailer = {
   sendCode: function () { sends++; return P(null) }
 }
 
-var DOMAIN = 'example.com'
-var models = require('../models')(DOMAIN, dbs, mailer)
+var config = {
+  domain: 'example.com',
+  dev: {}
+}
+var models = require('../models')(config, dbs, mailer)
 var RecoveryMethod = models.RecoveryMethod
 
 test(

--- a/test/srp_session_tests.js
+++ b/test/srp_session_tests.js
@@ -13,8 +13,11 @@ var dbs = require('../kv')({
 var mailer = {
   sendCode: function () { return P(null) }
 }
-
-var models = require('../models')('example.com', dbs, mailer)
+var config = {
+  domain: 'example.com',
+  dev: {}
+}
+var models = require('../models')(config, dbs, mailer)
 var Account = models.Account
 var SrpSession = models.SrpSession
 


### PR DESCRIPTION
Create new accounts in a verified state, and skip the initial verification email.

Useful for development and QA testing.

Example:

``` sh
DEV_VERIFIED=true npm start
```

Addresses #86
