### PR TITLE
test for oversized payloads

### DIFF
--- a/error.js
+++ b/error.js
@@ -10,6 +10,8 @@ var DEFAULTS = {
   info: 'https://github.com/mozilla/picl-idp/blob/master/docs/api.md#response-format'
 }
 
+var TOO_LARGE = /^Payload (?:content length|size) greater than maximum allowed/
+
 // Wrap an object into a Boom error response.
 //
 // If the object does not have an 'errno' attribute, this function
@@ -41,6 +43,11 @@ Boom.wrap = function (srcObject) {
         object = Boom.invalidTimestamp().response.payload
       } else {
         object = Boom.invalidSignature().response.payload
+      }
+    }
+    else if (object.code === 400) {
+      if (TOO_LARGE.test(object.message)) {
+        object = Boom.requestBodyTooLarge().response.payload
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mysql": "0.9.6",
     "srp": "0.2.0",
     "uuid": "1.4.1",
-    "hapi": "1.14.0",
+    "hapi": "1.15.0",
     "hawk": "1.1.2",
     "hkdf": "0.0.1",
     "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#961316282a",

--- a/test/run/integration_tests.js
+++ b/test/run/integration_tests.js
@@ -399,6 +399,29 @@ function main() {
   )
 
   test(
+    'oversized payload',
+    function (t) {
+      var client = new Client(config.public_url)
+      client.api.doRequest(
+        'POST',
+        client.api.baseURL + '/get_random_bytes',
+        null,
+        { big: Buffer(1024 * 512).toString('hex')}
+      )
+      .then(
+        function () {
+          t.fail('request should have failed')
+          t.end()
+        },
+        function (err) {
+          t.equal(err.errno, 113, 'payload too large')
+          t.end()
+        }
+      )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       if (server) server.kill('SIGINT')


### PR DESCRIPTION
This adds the custom error defined in api.md for requests that are too large (code:413 errno:113) and a test-case.

This is related to #216

The default `maxBytes` of a payload is 1MB. We may want to tune this by endpoint.
