### PR TITLE
Warn but don't die if using MemoryNonceDB in production.

### DIFF
--- a/noncedb.js
+++ b/noncedb.js
@@ -130,9 +130,8 @@ module.exports = function (config, log, now) {
     return RedisNonceDB
   } else {
     if (config.env === 'production') {
-        throw 'in-memory nonce db is not suitable for production use'
+      log.warn('using in-memory nonce db; this is likely not suitable for production')
     }
-    log.warn('using in-memory nonce db')
     return MemoryNonceDB
   }
 }


### PR DESCRIPTION
Per https://github.com/mozilla/fxa-auth-server/pull/253#issuecomment-28749199 let's remove the production-use-of-in-memory-noncedb killswitch and just issue a warning instead.  @chilts r?
