### PR TITLE
Update to README to avoid node errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Services ecosystem.
 
 ## Install
 
-You'll need node 0.10.x or higher and npm to run the server. On some systems running the server as root will cause working directory permissions issues with node during the install. It is recommended that you create a seperate user to ensure a clean and more secure installation.
+You'll need node 0.10.x or higher and npm to run the server. On some systems running the server as root will cause working directory permissions issues with node. It is recommended that you create a seperate, standard user to ensure a clean and more secure installation.
 
 Clone the git repository and install dependencies:
 


### PR DESCRIPTION
Included a warning in the instructions to not run as root to avoid potential Working Directory permissions errors with node that occur in RHEL based systems (including CentOS).
