### PR TITLE
fix no method 'wrap'

### DIFF
--- a/routes/sign.js
+++ b/routes/sign.js
@@ -79,9 +79,8 @@ module.exports = function (log, isA, error, signer, domain) {
               reply(error.serviceUnavailable())
             }
             else if (result && result.err) {
-              // TODO: parse result.err better
-              log.warn({ op: 'signer.enqueue', err: result.err })
-              reply(error.wrap(result.err))
+              log.warn({ op: 'signer.enqueue', err: result.err, req: request.payload })
+              reply(error.invalidRequestParameter(result.err.message))
             }
             else {
               reply(result)

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -74,6 +74,36 @@ TestServer.start(config)
   )
 
   test(
+    'bad key',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'allyourbasearebelongtous'
+      var client = null
+      var duration = 1000 * 60 * 60 * 24
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+        .then(
+          function (c) {
+            client = c
+            return client.sign(
+              {
+                "algorithm":"RS",
+                "n":"abcdef",
+                "e":"65537"
+              },
+              duration
+            )
+          }
+        )
+        .then(
+          t.fail,
+          function (err) {
+            t.equal(err.errno, 107, 'invalid parameter error')
+          }
+        )
+    }
+  )
+
+  test(
     '/certificate/sign inputs',
     function (t) {
       var email = server.uniqueEmail()


### PR DESCRIPTION
These happen when the submitted key is syntactically valid (according to our input validation) but semantically invalid (as a cryptographic key)

Somehow this `wrap` call was left behind when errors were refactored.
