### PR TITLE
limit payload.maxBytes to 16384

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,9 @@ module.exports = function (path, url, Hapi) {
           maxAge: 15552000,
           includeSubdomains: true
         }
+      },
+      payload: {
+        maxBytes: 16384
       }
     }
 

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -155,7 +155,8 @@ TestServer.start(config)
         'POST',
         client.api.baseURL + '/get_random_bytes',
         null,
-        { big: Buffer(1024 * 512).toString('hex')}
+        // See payload.maxBytes in ../../server/server.js
+        { big: Buffer(8192).toString('hex')}
       )
       .then(
         function (body) {


### PR DESCRIPTION
16384 bytes is arbitary but seems about right. In stage traffic logs, the maximum size I saw (which for nginx includes headers) was less than 1200 bytes.
