### PR TITLE
Enable build on ARM platforms (including Raspberry Pi)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4091,19 +4091,19 @@
       }
     },
     "scrypt-hash": {
-      "version": "1.1.8",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
-      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
+      "version": "1.1.10",
+      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.10.tgz",
       "dependencies": {
         "bindings": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz"
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
-          "version": "0.7.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
+          "version": "1.5.1",
+          "from": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "p-promise": "0.4.8",
     "poolee": "0.4.15",
     "request": "2.45.0",
-    "scrypt-hash": "1.1.8",
+    "scrypt-hash": "1.1.10",
     "through": "2.3.6",
     "uuid": "1.4.1"
   },


### PR DESCRIPTION
Older versions of scrypt-hash depend on the processor supporting SSE instructions, in newer versions there is also an alternative implementation. This patch enables fxa-auth-server to build on ARM.