### PR TITLE
certificate/sign produces all-hex "principal.email"

### DIFF
--- a/routes/sign.js
+++ b/routes/sign.js
@@ -67,7 +67,7 @@ module.exports = function (log, isA, error, signer, domain) {
           signer.enqueue(
             {
               uid: sessionToken.uid,
-              email: sessionToken.email,
+              email: Buffer(sessionToken.email, 'hex').toString(),
               publicKey: publicKey,
               duration: duration
             },

--- a/test/run/integration_tests.js
+++ b/test/run/integration_tests.js
@@ -68,6 +68,11 @@ TestServer.start(config.public_url)
         .then(
           function (cert) {
             t.equal(typeof(cert), 'string', 'cert exists')
+            var certData = Buffer(cert.split('.')[1], 'base64').toString()
+            cert = JSON.parse(certData)
+            t.equal(cert.principal.uid, client.uid, 'cert has correct uid')
+            t.equal(cert.principal.email, email, 'cert has correct email')
+            t.deepEqual(cert['public-key'], publicKey, 'cert has correct key')
           }
         )
         .done(


### PR DESCRIPTION
I finally added tests of certificate/sign to my python-based https://github.com/warner/picl-spec-crypto tool, and the signed payload of the cert it returns contains a `principal.email` that is all-hex. It's supposed to contain the (unencoded) email address. These certificates won't work at all with the browserid verifier.

We should probably do a full sweep of all the code that touches this "email" field, and either change the variable/argument/column names to include the type ("email" or "email_hex"), or pick one safe representation and use it everywhere.
