### PR TITLE
lockdown passwordStretching parameters

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -21,16 +21,21 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
             // TODO: still need to validate the utf8 string is a valid email
             email: isA.String().max(1024).regex(HEX_STRING).required(),
             srp: isA.Object({
-              type: isA.String().max(64).required(), // TODO valid()
+              type: isA.String().max(64).valid('SRP-6a/SHA256/2048/v1').required(),
               verifier: isA.String().min(512).max(512).regex(HEX_STRING).required(),
               salt: isA.String().min(64).max(64).regex(HEX_STRING).required(),
             }).required(),
             passwordStretching: isA.Object(
-              // {
-              //   type: isA.String().required(),
-              //   salt: isA.String().regex(HEX_STRING).required()
-              // }
-            ),
+              {
+                type: isA.String().required().valid('PBKDF2/scrypt/PBKDF2/v1'),
+                PBKDF2_rounds_1: isA.Number().integer().min(20000).max(20000).required(),
+                scrypt_N: isA.Number().integer().min(65536).max(65536).required(),
+                scrypt_r: isA.Number().integer().min(8).max(8).required(),
+                scrypt_p: isA.Number().integer().min(1).max(1).required(),
+                PBKDF2_rounds_2: isA.Number().integer().min(20000).max(20000).required(),
+                salt: isA.String().min(64).max(64).regex(HEX_STRING).required()
+              }
+            ).required(),
             preVerified: isProduction ? undefined : isA.Boolean()
           }
         },

--- a/test/run/integration_tests.js
+++ b/test/run/integration_tests.js
@@ -504,6 +504,47 @@ TestServer.start(config.publicUrl)
   )
 
   test(
+    'incorrect passwordStretching parameters are rejected on /account/create',
+    function (t) {
+      var client = new Client(config.publicUrl)
+      return client.setupCredentials(
+        'test@example.com',
+        Buffer('xxx')
+      )
+      .then(
+        function () {
+          return client.api.accountCreate(
+            client.email,
+            client.srp.verifier,
+            client.srp.salt,
+            {
+              type: 'invalid',
+              PBKDF2_rounds_1: 1,
+              scrypt_N: 8,
+              scrypt_r: 1,
+              scrypt_p: 0,
+              PBKDF2_rounds_2: 1,
+              salt: client.passwordSalt
+            },
+            {
+              preVerified: true,
+              lang: client.lang
+            }
+          )
+        }
+      )
+      .then(
+        function (x) {
+          t.fail('request should have failed')
+        },
+        function (err) {
+          t.equal(err.code, 400, 'bad request')
+        }
+      )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
Strictly validates the `passwordStretching` parameters to only allow:

``` js
{
  type: 'PBKDF2/scrypt/PBKDF2/v1',
  PBKDF2_rounds_1: 20000,
  scrypt_N: 65536,
  scrypt_r: 8,
  scrypt_p: 1,
  PBKDF2_rounds_2: 20000
}
```

This should address the immediate concerns of #400 and #401 but the flexibility of these values remains to be defined.

@rfk @warner r?
