### PR TITLE
don't delete keyFetchTokens on use until the account is verified

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -251,7 +251,7 @@ Client.prototype.keys = function () {
         return keys
       }.bind(this),
       function (err) {
-        this.keyFetchToken = null
+        if (err && err.errno !== 104) { this.keyFetchToken = null }
         throw err
       }.bind(this)
     )

--- a/routes/account.js
+++ b/routes/account.js
@@ -267,12 +267,13 @@ module.exports = function (log, crypto, P, uuid, isA, error, db, mailer, isProdu
           log.begin('Account.keys', request)
           var reply = request.reply.bind(request)
           var keyFetchToken = request.auth.credentials
+          if (!keyFetchToken.verified) {
+            // don't delete the token on use until the account is verified
+            return reply(error.unverifiedAccount())
+          }
           db.deleteKeyFetchToken(keyFetchToken)
             .then(
               function () {
-                if (!keyFetchToken.verified) {
-                  throw error.unverifiedAccount()
-                }
                 return {
                   bundle: keyFetchToken.keyBundle.toString('hex')
                 }

--- a/test/run/verification_tests.js
+++ b/test/run/verification_tests.js
@@ -26,6 +26,7 @@ TestServer.start(config.publicUrl)
       var password = 'allyourbasearebelongtous'
       var client = null
       var verifyCode = null
+      var keyFetchToken = null
       return Client.create(config.publicUrl, email, password)
         .then(
           function (x) {
@@ -42,6 +43,8 @@ TestServer.start(config.publicUrl)
             t.fail('got keys before verifying email')
           },
           function (err) {
+            keyFetchToken = client.keyFetchToken
+            t.ok(client.keyFetchToken, 'retained keyFetchToken')
             t.equal(err.message, 'Unverified account', 'account is unverified')
           }
         )
@@ -93,6 +96,7 @@ TestServer.start(config.publicUrl)
         )
         .then(
           function () {
+            t.equal(keyFetchToken, client.keyFetchToken, 'reusing keyFetchToken')
             return client.keys()
           }
         )


### PR DESCRIPTION
This should resolve #250

This change only deletes the keyFetchToken if the account is verified. If unverified, the token can be reused until the keys are actually fetched (account is verified) or the account is reset.

@ckarlof @warner is this the desired behavior?
