### PR TITLE
Remove unused data from the PasswordChangeToken class.

### DIFF
--- a/tokens/password_change_token.js
+++ b/tokens/password_change_token.js
@@ -7,8 +7,6 @@ module.exports = function (log, inherits, Token, lifetime) {
   function PasswordChangeToken(keys, details) {
     details.lifetime = lifetime
     Token.call(this, keys, details)
-    this.verifyHash = details.verifyHash || null
-    this.authSalt = details.authSalt || null
   }
   inherits(PasswordChangeToken, Token)
 


### PR DESCRIPTION
We attach `verifyHash` and `authSalt` properties to PasswordChangeToken instances, but I can't work out why or whether they're actually used.  All the tests still pass if I remove them, so perhaps they are vestigial?

@dannycoates r?