### PR TITLE
chore(shrinkwrap): get latest fxa-content-server-l10n version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2268,7 +2268,7 @@
         "fxa-content-server-l10n": {
           "version": "0.0.0",
           "from": "fxa-content-server-l10n@git://github.com/mozilla/fxa-content-server-l10n.git#b9c5127a00d23b153f754aeaf320f683682ed5e4",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#b9c5127a00d23b153f754aeaf320f683682ed5e4"
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#5e61c9f0b0b886ed5962a74290ad69631aaf4465"
         },
         "handlebars": {
           "version": "1.3.0",


### PR DESCRIPTION
Picks up subject lines and lockout strings. 