### PR TITLE
added preVerified option to /account/create

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -75,7 +75,7 @@ ClientApi.prototype.doRequest = function (method, url, token, payload) {
  *   {}
  *
  */
-ClientApi.prototype.accountCreate = function (email, verifier, salt, passwordStretching) {
+ClientApi.prototype.accountCreate = function (email, verifier, salt, passwordStretching, preVerified) {
   return this.doRequest(
     'POST',
     this.baseURL + '/account/create',
@@ -87,7 +87,8 @@ ClientApi.prototype.accountCreate = function (email, verifier, salt, passwordStr
         verifier: verifier,
         salt: salt
       },
-      passwordStretching: passwordStretching
+      passwordStretching: passwordStretching,
+      preVerified: preVerified
     }
   )
 }
@@ -317,14 +318,15 @@ ClientApi.prototype.sessionDestroy = function (sessionTokenHex) {
     )
 }
 
-ClientApi.prototype.rawPasswordAccountCreate = function (email, password) {
+ClientApi.prototype.rawPasswordAccountCreate = function (email, password, preVerified) {
   return this.doRequest(
     'POST',
     this.baseURL + '/raw_password/account/create',
     null,
     {
       email: email,
-      password: password
+      password: password,
+      preVerified: preVerified
     }
   )
 }

--- a/client/index.js
+++ b/client/index.js
@@ -86,9 +86,13 @@ Client.prototype.setupCredentials = function (email, password, customSalt, custo
     )
 }
 
-Client.create = function (origin, email, password, callback) {
+Client.create = function (origin, email, password, preVerified, callback) {
   var c = new Client(origin)
-
+  if (typeof(preVerified) === 'function') {
+    callback = preVerified
+    preVerified = false
+  }
+  c.preVerified = preVerified
   var p = c.setupCredentials(email, password)
     .then(
       function() {
@@ -175,7 +179,8 @@ Client.prototype.create = function (callback) {
       scrypt_p: 1,
       PBKDF2_rounds_2: 20000,
       salt: this.passwordSalt
-    }
+    },
+    this.preVerified
   )
     .then(
       function (a) {

--- a/config/awsbox.json
+++ b/config/awsbox.json
@@ -15,8 +15,5 @@
   "publicKeyFile": "/home/app/var/public-key.json",
   "contentServer": {
     "url": "https://accounts.dev.lcip.org"
-  },
-  "dev": {
-    "verified": false
   }
 }

--- a/config/config.js
+++ b/config/config.js
@@ -207,13 +207,6 @@ module.exports = function (fs, path, url, convict) {
         default: 70,
         env: 'TOOBUSY_MAX_LAG'
       }
-    },
-    dev: {
-      verified: {
-        doc: 'new Accounts should start already verified',
-        default: false,
-        env: 'DEV_VERIFIED'
-      }
     }
   })
 

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,6 +1,9 @@
 {
-  "dev": {
-    "verified": true
+  "smtp": {
+    "host": "127.0.0.1",
+    "port": 9999,
+    "secure": false,
+    "sender": "no-reply@example.com"
   },
   "toobusy": {
     "max_lag": 0

--- a/routes/account.js
+++ b/routes/account.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, config) {
+module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProduction) {
 
   const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/
 
@@ -38,7 +38,8 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, config)
               //   type: isA.String().required(),
               //   salt: isA.String().regex(HEX_STRING).required()
               // }
-            )
+            ),
+            preVerified: isProduction ? undefined : isA.Boolean()
           }
         },
         handler: function accountCreate(request) {
@@ -59,7 +60,7 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, config)
                   uid: uuid.v4('binary'),
                   email: form.email,
                   emailCode: crypto.randomBytes(4).toString('hex'),
-                  verified: false || config.dev.verified,
+                  verified: form.preVerified || false,
                   srp: form.srp,
                   kA: crypto.randomBytes(32),
                   wrapKb: crypto.randomBytes(32),

--- a/routes/index.js
+++ b/routes/index.js
@@ -20,15 +20,16 @@ module.exports = function (
   Token,
   config
   ) {
+  var isProduction = config.env === 'production'
   var auth = require('./auth')(log, isA, error, db, Token)
   var defaults = require('./defaults')(log, P, db)
   var idp = require('./idp')(log, serverPublicKey)
-  var account = require('./account')(log, crypto, P, uuid, isA, error, db, mailer, config)
+  var account = require('./account')(log, crypto, P, uuid, isA, error, db, mailer, isProduction)
   var password = require('./password')(log, isA, error, db, mailer)
   var session = require('./session')(log, isA, error, db)
   var sign = require('./sign')(log, isA, error, signer, config.domain)
   var util = require('./util')(log, crypto, isA, config)
-  var raw = require('./rawpassword')(log, isA, error, config.public_url, Client, crypto, db)
+  var raw = require('./rawpassword')(log, isA, error, config.public_url, Client, crypto, db, isProduction)
 
   var v1Routes = [].concat(
     auth,

--- a/routes/rawpassword.js
+++ b/routes/rawpassword.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (log, isA, error, public_url, Client, crypto, db) {
+module.exports = function (log, isA, error, public_url, Client, crypto, db, isProduction) {
 
   const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/
 
@@ -62,7 +62,8 @@ module.exports = function (log, isA, error, public_url, Client, crypto, db) {
           Client.create(
             public_url,
             Buffer(form.email, 'hex').toString('utf8'),
-            form.password
+            form.password,
+            form.preVerified || false
           )
           .done(
             function (client) {
@@ -77,7 +78,8 @@ module.exports = function (log, isA, error, public_url, Client, crypto, db) {
           payload: {
             // TODO: still need to validate the utf8 string is a valid email
             email: isA.String().max(1024).regex(HEX_STRING).required(),
-            password: isA.String().required()
+            password: isA.String().required(),
+            preVerified: isProduction ? undefined : isA.Boolean()
           }
         }
       }

--- a/test/config/verification.json
+++ b/test/config/verification.json
@@ -4,8 +4,5 @@
     "port": 9999,
     "secure": false,
     "sender": "no-reply@example.com"
-  },
-  "dev": {
-    "verified": false
   }
 }

--- a/test/run/api_error_tests.js
+++ b/test/run/api_error_tests.js
@@ -8,8 +8,6 @@ var crypto = require('crypto')
 var config = require('../../config').root()
 var Client = require('../../client')
 
-process.env.DEV_VERIFIED = 'true'
-
 function fail() { throw new Error() }
 
 TestServer.start(config.public_url)
@@ -21,7 +19,7 @@ TestServer.start(config.public_url)
       var email = crypto.randomBytes(10).toString('hex') + '@example.com'
       var password = '123456'
       var client = null
-      return Client.create('http://127.0.0.1:9000', email, password)
+      return Client.create('http://127.0.0.1:9000', email, password, true)
         .then(
           function (c) {
             client = c

--- a/test/run/integration_tests.js
+++ b/test/run/integration_tests.js
@@ -9,8 +9,6 @@ var TestServer = require('../test_server')
 var P = require('p-promise')
 var config = require('../../config').root()
 
-process.env.DEV_VERIFIED = 'true'
-
 function uniqueID() {
   return crypto.randomBytes(10).toString('hex');
 }
@@ -41,7 +39,7 @@ TestServer.start(config.public_url)
         "e":"65537"
       }
       var duration = 1000 * 60 * 60 * 24
-      return Client.create(config.public_url, email, password)
+      return Client.create(config.public_url, email, password, true)
         .then(
           function (x) {
             client = x
@@ -78,7 +76,7 @@ TestServer.start(config.public_url)
       var wrapKb = null
       var client = null
       var firstSrpPw
-      return Client.create(config.public_url, email, password)
+      return Client.create(config.public_url, email, password, true)
         .then(
           function (x) {
             client = x
@@ -159,7 +157,7 @@ TestServer.start(config.public_url)
       var email = email3
       var password = 'allyourbasearebelongtous'
       var client = null
-      return Client.create(config.public_url, email, password)
+      return Client.create(config.public_url, email, password, true)
         .then(
           function (x) {
             client = x
@@ -195,7 +193,7 @@ TestServer.start(config.public_url)
       var password = 'foobar'
       var client = null
       var sessionToken = null
-      return Client.create(config.public_url, email, password)
+      return Client.create(config.public_url, email, password, true)
         .then(
           function (x) {
             client = x
@@ -246,7 +244,7 @@ TestServer.start(config.public_url)
       var email = email6
       var password = 'ilikepancakes'
       var client
-      return Client.create(config.public_url, email, password)
+      return Client.create(config.public_url, email, password, true)
         .then(
           function (x) {
             client = x

--- a/test/run/raw_password_tests.js
+++ b/test/run/raw_password_tests.js
@@ -8,8 +8,6 @@ var Client = require('../../client')
 var config = require('../../config').root()
 var TestServer = require('../test_server')
 
-process.env.DEV_VERIFIED = 'true'
-
 function uniqueID() {
   return crypto.randomBytes(10).toString('hex');
 }
@@ -29,7 +27,7 @@ TestServer.start(config.public_url)
       var clientApi = new Client.Api(config.public_url)
       var email = Buffer(email1).toString('hex')
       var password = 'allyourbasearebelongtous'
-      return clientApi.rawPasswordAccountCreate(email, password)
+      return clientApi.rawPasswordAccountCreate(email, password, true)
         .then(
           function (result) {
             var client = null

--- a/test/run/verification_tests.js
+++ b/test/run/verification_tests.js
@@ -338,7 +338,6 @@ TestServer.start(config.public_url)
             t.fail('reset password with bad code')
           },
           function (err) {
-            console.error(err)
             t.equal(err.tries, 2, 'used a try')
             t.equal(err.message, 'Invalid verification code', 'bad attempt 1')
           }
@@ -390,9 +389,15 @@ TestServer.start(config.public_url)
   test(
     'teardown',
     function (t) {
+      t.end()
       mail.stop()
       server.stop()
-      t.end()
+      /*/
+      So, server keeps a persistent connection open to mail. If server
+      was started seperately, it's not easy to disconnect that connection.
+      Therefore bludgeon it to death
+      /*/
+      process.nextTick(process.exit)
     }
   )
 })


### PR DESCRIPTION
This is sort of phase 1 of N in improving the email verification dev and testing situation.
- removed `config.dev.verified` option
- added `preVerified` optional parameter to `/account/create` in non-production environments
- updated tests to use `preVerified`

Improves the #120 and #317 situation
Fixes #350
