### PR TITLE
Log account lockout events even if we don't actually do the lockout.

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -596,7 +596,11 @@ module.exports = function (
                     if (!butil.buffersAreEqual(code, expectedCode)) {
                       throw error.invalidVerificationCode()
                     }
-                    log.event('unlocked', { email: account.email, uid: account.uid })
+                    log.info({
+                      op: 'account.unlock',
+                      email: account.email,
+                      uid: account.uid
+                    })
                     return db.unlockAccount(account)
                   }
                 )
@@ -747,8 +751,11 @@ module.exports = function (
                   if (! match) {
                     throw error.incorrectPassword(emailRecord.email, email)
                   }
-
-                  log.event('locked', { email: emailRecord.email, uid: emailRecord.uid })
+                  log.info({
+                    op: 'account.lock',
+                    email: emailRecord.email,
+                    uid: emailRecord.uid
+                  })
                   return db.lockAccount(emailRecord)
                 }
               )

--- a/routes/utils/password_check.js
+++ b/routes/utils/password_check.js
@@ -27,9 +27,15 @@ module.exports = function (log, config, Password, customs, db) {
           return customs.flag(clientAddress, emailRecord)
             .then(
               function (result) {
-                if (result.lockout && config.lockoutEnabled) {
-                  log.event('locked', { email: emailRecord.email, uid: emailRecord.uid })
-                  return db.lockAccount(emailRecord)
+                if (result.lockout) {
+                  log.info({
+                    op: 'account.lock',
+                    email: emailRecord.email,
+                    uid: emailRecord.uid
+                  })
+                  if (config.lockoutEnabled) {
+                    return db.lockAccount(emailRecord)
+                  }
                 }
               }
             )

--- a/test/local/password_check_test.js
+++ b/test/local/password_check_test.js
@@ -4,7 +4,7 @@
 
 var P = require('../../promise')
 var test = require('../ptaptest')
-var MockLog = { event: function () { } }
+var MockLog = { info: function () { } }
 var config = { lockoutEnabled: true }
 var Password = require('../../crypto/password')(MockLog, config)
 


### PR DESCRIPTION
This will allow us to deploy the lockout code preffed off, but still get metrics on how often it would have triggered if it were enabled.  It would be good to have this in train-32 when the account lockout stuff starts to hit prod.

I also switched from `log.event` to `log.info` since the "events" things are special-purpose account lifecycle events designed to be consumed by downstream services, e.g. telling sync to delete a user's data if they delete their account.

@shane-tomlinson r?