### PR TITLE
Add (temporary) SNS notifications of account delete events.

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -66,7 +66,12 @@ function main() {
         DB.connect(config[config.db.backend])
           .done(
             function (db) {
-              var routes = require('../routes')(log, error, serverPublicKey, signer, db, mailer, config)
+
+              // notifier for account events.
+              // XXX TODO: replace this with an external process e.g. heka
+              var notifier = require('../notifier')(config)
+
+              var routes = require('../routes')(log, error, serverPublicKey, signer, db, mailer, notifier, config)
               server = Server.create(log, error, config, routes, db)
 
               server.start(

--- a/config/config.js
+++ b/config/config.js
@@ -264,6 +264,11 @@ module.exports = function (fs, path, url, convict) {
     verifierVersion: {
       doc: 'verifer version for new and changed passwords',
       default: 1
+    },
+    snsTopicArn: {
+      doc: 'Amazon SNS topic on which to send account event notifications',
+      format: String,
+      default: ''
     }
   })
 

--- a/notifier.js
+++ b/notifier.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Utilty for sending account-event notifications into SNS.
+// We will eventually replace this with a downstream solution based
+// on e.g. heka, but doing it in the app is easier to get up and
+// running for now.  Expect this code to go away in the future.
+
+module.exports = function(config, log) {
+
+  // By default we don't publish any notifications.
+  // It's only enabled by a config setting in production.
+  var publish = function(){}
+
+  if (config.snsTopicArn) {
+
+    var AWS = require('aws-sdk')
+ 
+    // Pull the region info out of the topic arn.
+    // For some reason we need to pass this in explicitly.
+    // Format is "arn:aws:sns:<region>:<other junk>"
+    var region = config.snsTopicArn.split(':')[3]
+
+    // This will pull in default credentials, region data etc
+    // from the metadata service available to the instance.
+    // It's magic, and it's awesome.
+    var sns = new AWS.SNS({ region: region });
+    
+    // Publishing notificatios is fire-and-forget.
+    // We'll log any errors but not surface them to the app.
+    publish = function(msg) {
+      sns.publish({
+        TopicArn: config.snsTopicArn,
+        Message: JSON.stringify(msg),
+      }, function(err) {
+        if (err) {
+          log.error({ op: 'Notifier.publish', err: err })
+        }
+      })
+    }
+  }
+
+  return {
+    publish: publish
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "nodemailer": "0.6.1",
     "then-redis": "0.3.10",
     "scrypt-hash": "1.1.8",
-    "request": "2.34.0"
+    "request": "2.34.0",
+    "aws-sdk": "2.0.0-rc11"
   },
   "devDependencies": {
     "awsbox": "0.7.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,6 +16,7 @@ module.exports = function (
   signer,
   db,
   mailer,
+  notifier,
   config
   ) {
   var isProduction = config.env === 'prod'
@@ -30,6 +31,7 @@ module.exports = function (
     error,
     db,
     mailer,
+    notifier,
     config.smtp.redirectDomain,
     config.verifierVersion,
     isProduction


### PR DESCRIPTION
As discussed in #608 and https://bugzilla.mozilla.org/show_bug.cgi?id=971907 we'd like to send notification of account deletion events via SNS, so that downstream apps can cleanup any data they have stored for a user. 

The ultimate plan is to have this managed by heka, but heka doesn't currently have SNS support and I don't want to block on fiddling around with that.  I think we should consider having the app do it in the first instance, so we can work on the downstream flows and the heka pieces in parallel.  This is my WIP attempt at some minimal temporary code in the app to manage this.

Not ready for merge, but @dannycoates f? on this as a temporary measure until we get the heka pieces in place?
