### PR TITLE
made test-quick faster by only starting one TestServer

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "scripts/start-local.sh",
     "test-mysql": "DB_BACKEND=mysql npm test",
     "test-all": "npm run test-quick && npm run test-mysql && grunt",
-    "test-quick": "tap test/local test/remote",
+    "test-quick": "tap test/local && scripts/test-remote-quick.js",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 tap --timeout=300 --tap test/remote"
   },
   "repository": {

--- a/scripts/test-remote-quick.js
+++ b/scripts/test-remote-quick.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var path = require('path')
+var spawn = require('child_process').spawn
+var config = require('../config').root()
+var TestServer = require('../test/test_server')
+
+TestServer.start(config, false)
+  .then(
+  function (server) {
+    var tap = spawn(
+      path.join(path.dirname(__dirname), 'node_modules/.bin/tap'),
+      ['test/remote'],
+      { stdio: 'inherit' }
+    )
+
+    tap.on('close', function(code) {
+        server.stop()
+    })
+  }
+)
+


### PR DESCRIPTION
Shaved off about 5 seconds from a `npm run test-quick` run. Spent 10 minutes writing it so after 120 runs it will be worth it :)
