### PR TITLE
Factor loads command-line options into config files.

### DIFF
--- a/loadtest/Makefile
+++ b/loadtest/Makefile
@@ -18,16 +18,17 @@ clean:
 
 # Run a single test from the local machine, for sanity-checking.
 test:
-	./bin/loads-runner --hits=1 --users=1 loadtests.LoadTest.test_auth_server --server-url=$(SERVER_URL)
+	./bin/loads-runner --config=./config/test.ini --server-url=$(SERVER_URL) loadtests.LoadTest.test_auth_server
 
 # Run a fuller bench suite from the local machine.
 bench:
-	./bin/loads-runner --users=20 --duration=300 --include-file=./loadtests.py --python-dep=hawkauthlib loadtests.LoadTest.test_auth_server --server-url=$(SERVER_URL)
+	./bin/loads-runner --config=./config/bench.ini --server-url=$(SERVER_URL) loadtests.LoadTest.test_auth_server
 
 # Run a full bench, by submitting to broker in AWS.
 megabench:
-	./bin/loads-runner --broker=tcp://loads.services.mozilla.com:7780 --users=20 --duration=1800 --agents=5 --include-file=./loadtests.py --python-dep=hawkauthlib loadtests.LoadTest.test_auth_server --detach --server-url=$(SERVER_URL)
+	./bin/loads-runner --config=./config/megabench.ini --server-url=$(SERVER_URL) loadtests.LoadTest.test_auth_server
+	#./bin/loads-runner --broker=tcp://loads.services.mozilla.com:7780 --users=20 --duration=1800 --agents=5 --include-file=./loadtests.py --python-dep=hawkauthlib loadtests.LoadTest.test_auth_server --detach --server-url=$(SERVER_URL)
 
 # Purge any currently-running loadtest runs.
 purge:
-	./bin/loads-runner --purge-broker
+	./bin/loads-runner --config=./config/megabench.ini --purge-broker

--- a/loadtest/config/bench.ini
+++ b/loadtest/config/bench.ini
@@ -1,0 +1,3 @@
+[loads]
+users = 20
+duration = 300

--- a/loadtest/config/megabench.ini
+++ b/loadtest/config/megabench.ini
@@ -1,0 +1,9 @@
+[loads]
+users = 20
+duration = 1800
+include_file = ./loadtests.py
+python_dep = hawkauthlib
+broker = tcp://loads.services.mozilla.com:7780
+agents = 5
+detach = true
+observer = irc

--- a/loadtest/config/test.ini
+++ b/loadtest/config/test.ini
@@ -1,0 +1,3 @@
+[loads]
+hits = 1
+users = 1


### PR DESCRIPTION
Per issue #560.  The IRC observer defaults to #services-dev channel, but won't work until https://github.com/mozilla-services/loads/pull/203 lands and is pushed to the shared loads cluster.  @jbonacci r?
