### PR TITLE
Turn ON customs server in dev

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -19,5 +19,5 @@
   "bounces": {
     "region": "us-east-1"
   },
-  "customsUrl": "none"
+  "customsUrl": "http://127.0.0.1:7000"
 }


### PR DESCRIPTION
A local version of the customs server (from `node_modules/`) is
automatically started by `scripts/start-local.sh` in dev. We may
as well turn it ON and use it.
