### PR TITLE
Write a test to verify timestamp checking in our use of HAWK

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -15,8 +15,10 @@ util.inherits(ClientApi, EventEmitter)
 function ClientApi(origin) {
   EventEmitter.call(this)
   this.origin = origin
-  this.baseURL = origin + "/v1";
+  this.baseURL = origin + "/v1"
 }
+
+ClientApi.prototype.Token = tokens
 
 function hawkHeader(token, method, url, payload) {
   var verify = {


### PR DESCRIPTION
By default, Hawk in Hapi accepts a clock skew of +/- 60 seconds between client and server. There has been confusion in past about whether is is enabled or not (#199), so we should have a test to make sure it is.
