### PR TITLE
Add optional opaque "rpid" parameter to verification emails.

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -100,6 +100,7 @@ ClientApi.prototype.accountCreate = function (email, verifier, salt, passwordStr
         salt: salt
       },
       passwordStretching: passwordStretching,
+      service: options.service || undefined,
       preVerified: options.preVerified
     },
     {
@@ -178,14 +179,19 @@ ClientApi.prototype.recoveryEmailStatus = function (sessionTokenHex) {
     )
 }
 
-ClientApi.prototype.recoveryEmailResendCode = function (sessionTokenHex) {
+ClientApi.prototype.recoveryEmailResendCode = function (sessionTokenHex, service) {
+  var payload = {}
+  if (service) {
+    payload.service = service
+  }
   return tokens.SessionToken.fromHex(sessionTokenHex)
     .then(
       function (token) {
         return this.doRequest(
           'POST',
           this.baseURL + '/recovery_email/resend_code',
-          token
+          token,
+          payload
         )
       }.bind(this)
     )

--- a/client/index.js
+++ b/client/index.js
@@ -29,6 +29,7 @@ function Client(origin) {
   this.wrapKb = null
   this._devices = null
   this.lang = null
+  this.service = null
 }
 
 Client.Api = ClientApi
@@ -94,6 +95,9 @@ Client.create = function (origin, email, password, options) {
   if (options.lang) {
     c.lang = options.lang
   }
+  if (options.service) {
+    c.service = options.service
+  }
 
   return c.setupCredentials(email, password)
     .then(
@@ -145,6 +149,7 @@ Client.parse = function (string) {
   client.forgotPasswordToken = object.forgotPasswordToken
   client.kA = object.kA
   client.wrapKb = object.wrapKb
+  client.service = object.service || null
 
   return client
 }
@@ -165,7 +170,8 @@ Client.prototype.create = function () {
     },
     {
       preVerified: this.preVerified,
-      lang: this.lang
+      lang: this.lang,
+      service: this.service
     }
   )
   .then(
@@ -325,7 +331,7 @@ Client.prototype.requestVerifyEmail = function () {
   var o = this.sessionToken ? P(null) : this.login()
   return o.then(
     function () {
-      return this.api.recoveryEmailResendCode(this.sessionToken)
+      return this.api.recoveryEmailResendCode(this.sessionToken, this.service)
     }.bind(this)
   )
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -145,6 +145,8 @@ Creates a user account. The client provides the email address with which this ac
 
 Because the account email is used for key-derivation by both client and server, it is important to deliver it accurately, byte-for-byte. To avoid transfer-encoding ambiguity (what does HTTP use? what does the JSON parser do? etc), the email should be transferred as a hex-encoded binary string, just like the salts, tokens, and SRP A/B values. For example, "me@example.com" is represented as "6d65406578616d706c652e636f6d", and "andré@example.org" is represented as "616e6472c3a9406578616d706c652e6f7267".
 
+This endpoint may send a verification email to the user.  Callers may optionally provide the `service` parameter to indicate what Identity-Attached Service they are acting on behalf of.  This is an opaque alphanumeric token which will be embedded in the verification link as a query parameter.
+
 ___Parameters___
 
 * email - the primary email for this account (UTF-8 encoded, as hex)
@@ -160,6 +162,8 @@ ___Parameters___
     * scrypt_p: 1
     * PBKDF2_rounds_2: 20000
     * salt: password stretching salt
+* service - opaque alphanumeric token to be included in verification links
+
 
 ### Request
 
@@ -558,6 +562,7 @@ ___Parameters___
 
 * email - the primary email for this account (UTF-8 encoded, as hex)
 * password - the user's plaintext password
+* service - opaque alphanumeric token to be included in verification links
 
 ### Request
 
@@ -875,11 +880,15 @@ Failing requests may be due to the following errors:
 
 Re-sends a verification code to the account's recovery email address. The code is first sent when the account is created, but if the user thinks the message was lost or accidentally deleted, they can request a new message to be sent with this endpoint. The new message will contain the same code as the original message. When this code is provided to `/v1/recovery_email/verify_code` (below), the email will be marked as "verified".
 
+This endpoint may send a verification email to the user.  Callers may optionally provide the `service` parameter to indicate what Identity-Attached Service they are acting on behalf of.  This is an opaque alphanumeric token which will be embedded in the verification link as a query parameter.
+
+
 ### Request
 
 ___Parameters___
 
-none (an empty request body)
+* service - opaque alphanumeric token to be included in verification links
+
 
 ___Headers___
 

--- a/mailer.js
+++ b/mailer.js
@@ -81,10 +81,13 @@ module.exports = function (config, i18n, log) {
     return d.promise
   }
 
-  Mailer.prototype.sendVerifyCode = function (account, code, preferredLang) {
+  Mailer.prototype.sendVerifyCode = function (account, code, service, preferredLang) {
     log.trace({ op: 'mailer.sendVerifyCode', email: account.email, uid: account.uid })
     var template = templates.verify
     var link = this.verificationUrl + '?uid=' + account.uid.toString('hex')
+    if (service) {
+      link += '&service=' + service
+    }
     link += '&code=' + code
     var reportLink = this.reportUrl
 
@@ -102,6 +105,7 @@ module.exports = function (config, i18n, log) {
       headers: {
         'X-Uid': account.uid.toString('hex'),
         'X-Verify-Code': code,
+        'X-Service-ID': service,
         'X-Link': link
       }
     }

--- a/routes/account.js
+++ b/routes/account.js
@@ -36,6 +36,7 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
                 salt: isA.String().min(64).max(64).regex(HEX_STRING).required()
               }
             ).required(),
+            service: isA.String().max(16).alphanum().optional(),
             preVerified: isA.Boolean()
           }
         },
@@ -77,6 +78,7 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
                 return mailer.sendVerifyCode(
                   account,
                   account.emailCode,
+                  form.service,
                   request.app.preferredLang
                 )
                 .then(function () { return account })
@@ -213,6 +215,11 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
         auth: {
           strategy: 'sessionToken'
         },
+        validate: {
+          payload: {
+            service: isA.String().max(16).alphanum().optional()
+          }
+        },
         tags: ["account", "recovery"],
         handler: function (request) {
           log.begin('Account.RecoveryEmailResend', request)
@@ -220,6 +227,7 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
           mailer.sendVerifyCode(
             sessionToken,
             sessionToken.emailCode,
+            request.payload.service,
             request.app.preferredLang
           ).done(
             function () {

--- a/routes/rawpassword.js
+++ b/routes/rawpassword.js
@@ -73,6 +73,7 @@ module.exports = function (log, isA, error, clientHelper, crypto, db, isProducti
               password: request.payload.password,
               options: {
                 preVerified: request.payload.preVerified || false,
+                service: request.payload.service,
                 lang: request.app.preferredLang
               }
             },
@@ -88,7 +89,8 @@ module.exports = function (log, isA, error, clientHelper, crypto, db, isProducti
           payload: {
             email: isA.String().max(1024).regex(HEX_EMAIL).required(),
             password: isA.String().required(),
-            preVerified: isA.Boolean()
+            preVerified: isA.Boolean(),
+            service: isA.String().max(16).alphanum().optional()
           }
         }
       }

--- a/test/run/verification_tests.js
+++ b/test/run/verification_tests.js
@@ -148,6 +148,56 @@ TestServer.start(config.publicUrl)
   )
 
   test(
+    'create account with service identifier',
+    function (t) {
+      var email = uniqueID() +'@example.com'
+      var password = 'allyourbasearebelongtous'
+      var client = null
+      var options = { service: 'abcdef' }
+      return Client.create(config.publicUrl, email, password, options)
+        .then(
+          function (x) {
+            client = x
+          }
+        )
+        .then(
+          function () {
+            return waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            t.equal(emailData.headers['x-service-id'], 'abcdef')
+            client.service = '123456'
+            return client.requestVerifyEmail()
+          }
+        )
+        .then(
+          function () {
+            return waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            t.equal(emailData.headers['x-service-id'], '123456')
+            client.service = null
+            return client.requestVerifyEmail()
+          }
+        )
+        .then(
+          function () {
+            return waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            t.equal(emailData.headers['x-service-id'], undefined)
+          }
+        )
+    }
+  )
+
+  test(
     'forgot password',
     function (t) {
       var email = uniqueID() +'@restmail.net'
@@ -466,7 +516,6 @@ function createFreshAccount(email, password) {
       }
     )
 }
-
 
 function waitForCode(email) {
   return waitForEmail(email)


### PR DESCRIPTION
Strawman for how the auth server can assist with #309

This allows requests that generate a verification email to include an optional "rpid" parameter, for use as a "Relying Party Identifier".  It's opaque to the auth server and is just included verbatim as a query parameter in the verification URL.

The idea is that the content-server can assign rpids via the magic of not-defined-in-this-protocol, submit the rpid during account creation, and use it when displaying the verification page in order to customize the messaging appropriately.

@ckarlof @dannycoates thoughts?  Total strawman so so feel free to brutally destroy it ;-)
