### PR TITLE
fix email links in local development mode

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -1,6 +1,6 @@
 {
   "contentServer": {
-    "url": "http://127.0.0.1:9001"
+    "url": "http://127.0.0.1:3030"
   },
   "templateServer": {
     "url": "http://127.0.0.1:9001"


### PR DESCRIPTION
The contentServer URL should use the same host/port as the default content-server in
local development, otherwise links point to a 404'd endpoint.
