### PR TITLE
Factor test-server spawn/teardown code into a single helper function

### DIFF
--- a/test/test_server.js
+++ b/test/test_server.js
@@ -1,0 +1,53 @@
+var cp = require('child_process')
+var P = require('p-promise')
+var request = require('request')
+
+function TestServer() {
+  this.server = cp.spawn(
+    'node',
+    ['../bin/key_server.js'],
+    {
+      cwd: __dirname
+    }
+  )
+  this.server.stdout.on('data', process.stdout.write.bind(process.stdout))
+  this.server.stderr.on('data', process.stderr.write.bind(process.stderr))
+}
+
+TestServer.server = { stop: function () {}, fake: true }
+
+function waitLoop(url, cb) {
+  request(
+    url + '/__heartbeat__',
+    function (err, res, body) {
+      if (err) {
+        if (err.errno !== 'ECONNREFUSED') {
+          console.log("ERROR: unexpected result from " + url)
+          console.log(err)
+          return cb(err)
+        }
+        if (TestServer.server.fake) {
+          console.log('starting...')
+          TestServer.server = new TestServer()
+        }
+        console.log('waiting...')
+        return setTimeout(waitLoop.bind(null, url, cb), 100)
+      }
+      cb()
+    }
+  )
+}
+
+TestServer.start = function (url) {
+  var d = P.defer()
+  waitLoop(url, function (err) {
+    return err ? d.reject(err) : d.resolve(TestServer.server)
+  })
+  return d.promise
+}
+
+TestServer.prototype.stop = function () {
+  this.server.kill('SIGINT')
+}
+
+module.exports = TestServer


### PR DESCRIPTION
We seem to have duplicate logic in a lot of integration tests for starting/stopping various servers.  This should be refactored out into a single helper function.
