### PR TITLE
Match the HSTS settings on `accounts.firefox.com`

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -72,7 +72,8 @@ module.exports = function (path, url, Hapi) {
         },
         security: {
           hsts: {
-            maxAge: 10886400
+            maxAge: 15552000,
+            includeSubdomains: true
           }
         }
       }

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -140,7 +140,7 @@ TestServer.start(config)
           url: config.publicUrl + '/'
         },
         function (err, res, body) {
-          t.equal(res.headers['strict-transport-security'], 'max-age=10886400')
+          t.equal(res.headers['strict-transport-security'], 'max-age=15552000; includeSubdomains')
           t.end()
         }
       )


### PR DESCRIPTION
We need the `includeSubdomains` option because we've requested that
to be preloaded in browsers. In addition, the HSTS headers on
`api.accounts.firefox.com` should match the ones on the parent
domain.

This is a followup to #747.
