### PR TITLE
joi doesn't like undefined entries

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -36,7 +36,7 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
                 salt: isA.String().min(64).max(64).regex(HEX_STRING).required()
               }
             ).required(),
-            preVerified: isProduction ? undefined : isA.Boolean()
+            preVerified: isA.Boolean()
           }
         },
         handler: function accountCreate(request) {
@@ -326,6 +326,10 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
       }
     }
   ]
+
+  if (isProduction) {
+    delete routes[0].config.validate.payload.preVerified
+  }
 
   return routes
 }

--- a/routes/rawpassword.js
+++ b/routes/rawpassword.js
@@ -88,7 +88,7 @@ module.exports = function (log, isA, error, clientHelper, crypto, db, isProducti
           payload: {
             email: isA.String().max(1024).regex(HEX_EMAIL).required(),
             password: isA.String().required(),
-            preVerified: isProduction ? undefined : isA.Boolean()
+            preVerified: isA.Boolean()
           }
         }
       }
@@ -176,6 +176,10 @@ module.exports = function (log, isA, error, clientHelper, crypto, db, isProducti
       }
     },
   ]
+
+  if (isProduction) {
+    delete routes[1].config.validate.payload.preVerified
+  }
 
   return routes
 }


### PR DESCRIPTION
Noticed this during a load test. Joi throws an error on the undefined property instead of skipping it. This solution isn't idea because its fragile. We should probably give each route a var.
