### PR TITLE
Add a bound on the number of in-flight scrypt hashes.

### DIFF
--- a/test/local/scrypt_tests.js
+++ b/test/local/scrypt_tests.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var test = require('../ptaptest')
+var promise = require('../../promise')
 var scrypt = require('../../crypto/scrypt')
 
 test(
@@ -17,5 +18,31 @@ test(
           t.equal(K2, '5b82f146a64126923e4167a0350bb181feba61f63cb1714012b19cb0be0119c5')
         }
       )
+  }
+)
+
+test(
+  'scrypt enforces maximum number of pending requests',
+  function (t) {
+    var K1 = Buffer('f84913e3d8e6d624689d0a3e9678ac8dcc79d2c2f3d9641488cd9d6ef6cd83dd', 'hex')
+    var salt = Buffer('identity.mozilla.com/picl/v1/scrypt')
+    // Set a lower MAX_PENDING so the test runs quicker.
+    var orig_max_pending = scrypt.MAX_PENDING;
+    scrypt.MAX_PENDING = 5;
+    // Send many concurent requests.
+    // Not yielding the event loop ensures they will pile up quickly.
+    var promises = [];
+    for (var i = 0; i < 10; i++) {
+      promises.push(scrypt.hash(K1, salt, 65536, 8, 1, 32))
+    }
+    scrypt.MAX_PENDING = orig_max_pending;
+    return promise.all(promises).then(
+      function () {
+        t.fail('too many pending scrypt hashes were allowed')
+      },
+      function (err) {
+        t.equal(err.message, 'too many pending scrypt hashes')
+      }
+    );
   }
 )


### PR DESCRIPTION
This adds a simple upper-bound on the number of scrypt hashes in-flight at any one time.  I plucked 100 out of the air as a sensible bound; current traffic puts us at < 4 scrypt-using requests per second and around 0.3 seconds per request, so I don't think we'll need a huge backlog.  Even 1000 might be fine as it's really just a back-stop to malicious activity.

Possible enhancement: a config option for setting this limit, which would also allow us to disable the limit entirely if things go pear-shaped in production.

@dannycoates thoughts?  Style nits welcomed, I've been over in python land for a while :-)
