### PR TITLE
adding copyright, removing dead code

### DIFF
--- a/test/run/signer_tests.js
+++ b/test/run/signer_tests.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 var path = require('path')
 var test = require('tap').test
 var CC = require('compute-cluster')

--- a/test/run/verification_tests.js
+++ b/test/run/verification_tests.js
@@ -12,8 +12,6 @@ var crypto = require('crypto')
 process.env.CONFIG_FILES = path.join(__dirname, '../config/verification.json')
 var config = require('../../config').root()
 
-var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/
-
 function uniqueID() {
   return crypto.randomBytes(10).toString('hex');
 }


### PR DESCRIPTION
Fixin' a missing copyright and some dead code reported by the JSHint Grunt task:

> Running "copyright:files" (copyright) task
> 
> The following files are missing copyright headers:
> ]] test/run/signer_tests.js
> Warning: Task "copyright:files" failed. Use --force to continue.

---

> Running "jshint:files" (jshint) task
> Linting test/run/verification_tests.js ...ERROR
> [L15:C15] W098: 'HEX_STRING' is defined but never used.
> `var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/`
> 
> Warning: Task "jshint:files" failed. Use --force to continue.

---

All tests still pass locally:

```
$ npm test

> fxa-auth-server@0.0.0 test /Users/pdehaan/dev/picl-idp_pd/picl-idp
> tap ./test/run

ok test/run/account_reset_token_tests.js .............. 13/13
ok test/run/api_error_tests.js .......................... 7/7
ok test/run/auth_token_tests.js ....................... 16/16
ok test/run/browserid_protocol_tests.js ................. 6/6
ok test/run/db_tests.js ............................... 59/59
ok test/run/forgot_password_token_tests.js ............ 17/17
ok test/run/hkdf_tests.js ............................... 6/6
ok test/run/integration_tests.js ...................... 36/36
ok test/run/key_fetch_token_tests.js .................. 16/16
ok test/run/key_stretch_tests.js ...................... 14/14
ok test/run/pbkdf2_tests.js ............................. 4/4
ok test/run/raw_password_tests.js ..................... 15/15
ok test/run/scrypt_tests.js ............................. 3/3
ok test/run/session_token_tests.js .................... 12/12
ok test/run/signer_tests.js ......................... 122/122
ok test/run/srp_session_tests.js ........................ 5/5
ok test/run/verification_tests.js ..................... 29/29
total ............................................... 380/380

ok
```
