### PR TITLE
added 'created' to all tokens and 'generation' to accounts

### DIFF
--- a/db/heap.js
+++ b/db/heap.js
@@ -62,7 +62,7 @@ module.exports = function (
         email: data && data.email
       }
     )
-    data.generation = Date.now()
+    data.verifierSetAt = Date.now()
     data.normalizedEmail = data.email.toLowerCase()
     this.accounts[data.uid.toString('hex')] = data
     this.emailRecords[data.normalizedEmail] = data.uid.toString('hex')

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,14 +9,14 @@ CREATE TABLE IF NOT EXISTS accounts (
   wrapWrapKb BINARY(32) NOT NULL,
   authSalt BINARY(32) NOT NULL,
   verifyHash BINARY(32) NOT NULL,
-  generation BIGINT UNSIGNED NOT NULL
+  verifierSetAt BIGINT UNSIGNED NOT NULL
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS sessionTokens (
   tokenid BINARY(32) PRIMARY KEY,
   tokendata BINARY(32) NOT NULL,
   uid BINARY(16) NOT NULL,
-  created BIGINT UNSIGNED NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
   INDEX session_uid (uid)
 ) ENGINE=InnoDB;
 
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS keyfetchTokens (
   authKey BINARY(32) NOT NULL,
   uid BINARY(16) NOT NULL,
   keyBundle BINARY(96) NOT NULL,
-  created BIGINT UNSIGNED NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
   INDEX key_uid (uid)
 ) ENGINE=InnoDB;
 
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS resetTokens (
   tokenid BINARY(32) PRIMARY KEY,
   tokendata BINARY(32) NOT NULL,
   uid BINARY(16) NOT NULL UNIQUE KEY,
-  created BIGINT UNSIGNED NOT NULL
+  createdAt BIGINT UNSIGNED NOT NULL
 ) ENGINE=InnoDB;
 
 
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS passwordForgotTokens (
   tokendata BINARY(32) NOT NULL,
   uid BINARY(16) NOT NULL UNIQUE KEY,
   passcode BINARY(16) NOT NULL,
-  created BIGINT UNSIGNED NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
   tries SMALLINT UNSIGNED NOT NULL
 ) ENGINE=InnoDB;
 
@@ -52,6 +52,6 @@ CREATE TABLE IF NOT EXISTS passwordChangeTokens (
   tokenid BINARY(32) PRIMARY KEY,
   tokendata BINARY(32) NOT NULL,
   uid BINARY(16) NOT NULL,
-  created BIGINT UNSIGNED NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
   INDEX session_uid (uid)
 ) ENGINE=InnoDB;

--- a/test/run/db_tests.js
+++ b/test/run/db_tests.js
@@ -19,18 +19,18 @@ var DB = require('../../db')(
   Token.PasswordChangeToken
 )
 
-var b16 = Buffer('00000000000000000000000000000000', 'hex')
-var b32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
+var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 
 var ACCOUNT = {
   uid: uuid.v4('binary'),
   email: 'foo@bar.com',
-  emailCode: b16,
+  emailCode: zeroBuffer16,
   verified: false,
-  verifyHash: b32,
-  authSalt: b32,
-  kA: b32,
-  wrapWrapKb: b32
+  verifyHash: zeroBuffer32,
+  authSalt: zeroBuffer32,
+  kA: zeroBuffer32,
+  wrapWrapKb: zeroBuffer32
 }
 
 

--- a/test/run/forgot_password_token_tests.js
+++ b/test/run/forgot_password_token_tests.js
@@ -59,7 +59,7 @@ test(
     return PasswordForgotToken.create(ACCOUNT)
       .then(
         function (token) {
-          token.created = timestamp
+          token.createdAt = timestamp
           t.equal(token.ttl(), 900)
           t.equal(token.ttl(), 899)
           t.equal(token.ttl(), 899)

--- a/tokens/password_forgot_token.js
+++ b/tokens/password_forgot_token.js
@@ -35,7 +35,7 @@ module.exports = function (log, inherits, now, Token, crypto) {
   }
 
   PasswordForgotToken.prototype.ttl = function () {
-    var ttl = (LIFETIME - (now() - this.created)) / 1000
+    var ttl = (LIFETIME - (now() - this.createdAt)) / 1000
     return Math.max(Math.ceil(ttl), 0)
   }
 

--- a/tokens/token.js
+++ b/tokens/token.js
@@ -37,7 +37,7 @@ module.exports = function (log, crypto, P, hkdf, Bundle, error) {
     this.bundleKey = keys.bundleKey
     this.algorithm = 'sha256'
     this.uid = details.uid || null
-    this.created = details.created || Date.now()
+    this.createdAt = details.createdAt || Date.now()
   }
 
   // Create a new token of the given type.
@@ -59,7 +59,7 @@ module.exports = function (log, crypto, P, hkdf, Bundle, error) {
           Token.deriveTokenKeys(TokenType, bytes)
             .then(
               function (keys) {
-                details.created = Date.now()
+                details.createdAt = Date.now()
                 d.resolve(new TokenType(keys, details || {}))
               }
             )


### PR DESCRIPTION
This doesn't actually do anything with the timestamps, it just brings them into existence. The 'generation' on accounts isn't _necessarily_ for [this proposal](https://mail.mozilla.org/pipermail/sync-dev/2014-January/000664.html) but it could be used for that; I was specifically thinking about https://github.com/mozilla/fxa-auth-server/issues/388#issuecomment-30184875

While I was at it I did a minor refactor to pull all of the sql statements up a notch. Also, it turns out that `db_tests.js` was totally busted and would silently always use `heap.js`. :banana: 

Lots more work to do in this area, but this is mergeable, so r?

P.S. bigint for timestamps, yea or nay?
