### PR TITLE
Increase default token lifetimes to 30mins.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -171,7 +171,7 @@ module.exports = function (fs, path, url, convict) {
         default: 1000 * 60 * 15
       },
       passwordForgotToken: {
-        default: 1000 * 60 * 15
+        default: 1000 * 60 * 60
       },
       passwordChangeToken: {
         default: 1000 * 60 * 15

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -246,7 +246,7 @@ TestServer.start(config)
               .then(
                 function (x) {
                   t.equal(x.tries, 3, 'three tries remaining')
-                  t.ok(x.ttl > 0 && x.ttl < (60*60), 'ttl is ok')
+                  t.ok(x.ttl > 0 && x.ttl <= (60*60), 'ttl is ok')
                 }
               )
           }


### PR DESCRIPTION
Fixes #845.

@dannycoates r?  Do we tweak these values in any production config?  I couldn't find it if so...