### PR TITLE
expose timestamp header to clients that use CORS

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -82,7 +82,9 @@ module.exports = function (path, url, Hapi, toobusy) {
             getCredentialsFunc: makeCredentialFn(db.forgotPasswordToken.bind(db))
           }
         },
-        cors: true,
+        cors: {
+          additionalExposedHeaders: ['Timestamp']
+        },
         files: {
           relativeTo: path.dirname(__dirname)
         },


### PR DESCRIPTION
This allows clients to see the header.
