### PR TITLE
Adding Gruntfile w/ JSHint task and copyright checker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,50 @@
+module.exports = function (grunt) {
+
+  require('load-grunt-tasks')(grunt);
+
+  grunt.initConfig({
+    copyright: {
+      files: [
+        "**/*.js",
+        "!**/node_modules/**"
+      ],
+      options: {
+        pattern: "This Source Code Form is subject to the terms of the Mozilla Public"
+      }
+    },
+    jshint: {
+      files: [
+        "**/*.js",
+        "**/*.json",
+        "!node_modules/**",
+        "!web/**"
+      ],
+      options: {
+        jshintrc: ".jshintrc"
+      }
+    }
+  });
+
+  grunt.registerMultiTask('copyright', 'Copyright all the things!', function () {
+    var pattern = this.options().pattern;
+    var files = this.filesSrc.map(function (file) {
+      return {
+        "name": file,
+        "txt": grunt.file.read(file, "utf8")
+      };
+    }).filter(function (file) {
+      return !file.txt.match(pattern);
+    });
+
+    if (files.length) {
+      grunt.log.subhead("The following files are missing copyright headers:");
+      files.forEach(function (file) {
+        grunt.log.warn(file.name);
+      });
+      return false;
+    }
+  });
+
+  grunt.registerTask('default', ['copyright']);
+  grunt.registerTask('qa', ['copyright', 'jshint']);
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "awsbox": "0.6.x",
     "awsboxen": "0.5.x",
     "lazysmtp": "git://github.com/dannycoates/node-lazysmtp.git#9bb3712992",
-    "tap": "0.4.4"
+    "tap": "0.4.4",
+    "grunt-contrib-jshint": "~0.7.0",
+    "load-grunt-tasks": "~0.2.0",
+    "grunt": "~0.4.1"
   }
 }


### PR DESCRIPTION
The irony of me checking in a Gruntfile.js with a copyright checker task and then forgetting to put a copyright header in the Gruntfile is not lost on me.
