### PR TITLE
WIP: support deviceName and lifetime as sessionToken metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,8 @@ ___Parameters___
 * redirectTo - (optional) a URL that the client should be redirected to after handling the request
 * resume - (optional) opaque url-encoded string that will be included in the verification link as a querystring parameter, useful for continuing an OAuth flow for example.
 * preVerifyToken - (optional) see below
+* deviceName - (optional) opaque string name used by the connecting client to describe itself to the user
+* sessionLifetime - (optional) time in seconds before the `sessionToken` should expire; if missing or null then the session is valid until destroyed
 
 ### Request
 
@@ -273,6 +275,10 @@ ___Parameters___
 
 * email - the primary email for this account
 * authPW - the PBKDF2/HKDF stretched password as a hex string
+* service - (optional) opaque alphanumeric token to be included in verification links
+* reason - (optional) alphanumeric string indicating the reason for establishing a new session; may be "login" (the default) or "reconnect"
+* deviceName - (optional) opaque string name used by the connecting client to describe itself to the user
+* sessionLifetime - (optional) time in seconds before the `sessionToken` should expire; if missing or null then the session is valid until destroyed
 
 ### Request
 
@@ -379,7 +385,7 @@ This request will fail unless the account's email address has been verified.
 
 ___Headers___
 
-The request must include a HAWK header that authenticates the request using a `keyFetchToken` received from `/session/create`.
+The request must include a HAWK header that authenticates the request using a `keyFetchToken` received from `/v1/account/create` or `/v1/account/login`.
 
 ```sh
 curl -v \
@@ -667,11 +673,12 @@ https://api-accounts.dev.lcip.org/v1/session/status \
 
 ### Response
 
-Successful requests will produce a "200 OK" response with the account uid in the JSON body object:
+Successful requests will produce a "200 OK" response with the account uid and session ttl in the JSON body object:
 
 ```json
 {
-  "uid": "80dc2f2e373b4b3bb992468e6d578cd2"
+  "uid": "80dc2f2e373b4b3bb992468e6d578cd2",
+  "ttl": null
 }
 ```
 
@@ -784,7 +791,7 @@ ___Parameters___
 
 ___Headers___
 
-The request must include a Hawk header that authenticates the request (including payload) using a `sessionToken` received from `/v1/session/create`.
+The request must include a Hawk header that authenticates the request (including payload) using a `sessionToken` received from `/v1/account/login`.
 
 ```sh
 curl -v \

--- a/routes/account.js
+++ b/routes/account.js
@@ -39,6 +39,8 @@ module.exports = function (
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             preVerified: isA.boolean(),
             service: isA.string().max(16).alphanum().optional(),
+            deviceName: isA.string().max(64).alphanum().optional(),
+            sessionLifetime: isA.number().integer().min(0).optional(),
             redirectTo: validators.redirectTo(redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
             preVerifyToken: isA.string().max(2048).regex(BASE64_JWT).optional()
@@ -117,7 +119,9 @@ module.exports = function (
                           email: account.email,
                           emailCode: account.emailCode,
                           emailVerified: account.emailVerified,
-                          verifierSetAt: account.verifierSetAt
+                          verifierSetAt: account.verifierSetAt,
+                          deviceName: form.deviceName || null,
+                          lifetime: form.sessionLifetime || null
                         }
                       )
                       .then(
@@ -202,6 +206,10 @@ module.exports = function (
           payload: {
             email: validators.email().required(),
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required()
+            service: isA.string().max(16).alphanum().optional(),
+            reason: isA.string().max(16).optional(),
+            deviceName: isA.string().max(64).alphanum().optional(),
+            sessionLifetime: isA.number().integer().min(0).optional(),
           }
         },
         response: {
@@ -241,7 +249,9 @@ module.exports = function (
                         email: emailRecord.email,
                         emailCode: emailRecord.emailCode,
                         emailVerified: emailRecord.emailVerified,
-                        verifierSetAt: emailRecord.verifierSetAt
+                        verifierSetAt: emailRecord.verifierSetAt,
+                        deviceName: form.deviceName || null,
+                        lifetime: form.sessionLifetime || null
                       }
                     )
                   }

--- a/routes/session.js
+++ b/routes/session.js
@@ -36,7 +36,10 @@ module.exports = function (log, isA, error, db) {
       handler: function (request, reply) {
         log.begin('Session.status', request)
         var sessionToken = request.auth.credentials
-        reply({ uid: sessionToken.uid.toString('hex') })
+        reply({
+          uid: sessionToken.uid.toString('hex'),
+          ttl: sessionToken.ttl()
+        })
       }
     }
   ]


### PR DESCRIPTION
Here's a quick riff on @shane-tomlinson's suggestion from https://github.com/mozilla/fxa-auth-server/issues/303#issuecomment-78311025

It adds the following metadata to each sessionToken:

  * `deviceName`: client-provided device description which we can use in emails, dashboards etc
  * `sessionLifetime`:  a ttl for the session, if the client knows it should be short-lived

(The `sessionLifetime` thing is not directly in service of the linked bug, but if we're in here mucking with sessions, it's something I've been thinking about for a while).

It also adds two informational parameters to the `/v1/account/login` request:

  * `service`:  the existing service identifier that we use on other endpoints, including `/v1/account/create`
  * `reason`: the flow-tagging reason for logging in

I proposed just two values for `reason`, to indicate either (a) establishing a new session, or (b) re-establishing a previous, invalidated session.  I wonder if there's a third reason that's something like "I just want to check the user's password for auth purposes, and don't actually need a session at all".

For completeness, I'll also note that these changes might feed back into another ancient bug, #286.  But I don't want to try to solve all the things all at once here if it blocks getting this long-standing metrics bug out the door.

@shane-tomlinson @dannycoates thoughts?

Oh, and for the benefit of waffle: Fixes #303 