### PR TITLE
Update hapi to latest stable version.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,35 +1,35 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "dependencies": {
     "ass": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
+      "from": "ass@0.0.4",
       "resolved": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
       "dependencies": {
         "blanket": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "from": "blanket@~1.1.5",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+              "from": "falafel@~0.1.6",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "from": "xtend@~2.1.1",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                  "from": "object-keys@~0.4.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -38,73 +38,73 @@
         },
         "temp": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
+          "from": "temp@~0.6.0",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "from": "rimraf@~2.1.4",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                  "from": "graceful-fs@~1",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+              "from": "osenv@0.0.3",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
           "version": "0.12.4",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+          "from": "cheerio@~0.12.4",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
+              "from": "cheerio-select@*",
               "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
-                  "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
+                  "from": "CSSselect@0.x",
                   "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                      "from": "CSSwhat@0.4",
                       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                      "from": "domutils@1.4",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "from": "domelementtype@1",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                      "from": "boolbase@~1.0.0",
                       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
                     },
                     "nth-check": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz",
+                      "from": "nth-check@~1.0.0",
                       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz"
                     }
                   }
@@ -113,47 +113,47 @@
             },
             "htmlparser2": {
               "version": "3.1.4",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+              "from": "htmlparser2@3.1.4",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
+                  "from": "domhandler@2.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+                  "from": "domutils@1.1",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@^1.0.27-1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -162,12 +162,12 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+              "from": "underscore@~1.4",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+              "from": "entities@0.x",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             }
           }
@@ -176,51 +176,51 @@
     },
     "aws-sdk": {
       "version": "2.0.21",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.21.tgz",
+      "from": "aws-sdk@2.0.21",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.21.tgz",
       "dependencies": {
         "xml2js": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+          "from": "xml2js@0.2.6",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
           "dependencies": {
             "sax": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+              "from": "sax@0.4.2",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
             }
           }
         },
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+          "from": "xmlbuilder@0.4.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "bigint": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/bigint/-/bigint-0.4.2.tgz",
+      "from": "bigint@0.4.2",
       "resolved": "https://registry.npmjs.org/bigint/-/bigint-0.4.2.tgz"
     },
     "binary-split": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
+      "from": "binary-split@0.1.2",
       "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
       "dependencies": {
         "bops": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+          "from": "bops@0.0.6",
           "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+              "from": "base64-js@0.0.2",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
             },
             "to-utf8": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+              "from": "to-utf8@0.0.1",
               "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz"
             }
           }
@@ -229,59 +229,59 @@
     },
     "browserid-crypto": {
       "version": "0.7.0",
-      "from": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.7.0.tgz",
+      "from": "browserid-crypto@0.7.0",
       "resolved": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.7.0.tgz",
       "dependencies": {
         "browserify": {
           "version": "5.9.1",
-          "from": "https://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
+          "from": "browserify@5.9.1",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "from": "JSONStream@~0.8.3",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "assert": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+              "from": "assert@~1.1.0",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
             },
             "browser-pack": {
               "version": "3.2.0",
-              "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+              "from": "browser-pack@^3.0.0",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
               "dependencies": {
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
+                      "from": "inline-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
-                      "version": "0.1.40",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                      "version": "0.1.42",
+                      "from": "source-map@~0.1.31",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -290,83 +290,90 @@
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "browser-resolve": {
-              "version": "1.4.1",
-              "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.4.1.tgz"
+              "version": "1.5.0",
+              "from": "browser-resolve@^1.3.0",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.5.0.tgz",
+              "dependencies": {
+                "resolve": {
+                  "version": "1.0.0",
+                  "from": "resolve@1.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
+                }
+              }
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "from": "browserify-zlib@~0.1.2",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
+                  "from": "pako@~0.2.0",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
                 }
               }
             },
             "buffer": {
-              "version": "2.8.1",
-              "from": "https://registry.npmjs.org/buffer/-/buffer-2.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.1.tgz",
+              "version": "2.8.2",
+              "from": "buffer@^2.3.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
+                  "from": "base64-js@0.0.7",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
+                  "from": "ieee754@^1.1.4",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+                  "from": "is-array@^1.0.1",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+              "from": "builtins@~0.0.3",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+              "from": "commondir@0.0.1",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
-              "version": "1.4.6",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.6.tgz",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.6.tgz",
+              "version": "1.4.7",
+              "from": "concat-stream@~1.4.1",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@~0.0.5",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -375,98 +382,265 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@^1.1.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+              "from": "constants-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
-              "version": "3.3.0",
-              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+              "version": "3.8.3",
+              "from": "crypto-browserify@^3.0.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.3.tgz",
               "dependencies": {
+                "browserify-aes": {
+                  "version": "0.8.0",
+                  "from": "browserify-aes@0.8.0",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.0.tgz"
+                },
+                "create-ecdh": {
+                  "version": "1.0.1",
+                  "from": "create-ecdh@1.0.1",
+                  "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.1.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "0.16.1",
+                      "from": "bn.js@^0.16.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+                    },
+                    "elliptic": {
+                      "version": "0.15.17",
+                      "from": "elliptic@^0.15.14",
+                      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.17.tgz",
+                      "dependencies": {
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@^1.0.1",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        },
+                        "hash.js": {
+                          "version": "0.2.1",
+                          "from": "hash.js@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "diffie-hellman": {
+                  "version": "2.2.2",
+                  "from": "diffie-hellman@2.2.2",
+                  "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.2.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "0.16.1",
+                      "from": "bn.js@^0.16.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+                    },
+                    "miller-rabin": {
+                      "version": "1.1.5",
+                      "from": "miller-rabin@^1.1.2",
+                      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "1.0.0",
+                          "from": "bn.js@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+                        },
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@^1.0.1",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "browserify-sign": {
+                  "version": "2.7.1",
+                  "from": "browserify-sign@2.7.1",
+                  "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.1.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "0.16.1",
+                      "from": "bn.js@^0.16.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+                    },
+                    "browserify-rsa": {
+                      "version": "1.1.0",
+                      "from": "browserify-rsa@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.0.tgz"
+                    },
+                    "elliptic": {
+                      "version": "0.15.17",
+                      "from": "elliptic@^0.15.14",
+                      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.17.tgz",
+                      "dependencies": {
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@^1.0.1",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        },
+                        "hash.js": {
+                          "version": "0.2.1",
+                          "from": "hash.js@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-asn1": {
+                      "version": "1.2.0",
+                      "from": "parse-asn1@^1.2.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.2.0.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "0.6.7",
+                          "from": "asn1.js@^0.6.5",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.7.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "0.15.2",
+                              "from": "bn.js@^0.15.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+                            }
+                          }
+                        },
+                        "asn1.js-rfc3280": {
+                          "version": "0.5.2",
+                          "from": "asn1.js-rfc3280@^0.5.1",
+                          "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-0.5.2.tgz"
+                        },
+                        "pemstrip": {
+                          "version": "0.0.1",
+                          "from": "pemstrip@0.0.1",
+                          "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "pbkdf2-compat": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+                  "from": "pbkdf2-compat@2.0.1",
                   "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "public-encrypt": {
+                  "version": "1.1.0",
+                  "from": "public-encrypt@1.1.0",
+                  "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.0.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "0.16.1",
+                      "from": "bn.js@^0.16.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+                    },
+                    "browserify-rsa": {
+                      "version": "1.1.0",
+                      "from": "browserify-rsa@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.0.tgz"
+                    },
+                    "parse-asn1": {
+                      "version": "1.2.0",
+                      "from": "parse-asn1@^1.2.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.2.0.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "0.6.7",
+                          "from": "asn1.js@^0.6.5",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.7.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "0.15.2",
+                              "from": "bn.js@^0.15.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+                            }
+                          }
+                        },
+                        "asn1.js-rfc3280": {
+                          "version": "0.5.2",
+                          "from": "asn1.js-rfc3280@^0.5.1",
+                          "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-0.5.2.tgz"
+                        },
+                        "pemstrip": {
+                          "version": "0.0.1",
+                          "from": "pemstrip@0.0.1",
+                          "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "ripemd160": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+                  "from": "ripemd160@0.2.0",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
                 },
                 "sha.js": {
-                  "version": "2.2.6",
-                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
-                },
-                "browserify-aes": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz"
+                  "version": "2.3.0",
+                  "from": "sha.js@2.3.0",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.0.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+              "from": "deep-equal@~0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
             },
             "defined": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+              "from": "defined@~0.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
             },
             "deps-sort": {
               "version": "1.3.5",
-              "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+              "from": "deps-sort@^1.3.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "domain-browser": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz",
+              "from": "domain-browser@~1.1.0",
               "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
             },
             "duplexer2": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "from": "duplexer2@~0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -475,27 +649,27 @@
             },
             "events": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+              "from": "events@~1.0.0",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.8",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -504,44 +678,73 @@
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+              "from": "https-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
-              "version": "6.1.0",
-              "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.1.0.tgz",
+              "version": "6.2.0",
+              "from": "insert-module-globals@^6.1.0",
+              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    }
+                  }
+                },
+                "combine-source-map": {
+                  "version": "0.3.0",
+                  "from": "combine-source-map@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "dependencies": {
+                    "inline-source-map": {
+                      "version": "0.3.0",
+                      "from": "inline-source-map@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
+                    },
+                    "convert-source-map": {
+                      "version": "0.3.5",
+                      "from": "convert-source-map@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.42",
+                      "from": "source-map@~0.1.31",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "lexical-scope": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                  "from": "lexical-scope@~1.1.0",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                      "from": "astw@~1.1.0",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "3001.1.0-dev-harmony-fb",
-                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                         }
                       }
@@ -550,51 +753,51 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+                  "from": "process@~0.6.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 }
               }
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "labeled-stream-splicer": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.0.tgz",
+              "version": "1.0.2",
+              "from": "labeled-stream-splicer@^1.0.0",
+              "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "dependencies": {
                 "stream-splicer": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+                  "from": "stream-splicer@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "readable-stream@^1.1.13-1",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                      "from": "readable-wrap@^1.0.0",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "from": "indexof@0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     }
                   }
@@ -602,110 +805,147 @@
               }
             },
             "module-deps": {
-              "version": "3.5.6",
-              "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.5.6.tgz",
+              "version": "3.6.4",
+              "from": "module-deps@^3.5.0",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "detective": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+                  "version": "4.0.0",
+                  "from": "detective@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "dependencies": {
+                    "acorn": {
+                      "version": "0.9.0",
+                      "from": "acorn@~0.9.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                    },
                     "escodegen": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+                      "version": "1.4.3",
+                      "from": "escodegen@^1.4.1",
+                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.4.3.tgz",
                       "dependencies": {
-                        "esprima": {
-                          "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                        },
                         "estraverse": {
-                          "version": "1.5.1",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                          "version": "1.9.1",
+                          "from": "estraverse@^1.9.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
                         },
                         "esutils": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                          "version": "1.1.6",
+                          "from": "esutils@^1.1.6",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                        },
+                        "esprima": {
+                          "version": "1.2.2",
+                          "from": "esprima@^1.2.2",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+                        },
+                        "optionator": {
+                          "version": "0.4.0",
+                          "from": "optionator@^0.4.0",
+                          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.4.0.tgz",
+                          "dependencies": {
+                            "prelude-ls": {
+                              "version": "1.1.1",
+                              "from": "prelude-ls@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                            },
+                            "deep-is": {
+                              "version": "0.1.3",
+                              "from": "deep-is@~0.1.2",
+                              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@~0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            },
+                            "type-check": {
+                              "version": "0.3.1",
+                              "from": "type-check@~0.3.1",
+                              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                            },
+                            "levn": {
+                              "version": "0.2.5",
+                              "from": "levn@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                            },
+                            "fast-levenshtein": {
+                              "version": "1.0.6",
+                              "from": "fast-levenshtein@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                            }
+                          }
                         },
                         "source-map": {
-                          "version": "0.1.40",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                          "version": "0.1.42",
+                          "from": "source-map@~0.1.40",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         }
                       }
-                    },
-                    "esprima-fb": {
-                      "version": "3001.1.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "parents": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/parents/-/parents-1.0.0.tgz",
+                  "from": "parents@^1.0.0",
                   "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.0.tgz",
                   "dependencies": {
                     "path-platform": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+                      "from": "path-platform@^0.0.1",
                       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                     }
                   }
                 },
                 "stream-combiner2": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                  "from": "stream-combiner2@~1.0.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "from": "through2@~0.5.1",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                  "from": "through2@~0.4.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                      "from": "xtend@~2.1.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                          "from": "object-keys@~0.4.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -716,81 +956,81 @@
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+              "from": "os-browserify@~0.1.1",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+              "from": "parents@~0.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+                  "from": "path-platform@^0.0.1",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "from": "path-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.7.0",
-              "from": "https://registry.npmjs.org/process/-/process-0.7.0.tgz",
+              "from": "process@^0.7.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+              "from": "punycode@~1.2.3",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+              "from": "querystring-es3@~0.2.0",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@^1.0.27-1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+              "from": "resolve@~0.7.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "shallow-copy": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+              "from": "shallow-copy@0.0.1",
               "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shasum": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.0.tgz",
+              "from": "shasum@^1.0.0",
               "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.0.tgz",
               "dependencies": {
                 "json-stable-stringify": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                  "from": "json-stable-stringify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                      "from": "jsonify@~0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
@@ -799,153 +1039,153 @@
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+              "from": "shell-quote@~0.0.1",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "from": "stream-browserify@^1.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+              "from": "stream-combiner@~0.0.2",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "dependencies": {
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                  "from": "duplexer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
+              "from": "string_decoder@~0.0.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "from": "subarg@0.0.1",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@~0.0.7",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "syntax-error": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.1.tgz",
+              "version": "1.1.2",
+              "from": "syntax-error@^1.1.1",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "dependencies": {
-                "esprima-fb": {
-                  "version": "3001.1.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@~0.9.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "from": "through2@^1.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "timers-browserify": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz",
+              "version": "1.2.0",
+              "from": "timers-browserify@^1.0.1",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz",
               "dependencies": {
                 "process": {
-                  "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+                  "version": "0.10.0",
+                  "from": "process@~0.10.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
                 }
               }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "from": "tty-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "umd": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+              "from": "umd@~2.1.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
               "dependencies": {
                 "rfile": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+                  "from": "rfile@~1.0.0",
                   "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
                   "dependencies": {
                     "callsite": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                      "from": "callsite@~1.0.0",
                       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                     },
                     "resolve": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+                      "from": "resolve@~0.3.0",
                       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                     }
                   }
                 },
                 "ruglify": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+                  "from": "ruglify@~1.0.0",
                   "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
                   "dependencies": {
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                      "from": "uglify-js@~2.2",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
-                          "version": "0.1.40",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                          "version": "0.1.42",
+                          "from": "source-map@~0.1.7",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                          "from": "optimist@~0.3.5",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
@@ -957,122 +1197,129 @@
               }
             },
             "url": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/url/-/url-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/url/-/url-0.10.1.tgz"
+              "version": "0.10.2",
+              "from": "url@~0.10.1",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@1.3.2",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
             },
             "util": {
               "version": "0.10.3",
-              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "from": "util@~0.10.1",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "from": "vm-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "from": "xtend@^3.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
         },
         "http-browserify": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.4.1.tgz",
+          "from": "http-browserify@1.4.1",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.4.1.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@~0.2.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "vows": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
+          "from": "vows@0.7.0",
           "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.6",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "diff": {
               "version": "1.0.8",
-              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+              "from": "diff@~1.0.3",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.4.15",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
+          "from": "uglify-js@2.4.15",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "from": "source-map@0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@~0.3.5",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@~1.0.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
@@ -1081,34 +1328,46 @@
     },
     "bunyan": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.2.0.tgz",
+      "from": "bunyan@1.2.0",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.2.0.tgz",
       "dependencies": {
+        "dtrace-provider": {
+          "version": "0.3.0",
+          "from": "dtrace-provider@0.3.0",
+          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.3.0.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.3.0",
+              "from": "nan@~1.3.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+            }
+          }
+        },
         "mv": {
           "version": "2.0.3",
-          "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+          "from": "mv@~2",
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@~0.5.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "ncp": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+              "from": "ncp@~0.6.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@~2.2.8",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -1117,17 +1376,17 @@
     },
     "compute-cluster": {
       "version": "0.0.9",
-      "from": "https://registry.npmjs.org/compute-cluster/-/compute-cluster-0.0.9.tgz",
+      "from": "compute-cluster@0.0.9",
       "resolved": "https://registry.npmjs.org/compute-cluster/-/compute-cluster-0.0.9.tgz",
       "dependencies": {
         "vows": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/vows/-/vows-0.6.0.tgz",
+          "from": "vows@0.6.0",
           "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.0.tgz",
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.6",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             }
           }
@@ -1136,47 +1395,47 @@
     },
     "convict": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
+      "from": "convict@0.6",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+          "from": "cjson@0.3.0",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>= 1.5.x",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@~1.6.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@~0.4.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@~0.1.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@~1.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@~0.1.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -1185,7 +1444,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>= 4.0.x",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -1194,105 +1453,105 @@
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
           "version": "2.8.3",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz",
+          "from": "moment@2.8.3",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.22.1",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz",
+          "from": "validator@3.22.1",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz"
         }
       }
     },
     "fxa-auth-db-mem": {
       "version": "0.18.2",
-      "from": "https://registry.npmjs.org/fxa-auth-db-mem/-/fxa-auth-db-mem-0.18.2.tgz",
+      "from": "fxa-auth-db-mem@0.18.2",
       "resolved": "https://registry.npmjs.org/fxa-auth-db-mem/-/fxa-auth-db-mem-0.18.2.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+          "from": "bluebird@2.2.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "fxa-auth-db-server": {
           "version": "1.18.1",
-          "from": "fxa-auth-db-server@git://github.com/dannycoates/fxa-auth-db-server.git#69752b9b93743113bd4f57258994291d9857fd5e",
+          "from": "fxa-auth-db-server@git://github.com/dannycoates/fxa-auth-db-server.git#reverse",
           "resolved": "git://github.com/dannycoates/fxa-auth-db-server.git#69752b9b93743113bd4f57258994291d9857fd5e",
           "dependencies": {
             "restify": {
               "version": "2.8.2",
-              "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+              "from": "restify@2.8.2",
               "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "backoff": {
-                  "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.0.tgz",
+                  "version": "2.4.1",
+                  "from": "backoff@^2.3.0",
+                  "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
                   "dependencies": {
                     "precond": {
                       "version": "0.2.3",
-                      "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                      "from": "precond@0.2",
                       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                     }
                   }
                 },
                 "bunyan": {
                   "version": "0.23.1",
-                  "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+                  "from": "bunyan@^0.23.1",
                   "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
                   "dependencies": {
                     "mv": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+                      "from": "mv@~2",
                       "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                       "dependencies": {
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "from": "mkdirp@~0.5.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "from": "minimist@0.0.8",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
                         "ncp": {
                           "version": "0.6.0",
-                          "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                          "from": "ncp@~0.6.0",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                         },
                         "rimraf": {
                           "version": "2.2.8",
-                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "from": "rimraf@~2.2.8",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
@@ -1301,140 +1560,135 @@
                 },
                 "csv": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
+                  "from": "csv@^0.4.0",
                   "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
                   "dependencies": {
                     "csv-generate": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
+                      "from": "csv-generate@*",
                       "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                     },
                     "csv-parse": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.6.tgz",
+                      "from": "csv-parse@*",
                       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.6.tgz"
                     },
                     "stream-transform": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.6.tgz",
+                      "from": "stream-transform@*",
                       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.6.tgz"
                     },
                     "csv-stringify": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.3.tgz"
+                      "version": "0.0.5",
+                      "from": "csv-stringify@*",
+                      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.5.tgz"
                     }
                   }
                 },
                 "deep-equal": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz",
+                  "from": "deep-equal@^0.2.1",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
                 },
                 "escape-regexp-component": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+                  "from": "escape-regexp-component@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
                 },
                 "formidable": {
-                  "version": "1.0.15",
-                  "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.15.tgz",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.15.tgz"
+                  "version": "1.0.16",
+                  "from": "formidable@^1.0.14",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz"
                 },
                 "http-signature": {
-                  "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "version": "0.10.1",
+                  "from": "http-signature@^0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                    },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
-                      "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "keep-alive-agent": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+                  "from": "keep-alive-agent@^0.0.1",
                   "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
                 },
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@~1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "negotiator": {
                   "version": "0.4.9",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                  "from": "negotiator@^0.4.5",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.1",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                  "version": "1.4.2",
+                  "from": "node-uuid@^1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+                  "from": "qs@^1.0.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "semver": {
                   "version": "2.3.2",
-                  "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+                  "from": "semver@^2.3.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
                 },
                 "spdy": {
-                  "version": "1.29.1",
-                  "from": "https://registry.npmjs.org/spdy/-/spdy-1.29.1.tgz",
-                  "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.29.1.tgz"
+                  "version": "1.29.2",
+                  "from": "spdy@^1.26.5",
+                  "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.29.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@^0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "verror": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/verror/-/verror-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.4.0.tgz",
+                  "version": "1.6.0",
+                  "from": "verror@^1.4.0",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
                   "dependencies": {
                     "extsprintf": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.3.tgz"
+                      "version": "1.2.0",
+                      "from": "extsprintf@1.2.0",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                     }
                   }
                 },
                 "dtrace-provider": {
                   "version": "0.2.8",
-                  "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+                  "from": "dtrace-provider@^0.2.8",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
                 }
               }
@@ -1460,12 +1714,12 @@
           "dependencies": {
             "mv": {
               "version": "2.0.3",
-              "from": "mv@>=2.0.0 <3.0.0",
+              "from": "mv@~2",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "mkdirp@~0.5.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
@@ -1477,12 +1731,12 @@
                 },
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "ncp@>=0.6.0 <0.7.0",
+                  "from": "ncp@~0.6.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@>=2.2.8 <2.3.0",
+                  "from": "rimraf@~2.2.8",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
@@ -1491,7 +1745,7 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "../../../../var/folders/y3/9qwwh1cx789d53l9l5c2lv380000gn/T/npm-5735-9a982c23/1418084875958-0.06095229950733483/4168ef3cb781349e1f65844192adcf961f7f0549",
+          "from": "fxa-content-server-l10n@git://github.com/mozilla/fxa-content-server-l10n.git#4168ef3cb7",
           "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#4168ef3cb781349e1f65844192adcf961f7f0549"
         },
         "handlebars": {
@@ -1501,30 +1755,30 @@
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
+              "from": "optimist@~0.3",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "from": "uglify-js@~2.3",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "async@~0.2.6",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
-                  "version": "0.1.40",
-                  "from": "source-map@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                  "version": "0.1.42",
+                  "from": "source-map@~0.1.7",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
@@ -1569,12 +1823,12 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "encoding@>=0.1.0 <0.2.0",
+                      "from": "encoding@~0.1",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.5",
-                          "from": "iconv-lite@>=0.4.4 <0.5.0",
+                          "from": "iconv-lite@~0.4.4",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                         }
                       }
@@ -1588,12 +1842,12 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.1.7",
-                      "from": "underscore@>=1.1.0 <1.2.0",
+                      "from": "underscore@1.1.x",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                     },
                     "colors": {
                       "version": "0.5.1",
-                      "from": "colors@>=0.5.0 <0.6.0",
+                      "from": "colors@0.5.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     }
                   }
@@ -1605,41 +1859,41 @@
                   "dependencies": {
                     "commander": {
                       "version": "1.1.1",
-                      "from": "commander@>=1.1.1 <1.2.0",
+                      "from": "commander@~1.1.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                       "dependencies": {
                         "keypress": {
                           "version": "0.1.0",
-                          "from": "keypress@>=0.1.0 <0.2.0",
+                          "from": "keypress@0.1.x",
                           "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "mkdirp@>=0.3.0 <0.4.0",
+                      "from": "mkdirp@0.3.x",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     },
                     "transformers": {
                       "version": "2.0.1",
-                      "from": "transformers@>=2.0.1 <2.1.0",
+                      "from": "transformers@~2.0.1",
                       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                       "dependencies": {
                         "promise": {
                           "version": "2.0.0",
-                          "from": "promise@>=2.0.0 <2.1.0",
+                          "from": "promise@~2.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                           "dependencies": {
                             "is-promise": {
                               "version": "1.0.1",
-                              "from": "is-promise@>=1.0.0 <2.0.0",
+                              "from": "is-promise@~1",
                               "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                             }
                           }
                         },
                         "css": {
                           "version": "1.0.8",
-                          "from": "css@>=1.0.8 <1.1.0",
+                          "from": "css@~1.0.8",
                           "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                           "dependencies": {
                             "css-parse": {
@@ -1656,13 +1910,13 @@
                         },
                         "uglify-js": {
                           "version": "2.2.5",
-                          "from": "uglify-js@>=2.2.5 <2.3.0",
+                          "from": "uglify-js@~2.2.5",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                           "dependencies": {
                             "source-map": {
-                              "version": "0.1.40",
-                              "from": "source-map@>=0.1.7 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.40.tgz",
+                              "version": "0.1.42",
+                              "from": "source-map@~0.1.7",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "0.1.0",
@@ -1673,12 +1927,12 @@
                             },
                             "optimist": {
                               "version": "0.3.7",
-                              "from": "optimist@>=0.3.5 <0.4.0",
+                              "from": "optimist@~0.3.5",
                               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                               "dependencies": {
                                 "wordwrap": {
                                   "version": "0.0.2",
-                                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                                  "from": "wordwrap@~0.0.2",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                                 }
                               }
@@ -1689,17 +1943,17 @@
                     },
                     "character-parser": {
                       "version": "1.0.2",
-                      "from": "character-parser@>=1.0.0 <1.1.0",
+                      "from": "character-parser@~1.0.0",
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                     },
                     "monocle": {
                       "version": "0.1.50",
-                      "from": "monocle@>=0.1.46 <0.2.0",
+                      "from": "monocle@~0.1.46",
                       "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                       "dependencies": {
                         "readdirp": {
                           "version": "0.2.5",
-                          "from": "readdirp@>=0.2.3 <0.3.0",
+                          "from": "readdirp@~0.2.3",
                           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                           "dependencies": {
                             "minimatch": {
@@ -1708,19 +1962,19 @@
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.0.1",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.0.1.tgz",
+                                  "version": "1.1.0",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.2.0",
-                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                      "from": "balanced-match@^0.2.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                     },
                                     "concat-map": {
-                                      "version": "0.0.0",
-                                      "from": "concat-map@0.0.0",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.0.tgz"
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
                                 }
@@ -1741,7 +1995,7 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
@@ -1753,12 +2007,12 @@
               "dependencies": {
                 "xmlbuilder": {
                   "version": "0.4.3",
-                  "from": "xmlbuilder@>=0.4.0 <0.5.0",
+                  "from": "xmlbuilder@0.4.x",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
                 },
                 "xmldom": {
                   "version": "0.1.19",
-                  "from": "xmldom@>=0.1.0 <0.2.0",
+                  "from": "xmldom@0.1.x",
                   "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
                 }
               }
@@ -1777,36 +2031,36 @@
           "dependencies": {
             "mailcomposer": {
               "version": "0.2.12",
-              "from": "mailcomposer@>=0.2.10 <0.3.0",
+              "from": "mailcomposer@~0.2.10",
               "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
               "dependencies": {
                 "mimelib": {
                   "version": "0.2.18",
-                  "from": "mimelib@>=0.2.15 <0.3.0",
+                  "from": "mimelib@~0.2.15",
                   "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.18.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "encoding@>=0.1.7 <0.2.0",
+                      "from": "encoding@~0.1.7",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.5",
-                          "from": "iconv-lite@>=0.4.4 <0.5.0",
+                          "from": "iconv-lite@~0.4.4",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                         }
                       }
                     },
                     "addressparser": {
                       "version": "0.2.1",
-                      "from": "addressparser@>=0.2.1 <0.3.0",
+                      "from": "addressparser@~0.2.1",
                       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
+                  "from": "mime@~1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "follow-redirects": {
@@ -1816,19 +2070,19 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.7.0",
-                      "from": "underscore@*",
+                      "from": "underscore@",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                     }
                   }
                 },
                 "dkim-signer": {
                   "version": "0.1.2",
-                  "from": "dkim-signer@>=0.1.1 <0.2.0",
+                  "from": "dkim-signer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.2.4",
-                      "from": "punycode@>=1.2.4 <1.3.0",
+                      "from": "punycode@~1.2.4",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
@@ -1837,17 +2091,17 @@
             },
             "directmail": {
               "version": "0.1.8",
-              "from": "directmail@>=0.1.7 <0.2.0",
+              "from": "directmail@~0.1.7",
               "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
             },
             "he": {
               "version": "0.3.6",
-              "from": "he@>=0.3.6 <0.4.0",
+              "from": "he@~0.3.6",
               "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
             },
             "public-address": {
               "version": "0.1.1",
-              "from": "public-address@>=0.1.1 <0.2.0",
+              "from": "public-address@~0.1.1",
               "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
             },
             "aws-sdk": {
@@ -1857,7 +2111,7 @@
               "dependencies": {
                 "aws-sdk-apis": {
                   "version": "3.1.10",
-                  "from": "aws-sdk-apis@>=3.0.0 <4.0.0",
+                  "from": "aws-sdk-apis@3.x",
                   "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
                 },
                 "xml2js": {
@@ -1881,12 +2135,12 @@
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -1896,12 +2150,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1915,7 +2169,7 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "nomnom": {
@@ -1925,29 +2179,29 @@
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@>=1.1.0 <1.2.0",
+                  "from": "underscore@1.1.x",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@>=0.5.0 <0.6.0",
+                  "from": "colors@0.5.x",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@>=0.2.0 <0.3.0",
+              "from": "gettext-parser@~0.2.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "encoding@>=0.1.0 <0.2.0",
+                  "from": "encoding@~0.1",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.5",
-                      "from": "iconv-lite@>=0.4.4 <0.5.0",
+                      "from": "iconv-lite@~0.4.4",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                     }
                   }
@@ -1963,22 +2217,22 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.7 <0.1.0",
+              "from": "minimist@~0.0.7",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "deep-extend@>=0.2.5 <0.3.0",
+              "from": "deep-extend@~0.2.5",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+              "from": "strip-json-comments@0.1.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "ini": {
               "version": "1.1.0",
-              "from": "ini@>=1.1.0 <1.2.0",
+              "from": "ini@~1.1.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
             }
           }
@@ -1990,34 +2244,34 @@
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "assert-plus@^0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "backoff@>=2.3.0 <3.0.0",
+              "from": "backoff@^2.3.0",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "precond@>=0.2.0 <0.3.0",
+                  "from": "precond@0.2",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "bunyan@>=0.23.1 <0.24.0",
+              "from": "bunyan@^0.23.1",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "mv@>=2.0.0 <3.0.0",
+                  "from": "mv@~2",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "mkdirp@~0.5.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
@@ -2029,12 +2283,12 @@
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "ncp@>=0.6.0 <0.7.0",
+                      "from": "ncp@~0.6.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@>=2.2.8 <2.3.0",
+                      "from": "rimraf@~2.2.8",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -2043,7 +2297,7 @@
             },
             "csv": {
               "version": "0.4.1",
-              "from": "csv@>=0.4.0 <0.5.0",
+              "from": "csv@^0.4.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "dependencies": {
                 "csv-generate": {
@@ -2062,109 +2316,104 @@
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.6.tgz"
                 },
                 "csv-stringify": {
-                  "version": "0.0.4",
+                  "version": "0.0.5",
                   "from": "csv-stringify@*",
-                  "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.5.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.1",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
+              "from": "deep-equal@^0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
+              "from": "escape-regexp-component@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
-              "version": "1.0.15",
-              "from": "formidable@>=1.0.14 <2.0.0",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.15.tgz"
+              "version": "1.0.16",
+              "from": "formidable@^1.0.14",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz"
             },
             "http-signature": {
-              "version": "0.10.0",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "version": "0.10.1",
+              "from": "http-signature@^0.10.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.2",
-                  "from": "assert-plus@0.1.2",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                },
                 "asn1": {
                   "version": "0.1.11",
                   "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
-                  "version": "0.5.2",
-                  "from": "ctype@0.5.2",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
+              "from": "keep-alive-agent@^0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "from": "lru-cache@^2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@>=1.2.11 <2.0.0",
+              "from": "mime@^1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "negotiator@>=0.4.5 <0.5.0",
+              "from": "negotiator@^0.4.5",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "node-uuid@^1.4.1",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.0.0 <2.0.0",
+              "from": "qs@^1.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
+              "from": "semver@^2.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
-              "version": "1.29.1",
-              "from": "spdy@>=1.26.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.29.1.tgz"
+              "version": "1.29.2",
+              "from": "spdy@^1.26.5",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.29.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@^0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "verror@>=1.4.0 <2.0.0",
+              "from": "verror@^1.4.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
@@ -2176,7 +2425,7 @@
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@>=0.2.8 <0.3.0",
+              "from": "dtrace-provider@^0.2.8",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -2185,62 +2434,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2249,144 +2498,144 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@~1",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+          "version": "1.0.8",
+          "from": "which@~1.0.5",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
-              "version": "0.1.15",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+              "version": "0.1.16",
+              "from": "argparse@~ 0.1.11",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.4.4",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                  "version": "1.7.0",
+                  "from": "underscore@~1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
-                  "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                  "version": "2.4.0",
+                  "from": "underscore.string@~2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@0.1.x",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -2395,49 +2644,49 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "from": "grunt-cli@0.1.13",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2446,56 +2695,56 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "from": "resolve@~0.3.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "from": "grunt-contrib-jshint@0.10.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
-          "version": "2.5.10",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
+          "version": "2.5.11",
+          "from": "jshint@~2.5.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+              "from": "cli@0.6.x",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "from": "glob@~ 3.2.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -2506,149 +2755,149 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@1.1.x",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@0.1.x",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "from": "htmlparser2@3.8.x",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "from": "domhandler@2.3",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@1.0.x",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "from": "shelljs@0.3.x",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+              "from": "strip-json-comments@1.0.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "from": "underscore@1.6.x",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
+      "from": "grunt-copyright@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "from": "cli-color@^0.2.3",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+              "from": "es5-ext@~0.9.2",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "from": "memoizee@~0.2.5",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                  "from": "event-emitter@~0.2.2",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                  "from": "next-tick@0.1.x",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -2657,146 +2906,165 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@^0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "hapi": {
-      "version": "7.0.0",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-7.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-7.0.0.tgz",
+      "version": "7.5.3",
+      "from": "hapi@7.5.3",
+      "resolved": "https://registry.npmjs.org/hapi/-/hapi-7.5.3.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "boom": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz"
-        },
-        "bossy": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz"
+          "version": "2.5.1",
+          "from": "boom@2.5.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.5.1.tgz"
         },
         "call": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/call/-/call-1.0.0.tgz",
+          "from": "call@1.0.0",
           "resolved": "https://registry.npmjs.org/call/-/call-1.0.0.tgz"
         },
         "catbox": {
           "version": "4.1.0",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz",
+          "from": "catbox@4.1.0",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz"
         },
         "catbox-memory": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
+          "version": "1.1.0",
+          "from": "catbox-memory@1.1.0",
+          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz",
+          "from": "h2o2@2.0.1",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz"
         },
         "heavy": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz",
+          "from": "heavy@1.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz"
         },
         "hoek": {
           "version": "2.9.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
+          "from": "hoek@2.9.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
+        "glue": {
+          "version": "1.0.0",
+          "from": "glue@1.0.0",
+          "resolved": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz"
+        },
         "inert": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/inert/-/inert-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/inert/-/inert-1.1.0.tgz"
+          "version": "1.1.1",
+          "from": "inert@1.1.1",
+          "resolved": "https://registry.npmjs.org/inert/-/inert-1.1.1.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            }
+          }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
+          "from": "mimos@1.0.1",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.2.0.tgz"
+              "version": "1.1.2",
+              "from": "mime-db@1.1.2",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
             }
           }
         },
         "qs": {
           "version": "2.3.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz",
+          "from": "qs@2.3.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
+        },
+        "rejoice": {
+          "version": "1.0.0",
+          "from": "rejoice@1.0.0",
+          "resolved": "https://registry.npmjs.org/rejoice/-/rejoice-1.0.0.tgz",
+          "dependencies": {
+            "bossy": {
+              "version": "1.0.2",
+              "from": "bossy@1.0.2",
+              "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz"
+            }
+          }
         },
         "shot": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz",
+          "from": "shot@1.3.5",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz"
         },
         "statehood": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz",
+          "from": "statehood@1.2.0",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz"
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+          "from": "subtext@1.0.2",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -2807,147 +3075,142 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz",
+          "from": "vision@1.2.1",
           "resolved": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz"
         },
         "wreck": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz",
+          "from": "wreck@5.0.1",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz"
-        },
-        "lru-cache": {
-          "version": "2.5.0",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         }
       }
     },
     "hapi-auth-hawk": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-1.1.1.tgz",
+      "from": "hapi-auth-hawk@1.1.1",
       "resolved": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-1.1.1.tgz",
       "dependencies": {
         "boom": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz"
+          "version": "2.6.1",
+          "from": "boom@2.x.x",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "hoek": {
-          "version": "2.9.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@2.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
     },
     "hawk": {
       "version": "2.3.0",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
+      "from": "hawk@2.3.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.9.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "boom": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.0.tgz"
+          "version": "2.6.1",
+          "from": "boom@2.x.x",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "from": "sntp@1.x.x",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "hkdf": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
+      "from": "hkdf@0.0.2",
       "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "joi": {
       "version": "4.7.0",
-      "from": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
+      "from": "joi@4.7.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.9.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+          "from": "isemail@1.x.x",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         }
       }
     },
     "jws": {
       "version": "0.2.6",
-      "from": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
+      "from": "jws@0.2.6",
       "resolved": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
       "dependencies": {
         "base64url": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+          "from": "base64url@0.0.6",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
         },
         "jwa": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/jwa/-/jwa-0.0.1.tgz",
+          "from": "jwa@0.0.1",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-0.0.1.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
+      "from": "load-grunt-tasks@0.6.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2956,46 +3219,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
+          "from": "multimatch@^0.3.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
+              "from": "array-differ@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+              "from": "array-union@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
+                  "from": "array-uniq@^0.1.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@^0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3006,68 +3269,68 @@
     },
     "mailparser": {
       "version": "0.4.6",
-      "from": "https://registry.npmjs.org/mailparser/-/mailparser-0.4.6.tgz",
+      "from": "mailparser@0.4.6",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.4.6.tgz",
       "dependencies": {
         "mimelib": {
           "version": "0.2.18",
-          "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.18.tgz",
+          "from": "mimelib@>=0.2.17",
           "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.18.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz",
+              "from": "addressparser@~0.2.1",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
             }
           }
         },
         "encoding": {
           "version": "0.1.11",
-          "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+          "from": "encoding@>=0.1.4",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
           "dependencies": {
             "iconv-lite": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+              "version": "0.4.5",
+              "from": "iconv-lite@~0.4.4",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@^1.2.11",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "uue": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/uue/-/uue-1.0.0.tgz",
+          "from": "uue@~1.0.0",
           "resolved": "https://registry.npmjs.org/uue/-/uue-1.0.0.tgz"
         }
       }
     },
     "nock": {
       "version": "0.48.1",
-      "from": "https://registry.npmjs.org/nock/-/nock-0.48.1.tgz",
+      "from": "nock@0.48.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-0.48.1.tgz",
       "dependencies": {
         "propagate": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.0.tgz",
+          "from": "propagate@0.3.x",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.0.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "debug": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "from": "debug@^1.0.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
@@ -3076,54 +3339,54 @@
     },
     "p-promise": {
       "version": "0.4.8",
-      "from": "https://registry.npmjs.org/p-promise/-/p-promise-0.4.8.tgz",
+      "from": "p-promise@0.4.8",
       "resolved": "https://registry.npmjs.org/p-promise/-/p-promise-0.4.8.tgz"
     },
     "poolee": {
       "version": "0.4.15",
-      "from": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
+      "from": "poolee@0.4.15",
       "resolved": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
       "dependencies": {
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+          "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.45.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
+      "from": "request@2.45.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.3",
-          "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+          "from": "bl@~0.9.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@~1.0.26",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -3132,240 +3395,240 @@
         },
         "caseless": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
+          "from": "caseless@~0.6.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "from": "forever-agent@~0.5.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "qs": {
           "version": "1.2.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "from": "qs@^1.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+          "from": "json-stringify-safe@~5.0.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "from": "mime-types@~1.0.1",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "node-uuid": {
-          "version": "1.4.1",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+          "version": "1.4.2",
+          "from": "node-uuid@^1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "from": "tunnel-agent@^0.4.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "from": "form-data@~0.1.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "from": "combined-stream@~0.0.4",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "from": "mime@~1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@~0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "from": "tough-cookie@>=0.12.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@>=0.2.0",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "http-signature": {
-          "version": "0.10.0",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+          "version": "0.10.1",
+          "from": "http-signature@^0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+              "version": "0.1.5",
+              "from": "assert-plus@^0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
-              "version": "0.5.2",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
+          "from": "oauth-sign@~0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
         },
         "hawk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "from": "hawk@1.1.1",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+              "from": "hoek@0.9.x",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+              "from": "boom@0.4.x",
               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+              "from": "cryptiles@0.2.x",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+              "from": "sntp@0.2.x",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "from": "aws-sign2@~0.5.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+          "from": "stringstream@~0.0.4",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         }
       }
     },
     "scrypt-hash": {
       "version": "1.1.8",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
+      "from": "scrypt-hash@1.1.8",
       "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz",
+          "from": "bindings@1.1.1",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz"
         },
         "nan": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz",
+          "from": "nan@0.7.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
         }
       }
     },
     "simplesmtp": {
       "version": "0.3.33",
-      "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.33.tgz",
+      "from": "simplesmtp@0.3.33",
       "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.33.tgz",
       "dependencies": {
         "rai": {
           "version": "0.1.11",
-          "from": "https://registry.npmjs.org/rai/-/rai-0.1.11.tgz",
+          "from": "rai@~0.1.11",
           "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.11.tgz"
         },
         "xoauth2": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
+          "from": "xoauth2@~0.1.8",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
         }
       }
     },
     "sjcl": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.1.tgz",
+      "from": "sjcl@1.0.1",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.1.tgz"
     },
     "tap": {
       "version": "0.4.13",
-      "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+      "from": "tap@0.4.13",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+          "from": "buffer-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+          "from": "deep-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "from": "difflet@~0.2.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+              "from": "traverse@0.6.x",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+              "from": "charm@0.1.x",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@0.1.x",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@~3.2.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3374,56 +3637,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@~0.3 || 0.4 || 0.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "from": "nopt@~2",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "from": "runforcover@~0.0.2",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "from": "bunker@0.1.X",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "from": "burrito@>=0.2.5 <0.3",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                      "from": "traverse@~0.5.1",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                      "from": "uglify-js@~1.1.1",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -3434,24 +3697,24 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
+          "from": "yamlish@*",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
         }
       }
     },
     "through": {
       "version": "2.3.6",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+      "from": "through@2.3.6",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
+      "from": "uuid@1.4.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compute-cluster": "0.0.9",
     "convict": "0.6",
     "fxa-auth-mailer": "1.0.7",
-    "hapi": "7.0.0",
+    "hapi": "7.5.3",
     "hapi-auth-hawk": "1.1.1",
     "hkdf": "0.0.2",
     "joi": "4.7.0",


### PR DESCRIPTION
@dannycoates r?

The many npm-shrinkwrap.json changes are mostly noise, e.g. the `from` field changing from URLs to version numbers for reasons I don't understand.  I manually sanity-checked it in `git diff` output and it seemed sensible.