### PR TITLE
Rename "kvstore" config settings to "db".

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -56,7 +56,7 @@ function main() {
 
   // databases
   var DB = require('../db')(
-    config.kvstore.backend,
+    config.db.backend,
     log,
     Token.error,
     Token.AuthToken,
@@ -71,7 +71,7 @@ function main() {
     config,
     log
   )
-  DB.connect(config[config.kvstore.backend])
+  DB.connect(config[config.db.backend])
     .then(
       function (db) {
         return noncedb.connect()

--- a/config/awsbox.json
+++ b/config/awsbox.json
@@ -1,5 +1,5 @@
 {
-  "kvstore": {
+  "db": {
     "backend": "mysql"
   },
   "mysql": {

--- a/config/config.js
+++ b/config/config.js
@@ -29,7 +29,7 @@ module.exports = function (fs, path, url, convict) {
     publicKeyFile: {
       default: path.resolve(__dirname, '../config/public-key.json')
     },
-    kvstore: {
+    db: {
       backend: {
         format: AVAILABLE_BACKENDS,
         default: "memory",


### PR DESCRIPTION
A brief follow-up to #384 - the config item "kvstore" is so-named for hysterical raisins, but no longer has anything to do with a kvstore.  Let's rename it just "db" since we're changing config keys anyway.  @dannycoates r?
