### PR TITLE
Include 'generation' field in signed certificates.

### DIFF
--- a/bin/signer.js
+++ b/bin/signer.js
@@ -34,7 +34,10 @@ process.on('message', function (message) {
         issuedAt: new Date(now - (10 * 1000)),
         expiresAt: new Date(now + message.duration)
       },
-      null,
+      {
+        // include additional keys in the cert payload
+        'fxa-generation': message.generation,
+      },
       _privKey,
       function (err, cert) {
         process.send({ err: err, cert: cert})

--- a/routes/account.js
+++ b/routes/account.js
@@ -85,7 +85,8 @@ module.exports = function (
                             uid: account.uid,
                             email: account.email,
                             emailCode: account.emailCode,
-                            emailVerified: account.emailVerified
+                            emailVerified: account.emailVerified,
+                            verifierSetAt: account.verifierSetAt
                           }
                         )
                         .then(
@@ -196,7 +197,8 @@ module.exports = function (
                         uid: emailRecord.uid,
                         email: emailRecord.email,
                         emailCode: emailRecord.emailCode,
-                        emailVerified: emailRecord.emailVerified
+                        emailVerified: emailRecord.emailVerified,
+                        verifierSetAt: emailRecord.verifierSetAt
                       }
                     )
                   }

--- a/routes/sign.js
+++ b/routes/sign.js
@@ -68,7 +68,8 @@ module.exports = function (log, isA, error, signer, domain) {
             {
               email: sessionToken.uid.toString('hex') + '@' + domain,
               publicKey: publicKey,
-              duration: duration
+              duration: duration,
+              generation: sessionToken.verifierSetAt,
             },
             function (err, result) {
               if (err) {

--- a/test/local/signer_tests.js
+++ b/test/local/signer_tests.js
@@ -228,6 +228,29 @@ test(
 )
 
 test(
+  'the cert includes a generation number if given',
+  function (t) {
+    var email = 'test@example.com'
+    var duration = 100
+    var generation = 1234
+    signer.enqueue(
+      {
+        email: email,
+        publicKey: validKey,
+        duration: duration,
+        generation: generation
+      },
+      function (err, result) {
+        t.ok(result, 'got cert')
+        var payload = jwcrypto.extractComponents(result.cert).payload
+        t.equal(payload['fxa-generation'], generation, 'generation, check')
+        t.end()
+      }
+    )
+  }
+)
+
+test(
   'teardown',
   function (t) {
     signer.exit(

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -35,6 +35,7 @@ TestServer.start(config)
             t.equal(typeof(cert), 'string', 'cert exists')
             var payload = jwcrypto.extractComponents(cert).payload
             t.equal(payload.principal.email.split('@')[0], client.uid, 'cert has correct uid')
+            t.ok(payload['fxa-generation'] > 0, 'cert has non-zero generation number')
           }
         )
         .then(

--- a/tokens/session_token.js
+++ b/tokens/session_token.js
@@ -9,6 +9,7 @@ module.exports = function (log, inherits, Token) {
     this.email = details.email || null
     this.emailCode = details.emailCode || null
     this.emailVerified = !!details.emailVerified
+    this.verifierSetAt = details.verifierSetAt
   }
   inherits(SessionToken, Token)
 


### PR DESCRIPTION
Preliminary implementation of #486.  This all needs to be revisited for new-format certificates, but this should be enough to get things working for now.  @dannycoates r?
