### PR TITLE
change package.json description to refer to Firefox Accounts, not 'PiCl'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fxa-auth-server",
   "version": "1.30.0",
-  "description": "An identity provider for PiCL services",
+  "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"
   },


### PR DESCRIPTION
Just happened to notice this outdated line. If folks have a better description, let me know.