### PR TITLE
implemented login on /account/create

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -88,9 +88,11 @@ ClientApi.prototype.doRequest = function (method, url, token, payload, headers) 
  */
 ClientApi.prototype.accountCreate = function (email, authPW, options) {
   options = options || {}
+  var url = this.baseURL + '/account/create'
+  if (options.keys) { url += '?keys=true' }
   return this.doRequest(
     'POST',
-    this.baseURL + '/account/create',
+    url,
     null,
     {
       email: email,

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,6 +140,8 @@ Creates a user account. The client provides the email address with which this ac
 
 This endpoint may send a verification email to the user.  Callers may optionally provide the `service` parameter to indicate what Identity-Attached Service they are acting on behalf of.  This is an opaque alphanumeric token which will be embedded in the verification link as a query parameter.
 
+Creating an account also logs in. The response contains a `sessionToken` and optionally a `keyFetchToken` if the url has a query parameter of `keys=true`.
+
 ___Parameters___
 
 * email - the primary email for this account
@@ -153,7 +155,7 @@ ___Parameters___
 curl -v \
 -X POST \
 -H "Content-Type: application/json" \
-https://api-accounts.dev.lcip.org/v1/account/create \
+https://api-accounts.dev.lcip.org/v1/account/create?keys=true \
 -d '{
   "email": "me@example.com",
   "authPW": "996bc6b1aa63cd69856a2ec81cbf19d5c8a604713362df9ee15c2bf07128efab"
@@ -166,7 +168,9 @@ Successful requests will produce a "200 OK" response with the account's unique i
 
 ```json
 {
-  "uid": "4c352927cd4f4a4aa03d7d1893d950b8"
+  "uid": "4c352927cd4f4a4aa03d7d1893d950b8",
+  "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d",
+  "keyFetchToken": "7d1893d950b8cd69856a2ec81cbfd7d1893d950b3362df9e56a2ec81cbf19d5c"
 }
 ```
 

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -257,6 +257,48 @@ TestServer.start(config)
   )
 
   test(
+    '/account/create returns a sessionToken',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'ilikepancakes'
+      var client = new Client(config.publicUrl)
+      return client.setupCredentials(email, password)
+        .then(
+          function (c) {
+            return c.api.accountCreate(c.email, c.authPW)
+              .then(
+                function (response) {
+                  t.ok(response.sessionToken, 'has a sessionToken')
+                  t.equal(response.keyFetchToken, undefined, 'no keyFetchToken without keys=true')
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    '/account/create returns a keyFetchToken when keys=true',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'ilikepancakes'
+      var client = new Client(config.publicUrl)
+      return client.setupCredentials(email, password)
+        .then(
+          function (c) {
+            return c.api.accountCreate(c.email, c.authPW, { keys: true })
+              .then(
+                function (response) {
+                  t.ok(response.sessionToken, 'has a sessionToken')
+                  t.ok(response.keyFetchToken, 'keyFetchToken with keys=true')
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
     '/account/create with malformed email address',
     function (t) {
       var email = 'notAnEmailAddress'

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -85,7 +85,7 @@ TestServer.start(config)
           function () {
             return server.assertLogs(t, {
               'account-create-success': 1,
-              'session-create': 3,
+              'session-create': 4,
               'pwd-reset-request': 1,
               'pwd-reset-verify-success': 1,
               'pwd-reset-verify-failure': 0,

--- a/test/remote/session_destroy_tests.js
+++ b/test/remote/session_destroy_tests.js
@@ -49,7 +49,7 @@ TestServer.start(config)
           function () {
             return server.assertLogs(t, {
               'login-success': 1,
-              'session-create': 1,
+              'session-create': 2,
               'session-destroy': 1,
             })
           }


### PR DESCRIPTION
This adds `sessionToken` and optionally `keyFetchToken` to the response from `/account/create`. No need to immediately call `/account/login` anymore.

There's a refactor opportunity to combine the common stuff with login, but first things first :)

r? @rfk @chilts

cc @ncalexan
