### PR TITLE
fix(logging): log emailRecord.uid as a hex string, not a byte array

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -754,7 +754,7 @@ module.exports = function (
                   log.info({
                     op: 'account.lock',
                     email: emailRecord.email,
-                    uid: emailRecord.uid
+                    uid: emailRecord.uid.toString('hex')
                   })
                   return db.lockAccount(emailRecord)
                 }

--- a/routes/utils/password_check.js
+++ b/routes/utils/password_check.js
@@ -31,7 +31,7 @@ module.exports = function (log, config, Password, customs, db) {
                   log.info({
                     op: 'account.lock',
                     email: emailRecord.email,
-                    uid: emailRecord.uid
+                    uid: emailRecord.uid.toString('hex')
                   })
                   if (config.lockoutEnabled) {
                     return db.lockAccount(emailRecord)


### PR DESCRIPTION
A PII scrubber is choking on the '[123, 65, 21, ...]' formatting, and it should be .toString('hex')

r? @rfk 