### PR TITLE
base64URL decode the sig of JWTs before verifying

### DIFF
--- a/preverifier.js
+++ b/preverifier.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 var jws = require('jws')
+var b64urltohex = require('jwcrypto/lib/utils').b64urltohex
 var P = require('./promise')
 
 module.exports = function (jwks, error, config) {
@@ -38,7 +39,7 @@ module.exports = function (jwks, error, config) {
         function (key) {
           var d = P.defer()
           var parts = token.split('.')
-          key.verify(parts[0] + '.' + parts[1], parts[2],
+          key.verify(parts[0] + '.' + parts[1], b64urltohex(parts[2]),
             function (err, result) {
               var invalid = jwtError(err, result, email, parseJwt(parts[1]))
               if (invalid) {

--- a/test/local/account_preverified_token_tests.js
+++ b/test/local/account_preverified_token_tests.js
@@ -9,6 +9,7 @@ var TestServer = require('../test_server')
 var Client = require('../client')
 var jwcrypto = require('jwcrypto')
 require('jwcrypto/lib/algs/rs')
+var hex2b64urlencode = require('jwcrypto/lib/utils').hex2b64urlencode
 var b64 = require('jwcrypto/lib/utils').base64urlencode
 
 process.env.CONFIG_FILES = path.join(__dirname, '../config/preverify_secret.json')
@@ -39,7 +40,7 @@ TestServer.start(config)
         }
       ))
       var sig = secretKey.sign(header + '.' + payload)
-      var token = header + '.' + payload + '.' + sig
+      var token = header + '.' + payload + '.' + hex2b64urlencode(sig)
       return Client.create(config.publicUrl, email, password, { preVerifyToken: token })
         .then(
           function (c) {
@@ -75,7 +76,7 @@ TestServer.start(config)
         }
       ))
       var sig = secretKey.sign(header + '.' + payload)
-      var token = header + '.' + payload + '.' + sig
+      var token = header + '.' + payload + '.' + hex2b64urlencode(sig)
       return Client.create(config.publicUrl, email, password, { preVerifyToken: token })
         .then(
           fail,
@@ -115,7 +116,7 @@ TestServer.start(config)
               }
             ))
             var sig = secretKey.sign(header + '.' + payload)
-            var token = header + '.' + payload + '.' + sig
+            var token = header + '.' + payload + '.' + hex2b64urlencode(sig)
             return Client.create(config.publicUrl, email, password, { preVerifyToken: token })
           }
         )


### PR DESCRIPTION
The preverified token verifier was expecting the signature portion to be hex encoded, which is incorrect.
Fixes #823 

@dannycoates r?
