### PR TITLE
Rename NODE_ENV=production to NODE_ENV=prod

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -9,7 +9,7 @@ var config = require('../config').root()
 function main() {
   var log = require('../log')(config.log.level)
 
-  if (config.env !== 'production') {
+  if (config.env !== 'prod') {
     log.info(config, "starting config")
   }
 

--- a/config/config.js
+++ b/config/config.js
@@ -9,7 +9,7 @@ module.exports = function (fs, path, url, convict) {
     env: {
       doc: "The current node.js environment",
       default: "dev",
-      format: [ "dev", "test", "stage", "production" ],
+      format: [ "dev", "test", "stage", "prod" ],
       env: 'NODE_ENV'
     },
     log: {

--- a/noncedb.js
+++ b/noncedb.js
@@ -129,7 +129,7 @@ module.exports = function (config, log, now) {
   if (config.redis && config.redis.host) {
     return RedisNonceDB
   } else {
-    if (config.env === 'production') {
+    if (config.env === 'prod') {
       log.warn('using in-memory nonce db; this is likely not suitable for production')
     }
     return MemoryNonceDB

--- a/routes/index.js
+++ b/routes/index.js
@@ -20,7 +20,7 @@ module.exports = function (
   Token,
   config
   ) {
-  var isProduction = config.env === 'production'
+  var isProduction = config.env === 'prod'
   var auth = require('./auth')(log, isA, error, db, Token)
   var defaults = require('./defaults')(log, P, db)
   var idp = require('./idp')(log, serverPublicKey)

--- a/server/server.js
+++ b/server/server.js
@@ -211,7 +211,7 @@ module.exports = function (path, url, Hapi, toobusy) {
             }
             response = error.wrap(details)
           }
-          if (config.env !== 'production') {
+          if (config.env !== 'prod') {
             response.response.payload.log = request.app.traced
           }
           if (response.response.payload.domainThrown) {


### PR DESCRIPTION
Per ops request in #437.  The diff seems pretty benign, unless this is against well-established nodejs conventions - @dannycoates r?
