### PR TITLE
use restmail api for mail_helper and verification tests

### DIFF
--- a/bin/mail_helper.js
+++ b/bin/mail_helper.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var Mail = require('lazysmtp').Mail
+var MailParser = require('mailparser').MailParser
 var hapi = require('hapi')
 var config = require('../config').root()
 
@@ -11,45 +12,50 @@ process.title = 'mail_helper.js'
 
 // SMTP half
 
-var codeMatch = /X-(\w+)-Code: (\w+)/
-var toMatch = /To: (\w+@\w+\.\w+)/
-var uidMatch = /X-Uid: (\w+)/
-var linkMatch = /X-Link: (\S+)/
-
 var mail = new Mail(config.smtp.host)
-var emailCodes = {}
-var emailBodies = {}
+var users = {}
+
+function emailName(emailAddress) {
+  return emailAddress.split('@')[0]
+}
+
 mail.on(
   'mail',
   function (email) {
-    var matchCode = codeMatch.exec(email)
-    var matchEmail = toMatch.exec(email)
-    if (matchCode && matchEmail) {
-      emailCodes[matchEmail[1]] = matchCode[2]
-      emailBodies[matchEmail[1]] = email
-      if (matchCode[1] === 'Verify') {
-        var matchUid = uidMatch.exec(email)
-        var matchLink = linkMatch.exec(email)
-        console.log(matchLink[1])
-        console.log(
-          "curl -v -XPOST -H'Content-Type: application/json' %s -d '%s'",
-          config.publicUrl + '/v1/recovery_email/verify_code',
-          JSON.stringify(
-            {
-              uid: matchUid[1],
-              code: matchCode[2]
-            }
+    var mp = new MailParser({ defaultCharset: 'utf8' })
+    mp.on(
+      'end',
+      function (mail) {
+        //console.log(mail)
+        var uid = mail.headers['x-uid']
+        var link = mail.headers['x-link']
+        var rc = mail.headers['x-recovery-code']
+        var vc = mail.headers['x-verify-code']
+        if (vc) {
+          console.log(link)
+          console.log(
+            "curl -v -XPOST -H'Content-Type: application/json' %s -d '%s'",
+            config.publicUrl + '/v1/recovery_email/verify_code',
+            JSON.stringify(
+              {
+                uid: uid,
+                code: vc
+              }
+            )
           )
-        )
+        }
+        else if (rc) {
+          console.log('recovery: %s email: %s', rc, mail.to.address)
+        }
+        else {
+          console.error('No verify code match')
+          console.error(email)
+        }
+        users[emailName(mail.headers.to)] = mail
       }
-      else if (matchCode[1] === 'Recovery') {
-        console.log('recovery: %s email: %s', matchCode[2], matchEmail[1])
-      }
-    }
-    else {
-      console.error('No verify code match')
-      console.error(email)
-    }
+    )
+    mp.write(email)
+    mp.end()
   }
 )
 
@@ -60,32 +66,36 @@ mail.start(config.smtp.port)
 var api = hapi.createServer(config.smtp.api.host, config.smtp.api.port)
 
 function loop(email, cb) {
-  var code = emailCodes[email]
-  if (!code) {
+  var mail = users[email]
+  if (!mail) {
     return setTimeout(loop.bind(null, email, cb), 50)
   }
-  var body = emailBodies[email]
-  delete emailCodes[email]
-  delete emailBodies[email]
-  cb({
-    code: code,
-    body: body
-  })
+  cb(mail)
 }
 
 api.route(
-  {
-    method: 'POST',
-    path: '/pop',
-    handler: function (request) {
-      loop(
-        request.payload.email,
-        function (emailData) {
-          request.reply(JSON.stringify(emailData))
-        }
-      )
+  [
+    {
+      method: 'GET',
+      path: '/mail/{email}',
+      handler: function (request) {
+        loop(
+          request.params.email,
+          function (emailData) {
+            request.reply([emailData])
+          }
+        )
+      }
+    },
+    {
+      method: 'DELETE',
+      path: '/mail/{email}',
+      handler: function (request) {
+        delete users[request.params.email]
+        request.reply()
+      }
     }
-  }
+  ]
 )
 
 api.start()

--- a/client/index.js
+++ b/client/index.js
@@ -323,13 +323,6 @@ Client.prototype.emailStatus = function () {
         return this.api.recoveryEmailStatus(this.sessionToken)
       }.bind(this)
     )
-    .then(
-    function (status) {
-      // decode email
-      status.email = Buffer(status.email, 'hex').toString()
-      return status
-    }
-  )
 }
 
 Client.prototype.requestVerifyEmail = function () {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "tap ./test/run",
     "start": "scripts/start-local.sh",
     "test-mysql": "DB_BACKEND=mysql npm test",
-    "test-all": "npm test && npm run test-mysql"
+    "test-all": "npm test && npm run test-mysql",
+    "test-remote-latest": "PUBLIC_URL=https://api-accounts-latest.dev.lcip.org MAILER_HOST=restmail.net MAILER_PORT=80 tap --timeout=120 --tap test/run/verification_tests.js"
   },
   "repository": {
     "type":"git",
@@ -48,7 +49,8 @@
     "awsbox": "0.6.x",
     "awsboxen": "0.5.x",
     "lazysmtp": "git://github.com/dannycoates/node-lazysmtp.git#9bb3712992",
-    "tap": "0.4.4",
+    "mailparser": "0.3.6",
+    "tap": "0.4.6",
     "grunt-contrib-jshint": "~0.7.0",
     "load-grunt-tasks": "~0.2.0",
     "grunt": "~0.4.1"

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -25,6 +25,8 @@ function TestServer() {
       cwd: __dirname
     }
   )
+  this.mail.stdout.on('data', process.stdout.write.bind(process.stdout))
+  this.mail.stderr.on('data', process.stderr.write.bind(process.stderr))
 }
 
 TestServer.server = { stop: function () {}, fake: true }


### PR DESCRIPTION
I thought this might help test remote hosts, but email delivery seems to be damn slow.

For example, run `npm run test-remote-latest` to run the verification tests against https://api-accounts-latest.dev.lcip.org

In theory it should work, but I was only able to get it to run successfully once out of many tries; the rest timed out.

@rfk r?
