### PR TITLE
Disable HTTP interface on awsbox deployments

### DIFF
--- a/scripts/awsbox/post_create.sh
+++ b/scripts/awsbox/post_create.sh
@@ -19,6 +19,7 @@ sudo /sbin/service memcached start
 
 echo "Setting up nginx"
 
+sudo mv /home/proxy/conf.d/http.conf /home/proxy/conf.d/http.conf.disabled
 sudo /sbin/chkconfig nginx on
 sudo /sbin/service nginx start
 


### PR DESCRIPTION
Per #404 we want to just disable HTTP access to this server entirely.
