### PR TITLE
make travis actually run 'npm test' again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ before_install:
   - sudo apt-get install libgmp3-dev
 
 script:
+  - npm test
   - grunt validate-shrinkwrap


### PR DESCRIPTION
adding a new `script:` target nullifies the default `npm test` and so only the grunt task was running.
