### PR TITLE
translate ER_DUP_ENTRY on account create

### DIFF
--- a/db/mysql.js
+++ b/db/mysql.js
@@ -207,6 +207,13 @@ module.exports = function (
     .then(
       function () {
         return data
+      },
+      function (err) {
+        log.error({ op: 'MySql.createAccount.1', err: err })
+        if (err.errno === 1062) {
+          err = error.accountExists(data.email)
+        }
+        throw err
       }
     )
   }

--- a/test/config/scrypt.json
+++ b/test/config/scrypt.json
@@ -1,0 +1,3 @@
+{
+	"verifierVersion": 1
+}

--- a/test/local/concurrent_tests.js
+++ b/test/local/concurrent_tests.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var path = require('path')
+var Client = require('../../client')
+var P = require('../../promise')
+
+process.env.CONFIG_FILES = path.join(__dirname, '../config/account_tests.json,')
+process.env.CONFIG_FILES += path.join(__dirname, '../config/scrypt.json')
+var config = require('../../config').root()
+
+// This test is mysql specific
+if (config.db.backend !== 'mysql') { return }
+
+TestServer.start(config)
+.then(function main(server) {
+
+  test(
+    'concurrent create requests',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'abcdef'
+      // Two shall enter, only one shall survive!
+      return P.all(
+        [
+          Client.create(config.publicUrl, email, password, server.mailbox),
+          Client.create(config.publicUrl, email, password, server.mailbox)
+        ]
+      )
+      .then(
+        t.fail.bind(t, 'created both accounts'),
+        function (err) {
+          t.equal(err.errno, 101, 'account exists')
+        }
+      )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -414,12 +414,17 @@ TestServer.start(config)
     're-signup against an unverified email',
     function (t) {
       var email = server.uniqueEmail()
-      var email2 = email.toUpperCase()
       var password = 'abcdef'
       return Client.create(config.publicUrl, email, password, server.mailbox)
         .then(
-          function (c) {
-            return Client.createAndVerify(config.publicUrl, email2, password, server.mailbox)
+          function () {
+            // delete the first verification email
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function () {
+            return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
           }
         )
         .then(


### PR DESCRIPTION
Concurrent `/account/create` requests will race to write to the db. Instead of surfacing the error as a 500, it should be a normal account exists error.

Note to self, audit endpoints for other concurrent errors that could be nicer.

Fixes #625
