### PR TITLE
chore(build): Use the new Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Firefox Accounts Server
 =======================
 
-[![Build Status](https://travis-ci.org/mozilla/fxa-auth-server.png)](https://travis-ci.org/mozilla/fxa-auth-server)
+[![Build Status](https://travis-ci.org/mozilla/fxa-auth-server.svg?branch=master)](https://travis-ci.org/mozilla/fxa-auth-server)
 
 This project implements the core server-side API for Firefox Accounts.  It
 provides account, device and encryption-key management for the Mozilla Cloud


### PR DESCRIPTION
Stealing @vladikoff's idea from mozilla/fxa-content-server#785

> _Also only use the 'master' branch for the badge_
