### PR TITLE
Non-numeric "code" properties on error objects?

### DIFF
--- a/error.js
+++ b/error.js
@@ -55,7 +55,7 @@ Boom.wrap = function (srcObject) {
   }
 
   // Intuit a status code for the error if it doesn't have one,
-  // of if it has some other garbage in its 'code' attribute.
+  // or if it has some other garbage in its 'code' attribute.
   if (typeof object.code === 'undefined') {
     if ([109, 110, 111].indexOf(object.errno) !== -1) {
       object.code = 401


### PR DESCRIPTION
Per https://github.com/mozilla/picl-deployment/issues/10#issuecomment-28015500 we are seeing some error objects with invalid 'code' attribute when running loadtests:

> Debug: hapi, uncaught, onPreResponse, error Error: First argument must be a number (400+)
> at Object.exports.assert (/home/app/picl-idp/node_modules/hapi/node_modules/hoek/lib/index.js:392:11)
> at new module.exports.internals.Boom (/home/app/picl-idp/node_modules/hapi/node_modules/boom/lib/index.js:45:14)
> at Function.Boom.wrap (/home/app/picl-idp/error.js:71:11)

However, we have a fallback to set code=999 if the error itself has no code:

  https://github.com/mozilla/picl-idp/blob/master/error.js#L55

So are we seeing error objects with a non-numeric `code` property?  What's an appropriate way to capture, log and re-format such errors?
