### PR TITLE
Remove references to old picl-idp repo name

### DIFF
--- a/loadtest/runbench.sh
+++ b/loadtest/runbench.sh
@@ -23,7 +23,7 @@ SSH_PID=$!
 # XXX TODO: better way to get the JS support code onto the agent boxes.
 
 # JavaScript runner:
-./bin/loads-runner --users=20 --duration=300 --external-process-timeout=60 --broker=tcp://localhost:7780 --zmq-publisher=tcp://localhost:7776 --agents=5 --test-runner="/home/app/picl-idp/loadtest/lib/loads.js/loadsjs/runner.js {test}" "/home/app/picl-idp/loadtest/loadtests.js"
+./bin/loads-runner --users=20 --duration=300 --external-process-timeout=60 --broker=tcp://localhost:7780 --zmq-publisher=tcp://localhost:7776 --agents=5 --test-runner="/home/app/fxa-auth-server/loadtest/lib/loads.js/loadsjs/runner.js {test}" "/home/app/fxa-auth-server/loadtest/loadtests.js"
 
 # Python runner
 #./bin/loads-runner --users=20 --duration=300 --broker=tcp://localhost:7780 --zmq-publisher=tcp://localhost:7776 --agents=5 --include-file=./loadtests.py --python-dep=hawkauthlib loadtests.LoadTest.test_idp

--- a/log.js
+++ b/log.js
@@ -40,7 +40,7 @@ module.exports = function (config) {
 
   var log = new Overdrive(
     {
-      name: 'picl-idp',
+      name: 'fxa-auth-server',
       streams: logStreams
     }
   )

--- a/scripts/awsbox/hekad.toml
+++ b/scripts/awsbox/hekad.toml
@@ -9,10 +9,10 @@ address = ":8125"
 
 [StatAccumInput]
 
-[picl-idp-log]
+[fxa-auth-server-log]
 type = "LogfileInput"
 logfile = "/home/app/code/server.log"
-logger = "picl-idp"
+logger = "fxa-auth-server-log"
 
 [nginx-access-log]
 type = "LogfileInput"
@@ -27,7 +27,7 @@ match_regex = '^(?P<RemoteIP>\S+) \S+ \S+ \[(?P<Timestamp>[^\]]+)\] "(?P<Method>
 [nginx-log-decoder.message_fields]
 Type = "logfile"
 Logger = "nginx"
-App = "picl-idp"
+App = "fxa-auth-server"
 Url|uri = "%Url%"
 Method = "%Method%"
 Status = "%StatusCode%"


### PR DESCRIPTION
Companion bug to Issue #310 

There are a few remaining mentions to `picl-idp` that I'd rather not touch since I'm "unknowledgeable" (to say the least).

---
### /loadtest/runbench.sh

https://github.com/mozilla/fxa-auth-server/blob/master/loadtest/runbench.sh#L17

> ./bin/loads-runner --users=20 --duration=300 --external-process-timeout=60 --broker=tcp://localhost:7780 --zmq-publisher=tcp://localhost:7776 --agents=3 --test-runner="/home/app/picl-idp/loadtest/lib/loads.js/runner.js {test}" "/home/app/picl-idp/loadtest/loadtests.js"
### /scripts/awsbox/hekad.toml

https://github.com/mozilla/fxa-auth-server/blob/master/scripts/awsbox/hekad.toml#L12
https://github.com/mozilla/fxa-auth-server/blob/master/scripts/awsbox/hekad.toml#L15
https://github.com/mozilla/fxa-auth-server/blob/master/scripts/awsbox/hekad.toml#L30

> [picl-idp-log] // L12
> logger = "picl-idp" // L15
> App = "picl-idp" // L30
### log.js

https://github.com/mozilla/fxa-auth-server/blob/master/log.js#L43

> name: 'picl-idp',
