### PR TITLE
Simplest possible patch to make scrypt-helper URL configurable.

### DIFF
--- a/bin/client_helper.js
+++ b/bin/client_helper.js
@@ -4,7 +4,11 @@
 
 const config = require('../config').root()
 const Client = require('../client')
+const keystretch = require('../client/keystretch')
 
+// Monkey-patch Client lib to use configurable SCRYPT_HELPER url.
+// This is awful but the whole thing is going to go away soon...
+keystretch.SCRYPT_HELPER = config.scryptHelper.url
 
 process.on('message', function (message) {
   if (message.action === 'crash') {

--- a/client/keystretch.js
+++ b/client/keystretch.js
@@ -37,7 +37,7 @@ function derive(email, password, saltHex) {
     .then(
       function(K1) {
         // request a hash from scrypt based on the first key
-        return scrypt.hash(K1, KW("scrypt"), SCRYPT_HELPER)
+        return scrypt.hash(K1, KW("scrypt"), module.exports.SCRYPT_HELPER)
       }
     )
     .then(
@@ -120,5 +120,6 @@ function KW(name) {
   return Buffer(NAMESPACE + name)
 }
 
+module.exports.SCRYPT_HELPER = SCRYPT_HELPER
 module.exports.derive = derive
 module.exports.xor = xor

--- a/config/config.js
+++ b/config/config.js
@@ -130,9 +130,16 @@ module.exports = function (fs, path, url, convict) {
     },
     contentServer: {
       url: {
-        doc: "Thes url of the correspoding fxa-content-server instance",
+        doc: "The url of the correspoding fxa-content-server instance",
         default: 'http://127.0.0.1:3030',
         env: 'CONTENT_SERVER_URL'
+      }
+    },
+    scryptHelper: {
+      url: {
+        doc: "The url of the correspoding fxa-scrypt-helper instance",
+        default: 'https://scrypt-accounts.dev.lcip.org',
+        env: 'SCRYPT_HELPER_URL'
       }
     },
     smtp: {


### PR DESCRIPTION
Fixes #434 in the simplest, dumbest way possible.  Since the plan is to get rid of `raw_password` and re-do the client library, let's not put any extra effort into making this work nice in the meantime.  @dannycoates r?
