### PR TITLE
Allow serving content directly over https to simplify development environment (second take)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Andrew Chilton <andychilton@gmail.com>
 Brian Warner <warner@lothar.com>
 Chris Karlof <ckarlof@mozilla.com>
 Danny Coates <dannycoates@gmail.com>
+Eric Le Lay <elelay@macports.org>
 Francois Marier <francois@mozilla.com>
 James Bonacci <jbonacci@mozilla.com>
 Jed Parsons <jedp@me.com>

--- a/config/config.js
+++ b/config/config.js
@@ -294,7 +294,19 @@ module.exports = function (fs, path, url, convict) {
         format: String,
         default: '',
       }
-    }
+    },
+    useHttps: {
+      doc: "set to true to serve directly over https",
+      default: false
+    },
+    keyPath: {
+      doc: "path to SSL key in PEM format if serving over https",
+      default: path.resolve(__dirname, '../key.pem')
+    },
+    certPath: {
+      doc: "path to SSL certificate in PEM format if serving over https",
+      default: path.resolve(__dirname, '../cert.pem')
+    },
   })
 
   // handle configuration files.  you can specify a CSV list of configuration

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+var fs = require('fs');
 
 var HEX_STRING = require('../routes/validators').HEX_STRING
 
@@ -53,11 +54,8 @@ module.exports = function (path, url, Hapi, toobusy) {
           )
       }
     }
-
-    var server = Hapi.createServer(
-      config.listen.host,
-      config.listen.port,
-      {
+    
+    var serverOptions = {
         cors: {
           additionalExposedHeaders: ['Timestamp', 'Accept-Language']
         },
@@ -70,6 +68,18 @@ module.exports = function (path, url, Hapi, toobusy) {
           }
         }
       }
+
+      if(config.useHttps) {
+          serverOptions.tls = {
+              key: fs.readFileSync(config.keyPath),
+              cert: fs.readFileSync(config.certPath)
+          }
+      }
+
+    var server = Hapi.createServer(
+      config.listen.host,
+      config.listen.port,
+      serverOptions
     )
 
     server.pack.require('hapi-auth-hawk', function (err) {


### PR DESCRIPTION
When developing/testing locally it's more convenient to let fxa-auth-server directly serve https.

This is what this pull request allows.  It is controlled by a useHttps config key, to turn it on/off, and two keyPath and certPath entries pointing to the pem key and certificate.

It's the same code as #727, except that keys have been renamed to camelCase.
