### PR TITLE
twerking the tests a bit and converting tabs to [2] spaces

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,7 @@ module.exports = function (grunt) {
         "**/*.js",
         "**/*.json",
         "!node_modules/**",
+        "!client/emscrypt.js",
         "!web/**"
       ],
       options: {

--- a/test/run/api_error_tests.js
+++ b/test/run/api_error_tests.js
@@ -15,77 +15,77 @@ function fail() { throw new Error() }
 TestServer.start(config.public_url)
 .then(function main(server) {
 
-	test(
-		'/certificate/sign inputs',
-		function (t) {
-			var email = crypto.randomBytes(10).toString('hex') + '@example.com'
-			var password = '123456'
-			var client = null
-			Client.create('http://127.0.0.1:9000', email, password)
-				.then(
-					function (c) {
-						client = c
-						// string as publicKey
-						return client.sign("tada", 1000)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'string as publicKey')
-						// empty object as publicKey
-						return client.sign({}, 1000)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'empty object as publicKey')
-						// invalid publicKey argument
-						return client.sign({ algorithm: 'RS', n: 'x', e: 'y', invalid: true }, 1000)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'invalid publicKey argument')
-						// undefined duration
-						return client.sign({ algorithm: 'RS', n: 'x', e: 'y' }, undefined)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'undefined duration')
-						// missing publicKey arguments (e)
-						return client.sign({ algorithm: 'RS', n: 'x' }, 1000)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'missing publicKey arguments (e)')
-						// invalid algorithm
-						return client.sign({ algorithm: 'NSA' }, 1000)
-					}
-				)
-				.then(
-					fail,
-					function (err) {
-						t.equal(err.code, 400, 'invalid algorithm')
-					}
-				)
-				.done(
-					function () {
-						t.end()
-					},
-					function (err) {
-						t.fail('sign should fail')
-						t.end()
-					}
-				)
-		}
-	)
+  test(
+    '/certificate/sign inputs',
+    function (t) {
+      var email = crypto.randomBytes(10).toString('hex') + '@example.com'
+      var password = '123456'
+      var client = null
+      Client.create('http://127.0.0.1:9000', email, password)
+        .then(
+          function (c) {
+            client = c
+            // string as publicKey
+            return client.sign("tada", 1000)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'string as publicKey')
+            // empty object as publicKey
+            return client.sign({}, 1000)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'empty object as publicKey')
+            // invalid publicKey argument
+            return client.sign({ algorithm: 'RS', n: 'x', e: 'y', invalid: true }, 1000)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'invalid publicKey argument')
+            // undefined duration
+            return client.sign({ algorithm: 'RS', n: 'x', e: 'y' }, undefined)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'undefined duration')
+            // missing publicKey arguments (e)
+            return client.sign({ algorithm: 'RS', n: 'x' }, 1000)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'missing publicKey arguments (e)')
+            // invalid algorithm
+            return client.sign({ algorithm: 'NSA' }, 1000)
+          }
+        )
+        .then(
+          fail,
+          function (err) {
+            t.equal(err.code, 400, 'invalid algorithm')
+          }
+        )
+        .done(
+          function () {
+            t.end()
+          },
+          function (err) {
+            t.fail('sign should fail')
+            t.end()
+          }
+        )
+    }
+  )
 
  test(
     'teardown',

--- a/test/run/integration_tests.js
+++ b/test/run/integration_tests.js
@@ -375,7 +375,7 @@ TestServer.start(config.public_url)
               },
               function (err, res, body) {
                 t.equal(body.errno, 111, 'invalid auth timestamp')
-                now = +new Date() / 1000
+                var now = +new Date() / 1000
                 t.ok(body.serverTime > now - 5, 'includes current time')
                 t.ok(body.serverTime < now + 5, 'includes current time')
                 t.end()


### PR DESCRIPTION
- Converted tabs to spaces.
- Excluded 1 vendor JS file from JSHint since it was a bit noisy.

We should now be down to only a small handful of JSHint warnings:

```
$ grunt jshint
Running "jshint:files" (jshint) task
Linting test/run/account_reset_token_tests.js ...ERROR
[L110:C33] W116: Expected '!==' and instead saw '!='.
          while (newSRPv.length != 512) {
Linting test/run/integration_tests.js ...ERROR
[L6:C9] W098: 'path' is defined but never used.
var path = require('path')
Linting test/run/integration_tests.js ...ERROR
[L30:C13] W098: 'email5' is defined but never used.
  var email5 = uniqueID() + "@example.com"
Linting test/run/raw_password_tests.js ...ERROR
[L25:C13] W098: 'email2' is defined but never used.
  var email2 = uniqueID() + "@example.com"
Linting test/run/raw_password_tests.js ...ERROR
[L26:C13] W098: 'email3' is defined but never used.
  var email3 = uniqueID() + "@example.com"
Linting test/run/session_token_tests.js ...ERROR
[L6:C11] W098: 'crypto' is defined but never used.
var crypto = require('crypto')
Linting tokens/srp_token.js ...ERROR
[L5:C11] W098: 'crypto' is defined but never used.
var crypto = require('crypto')

Warning: Task "jshint:files" failed. Use --force to continue.

Aborted due to warnings.
```

I'll do a separate PR for removing those unused `require()` statements and commenting out those unused test users.
