### PR TITLE
Signed certificate format: What is the principal?

### DIFF
--- a/bin/signer.js
+++ b/bin/signer.js
@@ -20,12 +20,15 @@ process.on('message', function (message) {
   if (!message.email || typeof(message.email) !== 'string') {
     return process.send({ err: { message: 'bad email' } })
   }
+  if (!message.uid || typeof(message.uid) !== 'string') {
+    return process.send({ err: { message: 'bad uid' } })
+  }
   try {
     var now = Date.now()
     jwcrypto.cert.sign(
       {
         publicKey: jwcrypto.loadPublicKeyFromObject(message.publicKey),
-        principal: { email: message.email },
+        principal: { email: message.email, uid: message.uid },
         //TODO: kA, etc
       },
       {

--- a/routes/sign.js
+++ b/routes/sign.js
@@ -66,7 +66,8 @@ module.exports = function (log, isA, error, signer, domain) {
 
           signer.enqueue(
             {
-              email: sessionToken.uid + '@' + domain,
+              uid: sessionToken.uid,
+              email: sessionToken.email,
               publicKey: publicKey,
               duration: duration
             },


### PR DESCRIPTION
When issuing certificates for FXA, what should the `principal` be?

As the [specs say](https://github.com/mozilla/id-specs/blob/prod/browserid/index.md#identity-certificate), the principal is a JSON object that indicates the type of principal, e.g., `{"email": "ludmilla@example.com"}`.

For FXA certificates, we may wish to issue a principal that contains the unique uid instead, so that it remains the same in the event of the user changing his or her email.

What should this look like?  

Related questions include: What concerns for backwards compatibility do we have for existing services (e.g., Marketplace)?  What does this do to the verifier?  In the future, would we share different information in the principal with third-party apps?
