### PR TITLE
write posted metrics to the log

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -11,6 +11,12 @@ var error = require('../error')
 var Client = require('../client')
 var isA = Hapi.types
 
+function addMetrics(route) {
+  if (route.method === 'POST' && route.validate && route.validate.payload) {
+    route.validate.payload.metrics = isA.Object()
+  }
+}
+
 module.exports = function (
   log,
   serverPublicKey,
@@ -46,6 +52,8 @@ module.exports = function (
   })
 
   var routes = defaults.concat(idp, v1Routes)
+
+  routes.forEach(addMetrics)
 
   return routes
 }

--- a/server/server.js
+++ b/server/server.js
@@ -150,6 +150,15 @@ module.exports = function (path, url, Hapi, toobusy, error) {
             payload: request.payload
           }
         )
+        if (request.payload && request.payload.metrics) {
+          log.info(
+            {
+              op: 'metrics',
+              metrics: request.payload.metrics
+              // TODO: locale once rfkelly's localization lands
+            }
+          )
+        }
         next()
       }
     )


### PR DESCRIPTION
Adds super dumb handling of metrics sent by the client for #351
- adds optional `metrics` object parameter to all POST endpoints
- simply dumps the metrics object to the log
  - probably needs _some_ kind of validation / whitelist of key names

no merge, just f?
