### PR TITLE
Update api docs for /certificate/sign to discuss expiry time.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -679,7 +679,7 @@ Failing requests may be due to the following errors:
 
 :lock: HAWK-authenticated with the sessionToken.
 
-Sign a BrowserID public key. The server is given a public key, and returns a signed certificate using the same JWT-like mechanism as a BrowserID primary IdP would (see the [browserid-certifier project](https://github.com/mozilla/browserid-certifier for details)). The signed certificate includes a `principal.email` property to indicate the Firefox Account identifier (a uuid at the account server's primary domain). The certificate is marked as being valid for a limited time period (TBD, but probably a few hours, maybe a day).
+Sign a BrowserID public key. The server is given a public key, and returns a signed certificate using the same JWT-like mechanism as a BrowserID primary IdP would (see the [browserid-certifier project](https://github.com/mozilla/browserid-certifier for details)). The signed certificate includes a `principal.email` property to indicate the Firefox Account identifier (a uuid at the account server's primary domain) and is stamped with an expiry time based on the "duration" parameter.
 
 This request will fail unless the account's email address has been verified.
 
@@ -693,7 +693,7 @@ ___Parameters___
     * p - DS only
     * q - DS only
     * g - DS only
-* duration - time interval from now when the certificate will expire in seconds
+* duration - time interval from now when the certificate will expire, in seconds, up to a maximum of 24 hours.
 
 ___Headers___
 


### PR DESCRIPTION
Fixes #693
