### PR TITLE
chore(release): add tasks "grunt version" and "grunt version:patch" to create release tags

### DIFF
--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// takes care of bumping the version number in package.json
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('bump', {
+    options: {
+      files: ['package.json', 'npm-shrinkwrap.json'],
+      bumpVersion: true,
+      commit: true,
+      commitMessage: 'Release v%VERSION%',
+      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG'],
+      createTag: true,
+      tagName: 'v%VERSION%',
+      tagMessage: 'Version %VERSION%',
+      push: false,
+      pushTo: 'origin',
+      gitDescribeOptions: '--tags --always --abrev=1 --dirty=-d'
+    }
+  });
+};
+

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -3,9 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = function (grunt) {
-  require('load-grunt-tasks')(grunt);
+  'use strict';
 
-  grunt.loadTasks('grunttasks');
-
-  grunt.registerTask('default', ['jshint', 'copyright']);
-};
+  grunt.config('copyright', {
+    files: [
+      "**/*.js",
+      "!node_modules/**",
+      "!sandbox/**"
+    ],
+    options: {
+      pattern: "This Source Code Form is subject to the terms of the Mozilla Public"
+    }
+  })
+}

--- a/grunttasks/jshint.js
+++ b/grunttasks/jshint.js
@@ -3,9 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = function (grunt) {
-  require('load-grunt-tasks')(grunt);
+  'use strict';
 
-  grunt.loadTasks('grunttasks');
-
-  grunt.registerTask('default', ['jshint', 'copyright']);
-};
+  grunt.config('jshint', {
+      files: [
+        "**/*.js",
+        "**/*.json",
+        "!node_modules/**",
+        "!sandbox/**",
+        "!web/**"
+      ],
+      options: {
+        jshintrc: ".jshintrc"
+      }
+  })
+}

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//
+// A task to stamp a new version.
+//
+// Before running this task you should update CHANGELOG with the
+// changes for this release. Protip: you only need to make changes
+// to CHANGELOG; this task will add and commit for you.
+//
+// * version is updated in package.json
+// * git tag with version name is created.
+// * git commit with updated package.json created.
+//
+// NOTE: This task will not push this commit for you.
+//
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.registerTask('version', [
+    'bump-only:minor',
+    'bump-commit'
+  ]);
+
+  grunt.registerTask('version:patch', [
+    'bump-only:patch',
+    'bump-commit'
+  ]);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "dependencies": {
     "ass": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ass": "0.0.4",
     "fxa-auth-db-mem": "git+https://github.com/mozilla/fxa-auth-db-mem.git#49e33d4a",
     "grunt": "0.4.5",
+    "grunt-bump": "0.3.0",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",


### PR DESCRIPTION
Folks can `git clone https://github.com/jrgm/fxa-auth-server/tree/add-version-task` and then try doing edit Changelog, `grunt version` or `grunt version:patch`, look at git log -3, and git tags, etc.. To get back to the original state,  do `git tag -d v1.33.0` (or whatever), and then do `git reset --hard origin/add-version-task`. 

@rfkelly, @dannycoates, @chilts - try it out and r?