### PR TITLE
Fix commit-ordering bug in mysql backend

### DIFF
--- a/db/mysql.js
+++ b/db/mysql.js
@@ -929,10 +929,10 @@ module.exports = function (
               // now commit and release
               commitTransaction(con).then(function() {
                 con.release()
-              })
-              d.resolve({
-                keyFetchToken: keyFetchToken,
-                sessionToken: sessionToken
+                d.resolve({
+                  keyFetchToken: keyFetchToken,
+                  sessionToken: sessionToken
+                })
               })
             }
           )


### PR DESCRIPTION
This was showing up sporadically as 401s under load - we would occasionally go to use a token before the commit had finished flushing it to the database.  @dannycoates r?
