### PR TITLE
added 'accountRecreated' flag to the request summary log line

### DIFF
--- a/log.js
+++ b/log.js
@@ -73,6 +73,7 @@ Overdrive.prototype.summary = function (request, response) {
     lang: request.app.acceptLanguage,
     agent: request.headers['user-agent'],
     remoteAddressChain: request.app.remoteAddressChain,
+    accountRecreated: request.app.accountRecreated,
     t: Date.now() - request.info.received
   }
   line.uid = (request.auth && request.auth.credentials) ?

--- a/routes/account.js
+++ b/routes/account.js
@@ -57,6 +57,7 @@ module.exports = function (
             function (emailRecord) {
               // account exists
               if (emailRecord.emailVerified) { throw error.accountExists(email) }
+              request.app.accountRecreated = true
               return db.deleteAccount(emailRecord)
             },
             function (err) {


### PR DESCRIPTION
This adds an `"accountRecreated":true` to the request summary log line when an unverified account gets recreated. The property is not present otherwise.

@kparlante boolean was easier because `createdAt` isn't being exposed on `emailRecord` presently. If we need it I can add it but I took the lazy approach first.

fixes #646
