### PR TITLE
Send verification code in query string, not url fragment.

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -85,7 +85,7 @@ module.exports = function (config, i18n, log) {
     log.trace({ op: 'mailer.sendVerifyCode', email: account.email, uid: account.uid })
     var template = templates.verify
     var link = this.verificationUrl + '?uid=' + account.uid.toString('hex')
-    link += '#code=' + code
+    link += '&code=' + code
     var reportLink = this.reportUrl
 
     var values = {

--- a/routes/util.js
+++ b/routes/util.js
@@ -25,7 +25,7 @@ module.exports = function (log, crypto, isA, config) {
         },
         validate: {
           query: {
-            code: isA.String().regex(HEX_STRING).optional(),
+            code: isA.String().regex(HEX_STRING).required(),
             uid: isA.String().max(64).required()
           }
         }


### PR DESCRIPTION
Like it says on the tin. Fixes #398.

This basically just reverts 1506ed0eb17ca82dfae58f7ee29eaf25b37b84c5.  I think that the content-server should still work with this change landed, as it looks for the code in both places.
