### PR TITLE
SRP Verifier should be padded to 256 bytes for N = 2048

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -57,14 +57,27 @@ function getAMK(srpSession, email, password) {
   }
 }
 
+function pad(n, length) {
+  var padding = length - n.length
+  console.assert(padding > -1, "Negative padding.  Very uncomfortable.")
+  if (padding === 0) { return n }
+  var result = new Buffer(length)
+  result.fill(0, 0, padding)
+  n.copy(result, padding)
+  return result
+}
+
 function verifier(salt, email, password, algorithm) {
-  return srp.getv(
-    Buffer(salt, 'hex'),
-    Buffer(email),
-    Buffer(password),
-    srp.params['2048'].N,
-    srp.params['2048'].g,
-    algorithm
+  return pad(
+    srp.getv(
+      Buffer(salt, 'hex'),
+      Buffer(email),
+      Buffer(password),
+      srp.params['2048'].N,
+      srp.params['2048'].g,
+      algorithm
+    ),
+    256
   ).toString('hex')
 }
 
@@ -118,7 +131,7 @@ Client.parse = function (string) {
   client.email = object.email
   client.password = object.password
   client.srp = object.srp
-  c.passwordSalt = object.passwordSalt
+  client.passwordSalt = object.passwordSalt
   client.passwordStretching = object.passwordStretching
   client.sessionToken = object.sessionToken
   client.accountResetToken = object.accountResetToken

--- a/routes/account.js
+++ b/routes/account.js
@@ -22,7 +22,7 @@ module.exports = function (crypto, uuid, isA, error, Account, RecoveryEmail) {
             email: isA.String().max(1024).regex(HEX_STRING).required(),
             srp: isA.Object({
               type: isA.String().max(64).required(), // TODO valid()
-              verifier: isA.String().max(512).regex(HEX_STRING).required(),
+              verifier: isA.String().min(512).max(512).regex(HEX_STRING).required(),
               salt: isA.String().min(64).max(64).regex(HEX_STRING).required(),
             }).required(),
             passwordStretching: isA.Object(
@@ -35,6 +35,7 @@ module.exports = function (crypto, uuid, isA, error, Account, RecoveryEmail) {
         },
         handler: function accountCreate(request) {
           var form = request.payload
+
           Account
             .create(
               {


### PR DESCRIPTION
The server needs to pad the value of `srp.verifier` that's received from `/account/create`

The client _should_ pad the value to be nice.

@dannycoates - also audit other values for proper padding
