### PR TITLE
Clarify splitting {session,keyFetch}Token into id and reqHMACKey

### DIFF
--- a/models/account_reset_token.js
+++ b/models/account_reset_token.js
@@ -25,7 +25,7 @@ module.exports = function (inherits, Token, crypto, db) {
           t.uid = uid
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.xorKey = key.slice(64, 352).toString('hex')
           return t.save()
         }
@@ -45,7 +45,7 @@ module.exports = function (inherits, Token, crypto, db) {
           var t = new AccountResetToken()
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.xorKey = key.slice(64, 352).toString('hex')
           return t
         }

--- a/models/auth_token.js
+++ b/models/auth_token.js
@@ -28,7 +28,7 @@ module.exports = function (inherits, Token, db) {
           t.uid = uid
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.opKey = key.slice(64, 96).toString('hex')
           return t.save()
         }
@@ -58,7 +58,7 @@ module.exports = function (inherits, Token, db) {
           var t = new AuthToken()
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.opKey = key.slice(64, 96).toString('hex')
           return t
         }

--- a/models/key_fetch_token.js
+++ b/models/key_fetch_token.js
@@ -23,7 +23,7 @@ module.exports = function (inherits, Token, db) {
           t.uid = uid
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.hmacKey = key.slice(64, 96).toString('hex')
           t.xorKey = key.slice(96, 160).toString('hex')
           return t.save()
@@ -54,7 +54,7 @@ module.exports = function (inherits, Token, db) {
           var t = new KeyFetchToken()
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           t.hmacKey = key.slice(64, 96).toString('hex')
           t.xorKey = key.slice(96, 160).toString('hex')
           return t

--- a/models/session_token.js
+++ b/models/session_token.js
@@ -23,7 +23,7 @@ module.exports = function (inherits, Token, db) {
           t.uid = uid
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           return t.save()
         }
       )
@@ -42,7 +42,7 @@ module.exports = function (inherits, Token, db) {
           var t = new SessionToken()
           t.data = data[0].toString('hex')
           t.id = key.slice(0, 32).toString('hex')
-          t.key = key.slice(32, 64).toString('hex')
+          t._key = key.slice(32, 64).toString('hex')
           return t
         }
       )

--- a/models/token.js
+++ b/models/token.js
@@ -7,12 +7,21 @@ module.exports = function (inherits, Bundle) {
   function Token() {
     Bundle.call(this)
     this.id = null
-    this.key = null
+    this._key = null
     this.algorithm = 'sha256'
     this.uid = null
     this.data = null
   }
   inherits(Token, Bundle)
+
+  Object.defineProperty(
+    Token.prototype,
+    'key',
+    {
+      get: function () { return Buffer(this._key, 'hex') },
+      set: function (x) { this._key = x.toString('hex') }
+    }
+  )
 
   Token.randomTokenData = function (info, size) {
     return Bundle
@@ -34,7 +43,7 @@ module.exports = function (inherits, Bundle) {
     if (!raw) return null
     if (raw.value) raw = raw.value
     token.id = raw.id
-    token.key = raw.key,
+    token._key = raw._key,
     token.uid = raw.uid
     token.data = raw.data,
     token.hmacKey = raw.hmacKey

--- a/test/run/verification_tests.js
+++ b/test/run/verification_tests.js
@@ -101,8 +101,7 @@ mail.on(
   function (email) {
     var match = codeMatch.exec(email)
     if (match) {
-      var code = match[1]
-      verifyCode = code.toString().trim()
+      verifyCode = match[1]
     }
     else {
       console.error('No verify code match')


### PR DESCRIPTION
Token is 64 bytes, which gets split into 32 byte id and 32 byte request HMAC key.  The Hawk id is the hex-string of id and the key that Hawk is using to HMAC is actually the UTF-8 bytes of the hex-string of the request HMAC key.  That surprised me.  We should clarify _exactly_ what the id and the key are.
