### PR TITLE
connect to local postfix

### DIFF
--- a/config/awsbox.json
+++ b/config/awsbox.json
@@ -7,7 +7,8 @@
     "user": "picl"
   },
   "smtp": {
-    "sender": "webmaster@lcip.org",
+    "host": "localhost",
+    "port": 25,
     "secure": false
   },
   "secretKeyFile": "/home/app/var/secret-key.json",


### PR DESCRIPTION
Gene has manually set up postfix on the current dev box. This ensures we use that for sending emails. We'll also need to do #161 for future box creation.
