### PR TITLE
update convict and fix smtp param settings

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -190,12 +190,14 @@ module.exports = function (fs, path, url, convict) {
       },
       user: {
         doc: 'SMTP username',
-        default: null,
+        format: String,
+        default: undefined,
         env: 'SMTP_USER'
       },
       password: {
         doc: 'SMTP password',
-        default: null,
+        format: String,
+        default: undefined,
         env: 'SMTP_PASS'
       },
       sender: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "compute-cluster": "0.0.7",
     "jwcrypto": "0.4.3",
     "handlebars": "1.0.10",
-    "convict": "0.3.3",
+    "convict": "0.4.0",
     "p-promise": "0.2.3",
     "kvstore": "0.0.4",
     "bunyan": "0.21.4",


### PR DESCRIPTION
I was getting errors when the smtp params were set using @rfk's bundle, due to `null` being the default. Convict was inferring null was the type (since no `format` was set) and throwing when strings were supplied. This should fix things.
