### PR TITLE
verify an account if its unverified when forgot password verification succeeds

### DIFF
--- a/db/heap.js
+++ b/db/heap.js
@@ -327,6 +327,8 @@ module.exports = function (
 
   Heap.prototype.forgotPasswordVerified = function (passwordForgotToken) {
     log.trace({ op: 'Heap.forgotPasswordVerified', uid: passwordForgotToken && passwordForgotToken.uid })
+    var account = this.accounts[passwordForgotToken.uid.toString('hex')]
+    if (account) { account.emailVerified = true }
     return this.deletePasswordForgotToken(passwordForgotToken)
       .then(this.createAccountResetToken.bind(this, passwordForgotToken))
   }

--- a/db/mysql.js
+++ b/db/mysql.js
@@ -706,6 +706,13 @@ var KEY_FETCH_TOKEN = 'SELECT t.authKey, t.uid, t.keyBundle, t.createdAt,' +
                   ]
                 )
               )
+              queries.push(
+                query(
+                  connection,
+                  VERIFY_EMAIL,
+                  [passwordForgotToken.uid]
+                )
+              )
               return P.all(queries)
                 .then(
                   function () {

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -270,6 +270,57 @@ TestServer.start(config)
   )
 
   test(
+    '/password/forgot/verify_code should set an unverified account as verified',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'something'
+      var client = null
+      return Client.create(config.publicUrl, email, password)
+        .then(function (c) { client = c })
+        .then(
+          function () {
+            return client.emailStatus()
+          }
+        )
+        .then(
+          function (status) {
+            t.equal(status.verified, false, 'email unverified')
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForCode(email) // ignore this code
+          }
+        )
+        .then(
+          function () {
+            return client.forgotPassword()
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForCode(email)
+          }
+        )
+        .then(
+          function (code) {
+            return client.verifyPasswordResetCode(code)
+          }
+        )
+        .then(
+          function () {
+            return client.emailStatus()
+          }
+        )
+        .then(
+          function (status) {
+            t.equal(status.verified, true, 'email verified')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
All we needed to do was add the verify_email query to the forgotPasswordVerified transaction.

fixes #690
