### PR TITLE
chore(config): Add a default trusted JKU for local development.

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -19,5 +19,6 @@
   "bounces": {
     "region": "us-east-1"
   },
-  "customsUrl": "none"
+  "customsUrl": "none",
+  "trustedJKUs": ["http://127.0.0.1:8080/.well-known/public-keys"]
 }


### PR DESCRIPTION
- `trustedJKUs` is set to allow a local 123done to be a trusted preVerifyToken generating RP.

For more backgroud, see https://github.com/mozilla/fxa-content-server/pull/1606
