### PR TITLE
Send verification code in URL fragment, not querystring

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -76,7 +76,7 @@ module.exports = function (config, log) {
   Mailer.prototype.sendVerifyCode = function (email, code, uid) {
     log.trace({ op: 'mailer.sendVerifyCode', email: email, uid: uid })
     var template = templates.verify
-    var link = this.verification_url + '?uid=' + uid + '&code=' + code
+    var link = this.verification_url + '?uid=' + uid + '#code=' + code
     var reportLink = this.report_url
 
     var values = {


### PR DESCRIPTION
The spec says that we will send the verification code in the fragment portion of the verification URL, presumably so that it will not be leaked in logs etc.  We currently send it in the querystring.
