### PR TITLE
Call customs-server /passwordReset endpoint on password reset.

### DIFF
--- a/customs.js
+++ b/customs.js
@@ -60,6 +60,22 @@
     )
   }
 
+  Customs.prototype.reset = function (email) {
+    log.trace({ op: 'customs.reset', email: email })
+    return this.pool.post(
+      '/passwordReset',
+      {
+        email: email
+      }
+    )
+    .then(
+      function () {},
+      function (err) {
+        log.error({ op: 'customs.reset.1', email: email, err: err })
+      }
+    )
+  }
+
   Customs.prototype.close = function () {
     return this.pool.close()
   }

--- a/routes/account.js
+++ b/routes/account.js
@@ -527,6 +527,16 @@ module.exports = function (
           )
           .then(
             function () {
+              return db.account(accountResetToken.uid)
+            }
+          )
+          .then(
+            function (accountRecord) {
+              return customs.reset(accountRecord.email)
+            }
+          )
+          .then(
+            function () {
               return {}
             }
           )


### PR DESCRIPTION
This is an initial attempt at #787, calling the `/passwordReset` customs endpoint when the user successfully resets their password.

Unfortunately the `accountResetToken` doesn't currently provide the email address, so we have to do a separate db lookup to obtain it.  I think we should make `email` a field on the reset token to make this cleaner, but this version might be useful in the meantime.  @chilts thoughts?

(Also, we don't seem to have any tests that check whether the customs endpoints are called as expected, so I haven't added tests for this one either)
