### PR TITLE
Upgrade customs server

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -682,9 +682,9 @@
       }
     },
     "fxa-customs-server": {
-      "version": "0.0.0",
-      "from": "fxa-customs-server@git://github.com/mozilla/fxa-customs-server.git#74d7b8d6dc239335178cef287794af7a1c028114",
-      "resolved": "git://github.com/mozilla/fxa-customs-server.git#74d7b8d6dc239335178cef287794af7a1c028114",
+      "version": "0.0.1",
+      "from": "fxa-customs-server@git://github.com/mozilla/fxa-customs-server.git#a6a3db4f607a72dde10490fc112685c60b89807a",
+      "resolved": "git://github.com/mozilla/fxa-customs-server.git#a6a3db4f607a72dde10490fc112685c60b89807a",
       "dependencies": {
         "bluebird": {
           "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "compute-cluster": "git://github.com/dannycoates/node-compute-cluster.git#0222a742",
     "convict": "0.4.2",
     "fxa-auth-mailer": "git://github.com/dannycoates/fxa-auth-mailer.git#4e3d910ae5",
-    "fxa-customs-server": "git://github.com/mozilla/fxa-customs-server.git#74d7b8d6",
+    "fxa-customs-server": "git://github.com/mozilla/fxa-customs-server.git#a6a3db4f607a",
     "hapi": "5.1.0",
     "hapi-auth-hawk": "git://github.com/dannycoates/hapi-auth-hawk.git#146758e444",
     "hkdf": "0.0.2",


### PR DESCRIPTION
I have no idea why my version of npm-shrinkwrap shat all over the existing `npm-shrinkwrap.json` but it seems like it needed to be re-generated...
