### PR TITLE
make Hapi option payload.maxBytes configurable (as payloadMaxBytes)

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -205,6 +205,10 @@ module.exports = function (fs, path, url, convict) {
       doc: "path to SSL certificate in PEM format if serving over https",
       default: path.resolve(__dirname, '../cert.pem')
     },
+    payloadMaxBytes: {
+      doc: "Hapi option: limits the size of incoming payloads to the specified byte count",
+      default: 16384
+    }
   })
 
   // handle configuration files.  you can specify a CSV list of configuration

--- a/server/server.js
+++ b/server/server.js
@@ -77,7 +77,7 @@ module.exports = function (path, url, Hapi) {
         }
       },
       payload: {
-        maxBytes: 16384
+        maxBytes: config.payloadMaxBytes
       }
     }
 


### PR DESCRIPTION
Yeah, I figured later it would be useful to make this easy to change in the field.
