### PR TITLE
first stab at a vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ secret*
 /loadtest/include
 *~
 *.pyc
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true
+  config.ssh.forward_agent = true
+  script =
+    "wget -q http://nodejs.org/dist/v0.10.22/node-v0.10.22-linux-x64.tar.gz;" \
+    "tar --strip-components 1 -C /usr/local -xzf node-v0.10.22-linux-x64.tar.gz;" \
+    "apt-get -qq update;" \
+    "export DEBIAN_FRONTEND=noninteractive;" \
+    "apt-get -qq install curl mysql-server-5.5 libgmp-dev git build-essential python-dev python-pip libevent-dev;" \
+    ""
+  config.vm.provision "shell", inline: script
+end


### PR DESCRIPTION
This is a very basic start on a vagrant environment.

To try it out first install [virtualbox](https://www.virtualbox.org/wiki/Downloads) and [vagrant](http://docs.vagrantup.com/v2/installation/index.html).

Then from the project root:
- optionally `vagrant plugin install vagrant-vbguest`
  - this will keep the virtualbox additions up to date.
- `vagrant up`
  - first run will install all the dependencies. It may take some time.
- `vagrant ssh`
  - you should now be logged into the vm
- `cd /vagrant`
  - this is a shared folder of the project root with the host
- `npm rebuild`
  - rebuilds the native node modules for linux
- `npm test`
  - all tests should pass
- `IP_ADDRESS=0.0.0.0 npm start`
  - The auth server running in the vm is now accessible from the host at http://127.0.0.1:9000
- after quitting the ssh session
  - `vagrant halt` or `vagrant suspend`

Unfortunately, anytime you switch running between the host and vm you'll need to `npm rebuild`.

Its not all that useful yet, but I hope to make this like a mini-stack for the whole system - soup to nuts.
