### PR TITLE
Update the URL for the customs server

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "through": "2.3.4",
     "toobusy": "0.2.4",
     "uuid": "1.4.1",
-    "fxa-customs-server": "git://github.com/dannycoates/fxa-customs-server.git#74d7b8d6"
+    "fxa-customs-server": "git://github.com/mozilla/fxa-customs-server.git#74d7b8d6"
   },
   "devDependencies": {
     "ass": "0.0.4",


### PR DESCRIPTION
This got moved to the mozilla namespace and so we should avoid
relying on Github maintaining the redirection.
