### PR TITLE
Update to convict 0.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -337,7 +337,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
@@ -458,7 +458,7 @@
                       "dependencies": {
                         "esprima": {
                           "version": "1.0.4",
-                          "from": "esprima@~1.0.2",
+                          "from": "esprima@~1.0.4",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                         },
                         "estraverse": {
@@ -975,9 +975,9 @@
       }
     },
     "convict": {
-      "version": "0.5.1",
-      "from": "convict@0.5.1",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-0.5.1.tgz",
+      "version": "0.6.0",
+      "from": "convict@0.6",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
@@ -990,9 +990,9 @@
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
-                  "version": "1.8.0",
+                  "version": "1.8.1",
                   "from": "nomnom@>= 1.5.x",
-                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
@@ -1032,6 +1032,11 @@
             }
           }
         },
+        "depd": {
+          "version": "1.0.0",
+          "from": "depd@1.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+        },
         "moment": {
           "version": "2.8.3",
           "from": "moment@2.8.3",
@@ -1055,9 +1060,9 @@
           }
         },
         "validator": {
-          "version": "2.1.0",
-          "from": "validator@2.1.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-2.1.0.tgz"
+          "version": "3.22.1",
+          "from": "validator@3.22.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz"
         }
       }
     },
@@ -1186,7 +1191,7 @@
                   "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
                   "dependencies": {
                     "encoding": {
-                      "version": "0.1.10",
+                      "version": "0.1.11",
                       "from": "encoding@~0.1",
                       "dependencies": {
                         "iconv-lite": {
@@ -1395,7 +1400,7 @@
                   "from": "mimelib@~0.2.15",
                   "dependencies": {
                     "encoding": {
-                      "version": "0.1.10",
+                      "version": "0.1.11",
                       "from": "encoding@~0.1.7",
                       "dependencies": {
                         "iconv-lite": {
@@ -1548,7 +1553,7 @@
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
-                  "version": "0.1.10",
+                  "version": "0.1.11",
                   "from": "encoding@~0.1",
                   "dependencies": {
                     "iconv-lite": {
@@ -1840,9 +1845,9 @@
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz"
         },
         "hoek": {
-          "version": "2.8.1",
+          "version": "2.9.0",
           "from": "hoek@^2.4.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.8.1.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
         "inert": {
           "version": "1.1.0",
@@ -1865,14 +1870,14 @@
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "mimos@1.x.x",
-          "resolved": "https://registry.npmjs.org/mimos/-/mimos-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.1.2",
+              "version": "1.2.0",
               "from": "mime-db@1.x.x",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.2.0.tgz"
             }
           }
         },
@@ -1892,9 +1897,9 @@
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz"
         },
         "subtext": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "from": "subtext@1.x.x",
-          "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
@@ -1933,9 +1938,9 @@
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
-          "version": "1.2.0",
+          "version": "1.2.1",
           "from": "vision@1.x.x",
-          "resolved": "https://registry.npmjs.org/vision/-/vision-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz"
         },
         "wreck": {
           "version": "5.0.1",
@@ -1960,9 +1965,9 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz"
         },
         "hoek": {
-          "version": "2.8.1",
+          "version": "2.9.0",
           "from": "hoek@^2.2.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.8.1.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         }
       }
     },
@@ -1977,9 +1982,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.8.1",
+          "version": "2.9.0",
           "from": "hoek@^2.2.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.8.1.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
@@ -2251,9 +2256,9 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.8.1",
+          "version": "2.9.0",
           "from": "hoek@^2.2.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.8.1.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
         "boom": {
           "version": "2.6.0",
@@ -2307,9 +2312,9 @@
           }
         },
         "encoding": {
-          "version": "0.1.10",
+          "version": "0.1.11",
           "from": "encoding@>=0.1.4",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.10.tgz",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.4",
@@ -2687,7 +2692,7 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.0",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
@@ -2697,7 +2702,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -2808,7 +2813,7 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.9",
+          "from": "glob@~3.2.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
@@ -3080,9 +3085,9 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
-          "version": "2.5.8",
+          "version": "2.5.10",
           "from": "jshint@~2.5.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.8.tgz",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
@@ -3159,7 +3164,7 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "browserid-crypto": "0.7.0",
     "bunyan": "1.2.0",
     "compute-cluster": "0.0.9",
-    "convict": "0.5.1",
+    "convict": "0.6",
     "fxa-auth-mailer": "1.0.6",
     "hapi": "7.0.0",
     "hapi-auth-hawk": "1.1.1",


### PR DESCRIPTION
This fixes build errors due to "known vulnerable modules".  It also brings with it the usual bevy of patch-level version updates.
