### PR TITLE
Update heka configuration for awsbox

### DIFF
--- a/scripts/awsbox/hekad.toml
+++ b/scripts/awsbox/hekad.toml
@@ -1,9 +1,6 @@
 [hekad]
 base_dir = "/home/app/hekad"
 
-[UdpInput]
-address = "127.0.0.1:4880"
-
 [StatsdInput]
 address = ":8125"
 
@@ -11,13 +8,13 @@ address = ":8125"
 
 [fxa-auth-server-log]
 type = "LogfileInput"
-logfile = "/home/app/code/server.log"
+logfile = "/home/app/code/var/log/key_server.js.log"
 logger = "fxa-auth-server-log"
 
 [nginx-access-log]
 type = "LogfileInput"
 logfile = "/home/proxy/var/log/nginx/access.log"
-decoders = ["nginx-log-decoder"]
+decoder = "nginx-log-decoder"
 
 [nginx-log-decoder]
 type = "PayloadRegexDecoder"

--- a/scripts/awsbox/post_create.sh
+++ b/scripts/awsbox/post_create.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 MYPWD=`pwd`
 
+
 echo "Setting up mysql"
 
 sudo /sbin/chkconfig mysqld on
@@ -9,24 +10,51 @@ echo "CREATE USER 'fxa'@'localhost';" | mysql -u root
 echo "CREATE DATABASE fxa;" | mysql -u root
 echo "GRANT ALL ON fxa.* TO 'fxa'@'localhost';" | mysql -u root
 
+
 echo "Setting up memcached"
 
 sudo /sbin/chkconfig memcached on
 sudo /sbin/service memcached start
+
 
 echo "Setting up nginx"
 
 sudo /sbin/chkconfig nginx on
 sudo /sbin/service nginx start
 
+
 echo "Setting up heka"
 
-HEKAFILE=heka-0_4_0-picl-idp-amd64.tar.gz
-wget https://people.mozilla.com/~rmiller/heka/$HEKAFILE
+HEKAURL=https://github.com/mozilla-services/heka/releases/download/v0.4.1/heka-0_4_1-linux-amd64.tar.gz
+HEKAFILE=`basename $HEKAURL`
+wget $HEKAURL
 pushd /home/app
 sudo tar zxvf $MYPWD/$HEKAFILE
-sudo chown -R app:app heka-0_4_0-linux-amd64
+sudo chown -R app:app heka-0_4_1-linux-amd64
 popd
+
+
+echo "Setting up circus"
+
+sudo yum install --assumeyes python-devel python-pip
+sudo pip install circus
+sudo tee --append /home/app/circus.ini << EOF
+[watcher:hekad]
+working_dir=/home/app/hekad
+cmd=/home/app/heka-0_4_1-linux-amd64/bin/hekad -config=/home/app/code/scripts/awsbox/hekad.toml
+numprocesses = 1
+stdout_stream.class = FileStream
+stdout_stream.filename = /home/app/hekad/circus.stdout.log
+stdout_stream.refresh_time = 0.5
+stdout_stream.max_bytes = 1073741824
+stdout_stream.backup_count = 3
+stderr_stream.class = FileStream
+stderr_stream.filename = /home/app/hekad/circus.stderr.log
+stderr_stream.refresh_time = 0.5
+stderr_stream.max_bytes = 1073741824
+stderr_stream.backup_count = 3
+EOF
+
 
 echo "Installing identity team public keys"
 
@@ -36,6 +64,7 @@ git checkout 9e009e6f15f28debfb59d3d7787dfc20c50e230f
 cat *.pub >> /home/ec2-user/.ssh/authorized_keys
 cd ..
 rm -rf identity-pubkeys
+
 
 echo "Setting up postfix as the mailserver"
 
@@ -69,9 +98,11 @@ sudo /usr/sbin/postmap /etc/postfix/sasl_passwd
 sudo service postfix start
 sudo chkconfig postfix on
 
+
 echo "Cleaning up old logfiles"
 
 sudo rm -rf /var/log/nginx/access.log-*
 sudo rm -rf /var/log/nginx/error.log-*
+
 
 echo "post-create complete!"

--- a/scripts/awsbox/post_deploy.sh
+++ b/scripts/awsbox/post_deploy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-echo "Restarting hekad"
+echo "Restarting hekad via circus"
 
-pid=`pgrep -f hekad`
-if [[ $pid ]] ; then
-	kill -s INT $pid
-fi
 mkdir -p /home/app/hekad
-nohup /home/app/heka-0_4_0-linux-amd64/bin/hekad -config=$HEKAD_CONFIG > /home/app/hekad/hekad.log 2>&1 &
+if pgrep -f circusd
+then
+    circusctl restart hekad
+else
+    nohup /usr/bin/circusd --daemon /home/app/circus.ini > /home/app/circusd.log 2>&1 &
+fi
 
 echo "DONE"


### PR DESCRIPTION
This updates our scripted awsbox setup to latest heka release, and adds a bit better log/process management.  Fixes #352 for fxa-auth-server.

@dannycoates r?

Once this is merged we need to:
- copy similar logic into fxa-content-server
- deploy api-accounts, accounts and accounts-latest with the changes (I already did accounts-latest as a test-run)
