### PR TITLE
Allow signing certificates as secondary authority over the verified email address

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -226,7 +226,7 @@ ClientApi.prototype.recoveryEmailVerifyCode = function (uid, code) {
   )
 }
 
-ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration) {
+ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration, sub) {
   return tokens.SessionToken.fromHex(sessionTokenHex)
     .then(
       function (token) {
@@ -236,7 +236,8 @@ ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, dura
           token,
           {
             publicKey: publicKey,
-            duration: duration
+            duration: duration,
+            sub: sub
           }
         )
       }.bind(this)

--- a/client/index.js
+++ b/client/index.js
@@ -193,11 +193,11 @@ Client.prototype.requestVerifyEmail = function () {
   )
 }
 
-Client.prototype.sign = function (publicKey, duration) {
+Client.prototype.sign = function (publicKey, duration, sub) {
   var o = this.sessionToken ? P(null) : this.login()
   return o.then(
       function () {
-        return this.api.certificateSign(this.sessionToken, publicKey, duration)
+        return this.api.certificateSign(this.sessionToken, publicKey, duration, sub)
       }.bind(this)
     )
     .then(

--- a/docs/api.md
+++ b/docs/api.md
@@ -694,6 +694,7 @@ ___Parameters___
     * q - DS only
     * g - DS only
 * duration - time interval from now when the certificate will expire, in seconds, up to a maximum of 24 hours.
+* sub - optional subject of the certificate; this must be either the account email or the Firefox Account identifier.
 
 ___Headers___
 


### PR DESCRIPTION
Just a little thought experiment, not expecting anyone to merge this :-)

What if we allowed the client to ask for persona-style fallback certificates?  That is, certificates for the user's actual verified email address, but signed by the fxa server as secondary identity authority.  It's a pretty minimal change from an API point of view.  It might terrify @warner though...

This is, in a way, the dual of the https://verifier.accounts.firefox.com API which allows you to customize the list of trusted secondaries - it lets you ask https://api.accounts.firefox.com to act as a secondary authority.

Why would anyone want to do this?  Dunno really, just pondering potential synergies that might stem from our shiny new database full of verified emails...
