### PR TITLE
Error response format change

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,11 +22,16 @@ For example:
 ```js
 {
   "code": 400, // matches the HTTP status code
-  "error": 1234, // stable application level error type
+  "errno": 101, // stable application level error number
+  "error": "Bad Request", // string description of the error type
   "message": "the value of salt is not allowed to be undefined",
   "info": "https://dev.picl.org/errors/1234" // link to more info on the error
 }
 ```
+
+Individual `errno`s may include additional parameters
+
+---
 
 # Endpoints
 

--- a/error.js
+++ b/error.js
@@ -1,47 +1,35 @@
 var Boom = require('hapi').error
 
 Boom.accountExists = function (email) {
-  var b = new Boom(400)
-  b.appError = {
-    code: 400,
-    error: 101,
-    message: 'Account already exists',
-    info: 'http://errors.lcip.org/todo/101',
-    email: email
-  }
+  var b = new Boom(400, 'Account already exists')
+  var p = b.response.payload
+  p.errno = 101
+  p.info = 'http://errors.lcip.org/todo/101'
+  p.email = email
   return b
 }
 
 Boom.unknownAccount = function () {
-  var b = new Boom(400)
-  b.appError = {
-    code: 400,
-    error: 102,
-    message: 'Unknown account',
-    info: 'http://errors.lcip.org/todo/102'
-  }
+  var b = new Boom(400, 'Unknown account')
+  var p = b.response.payload
+  p.errno = 102
+  p.info = 'http://errors.lcip.org/todo/102'
   return b
 }
 
 Boom.incorrectPassword = function () {
-  var b = new Boom(400)
-  b.appError = {
-    code: 400,
-    error: 103,
-    message: 'Incorrect password',
-    info: 'http://errors.lcip.org/todo/103'
-  }
+  var b = new Boom(400, 'Incorrect password')
+  var p = b.response.payload
+  p.errno = 103
+  p.info = 'http://errors.lcip.org/todo/103'
   return b
 }
 
 Boom.unverifiedAccount = function () {
-  var b = new Boom(400)
-  b.appError = {
-    code: 400,
-    error: 104,
-    message: 'Unverified account',
-    info: 'http://errors.lcip.org/todo/104'
-  }
+  var b = new Boom(400, 'Unverified account')
+  var p = b.response.payload
+  p.errno = 104
+  p.info = 'http://errors.lcip.org/todo/104'
   return b
 }
 
@@ -50,15 +38,12 @@ Boom.notImplemented = function () {
 }
 
 Boom.invalidCode = function (forgotPasswordToken) {
-  var b = new Boom(400)
-  b.appError = {
-    code: 400,
-    error: 105,
-    message: 'Invalid code',
-    info: 'http://errors.lcip.org/todo/105',
-    tries: forgotPasswordToken.tries,
-    ttl: forgotPasswordToken.ttl()
-  }
+  var b = new Boom(400, 'Invalid code')
+  var p = b.response.payload
+  p.errno = 105
+  p.info = 'http://errors.lcip.org/todo/105'
+  p.tries = forgotPasswordToken.tries
+  p.ttl = forgotPasswordToken.ttl()
   return b
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -96,8 +96,8 @@ module.exports = function (path, Hapi, toobusy) {
       function (request, next) {
         var response = request.response()
         if (response.isBoom) {
-          if (response.appError) {
-            response.response.payload = response.appError
+          if (!response.response.payload.errno) {
+            response.response.payload.errno = response.response.payload.code
           }
           log.error(response.response.payload)
         }

--- a/test/run/account_tests.js
+++ b/test/run/account_tests.js
@@ -90,7 +90,7 @@ test(
         },
         function (err) {
           t.equal(err.response.code, 400)
-          t.equal(err.appError.message, 'Account already exists')
+          t.equal(err.message, 'Account already exists')
         }
       )
       .then(Account.del.bind(null, a.uid))


### PR DESCRIPTION
Our current error response format defined in `api.md` doesn't cooperate with hapi very well.

Default hapi output looks like:

``` json
{
  "code": 400,
  "error": "Bad Request",
  "message": "Validation error, blah blah..."
}
```

It nicely responds to validation errors (for example) without any app code assistance.

`api.md` clashes a bit with this format because `error` becomes a number. I propose we just add an `errno` instead for application level error numbers.

Not a big change, just thought I'd bring it up.
