### PR TITLE
for train-32 only, a heinous hack to get email subjects back

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1419,7 +1419,7 @@
         "fxa-content-server-l10n": {
           "version": "0.0.0",
           "from": "../../../../../var/folders/rv/6mf4_t5x169fdxtrnd14y7500000gq/T/npm-5674-8640dc71/git-cache-5c04985ffe86/b9c5127a00d23b153f754aeaf320f683682ed5e4",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#b9c5127a00d23b153f754aeaf320f683682ed5e4"
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#4168ef3cb781349e1f65844192adcf961f7f0549"
         },
         "handlebars": {
           "version": "1.3.0",


### PR DESCRIPTION
Related to https://github.com/mozilla/fxa-auth-mailer/issue/31 and https://github.com/mozilla/fxa-auth-mailer/pull/32, this (ab)use of shrinkwrap will cause npm to put the strings used in train-31. This means we don't get 'Almost There' translated in some languages (not all locales have translated it yet), but we get back the translations of the email `Subject:` header for 'Verify your account' and 'Reset your password'.