### PR TITLE
First commit for jscs style changes

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,25 @@
+{
+    "disallowKeywords": ["with", "eval"],
+    "disallowKeywordsOnNewLine": ["else"],
+    "disallowLeftStickedOperators": ["?", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    "disallowMultipleLineStrings": true,
+    "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+    "disallowSpaceAfterObjectKeys": true,
+    "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-"],
+    "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+    "maximumLineLength": 120,
+    "requireCapitalizedConstructors": true,
+    "requireCurlyBraces": ["if", "else", "for", "while", "do"],
+    "requireLeftStickedOperators": [","],
+    "requireLineFeedAtFileEnd": true,
+    "requireRightStickedOperators": ["!"],
+    "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return"],
+    "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": true,
+    "validateJSDoc": {
+        "checkParamNames": true,
+        "checkRedundantParams": true,
+        "requireParamTypes": true
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@
 
 module.exports = function (grunt) {
 
-  require('load-grunt-tasks')(grunt);
+  require("load-grunt-tasks")(grunt);
 
   grunt.initConfig({
     copyright: {
@@ -16,6 +16,18 @@ module.exports = function (grunt) {
         pattern: "This Source Code Form is subject to the terms of the Mozilla Public"
       }
     },
+
+    jscs: {
+        src: [
+          "**/*.js",
+          "!node_modules/**",
+          "!test/**"
+        ],
+        options: {
+            config: ".jscs.json"
+        }
+    },
+
     jshint: {
       files: [
         "**/*.js",
@@ -29,5 +41,5 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('default', ['jshint', 'copyright']);
+  grunt.registerTask("default", ["jshint", "jscs", "copyright"]);
 };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "request": "2.31.0",
     "binary-split": "0.1.1",
     "through": "2.3.4",
-    "grunt-copyright": "~0.1.0"
+    "grunt-copyright": "~0.1.0",
+    "grunt-jscs-checker": "~0.3.2"
   }
 }


### PR DESCRIPTION
About 220 errors being reported by jscs (not including the /test directory).
You can run the linter using `grunt` (runs jshint, jscs, and copyright tasks) or just running `grunt jscs` task directly.
