### PR TITLE
increase the max lag to prevent integration tests from failing on travis-ci

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -69,6 +69,8 @@ module.exports = function (path, url, Hapi, toobusy) {
 
     //TODO throttle extension
 
+    // twice the default max lag of 70ms
+    toobusy.maxLag(140)
     server.ext(
       'onRequest',
       function (request, next) {


### PR DESCRIPTION
See travis-ci failures for #242 and #243. Also #204.
