### PR TITLE
always return a 503 on __heartbeat__ failure

### DIFF
--- a/routes/defaults.js
+++ b/routes/defaults.js
@@ -68,7 +68,10 @@ module.exports = function (log, P, db, error) {
             function () {
               reply({})
             },
-            reply
+            function (err) {
+              log.error({ op: 'heartbeat', err: err })
+              reply(error.serviceUnavailable())
+            }
           )
       }
     },


### PR DESCRIPTION
@jrgm I added the error as you suggested, but I moved it up to the route handler to prevent any ambiguity in the future.
