### PR TITLE
Adding CONTRIBUTING and CONTRIBUTORS files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Firefox Accounts Server
+
+This project implements the core server-side API for Firefox Accounts.  It
+provides account, device and encryption-key management for the Mozilla Cloud
+Services ecosystem.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,16 @@
+Danny Coates
+Ryan Kelly
+Zachary Carter
+Andrew Chilton
+Zach Carter
+Peter deHaan
+Brian Warner
+Chris Karlof
+ckarlof
+vladikoff
+jbonacci
+Jed Parsons
+Lloyd Hilaiel
+MrDHat
+rafrombrc
+John Morrison

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test-all": "npm run test-quick && npm run test-mysql && grunt",
     "test-quick": "npm run tq",
     "tq": "tap test/local && scripts/test-remote-quick.js",
-    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 tap --timeout=300 --tap test/remote"
+    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 tap --timeout=300 --tap test/remote",
+    "contributors": "git shortlog -s -n | cut -c8- > CONTRIBUTORS.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding temp page for CONTRIBUTING.md (not sure what it should have in it yet, or what we want to move from README.md into there).

Also created an initial CONTRIBUTORS.md file with all the current contributors. You can update this by calling `$ npm run contributors`. Output can be tweaked as far as you can customize `$ git shortlog -s -n` output. I make no guarantees how it will work on Windows or other platforms, but "works on my machine".

Closes #590
