### PR TITLE
Add crontab-based auto-update to awsbox deployment.

### DIFF
--- a/scripts/awsbox/auto_update.sh
+++ b/scripts/awsbox/auto_update.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# A little helper script for an awsbox to auto-update itself.
+# This script will pull updates from the origin repo, update local master
+# to match them, and initiate the post-deploy hooks.  If you run it as
+# a cronjob then you'll get an auto-updating awsbox deployment.
+
+set -e
+
+CURCOMMIT="git log --pretty=%h -1"
+ORIGIN="https://github.com/mozilla/picl-idp.git"
+
+cd /home/app/git
+git remote add origin $ORIGIN || true
+git fetch origin
+
+if [ `$CURCOMMIT master` != `$CURCOMMIT origin/master` ]; then
+  git branch -f master origin/master
+  /usr/local/bin/node ../post-update.js
+fi

--- a/scripts/awsbox/post_create.sh
+++ b/scripts/awsbox/post_create.sh
@@ -24,3 +24,9 @@ git checkout b63a19a153f631c949e7f6506ad4bf1f258dda69
 cat *.pub >> /home/ec2-user/.ssh/authorized_keys
 cd ..
 rm -rf identity-pubkeys
+
+echo "Establishing auto-update crontab"
+
+echo "*/5 * * * * /bin/bash -l /home/app/code/scripts/awsbox/auto_update.sh > /dev/null 2> /dev/null" | sudo crontab -u app -
+
+echo "post-create complete!"


### PR DESCRIPTION
The simplest thing that could possibly work: install a cron job at instance creation time, have it poll github for updates and push them live if available.

We'll do something fancier later, but this should be a solid start for now.

@dannycoates r?
