### PR TITLE
feature(server): Add ability to set displayed log level from an environment variable.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -14,7 +14,8 @@ module.exports = function (fs, path, url, convict) {
     },
     log: {
       level: {
-        default: 'info'
+        default: 'info',
+        env: 'LOG_LEVEL'
       }
     },
     publicUrl: {


### PR DESCRIPTION
- Use the `LOG_LEVEL` environment variable.

The purpose of this PR is to allow us to run the the fxa-content-server's travis tests with minimal logging from the auth-server. We could start the auth-server with minimal logging using the environment rather than updating dev.json.
