### PR TITLE
slightly increase logging of hawk requests

### DIFF
--- a/error.js
+++ b/error.js
@@ -44,7 +44,7 @@ Boom.wrap = function (srcObject) {
       } else if (object.message === 'Invalid nonce') {
         object = Boom.invalidNonce().response.payload
       } else {
-        object = Boom.invalidSignature().response.payload
+        object = Boom.invalidSignature(object.message).response.payload
       }
     }
     else if (object.code === 400) {
@@ -146,11 +146,11 @@ Boom.missingRequestParameter = function (param) {
   })
 }
 
-Boom.invalidSignature = function () {
+Boom.invalidSignature = function (message) {
   return Boom.wrap({
     code: 401,
     errno: 109,
-    message: 'Invalid request signature'
+    message: message || 'Invalid request signature'
   })
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -110,6 +110,24 @@ module.exports = function (path, url, Hapi, toobusy, error) {
     )
 
     server.ext(
+      'onPreAuth',
+      function (request, next) {
+        if (request.headers.authorization) {
+          log.trace(
+            {
+              op: 'server.onPreAuth',
+              rid: request.id,
+              path: request.path,
+              auth: request.headers.authorization,
+              type: request.headers['content-type'] || ''
+            }
+          )
+        }
+        next()
+      }
+    )
+
+    server.ext(
       'onPreHandler',
       function (request, next) {
         log.trace(


### PR DESCRIPTION
What's happening inside the auth phase with hapi/hawk is too opaque to debug easily.

This adds a trace log line for the authorization header and content-type before sending the request to hawk. I don't know how useful it will be though. Perhaps more useful is the addition of the error message from hawk when it isn't one of the specific ones we handle, which _should_ help debug the details of failed hawk requests.
