### PR TITLE
add content-langauge header to sent emails

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -237,7 +237,7 @@ module.exports = function (fs, path, url, convict) {
       supportedLanguages: {
         doc: "List of languages this deployment should detect and display localized strings.",
         format: Array,
-        default: ['en', 'en-AU'],
+        default: ['en', 'en-AU', 'it-CH'],
         env: 'I18N_SUPPORTED_LANGUAGES'
       },
       translationDirectory: {

--- a/i18n.js
+++ b/i18n.js
@@ -72,5 +72,7 @@ module.exports = function (config) {
     return l10n
   }
 
+  abideObj.defaultLang = config.defaultLang
+
   return abideObj
 }

--- a/mailer.js
+++ b/mailer.js
@@ -121,7 +121,8 @@ module.exports = function (config, i18n, log) {
         'X-Uid': account.uid.toString('hex'),
         'X-Verify-Code': code,
         'X-Service-ID': opts.service,
-        'X-Link': link
+        'X-Link': link,
+        'Content-Language': opts.preferredLang || i18n.defaultLang
       }
     }
     return this.send(message)
@@ -162,7 +163,8 @@ module.exports = function (config, i18n, log) {
       html: template.html(values),
       headers: {
         'X-Recovery-Code': code,
-        'X-Link': link
+        'X-Link': link,
+        'Content-Language': opts.preferredLang || i18n.defaultLang
       }
     }
     return this.send(message)


### PR DESCRIPTION
Servers can set this header to let clients know the language the content is being sent with. It also helps us test the client: https://github.com/mozilla/fxa-js-client/pull/77
