### PR TITLE
Increase limit on pending scrypt requests.

### DIFF
--- a/crypto/scrypt.js
+++ b/crypto/scrypt.js
@@ -7,7 +7,7 @@ var scrypt = require('scrypt-hash')
  
 // The maximum numer of hash operations allowed concurrently.
 // This can be customized by setting module.exports.MAX_PENDING
-const DEFAULT_MAX_PENDING = 100
+const DEFAULT_MAX_PENDING = 1000
 
 // The current number of hash operations in progress.
 var num_pending = 0


### PR DESCRIPTION
We appear to have hit this limit in prod today, so let's increase it and continue to monitor.  We need follow-up bugs to make this nicer in future:
- make this a config option
- log an event when this occurs so we can monitor it in prod

But let's get the obvious fix out in the next train.  @dannycoates r?
