### PR TITLE
Issue #299 : Add transaction for deleteAccount()

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "toobusy": "0.2.4",
     "nodemailer": "0.5.3",
     "then-redis": "0.3.x",
-    "request": "2.27.0"
+    "request": "2.27.0",
+    "q": "~0.9.7"
   },
   "devDependencies": {
     "awsbox": "0.6.x",


### PR DESCRIPTION
Since the resetAccount() function has changed a fair bit, have a look at the before and after:
- before : https://github.com/chilts/fxa-auth-server/blob/master/db/mysql.js#L512-L537
- after : https://github.com/chilts/fxa-auth-server/blob/issue-299-add-transactions/db/mysql.js#L549-L567
