### PR TITLE
resend blackout period

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -227,6 +227,10 @@ module.exports = function (fs, path, url, convict) {
         doc: 'Domain that mail urls are allowed to redirect to',
         format: String,
         default: 'firefox.com'
+      },
+      resendBlackoutPeriod: {
+        doc: 'Blackout period for resending verification emails',
+        default: 1000 * 60 * 10
       }
     },
     toobusy: {

--- a/routes/account.js
+++ b/routes/account.js
@@ -20,7 +20,8 @@ module.exports = function (
   redirectDomain,
   verifierVersion,
   isProduction,
-  domain
+  domain,
+  resendBlackoutPeriod
   ) {
 
   var routes = [
@@ -364,7 +365,8 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailResend', request)
         var sessionToken = request.auth.credentials
-        if (sessionToken.emailVerified) {
+        if (sessionToken.emailVerified ||
+            Date.now() - sessionToken.verifierSetAt < resendBlackoutPeriod) {
           return reply({})
         }
         mailer.sendVerifyCode(sessionToken, sessionToken.emailCode, {

--- a/routes/index.js
+++ b/routes/index.js
@@ -33,7 +33,8 @@ module.exports = function (
     config.smtp.redirectDomain,
     config.verifierVersion,
     isProduction,
-    config.domain
+    config.domain,
+    config.smtp.resendBlackoutPeriod
   )
   var password = require('./password')(
     log,

--- a/test/config/resend_blackout.json
+++ b/test/config/resend_blackout.json
@@ -1,0 +1,5 @@
+{
+  "smtp": {
+    "resendBlackoutPeriod": 500
+  }
+}

--- a/test/local/resend_blackout_tests.js
+++ b/test/local/resend_blackout_tests.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var path = require('path')
+var Client = require('../../client')
+var P = require('../../promise')
+
+process.env.CONFIG_FILES = path.join(__dirname, '../config/resend_blackout.json')
+var config = require('../../config').root()
+
+TestServer.start(config)
+.then(function main(server) {
+
+  test(
+    'resend blackout period',
+    function (t) {
+      // FYI config.tokenLifetimes.passwordChangeToken = -1
+      var email = Math.random() + "@example.com"
+      var password = 'ok'
+      var client = null
+      return Client.create(config.publicUrl, email, password, { preVerified: false })
+        .then(
+          function (c) {
+            client = c
+            return server.mailbox.waitForCode(email)
+          }
+        )
+        .then(
+          function () {
+            return client.requestVerifyEmail()
+          }
+        )
+        .then(
+          function () {
+            var d = P.defer()
+            setTimeout(d.resolve.bind(d), config.smtp.resendBlackoutPeriod)
+            return d.promise
+          }
+        )
+        .then(
+          function () {
+            return client.requestVerifyEmail()
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForCode(email)
+          }
+        )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -21,7 +21,6 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var client = null
-      var verifyCode = null
       var keyFetchToken = null
       return Client.create(config.publicUrl, email, password)
         .then(
@@ -61,23 +60,7 @@ TestServer.start(config)
           }
         )
         .then(
-          function (code) {
-            verifyCode = code
-            return client.requestVerifyEmail()
-          }
-        )
-        .then(
-          function () {
-            return server.mailbox.waitForCode(email)
-          }
-        )
-        .then(
-          function (code) {
-            t.equal(code, verifyCode, 'verify codes are the same')
-          }
-        )
-        .then(
-          function () {
+          function (verifyCode) {
             return client.verifyEmail(verifyCode)
           }
         )
@@ -100,6 +83,7 @@ TestServer.start(config)
     }
   )
 
+/*/ TODO: revisit after the "dumb" resend logic is updated
   test(
     'create account with service identifier',
     function (t) {
@@ -149,7 +133,7 @@ TestServer.start(config)
         )
     }
   )
-
+/*/
   test(
     'create account allows localization of emails',
     function (t) {

--- a/test/remote/recovery_email_verify_tests.js
+++ b/test/remote/recovery_email_verify_tests.js
@@ -93,26 +93,6 @@ TestServer.start(config)
             t.equal(query.service, options.service, 'service is in link')
           }
         )
-        .then(
-          function () {
-            return client.requestVerifyEmail()
-          }
-        )
-        .then(
-          function () {
-            return server.mailbox.waitForEmail(email)
-          }
-        )
-        .then(
-          function (emailData) {
-            var link = emailData.headers['x-link']
-            var query = url.parse(link, true).query
-            t.ok(query.uid, 'uid is in resend link')
-            t.ok(query.code, 'code is in resend link')
-            t.equal(query.redirectTo, options.redirectTo, 'redirectTo is in resend link')
-            t.equal(query.service, options.service, 'service is in resend link')
-          }
-        )
     }
   )
 


### PR DESCRIPTION
This adds a temporary blackout window where calls to `/recovery_email/resend_code` will not send an email for the configured period of time after an account is created (default 10 minutes).

I've manually inspected the logs of the test in `resend_blackout_tests.js` to verify the correct behavior because it is not ideal. It doesn't automatically verify that the second email doesn't get sent. The edits to the other tests are because those resends were failing (as now expected), so... anyway I'll make these tests better if we keep this blackout long term. 

Otherwise, the meat of this change is line 369 in `routes/account.js`

r? @ckarlof
