### PR TITLE
Fixed nonceCheck type conversion bug

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -20,10 +20,10 @@ module.exports = function (path, url, Hapi, toobusy) {
       port: publicURL.port ? publicURL.port : defaultPorts[publicURL.protocol],
       timestampSkewSec: 60,
       nonceFunc: function nonceCheck(nonce, ts, cb) {
-        var maxValidTime = ts + hawkOptions.timestampSkewSec
+        var maxValidTime = (+ts) + hawkOptions.timestampSkewSec
         var ttl = Math.ceil(maxValidTime - (Date.now() / 1000))
         if (ttl <= 0) {
-          return cb('stale timestamp')
+          return cb()
         }
         noncedb.checkAndSetNonce(nonce, ttl)
                .done(


### PR DESCRIPTION
This was causing TTLs a _bit_ longer than 60 seconds... around 4351.15 years actually. :laughing: 

@rfk remedial js http://wtfjs.com/

``` js
assert.equal("12345" + 60, "1234560")
assert.equal(+"12345" + 60, 12405)
assert.equal("1234560" - 60, 1234500)
assert.equal("12345" * 1000, 12345000)
```

see also #426
