### PR TITLE
add accept-language to cors headers

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -62,7 +62,7 @@ module.exports = function (path, url, Hapi, toobusy) {
       config.listen.port,
       {
         cors: {
-          additionalExposedHeaders: ['Timestamp']
+          additionalExposedHeaders: ['Timestamp', 'Accept-Language']
         },
         files: {
           relativeTo: path.dirname(__dirname)


### PR DESCRIPTION
CORS needs to know about the `accept-langauge` header.
