### PR TITLE
removing npm spinner from travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ notifications:
 
 before_install:
   - sudo apt-get install libgmp3-dev
+  - npm config set spin false
 
 script:
-  - npm config set spin false
   - npm test
   - grunt validate-shrinkwrap


### PR DESCRIPTION
Hopefully should clean up this junk in the Travis logs:

```
> fxa-auth-server@0.18.0 test /home/travis/build/mozilla/fxa-auth-server
> NODE_ENV=dev scripts/test-local.sh && grunt
-p if this takes more than a second)
|e/travis/build/mozilla/fxa-auth-server/config/public-key.json
Secret Key saved: /home/travis/build/mozilla/fxa-auth-server/config/secret-key.json
\---//|||\/|-|\/|-ote/account_create_tests.js ................ 39/39
|ote/account_destroy_tests.js ................. 3/3
|ote/account_locale_tests.js .................. 5/5
-ote/account_login_tests.js ................... 9/9
\ote/account_status_tests.js .................. 7/7
-ote/certificate_sign_tests.js .............. 20/20
\ote/flow_tests.js .......................... 15/15
-ote/misc_tests.js .......................... 17/17
\ote/password_change_tests.js ................. 5/5
\ote/password_forgot_tests.js ............... 27/27
/ote/recovery_email_verify_tests.js ........... 8/8
-ote/session_destroy_tests.js ................. 5/5
total ............................................... 292/292
```

Not sure if `script:` is the best place to do `npm config set spin false` or if we prefer `before_install:` or some other approach. As long as the spinner dies, I'm happy.
