### PR TITLE
updated hapi-auth-hawk

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,22 +10,27 @@
         "blanket": {
           "version": "1.1.6",
           "from": "blanket@~1.1.5",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~1.0.2"
+              "from": "esprima@~1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@~0.1.6"
+              "from": "falafel@~0.1.6",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
               "from": "xtend@~2.1.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@~0.4.0"
+                  "from": "object-keys@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
             }
@@ -34,14 +39,17 @@
         "temp": {
           "version": "0.6.0",
           "from": "temp@~0.6.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
               "from": "rimraf@~2.1.4",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1"
+                  "from": "graceful-fs@~1",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
             },
@@ -54,23 +62,28 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9"
+          "from": "async@~0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
           "version": "0.12.4",
           "from": "cheerio@~0.12.4",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
               "version": "0.0.3",
               "from": "cheerio-select@*",
+              "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
                   "from": "CSSselect@0.x",
+                  "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
-                      "version": "0.4.5",
-                      "from": "CSSwhat@0.4"
+                      "version": "0.4.7",
+                      "from": "CSSwhat@0.4",
+                      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
@@ -79,17 +92,20 @@
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.1",
-                          "from": "domelementtype@1"
+                          "from": "domelementtype@1",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "boolbase@~1.0.0"
+                      "from": "boolbase@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
                     },
                     "nth-check": {
                       "version": "1.0.0",
-                      "from": "nth-check@~1.0.0"
+                      "from": "nth-check@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz"
                     }
                   }
                 }
@@ -98,39 +114,47 @@
             "htmlparser2": {
               "version": "3.1.4",
               "from": "htmlparser2@3.1.4",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "domhandler@2.0"
+                  "from": "domhandler@2.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "domutils@1.1"
+                  "from": "domutils@1.1",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.1",
-                  "from": "domelementtype@1"
+                  "from": "domelementtype@1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.0.26-4",
+                  "version": "1.0.27-1",
                   "from": "readable-stream@1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26-4.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0"
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1"
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@~0.10.x"
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -138,11 +162,13 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@~1.4"
+              "from": "underscore@~1.4",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x"
+              "from": "entities@0.x",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             }
           }
         }
@@ -156,10 +182,12 @@
         "xml2js": {
           "version": "0.2.4",
           "from": "xml2js@0.2.4",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.4.tgz",
           "dependencies": {
             "sax": {
               "version": "0.6.0",
-              "from": "sax@>=0.4.2"
+              "from": "sax@>=0.4.2",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
             }
           }
         },
@@ -173,10 +201,12 @@
     "awsbox": {
       "version": "0.7.0",
       "from": "awsbox@0.7.0",
+      "resolved": "https://registry.npmjs.org/awsbox/-/awsbox-0.7.0.tgz",
       "dependencies": {
         "awssum-amazon-ec2": {
           "version": "1.4.0",
-          "from": "awssum-amazon-ec2@1.4.0",
+          "from": "awssum-amazon-ec2@>=1.3.2",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-ec2/-/awssum-amazon-ec2-1.4.0.tgz",
           "dependencies": {
             "data2xml": {
               "version": "0.8.1",
@@ -185,21 +215,24 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.4"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "awssum-amazon-route53": {
           "version": "1.1.0",
-          "from": "awssum-amazon-route53@1.1.0",
+          "from": "awssum-amazon-route53@1.x",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.1.0.tgz",
           "dependencies": {
             "fmt": {
               "version": "0.4.0",
-              "from": "fmt@0.4.0",
+              "from": "fmt@0.4.x",
               "resolved": "https://registry.npmjs.org/fmt/-/fmt-0.4.0.tgz"
             },
             "data2xml": {
@@ -209,21 +242,24 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.4"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "nice-route53": {
           "version": "0.3.4",
           "from": "nice-route53@0.3.4",
+          "resolved": "https://registry.npmjs.org/nice-route53/-/nice-route53-0.3.4.tgz",
           "dependencies": {
             "awssum-amazon-route53": {
               "version": "1.0.3",
-              "from": "awssum-amazon-route53@1.0.3",
+              "from": "awssum-amazon-route53@1.0.x",
               "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.0.3.tgz",
               "dependencies": {
                 "fmt": {
@@ -238,45 +274,13 @@
                 },
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.x"
+                  "from": "underscore@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "dateformat": {
                   "version": "1.0.4-1.2.3",
-                  "from": "dateformat@1.0.4-1.2.3"
-                }
-              }
-            },
-            "awssum-amazon": {
-              "version": "1.3.0",
-              "from": "awssum-amazon@1.3.0",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.4.4",
-                  "from": "underscore@1.4.4"
-                },
-                "dateformat": {
-                  "version": "1.0.4-1.2.3",
-                  "from": "dateformat@1.0.4-1.2.3"
-                }
-              }
-            },
-            "awssum": {
-              "version": "1.2.0",
-              "from": "awssum@~1",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.4.4",
-                  "from": "underscore@1.4.x"
-                },
-                "xml2js": {
-                  "version": "0.2.8",
-                  "from": "xml2js@0.2.x",
-                  "dependencies": {
-                    "sax": {
-                      "version": "0.5.8",
-                      "from": "sax@0.5.x"
-                    }
-                  }
+                  "from": "dateformat@1.0.4-1.2.3",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
                 }
               }
             }
@@ -284,11 +288,13 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@0.2.10"
+          "from": "async@0.2.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "JSONSelect": {
           "version": "0.4.0",
-          "from": "JSONSelect@0.4.0"
+          "from": "JSONSelect@0.4.0",
+          "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz"
         },
         "temp": {
           "version": "0.4.0",
@@ -298,10 +304,12 @@
         "xml2js": {
           "version": "0.1.13",
           "from": "xml2js@0.1.13",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.13.tgz",
           "dependencies": {
             "sax": {
               "version": "0.6.0",
-              "from": "sax@>=0.1.1"
+              "from": "sax@>=0.1.1",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
             }
           }
         },
@@ -312,21 +320,25 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@>=0.0.1 <0.1",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "urlparse": {
           "version": "0.0.1",
-          "from": "urlparse@0.0.1"
+          "from": "urlparse@0.0.1",
+          "resolved": "https://registry.npmjs.org/urlparse/-/urlparse-0.0.1.tgz"
         },
         "relative-date": {
           "version": "1.1.1",
-          "from": "relative-date@1.1.1"
+          "from": "relative-date@1.1.1",
+          "resolved": "https://registry.npmjs.org/relative-date/-/relative-date-1.1.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@0.6.2"
+          "from": "colors@~0.6.0-1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "awssum": {
           "version": "1.1.0",
@@ -335,15 +347,18 @@
           "dependencies": {
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "xml2js": {
               "version": "0.2.8",
               "from": "xml2js@0.2.x",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.5.8",
-                  "from": "sax@0.5.x"
+                  "from": "sax@0.5.x",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
                 }
               }
             }
@@ -356,59 +371,69 @@
           "dependencies": {
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "read-package-json": {
-          "version": "1.1.8",
-          "from": "read-package-json@1.1.8",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.8.tgz",
+          "version": "1.1.9",
+          "from": "read-package-json@~1.1.3",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.9.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.9",
+              "version": "3.2.11",
               "from": "glob@~3.2.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2"
                 }
               }
             },
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2"
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "normalize-package-data": {
-              "version": "0.2.12",
-              "from": "normalize-package-data@~0.2.9",
+              "version": "0.2.13",
+              "from": "normalize-package-data@^0.2.13",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-0.2.13.tgz",
               "dependencies": {
-                "semver": {
-                  "version": "2.2.1",
-                  "from": "semver@2"
-                },
                 "github-url-from-git": {
                   "version": "1.1.1",
-                  "from": "github-url-from-git@~1.1.1"
+                  "from": "github-url-from-git@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.1.1.tgz"
                 },
                 "github-url-from-username-repo": {
-                  "version": "0.0.2",
-                  "from": "github-url-from-username-repo@0.0.2"
+                  "version": "0.1.0",
+                  "from": "github-url-from-username-repo@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-0.1.0.tgz"
+                },
+                "semver": {
+                  "version": "2.3.0",
+                  "from": "semver@2",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.0.tgz"
                 }
               }
             },
@@ -424,6 +449,7 @@
     "awsboxen": {
       "version": "0.5.2",
       "from": "awsboxen@0.5.2",
+      "resolved": "https://registry.npmjs.org/awsboxen/-/awsboxen-0.5.2.tgz",
       "dependencies": {
         "awsbox": {
           "version": "0.6.2",
@@ -433,6 +459,7 @@
             "awssum-amazon-route53": {
               "version": "1.1.0",
               "from": "awssum-amazon-route53@1.x",
+              "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.1.0.tgz",
               "dependencies": {
                 "fmt": {
                   "version": "0.4.0",
@@ -446,11 +473,13 @@
                 },
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.x"
+                  "from": "underscore@1.4.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "dateformat": {
                   "version": "1.0.4-1.2.3",
-                  "from": "dateformat@1.0.4-1.2.3"
+                  "from": "dateformat@1.0.4-1.2.3",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
                 }
               }
             },
@@ -476,11 +505,13 @@
                     },
                     "underscore": {
                       "version": "1.4.4",
-                      "from": "underscore@1.4.x"
+                      "from": "underscore@1.4.x",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                     },
                     "dateformat": {
                       "version": "1.0.4-1.2.3",
-                      "from": "dateformat@1.0.4-1.2.3"
+                      "from": "dateformat@1.0.4-1.2.3",
+                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
                     }
                   }
                 }
@@ -499,10 +530,12 @@
             "xml2js": {
               "version": "0.1.13",
               "from": "xml2js@0.1.13",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.13.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.6.0",
-                  "from": "sax@>=0.1.1"
+                  "from": "sax@>=0.1.1",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
                 }
               }
             },
@@ -513,7 +546,8 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.1 <0.1.0"
+                  "from": "wordwrap@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
@@ -529,7 +563,8 @@
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@~0.6.0-1"
+              "from": "colors@~0.6.0-1",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "awssum": {
               "version": "1.1.0",
@@ -538,15 +573,18 @@
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.x"
+                  "from": "underscore@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "xml2js": {
                   "version": "0.2.8",
                   "from": "xml2js@0.2.x",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "0.5.8",
-                      "from": "sax@0.5.x"
+                      "from": "sax@0.5.x",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
                     }
                   }
                 }
@@ -559,55 +597,64 @@
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.x"
+                  "from": "underscore@1.4.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "dateformat": {
                   "version": "1.0.4-1.2.3",
-                  "from": "dateformat@1.0.4-1.2.3"
+                  "from": "dateformat@1.0.4-1.2.3",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
                 }
               }
             },
             "read-package-json": {
-              "version": "1.1.8",
+              "version": "1.1.9",
               "from": "read-package-json@~1.1.3",
-              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.9.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "3.2.9",
+                  "version": "3.2.11",
                   "from": "glob@~3.2.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0"
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2"
                     }
                   }
                 },
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "normalize-package-data": {
-                  "version": "0.2.12",
-                  "from": "normalize-package-data@~0.2.9",
+                  "version": "0.2.13",
+                  "from": "normalize-package-data@^0.2.13",
+                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-0.2.13.tgz",
                   "dependencies": {
                     "github-url-from-git": {
                       "version": "1.1.1",
-                      "from": "github-url-from-git@~1.1.1"
+                      "from": "github-url-from-git@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.1.1.tgz"
                     },
                     "github-url-from-username-repo": {
-                      "version": "0.0.2",
-                      "from": "github-url-from-username-repo@0.0.2"
+                      "version": "0.1.0",
+                      "from": "github-url-from-username-repo@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-0.1.0.tgz"
                     }
                   }
                 },
@@ -622,7 +669,7 @@
         },
         "awssum-amazon-cloudformation": {
           "version": "1.2.1",
-          "from": "awssum-amazon-cloudformation@1.2.1",
+          "from": "awssum-amazon-cloudformation@1.2.x",
           "resolved": "https://registry.npmjs.org/awssum-amazon-cloudformation/-/awssum-amazon-cloudformation-1.2.1.tgz",
           "dependencies": {
             "data2xml": {
@@ -632,19 +679,26 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "awssum-amazon-ec2": {
           "version": "1.3.2",
-          "from": "awssum-amazon-ec2@1.3.2",
+          "from": "awssum-amazon-ec2@1.3.x",
           "resolved": "https://registry.npmjs.org/awssum-amazon-ec2/-/awssum-amazon-ec2-1.3.2.tgz",
           "dependencies": {
+            "awssum-amazon": {
+              "version": "1.3.0",
+              "from": "awssum-amazon@1.x.x",
+              "resolved": "https://registry.npmjs.org/awssum-amazon/-/awssum-amazon-1.3.0.tgz"
+            },
             "data2xml": {
               "version": "0.8.1",
               "from": "data2xml@0.8.x",
@@ -652,17 +706,38 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@~1.4",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            },
+            "awssum": {
+              "version": "1.2.0",
+              "from": "awssum@~1",
+              "resolved": "https://registry.npmjs.org/awssum/-/awssum-1.2.0.tgz",
+              "dependencies": {
+                "xml2js": {
+                  "version": "0.2.8",
+                  "from": "xml2js@0.2.x",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "0.5.8",
+                      "from": "sax@0.5.x",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                    }
+                  }
+                }
+              }
             }
           }
         },
         "awssum-amazon-elb": {
           "version": "1.0.0",
-          "from": "awssum-amazon-elb@1.0.0",
+          "from": "awssum-amazon-elb@1.0.x",
           "resolved": "https://registry.npmjs.org/awssum-amazon-elb/-/awssum-amazon-elb-1.0.0.tgz",
           "dependencies": {
             "data2xml": {
@@ -672,59 +747,69 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.x"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "docopt": {
           "version": "0.4.0",
-          "from": "docopt@0.4.0"
+          "from": "docopt@0.4.x",
+          "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.4.0.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@2.0.x",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.15",
               "from": "argparse@~ 0.1.11",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@~1.4.3"
+                  "from": "underscore@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.1"
+                  "from": "underscore.string@~2.3.1",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2"
+              "from": "esprima@~ 1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@0.2.10"
+          "from": "async@~0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "temp": {
           "version": "0.5.1",
-          "from": "temp@0.5.1",
+          "from": "temp@0.5.x",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
               "from": "rimraf@~2.1.4",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1"
+                  "from": "graceful-fs@~1",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
             }
@@ -732,41 +817,50 @@
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@2.2.1"
+          "from": "semver@2.2.x",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
         },
         "traverse": {
           "version": "0.6.6",
-          "from": "traverse@0.6.6"
+          "from": "traverse@0.6.x",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
         },
         "awssum-amazon": {
           "version": "1.3.0",
-          "from": "awssum-amazon@1.3.0",
+          "from": "awssum-amazon@1.x.x",
+          "resolved": "https://registry.npmjs.org/awssum-amazon/-/awssum-amazon-1.3.0.tgz",
           "dependencies": {
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.4"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "dateformat": {
               "version": "1.0.4-1.2.3",
-              "from": "dateformat@1.0.4-1.2.3"
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
             }
           }
         },
         "awssum": {
           "version": "1.2.0",
-          "from": "awssum@1.2.0",
+          "from": "awssum@~1",
+          "resolved": "https://registry.npmjs.org/awssum/-/awssum-1.2.0.tgz",
           "dependencies": {
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.4"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "xml2js": {
               "version": "0.2.8",
-              "from": "xml2js@0.2.8",
+              "from": "xml2js@0.2.x",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.5.8",
-                  "from": "sax@0.5.8"
+                  "from": "sax@0.5.x",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
                 }
               }
             }
@@ -777,6 +871,7 @@
     "binary-split": {
       "version": "0.1.2",
       "from": "binary-split@0.1.2",
+      "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
       "dependencies": {
         "bops": {
           "version": "0.0.6",
@@ -800,14 +895,17 @@
     "bunyan": {
       "version": "0.22.1",
       "from": "bunyan@0.22.1",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
       "dependencies": {
         "mv": {
           "version": "0.0.5",
-          "from": "mv@0.0.5"
+          "from": "mv@0.0.5",
+          "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@0.2.8"
+          "from": "dtrace-provider@0.2.8",
+          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
     },
@@ -819,10 +917,12 @@
         "vows": {
           "version": "0.6.0",
           "from": "vows@0.6.0",
+          "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.0.tgz",
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.6"
+              "from": "eyes@>=0.1.6",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             }
           }
         }
@@ -831,33 +931,39 @@
     "convict": {
       "version": "0.4.2",
       "from": "convict@0.4.2",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
           "from": "cjson@0.3.0",
+          "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
               "from": "jsonlint@1.6.0",
+              "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
-                  "version": "1.6.2",
-                  "from": "nomnom@1.6.2",
+                  "version": "1.7.0",
+                  "from": "nomnom@>= 1.5.x",
+                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.7.0.tgz",
                   "dependencies": {
                     "colors": {
                       "version": "0.5.1",
-                      "from": "colors@0.5.1",
+                      "from": "colors@0.5.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     },
                     "underscore": {
                       "version": "1.4.4",
-                      "from": "underscore@1.4.4"
+                      "from": "underscore@~1.4.4",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                     }
                   }
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@4.0.2"
+                  "from": "JSV@>= 4.0.x",
+                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
             }
@@ -865,7 +971,8 @@
         },
         "validator": {
           "version": "1.5.1",
-          "from": "validator@1.5.1"
+          "from": "validator@1.5.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
         },
         "moment": {
           "version": "2.3.1",
@@ -875,14 +982,17 @@
         "optimist": {
           "version": "0.6.0",
           "from": "optimist@0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@~0.0.1"
+              "version": "0.0.10",
+              "from": "minimist@~0.0.1",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         }
@@ -896,50 +1006,61 @@
         "rc": {
           "version": "0.3.4",
           "from": "rc@0.3.4",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-0.3.4.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.7"
+              "from": "minimist@~0.0.7",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "deep-extend": {
-              "version": "0.2.8",
-              "from": "deep-extend@~0.2.5"
+              "version": "0.2.10",
+              "from": "deep-extend@~0.2.5",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.10.tgz"
             },
             "ini": {
               "version": "1.1.0",
-              "from": "ini@~1.1.0"
+              "from": "ini@~1.1.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
             }
           }
         },
         "bluebird": {
           "version": "1.2.2",
-          "from": "bluebird@1.2.2"
+          "from": "bluebird@1.2.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.2.tgz"
         },
         "bunyan": {
           "version": "0.22.3",
           "from": "bunyan@0.22.3",
+          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.3.tgz",
           "dependencies": {
             "mv": {
               "version": "2.0.0",
               "from": "mv@~2",
+              "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.0.tgz",
               "dependencies": {
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "ncp@~0.4.2"
+                  "from": "ncp@~0.4.2",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@~2.2.6"
+                  "from": "rimraf@~2.2.6",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.5"
+                  "from": "mkdirp@~0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@0.2.8"
+              "from": "dtrace-provider@0.2.8",
+              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
         },
@@ -950,137 +1071,168 @@
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@0.1.5"
+              "from": "assert-plus@0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.3.0",
-              "from": "backoff@2.3.0"
+              "from": "backoff@2.3.0",
+              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz"
             },
             "bunyan": {
               "version": "0.22.1",
               "from": "bunyan@0.22.1",
+              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "0.0.5",
-                  "from": "mv@0.0.5"
+                  "from": "mv@0.0.5",
+                  "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
                 }
               }
             },
             "csv": {
               "version": "0.3.7",
-              "from": "csv@0.3.7"
+              "from": "csv@0.3.7",
+              "resolved": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "deep-equal@0.0.0"
+              "from": "deep-equal@0.0.0",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "escape-regexp-component@1.0.2"
+              "from": "escape-regexp-component@1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.14",
-              "from": "formidable@1.0.14"
+              "from": "formidable@1.0.14",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
             },
             "http-signature": {
               "version": "0.10.0",
               "from": "http-signature@0.10.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.2",
-                  "from": "assert-plus@0.1.2"
+                  "from": "assert-plus@0.1.2",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11"
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.2",
-                  "from": "ctype@0.5.2"
+                  "from": "ctype@0.5.2",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "keep-alive-agent@0.0.1"
+              "from": "keep-alive-agent@0.0.1",
+              "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.3.1",
-              "from": "lru-cache@2.3.1"
+              "from": "lru-cache@2.3.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11"
+              "from": "mime@1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "negotiator": {
               "version": "0.3.0",
-              "from": "negotiator@0.3.0"
+              "from": "negotiator@0.3.0",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
             },
             "node-uuid": {
               "version": "1.4.1",
-              "from": "node-uuid@1.4.1"
+              "from": "node-uuid@1.4.1",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
             },
             "once": {
               "version": "1.3.0",
-              "from": "once@1.3.0"
+              "from": "once@1.3.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
             },
             "qs": {
               "version": "0.6.6",
-              "from": "qs@0.6.6"
+              "from": "qs@0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "semver": {
               "version": "2.2.1",
-              "from": "semver@2.2.1"
+              "from": "semver@2.2.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
             },
             "spdy": {
               "version": "1.19.3",
-              "from": "spdy@1.19.3"
+              "from": "spdy@1.19.3",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@0.4.0"
+              "from": "tunnel-agent@0.4.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.3.7",
               "from": "verror@1.3.7",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2"
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@0.2.8"
+              "from": "dtrace-provider@0.2.8",
+              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
         },
         "memcached": {
           "version": "0.2.8",
           "from": "memcached@0.2.8",
+          "resolved": "https://registry.npmjs.org/memcached/-/memcached-0.2.8.tgz",
           "dependencies": {
             "hashring": {
               "version": "0.0.8",
               "from": "hashring@0.0.x",
+              "resolved": "https://registry.npmjs.org/hashring/-/hashring-0.0.8.tgz",
               "dependencies": {
                 "bisection": {
                   "version": "0.0.3",
-                  "from": "bisection@"
+                  "from": "bisection@",
+                  "resolved": "https://registry.npmjs.org/bisection/-/bisection-0.0.3.tgz"
                 },
                 "simple-lru-cache": {
                   "version": "0.0.1",
-                  "from": "simple-lru-cache@0.0.x"
+                  "from": "simple-lru-cache@0.0.x",
+                  "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.1.tgz"
                 }
               }
             },
             "jackpot": {
               "version": "0.0.6",
               "from": "jackpot@>=0.0.6",
+              "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
               "dependencies": {
                 "retry": {
                   "version": "0.6.0",
-                  "from": "retry@0.6.0"
+                  "from": "retry@0.6.0",
+                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
                 }
               }
             }
@@ -1090,156 +1242,193 @@
     },
     "grunt": {
       "version": "0.4.4",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.4.tgz",
+      "from": "grunt@0.4.4",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.4.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@0.1.22",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@1.3.3"
+          "from": "coffee-script@~1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@0.6.2"
+          "from": "colors@~0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.13",
-          "from": "eventemitter2@0.4.13"
+          "from": "eventemitter2@~0.4.13",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.13.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.9",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "version": "3.2.11",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1"
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
                 }
               }
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@3.1.21",
+          "from": "glob@~3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@1.2.3"
+              "from": "graceful-fs@~1.2.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1.0.0"
+              "from": "inherits@1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@0.2.3"
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@0.2.11"
+          "from": "iconv-lite@~0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@0.2.14",
+          "from": "minimatch@~0.2.12",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2.5.0"
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@1.0.0"
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@1.0.10",
+          "from": "nopt@~1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.4",
-              "from": "abbrev@1.0.4"
+              "version": "1.0.5",
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
-          "version": "2.2.6",
-          "from": "rimraf@2.2.6",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+          "version": "2.2.8",
+          "from": "rimraf@~2.2.6",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@0.9.2",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@2.2.1",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.5",
-          "from": "which@1.0.5"
+          "from": "which@~1.0.5",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@2.0.x",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.15",
-              "from": "argparse@0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.4"
+                  "from": "underscore@1.4.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@2.3.3"
+                  "from": "underscore.string@~2.3.1",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@1.0.4"
+              "from": "esprima@~ 1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.2"
+          "from": "exit@~0.1.1",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@0.1.0",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.1.2",
-          "from": "grunt-legacy-util@0.1.2",
+          "from": "grunt-legacy-util@~0.1.2",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.1.2.tgz"
         }
       }
@@ -1252,144 +1441,163 @@
         "nopt": {
           "version": "1.0.10",
           "from": "nopt@~1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.4",
-              "from": "abbrev@1"
+              "version": "1.0.5",
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.9",
-              "from": "glob@~3.2.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "version": "3.2.11",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2"
                 }
               }
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@~0.3.1"
+          "from": "resolve@~0.3.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.9.2",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.9.2.tgz",
+      "from": "grunt-contrib-jshint@0.9.2",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.9.2.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.4.4",
-          "from": "jshint@2.4.4",
+          "from": "jshint@~2.4.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.4.4.tgz",
           "dependencies": {
             "shelljs": {
               "version": "0.1.4",
-              "from": "shelljs@0.1.4",
+              "from": "shelljs@0.1.x",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@1.4.4"
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "cli": {
               "version": "0.4.5",
-              "from": "cli@0.4.5",
+              "from": "cli@0.4.x",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "3.2.9",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+                  "version": "4.0.0",
+                  "from": "glob@>= 3.1.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2.0.1"
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@0.2.14",
+              "version": "0.3.0",
+              "from": "minimatch@0.x.x",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2.5.0"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "htmlparser2": {
               "version": "3.3.0",
-              "from": "htmlparser2@3.3.0",
+              "from": "htmlparser2@3.3.x",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.1.0",
-                  "from": "domhandler@2.1.0"
+                  "from": "domhandler@2.1",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "domutils@1.1.6",
+                  "from": "domutils@1.1",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.1",
-                  "from": "domelementtype@1.1.1"
+                  "from": "domelementtype@1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.0.26-4",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26-4.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.26-4.tgz",
+                  "version": "1.0.27-1",
+                  "from": "readable-stream@1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@1.0.1"
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1"
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@0.10.25-1"
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2.0.1"
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -1397,24 +1605,27 @@
             },
             "console-browserify": {
               "version": "0.1.6",
-              "from": "console-browserify@0.1.6",
+              "from": "console-browserify@0.1.x",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@0.1.2"
+              "from": "exit@0.1.x",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@0.2.3"
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "grunt-copyright@0.1.0"
+      "from": "grunt-copyright@0.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
@@ -1424,22 +1635,27 @@
         "cli-color": {
           "version": "0.2.3",
           "from": "cli-color@^0.2.3",
+          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2"
+              "from": "es5-ext@~0.9.2",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
               "from": "memoizee@~0.2.5",
+              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2"
+                  "from": "event-emitter@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x"
+                  "from": "next-tick@0.1.x",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
             }
@@ -1447,156 +1663,13 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2"
-        },
-        "grunt": {
-          "version": "0.4.4",
-          "from": "grunt@^0.4.4",
-          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.4.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.22",
-              "from": "async@~0.1.22"
-            },
-            "coffee-script": {
-              "version": "1.3.3",
-              "from": "coffee-script@~1.3.3"
-            },
-            "dateformat": {
-              "version": "1.0.2-1.2.3",
-              "from": "dateformat@1.0.2-1.2.3",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
-            },
-            "eventemitter2": {
-              "version": "0.4.13",
-              "from": "eventemitter2@~0.4.13"
-            },
-            "findup-sync": {
-              "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.9",
-                  "from": "glob@~3.2.9",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2"
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "lodash@~2.4.1"
-                }
-              }
-            },
-            "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.21",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1"
-                }
-              }
-            },
-            "hooker": {
-              "version": "0.2.3",
-              "from": "hooker@~0.2.3"
-            },
-            "iconv-lite": {
-              "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11"
-            },
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@~0.2.11",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
-                }
-              }
-            },
-            "nopt": {
-              "version": "1.0.10",
-              "from": "nopt@~1.0.10",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.4",
-                  "from": "abbrev@1"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.6",
-              "from": "rimraf@~2.2.6"
-            },
-            "lodash": {
-              "version": "0.9.2",
-              "from": "lodash@~0.9.2"
-            },
-            "underscore.string": {
-              "version": "2.2.1",
-              "from": "underscore.string@~2.2.1"
-            },
-            "which": {
-              "version": "1.0.5",
-              "from": "which@~1.0.5"
-            },
-            "js-yaml": {
-              "version": "2.0.5",
-              "from": "js-yaml@~2.0.5",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "0.1.15",
-                  "from": "argparse@~ 0.1.11",
-                  "dependencies": {
-                    "underscore": {
-                      "version": "1.4.4",
-                      "from": "underscore@~1.4.3"
-                    },
-                    "underscore.string": {
-                      "version": "2.3.3",
-                      "from": "underscore.string@~2.3.1"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@~0.1.1"
-            },
-            "getobject": {
-              "version": "0.1.0",
-              "from": "getobject@~0.1.0"
-            },
-            "grunt-legacy-util": {
-              "version": "0.1.2",
-              "from": "grunt-legacy-util@~0.1.2"
-            }
-          }
+          "from": "colors@^0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0"
+          "from": "text-table@^0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
@@ -1608,28 +1681,34 @@
         "optimist": {
           "version": "0.3.7",
           "from": "optimist@~0.3",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
           "from": "uglify-js@~2.3",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6"
+              "from": "async@~0.2.6",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.33",
               "from": "source-map@~0.1.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4"
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             }
@@ -1644,22 +1723,25 @@
       "dependencies": {
         "hoek": {
           "version": "1.5.2",
-          "from": "hoek@^1.5.x"
+          "from": "hoek@^1.5.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-1.5.2.tgz"
         },
         "boom": {
           "version": "2.4.1",
           "from": "boom@^2.2.x",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.4.1.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.1.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
         "joi": {
           "version": "2.9.0",
-          "from": "joi@^2.8.x"
+          "from": "joi@^2.8.x",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-2.9.0.tgz"
         },
         "catbox": {
           "version": "2.2.1",
@@ -1667,15 +1749,23 @@
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-2.2.1.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.1.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
         "catbox-memory": {
-          "version": "1.0.1",
-          "from": "catbox-memory@1.x.x"
+          "version": "1.0.2",
+          "from": "catbox-memory@1.x.x",
+          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.0.2.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "2.3.0",
+              "from": "hoek@2.x.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
+            }
+          }
         },
         "shot": {
           "version": "1.3.3",
@@ -1683,48 +1773,53 @@
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.3.tgz"
         },
         "nipple": {
-          "version": "2.5.1",
+          "version": "2.5.2",
           "from": "nipple@^2.4.x",
-          "resolved": "https://registry.npmjs.org/nipple/-/nipple-2.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/nipple/-/nipple-2.5.2.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.1.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
         "cryptiles": {
           "version": "2.0.1",
-          "from": "cryptiles@2.x.x"
+          "from": "cryptiles@2.x.x",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.1.tgz"
         },
         "iron": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "from": "iron@2.x.x",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.0.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.1.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@0.2.x"
+          "from": "async@0.2.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "multiparty": {
-          "version": "3.2.4",
+          "version": "3.2.8",
           "from": "multiparty@3.2.x",
+          "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.2.8.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13-1",
               "from": "readable-stream@~1.1.9",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0"
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
@@ -1733,74 +1828,88 @@
                 },
                 "string_decoder": {
                   "version": "0.10.25-1",
-                  "from": "string_decoder@~0.10.x"
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1"
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "stream-counter": {
               "version": "0.2.0",
-              "from": "stream-counter@~0.2.0"
+              "from": "stream-counter@~0.2.0",
+              "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@1.2.x"
+          "from": "mime@1.2.x",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@2.5.x"
+          "from": "lru-cache@2.5.x",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "optimist": {
           "version": "0.6.1",
           "from": "optimist@0.6.x",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@~0.0.1"
+              "version": "0.0.10",
+              "from": "minimist@~0.0.1",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "negotiator": {
-          "version": "0.4.3",
-          "from": "negotiator@0.4.x"
+          "version": "0.4.5",
+          "from": "negotiator@0.4.x",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.5.tgz"
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@2.2.x"
+          "from": "semver@2.2.x",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
         },
         "qs": {
           "version": "0.6.6",
-          "from": "qs@0.6.x"
+          "from": "qs@0.6.x",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         }
       }
     },
     "hapi-auth-hawk": {
       "version": "1.0.1",
-      "from": "hapi-auth-hawk@git://github.com/dannycoates/hapi-auth-hawk.git#f9d44ce2",
-      "resolved": "git://github.com/dannycoates/hapi-auth-hawk.git#f9d44ce20362b19c089b36e96af7acdbdeae2f65",
+      "from": "hapi-auth-hawk@git://github.com/dannycoates/hapi-auth-hawk.git#146758e444",
+      "resolved": "git://github.com/dannycoates/hapi-auth-hawk.git#146758e444f6ada71591ad31ab09192596b0ede1",
       "dependencies": {
         "boom": {
           "version": "2.4.1",
           "from": "boom@2.x.x",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.4.1.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.1.0",
-              "from": "hoek@2.x.x"
+              "version": "2.3.0",
+              "from": "hoek@2.x.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
         "hoek": {
           "version": "1.5.2",
-          "from": "hoek@1.x.x"
+          "from": "hoek@1.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-1.5.2.tgz"
         }
       }
     },
@@ -1820,9 +1929,9 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.4.1.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.0.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         },
@@ -1832,14 +1941,14 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.1.tgz"
         },
         "sntp": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "from": "sntp@1.x.x",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.6.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.0.0",
+              "version": "2.3.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
             }
           }
         }
@@ -1847,7 +1956,8 @@
     },
     "hkdf": {
       "version": "0.0.2",
-      "from": "hkdf@0.0.2"
+      "from": "hkdf@0.0.2",
+      "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "jwcrypto": {
       "version": "0.4.4",
@@ -1862,28 +1972,34 @@
             "detective": {
               "version": "0.1.1",
               "from": "detective@~0.1.1",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.6",
-                  "from": "uglify-js@~1.2.5"
+                  "from": "uglify-js@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz"
                 }
               }
             },
             "deputy": {
               "version": "0.0.4",
               "from": "deputy@~0.0.0",
+              "resolved": "https://registry.npmjs.org/deputy/-/deputy-0.0.4.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.3"
+                  "from": "mkdirp@~0.3.3",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "detective": {
                   "version": "0.2.1",
                   "from": "detective@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/detective/-/detective-0.2.1.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "0.9.9",
-                      "from": "esprima@~0.9.9"
+                      "from": "esprima@~0.9.9",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-0.9.9.tgz"
                     }
                   }
                 }
@@ -1891,49 +2007,59 @@
             },
             "resolve": {
               "version": "0.2.8",
-              "from": "resolve@~0.2.0"
+              "from": "resolve@~0.2.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.8.tgz"
             },
             "nub": {
               "version": "0.0.0",
-              "from": "nub@~0.0.0"
+              "from": "nub@~0.0.0",
+              "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "commondir@~0.0.1"
+              "from": "commondir@~0.0.1",
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "coffee-script": {
               "version": "1.7.1",
               "from": "coffee-script@1.x.x",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.5"
+                  "from": "mkdirp@~0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
               "from": "optimist@~0.3.4",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2"
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "vm-browserify": {
               "version": "0.0.4",
               "from": "vm-browserify@~0.0.0",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1"
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "crypto-browserify": {
               "version": "0.4.0",
-              "from": "crypto-browserify@~0"
+              "from": "crypto-browserify@~0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.4.0.tgz"
             }
           }
         },
@@ -1949,7 +2075,8 @@
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.6"
+              "from": "eyes@>=0.1.6",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             }
           }
         },
@@ -1960,13 +2087,15 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.1 <0.1"
+              "from": "wordwrap@>=0.0.1 <0.1",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "1.0.6",
-          "from": "uglify-js@1.0.6"
+          "from": "uglify-js@1.0.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.0.6.tgz"
         },
         "bigint": {
           "version": "0.4.2",
@@ -1982,67 +2111,74 @@
     },
     "load-grunt-tasks": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.4.0.tgz",
+      "from": "load-grunt-tasks@0.4.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.4.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@^0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.9",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "version": "3.2.11",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@0.2.14",
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2.5.0"
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@1.0.0"
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2.0.1"
                 }
               }
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.1.0",
-          "from": "multimatch@0.1.0",
+          "from": "multimatch@^0.1.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.1.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@0.2.14",
+              "from": "minimatch@~0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2.5.0"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -2056,28 +2192,33 @@
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.4.1.tgz",
       "dependencies": {
         "mimelib": {
-          "version": "0.2.14",
+          "version": "0.2.16",
           "from": "mimelib@>=0.2.6",
+          "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.16.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.2.1",
-              "from": "addressparser@~0.2.0"
+              "from": "addressparser@~0.2.1",
+              "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
             }
           }
         },
         "encoding": {
           "version": "0.1.7",
           "from": "encoding@>=0.1.4",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11"
+              "from": "iconv-lite@~0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@*"
+          "from": "mime@*",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         }
       }
     },
@@ -2088,19 +2229,23 @@
       "dependencies": {
         "require-all": {
           "version": "0.0.3",
-          "from": "require-all@0.0.3"
+          "from": "require-all@0.0.3",
+          "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.3.tgz"
         },
         "bignumber.js": {
           "version": "1.0.1",
-          "from": "bignumber.js@1.0.1"
+          "from": "bignumber.js@1.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13-1",
           "from": "readable-stream@~1.1.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0"
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
@@ -2109,11 +2254,13 @@
             },
             "string_decoder": {
               "version": "0.10.25-1",
-              "from": "string_decoder@~0.10.x"
+              "from": "string_decoder@~0.10.x",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1"
+              "from": "inherits@~2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -2122,39 +2269,46 @@
     "nodemailer": {
       "version": "0.6.1",
       "from": "nodemailer@0.6.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.6.1.tgz",
       "dependencies": {
         "mailcomposer": {
-          "version": "0.2.9",
+          "version": "0.2.11",
           "from": "mailcomposer@~0.2.7",
-          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.11.tgz",
           "dependencies": {
             "mimelib": {
-              "version": "0.2.14",
-              "from": "mimelib@~0.2.14",
+              "version": "0.2.16",
+              "from": "mimelib@~0.2.15",
+              "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.16.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
-                  "from": "encoding@~0.1",
+                  "from": "encoding@~0.1.7",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.2.11",
-                      "from": "iconv-lite@~0.2.11"
+                      "from": "iconv-lite@~0.2.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
                     }
                   }
                 },
                 "addressparser": {
                   "version": "0.2.1",
-                  "from": "addressparser@~0.2.0"
+                  "from": "addressparser@~0.2.1",
+                  "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11"
+              "from": "mime@~1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@~1.2.3"
+              "from": "punycode@~1.2.4",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "follow-redirects": {
               "version": "0.0.3",
@@ -2163,62 +2317,74 @@
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@"
+                  "from": "underscore@",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
             },
             "dkim-signer": {
-              "version": "0.1.0",
-              "from": "dkim-signer@~0.1.0"
+              "version": "0.1.2",
+              "from": "dkim-signer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz"
             }
           }
         },
         "simplesmtp": {
-          "version": "0.3.24",
+          "version": "0.3.32",
           "from": "simplesmtp@~0.2 || ~0.3",
-          "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.24.tgz",
+          "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.32.tgz",
           "dependencies": {
             "rai": {
-              "version": "0.1.9",
-              "from": "rai@~0.1"
+              "version": "0.1.11",
+              "from": "rai@~0.1.11",
+              "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.11.tgz"
             },
             "xoauth2": {
               "version": "0.1.8",
-              "from": "xoauth2@~0.1"
+              "from": "xoauth2@~0.1.8",
+              "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
             }
           }
         },
         "directmail": {
-          "version": "0.1.6",
-          "from": "directmail@~0.1.6"
+          "version": "0.1.8",
+          "from": "directmail@~0.1.6",
+          "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
         },
         "he": {
           "version": "0.3.6",
-          "from": "he@~0.3.6"
+          "from": "he@~0.3.6",
+          "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
         },
         "public-address": {
-          "version": "0.1.0",
-          "from": "public-address@~0.1.0"
+          "version": "0.1.1",
+          "from": "public-address@~0.1.0",
+          "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
         },
         "readable-stream": {
-          "version": "1.1.12",
+          "version": "1.1.13-1",
           "from": "readable-stream@~1.1.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0"
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1"
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.25-1",
-              "from": "string_decoder@~0.10.x"
+              "from": "string_decoder@~0.10.x",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@^2.0.1"
+              "from": "inherits@~2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -2226,122 +2392,145 @@
     },
     "p-promise": {
       "version": "0.2.5",
-      "from": "p-promise@0.2.5"
+      "from": "p-promise@0.2.5",
+      "resolved": "https://registry.npmjs.org/p-promise/-/p-promise-0.2.5.tgz"
     },
     "request": {
       "version": "2.34.0",
       "from": "request@2.34.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "qs@0.6.6"
+          "from": "qs@~0.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@5.0.0"
+          "from": "json-stringify-safe@~5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@0.5.2"
+          "from": "forever-agent@~0.5.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@1.4.1"
+          "from": "node-uuid@~1.4.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@1.2.11"
+          "from": "mime@~1.2.9",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@0.12.1",
+          "from": "tough-cookie@>=0.12.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@1.2.4"
+              "from": "punycode@>=0.2.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.2",
-          "from": "form-data@0.1.2",
+          "from": "form-data@~0.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
-              "from": "combined-stream@0.0.4",
+              "from": "combined-stream@~0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5"
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@0.2.10"
+              "from": "async@~0.2.9",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@0.3.0",
+          "from": "tunnel-agent@~0.3.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@0.10.0",
+          "from": "http-signature@~0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2"
+              "from": "assert-plus@0.1.2",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11"
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2"
+              "from": "ctype@0.5.2",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@0.3.0",
+          "from": "oauth-sign@~0.3.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.0.0",
-          "from": "hawk@1.0.0",
+          "from": "hawk@~1.0.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.x",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.x",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.x",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@0.5.0"
+          "from": "aws-sign2@~0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         }
       }
     },
     "scrypt-hash": {
       "version": "1.1.8",
       "from": "scrypt-hash@1.1.8",
+      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.1.1",
@@ -2350,17 +2539,20 @@
         },
         "nan": {
           "version": "0.7.0",
-          "from": "nan@0.7.0"
+          "from": "nan@0.7.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
         }
       }
     },
     "sjcl": {
       "version": "1.0.0",
-      "from": "sjcl@1.0.0"
+      "from": "sjcl@1.0.0",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.0.tgz"
     },
     "tap": {
       "version": "0.4.8",
       "from": "tap@0.4.8",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.8.tgz",
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -2372,28 +2564,33 @@
         },
         "slide": {
           "version": "1.1.5",
-          "from": "slide@1.1.5"
+          "from": "slide@*",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.5.tgz"
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "runforcover@0.0.2",
+          "from": "runforcover@~0.0.2",
+          "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "bunker@0.1.2",
+              "from": "bunker@0.1.X",
+              "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "burrito@0.2.12",
+                  "from": "burrito@>=0.2.5 <0.3",
+                  "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@0.5.2",
+                      "from": "traverse@~0.5.1",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@1.1.1"
+                      "from": "uglify-js@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
                 }
@@ -2402,62 +2599,78 @@
           }
         },
         "nopt": {
-          "version": "2.2.0",
-          "from": "nopt@2.2.0",
+          "version": "2.2.1",
+          "from": "nopt@~2",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.4",
-              "from": "abbrev@1.0.4"
+              "version": "1.0.5",
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@0.3.5"
+          "from": "mkdirp@~0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "difflet@0.2.6",
+          "from": "difflet@~0.2.0",
+          "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@0.6.6"
+              "from": "traverse@0.6.x",
+              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@0.1.2",
+              "from": "charm@0.1.x",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.2",
-              "from": "deep-is@0.1.2"
+              "from": "deep-is@0.1.x",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@0.0.0"
+          "from": "deep-equal@~0.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "buffer-equal": {
-          "version": "0.0.0",
-          "from": "buffer-equal@0.0.0"
+          "version": "0.0.1",
+          "from": "buffer-equal@~0.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "glob": {
-          "version": "3.2.9",
+          "version": "3.2.11",
           "from": "glob@~3.2.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
             "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@~0.2.11",
+              "version": "0.3.0",
+              "from": "minimatch@0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -2467,11 +2680,13 @@
     },
     "through": {
       "version": "2.3.4",
-      "from": "through@2.3.4"
+      "from": "through@2.3.4",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
     },
     "toobusy": {
       "version": "0.2.4",
       "from": "toobusy@0.2.4",
+      "resolved": "https://registry.npmjs.org/toobusy/-/toobusy-0.2.4.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.1.0",
@@ -2482,7 +2697,8 @@
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "uuid@1.4.1"
+      "from": "uuid@1.4.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "convict": "0.4.2",
     "handlebars": "1.3.0",
     "hapi": "3.0.2",
-    "hapi-auth-hawk": "git://github.com/dannycoates/hapi-auth-hawk.git#f9d44ce2",
+    "hapi-auth-hawk": "git://github.com/dannycoates/hapi-auth-hawk.git#146758e444",
     "hkdf": "0.0.2",
     "jwcrypto": "0.4.4",
     "mysql": "2.1.1",


### PR DESCRIPTION
This prevents hapi-auth-hawk from crashing the process when bug #700 bites until we pin it down and kill it.
