### PR TITLE
/account/reset was mistakenly requiring a 'verifier' argument

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -257,8 +257,7 @@ module.exports = function (crypto, uuid, isA, error, Account, RecoveryEmail) {
             bundle: isA.String().max((32 + 256) * 2).regex(HEX_STRING).required(),
             srp: isA.Object({
               type: isA.String().max(64).required(),
-              salt: isA.String().min(64).max(64).regex(HEX_STRING).required(),
-              verifier: isA.String().regex(HEX_STRING).required()
+              salt: isA.String().min(64).max(64).regex(HEX_STRING).required()
             }).required(),
             passwordStretching: isA.Object()
           }


### PR DESCRIPTION
This was preventing change-password from working. The new SRP verifier
is actually encrypted inside the 'bundle' argument, not free-standing.
