### PR TITLE
WIP feat(auth): allow backend server access to our API with JWT authentication

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,32 +4,32 @@
   "dependencies": {
     "ass": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
+      "from": "ass@0.0.4",
       "resolved": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
       "dependencies": {
         "blanket": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "from": "blanket@~1.1.5",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+              "from": "falafel@~0.1.6",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "from": "xtend@~2.1.1",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                  "from": "object-keys@~0.4.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -38,74 +38,74 @@
         },
         "temp": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
+          "from": "temp@~0.6.0",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "from": "rimraf@~2.1.4",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                  "from": "graceful-fs@~1",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+              "from": "osenv@0.0.3",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
           "version": "0.12.4",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+          "from": "cheerio@~0.12.4",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
+              "from": "cheerio-select@*",
               "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
-                  "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
+                  "from": "CSSselect@0.x",
                   "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                      "from": "CSSwhat@0.4",
                       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                      "from": "domutils@1.4",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                          "from": "domelementtype@1",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                      "from": "boolbase@~1.0.0",
                       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
                     },
                     "nth-check": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "nth-check@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
                     }
                   }
                 }
@@ -113,47 +113,47 @@
             },
             "htmlparser2": {
               "version": "3.1.4",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+              "from": "htmlparser2@3.1.4",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
+                  "from": "domhandler@2.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+                  "from": "domutils@1.1",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -162,12 +162,12 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+              "from": "underscore@~1.4",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+              "from": "entities@0.x",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             }
           }
@@ -176,107 +176,119 @@
     },
     "aws-sdk": {
       "version": "2.0.21",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.21.tgz",
+      "from": "aws-sdk@2.0.21",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.21.tgz",
       "dependencies": {
         "xml2js": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+          "from": "xml2js@0.2.6",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
           "dependencies": {
             "sax": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+              "from": "sax@0.4.2",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
             }
           }
         },
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+          "from": "xmlbuilder@0.4.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "bigint": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/bigint/-/bigint-0.4.2.tgz",
+      "from": "bigint@0.4.2",
       "resolved": "https://registry.npmjs.org/bigint/-/bigint-0.4.2.tgz"
     },
     "binary-split": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
+      "from": "binary-split@0.1.2",
       "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
       "dependencies": {
         "bops": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+          "from": "bops@0.0.6",
           "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+              "from": "base64-js@0.0.2",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
             },
             "to-utf8": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+              "from": "to-utf8@0.0.1",
               "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz"
             }
           }
         }
       }
     },
+    "boom": {
+      "version": "2.6.1",
+      "from": "boom@2.6.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "2.12.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+        }
+      }
+    },
     "browserid-crypto": {
       "version": "0.7.0",
-      "from": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.7.0.tgz",
+      "from": "browserid-crypto@0.7.0",
       "resolved": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.7.0.tgz",
       "dependencies": {
         "browserify": {
           "version": "5.9.1",
-          "from": "https://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
+          "from": "browserify@5.9.1",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "from": "JSONStream@~0.8.3",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "assert": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+              "from": "assert@~1.1.0",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
             },
             "browser-pack": {
               "version": "3.2.0",
-              "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+              "from": "browser-pack@^3.0.0",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
               "dependencies": {
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "from": "inline-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "from": "source-map@~0.3.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -285,17 +297,17 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -304,90 +316,90 @@
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "browser-resolve": {
-              "version": "1.7.2",
-              "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
+              "version": "1.8.1",
+              "from": "browser-resolve@^1.3.0",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.1.tgz",
               "dependencies": {
                 "resolve": {
-                  "version": "1.1.5",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+                  "version": "1.1.6",
+                  "from": "resolve@1.1.6",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
                 }
               }
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "from": "browserify-zlib@~0.1.2",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
-                  "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+                  "version": "0.2.6",
+                  "from": "pako@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
                 }
               }
             },
             "buffer": {
               "version": "2.8.2",
-              "from": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
+              "from": "buffer@^2.3.0",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
+                  "from": "base64-js@0.0.7",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
+                  "from": "ieee754@^1.1.4",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+                  "from": "is-array@^1.0.1",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+              "from": "builtins@~0.0.3",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+              "from": "commondir@0.0.1",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+              "from": "concat-stream@~1.4.1",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@~0.0.5",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -396,88 +408,88 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@^1.1.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+              "from": "constants-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
               "version": "3.9.13",
-              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+              "from": "crypto-browserify@^3.0.0",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
               "dependencies": {
                 "browserify-aes": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
+                  "from": "browserify-aes@^1.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
                 },
                 "browserify-sign": {
                   "version": "2.8.0",
-                  "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+                  "from": "browserify-sign@2.8.0",
                   "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
+                      "from": "browserify-rsa@^1.1.0",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                      "from": "parse-asn1@^2.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                          "from": "asn1.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "asn1.js-rfc3280": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
+                          "from": "asn1.js-rfc3280@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                         },
                         "pemstrip": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
+                          "from": "pemstrip@0.0.1",
                           "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                         }
                       }
@@ -486,27 +498,27 @@
                 },
                 "create-ecdh": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+                  "from": "create-ecdh@^2.0.0",
                   "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
@@ -514,45 +526,45 @@
                   }
                 },
                 "create-hash": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "create-hash@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "dependencies": {
                     "ripemd160": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
+                      "from": "ripemd160@^1.0.0",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                     },
                     "sha.js": {
                       "version": "2.3.6",
-                      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+                      "from": "sha.js@^2.3.6",
                       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                     }
                   }
                 },
                 "create-hmac": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
+                  "from": "create-hmac@^1.1.0",
                   "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
                 },
                 "diffie-hellman": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+                  "from": "diffie-hellman@^3.0.1",
                   "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "miller-rabin": {
                       "version": "1.1.5",
-                      "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                      "from": "miller-rabin@^1.1.2",
                       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         }
                       }
@@ -561,37 +573,37 @@
                 },
                 "pbkdf2-compat": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
+                  "from": "pbkdf2-compat@^3.0.1",
                   "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                 },
                 "public-encrypt": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+                  "from": "public-encrypt@^2.0.0",
                   "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
+                      "from": "browserify-rsa@^2.0.0",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "parse-asn1": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                      "from": "parse-asn1@^3.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                          "from": "asn1.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
@@ -602,61 +614,61 @@
                 },
                 "randombytes": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+                  "from": "randombytes@^2.0.0",
                   "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "from": "deep-equal@~0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "defined": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+              "from": "defined@~0.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
             },
             "deps-sort": {
               "version": "1.3.5",
-              "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+              "from": "deps-sort@^1.3.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "domain-browser": {
               "version": "1.1.4",
-              "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+              "from": "domain-browser@~1.1.0",
               "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
             },
             "duplexer2": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "from": "duplexer2@~0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -665,27 +677,27 @@
             },
             "events": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+              "from": "events@~1.0.0",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.8",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -694,49 +706,49 @@
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+              "from": "https-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
               "version": "6.2.1",
-              "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+              "from": "insert-module-globals@^6.1.0",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "from": "inline-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "from": "source-map@~0.3.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -745,17 +757,17 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -764,17 +776,17 @@
                 },
                 "lexical-scope": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                  "from": "lexical-scope@~1.1.0",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                      "from": "astw@~1.1.0",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "3001.1.0-dev-harmony-fb",
-                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                         }
                       }
@@ -783,51 +795,51 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+                  "from": "process@~0.6.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 }
               }
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "labeled-stream-splicer": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+              "from": "labeled-stream-splicer@^1.0.0",
               "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "dependencies": {
                 "stream-splicer": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+                  "from": "stream-splicer@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "readable-stream@^1.1.13-1",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                      "from": "readable-wrap@^1.0.0",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "from": "indexof@0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     }
                   }
@@ -835,97 +847,97 @@
               }
             },
             "module-deps": {
-              "version": "3.7.2",
-              "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
+              "version": "3.7.3",
+              "from": "module-deps@^3.5.0",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+                  "from": "detective@^4.0.0",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "0.9.0",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+                      "from": "acorn@~0.9.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                     },
                     "escodegen": {
                       "version": "1.6.1",
-                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                      "from": "escodegen@^1.4.1",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                       "dependencies": {
                         "estraverse": {
-                          "version": "1.9.1",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
-                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+                          "version": "1.9.3",
+                          "from": "estraverse@^1.9.1",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                         },
                         "esutils": {
                           "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                          "from": "esutils@^1.1.6",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                         },
                         "esprima": {
                           "version": "1.2.5",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                          "from": "esprima@^1.2.2",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                         },
                         "optionator": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                          "from": "optionator@^0.5.0",
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                           "dependencies": {
                             "prelude-ls": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
+                              "from": "prelude-ls@~1.1.1",
                               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                             },
                             "deep-is": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                              "from": "deep-is@~0.1.2",
                               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             },
                             "type-check": {
                               "version": "0.3.1",
-                              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                              "from": "type-check@~0.3.1",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                             },
                             "levn": {
                               "version": "0.2.5",
-                              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                              "from": "levn@~0.2.5",
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                             },
                             "fast-levenshtein": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                              "from": "fast-levenshtein@~1.0.0",
                               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@~0.1.40",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -936,39 +948,39 @@
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "parents": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+                  "from": "parents@^1.0.0",
                   "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
                   "dependencies": {
                     "path-platform": {
                       "version": "0.11.15",
-                      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+                      "from": "path-platform@~0.11.15",
                       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                     }
                   }
                 },
                 "resolve": {
-                  "version": "1.1.5",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+                  "version": "1.1.6",
+                  "from": "resolve@^1.1.3",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
                 },
                 "stream-combiner2": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                  "from": "stream-combiner2@~1.0.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "from": "through2@~0.5.1",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                       "dependencies": {
                         "xtend": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                          "from": "xtend@~3.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                         }
                       }
@@ -977,17 +989,17 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                  "from": "through2@~0.4.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                      "from": "xtend@~2.1.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                          "from": "object-keys@~0.4.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -996,248 +1008,248 @@
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+              "from": "os-browserify@~0.1.1",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+              "from": "parents@~0.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+                  "from": "path-platform@^0.0.1",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "from": "path-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.7.0",
-              "from": "https://registry.npmjs.org/process/-/process-0.7.0.tgz",
+              "from": "process@^0.7.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+              "from": "punycode@~1.2.3",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+              "from": "querystring-es3@~0.2.0",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@^1.0.27-1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+              "from": "resolve@~0.7.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "shallow-copy": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+              "from": "shallow-copy@0.0.1",
               "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shasum": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+              "from": "shasum@^1.0.0",
               "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
               "dependencies": {
                 "json-stable-stringify": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                  "from": "json-stable-stringify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                      "from": "jsonify@~0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
                 },
                 "sha.js": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+                  "from": "sha.js@~2.3.0",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+              "from": "shell-quote@~0.0.1",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "from": "stream-browserify@^1.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+              "from": "stream-combiner@~0.0.2",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "dependencies": {
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                  "from": "duplexer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz",
+              "from": "string_decoder@~0.0.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "from": "subarg@0.0.1",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@~0.0.7",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "syntax-error": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+              "from": "syntax-error@^1.1.1",
               "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+                  "from": "acorn@~0.9.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "from": "through2@^1.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "timers-browserify": {
               "version": "1.4.0",
-              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+              "from": "timers-browserify@^1.0.1",
               "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
               "dependencies": {
                 "process": {
-                  "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+                  "version": "0.10.1",
+                  "from": "process@~0.10.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
                 }
               }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "from": "tty-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "umd": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+              "from": "umd@~2.1.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
               "dependencies": {
                 "rfile": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+                  "from": "rfile@~1.0.0",
                   "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
                   "dependencies": {
                     "callsite": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                      "from": "callsite@~1.0.0",
                       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                     },
                     "resolve": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+                      "from": "resolve@~0.3.0",
                       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                     }
                   }
                 },
                 "ruglify": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+                  "from": "ruglify@~1.0.0",
                   "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
                   "dependencies": {
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                      "from": "uglify-js@~2.2",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@~0.1.7",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                          "from": "optimist@~0.3.5",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
@@ -1250,133 +1262,133 @@
             },
             "url": {
               "version": "0.10.3",
-              "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "from": "url@~0.10.1",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@1.3.2",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 },
                 "querystring": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+                  "from": "querystring@0.2.0",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "from": "util@~0.10.1",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "from": "vm-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "from": "xtend@^3.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
         },
         "http-browserify": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.4.1.tgz",
+          "from": "http-browserify@1.4.1",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.4.1.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@~0.2.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "vows": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
+          "from": "vows@0.7.0",
           "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.6",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "diff": {
               "version": "1.0.8",
-              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+              "from": "diff@~1.0.3",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.4.15",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
+          "from": "uglify-js@2.4.15",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "from": "source-map@0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@~0.3",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@~1.0.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
@@ -1385,46 +1397,46 @@
     },
     "bunyan": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.2.0.tgz",
+      "from": "bunyan@1.2.0",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.2.0.tgz",
       "dependencies": {
         "dtrace-provider": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.3.0.tgz",
+          "from": "dtrace-provider@0.3.0",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.3.0.tgz",
           "dependencies": {
             "nan": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz",
+              "from": "nan@~1.3.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
             }
           }
         },
         "mv": {
           "version": "2.0.3",
-          "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+          "from": "mv@~2",
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@~0.5.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "ncp": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+              "from": "ncp@~0.6.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@~2.2.8",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -1433,17 +1445,17 @@
     },
     "compute-cluster": {
       "version": "0.0.9",
-      "from": "https://registry.npmjs.org/compute-cluster/-/compute-cluster-0.0.9.tgz",
+      "from": "compute-cluster@0.0.9",
       "resolved": "https://registry.npmjs.org/compute-cluster/-/compute-cluster-0.0.9.tgz",
       "dependencies": {
         "vows": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/vows/-/vows-0.6.0.tgz",
+          "from": "vows@0.6.0",
           "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.0.tgz",
           "dependencies": {
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.6",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             }
           }
@@ -1452,47 +1464,47 @@
     },
     "convict": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+      "from": "convict@0.6.1",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+          "from": "cjson@0.3.0",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>= 1.5.x",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@~1.6.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@~0.4.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@~0.1.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@~1.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@~0.1.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -1501,7 +1513,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>= 4.0.x",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -1510,46 +1522,46 @@
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
           "version": "2.8.4",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+          "from": "moment@2.8.4",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.26.0",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz",
+          "from": "validator@3.26.0",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
         }
       }
     },
     "fxa-auth-db-mem": {
       "version": "0.18.2",
-      "from": "fxa-auth-db-mem@git+https://github.com/mozilla/fxa-auth-db-mem.git#49e33d4a84ae3a28686bfea44ab8b31156163b3c",
+      "from": "fxa-auth-db-mem@git+https://github.com/mozilla/fxa-auth-db-mem.git#49e33d4a",
       "resolved": "git+https://github.com/mozilla/fxa-auth-db-mem.git#49e33d4a84ae3a28686bfea44ab8b31156163b3c",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+          "from": "bluebird@2.2.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "fxa-auth-db-server": {
@@ -2057,7 +2069,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "from": "uuid@2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
         },
         "ass": {
@@ -2067,32 +2079,32 @@
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "blanket": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+              "from": "blanket@1.1.6",
               "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                  "from": "esprima@1.0.4",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 },
                 "falafel": {
                   "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+                  "from": "falafel@0.1.6",
                   "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "from": "xtend@2.1.2",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "from": "object-keys@0.4.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -2101,32 +2113,32 @@
             },
             "cheerio": {
               "version": "0.14.0",
-              "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+              "from": "cheerio@0.14.0",
               "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
               "dependencies": {
                 "htmlparser2": {
                   "version": "3.7.3",
-                  "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+                  "from": "htmlparser2@3.7.3",
                   "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
                   "dependencies": {
                     "domhandler": {
                       "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+                      "from": "domhandler@2.2.1",
                       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                     },
                     "domutils": {
                       "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "from": "domutils@1.5",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                       "dependencies": {
                         "dom-serializer": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
+                          "from": "dom-serializer@0.0.1",
                           "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
                           "dependencies": {
                             "entities": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                              "from": "entities@1.1.1",
                               "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                             }
                           }
@@ -2135,32 +2147,32 @@
                     },
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "from": "domelementtype@1.1.3",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "readable-stream@1.1",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@1.0.1",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@0.10.31",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -2169,27 +2181,27 @@
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@1.0.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 },
                 "CSSselect": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+                  "from": "CSSselect@0.4.1",
                   "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                      "from": "CSSwhat@0.4",
                       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                      "from": "domutils@1.4",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "from": "domelementtype@1.1.3",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         }
                       }
@@ -2198,19 +2210,19 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+                  "from": "lodash@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 }
               }
             },
             "temp": {
               "version": "0.8.1",
-              "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+              "from": "temp@0.8.1",
               "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
               "dependencies": {
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "from": "rimraf@2.2.8",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
@@ -2221,44 +2233,44 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.7",
-      "from": "fxa-auth-mailer@git+https://github.com/mozilla/fxa-auth-mailer.git#a2d00cf6596ded183673fcd3d131c970236ea6ec",
+      "from": "fxa-auth-mailer@git+https://github.com/mozilla/fxa-auth-mailer.git#a2d00cf6",
       "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#a2d00cf6596ded183673fcd3d131c970236ea6ec",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+          "from": "bluebird@2.2.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "bunyan": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.0.0.tgz",
+          "from": "bunyan@1.0.0",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.0.0.tgz",
           "dependencies": {
             "mv": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+              "from": "mv@~2",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "from": "mkdirp@~0.5.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                  "from": "ncp@~0.6.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "from": "rimraf@~2.2.8",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
@@ -2267,44 +2279,44 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "fxa-content-server-l10n@git://github.com/mozilla/fxa-content-server-l10n.git#b9c5127a00d23b153f754aeaf320f683682ed5e4",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#b9c5127a00d23b153f754aeaf320f683682ed5e4"
+          "from": "fxa-content-server-l10n@git://github.com/mozilla/fxa-content-server-l10n.git",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#fb2c5223cb638e5fcb60fb9579f4387403c8ca9f"
         },
         "handlebars": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+          "from": "handlebars@1.3.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@~0.3",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "from": "uglify-js@~2.3",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@~0.2.6",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@~0.1.7",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -2315,12 +2327,12 @@
         },
         "i18n-abide": {
           "version": "0.0.22",
-          "from": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
+          "from": "i18n-abide@0.0.22",
           "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+              "from": "async@0.1.22",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "gobbledygook": {
@@ -2330,27 +2342,27 @@
             },
             "jsxgettext": {
               "version": "0.3.9",
-              "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
+              "from": "jsxgettext@0.3.9",
               "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz",
+                  "from": "acorn@0.4.2",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz"
                 },
                 "gettext-parser": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+                  "from": "gettext-parser@0.2.0",
                   "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                      "from": "encoding@~0.1",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.7",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz",
+                          "from": "iconv-lite@~0.4.4",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
                         }
                       }
@@ -2359,102 +2371,102 @@
                 },
                 "nomnom": {
                   "version": "1.5.2",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+                  "from": "nomnom@1.5.2",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.1.7",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+                      "from": "underscore@1.1.x",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                     },
                     "colors": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                      "from": "colors@0.5.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     }
                   }
                 },
                 "jade": {
                   "version": "0.30.0",
-                  "from": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
+                  "from": "jade@0.30.0",
                   "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+                      "from": "commander@~1.1.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                       "dependencies": {
                         "keypress": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+                          "from": "keypress@0.1.x",
                           "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                      "from": "mkdirp@0.3.x",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     },
                     "transformers": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
+                      "from": "transformers@~2.0.1",
                       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                       "dependencies": {
                         "promise": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                          "from": "promise@~2.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                           "dependencies": {
                             "is-promise": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                              "from": "is-promise@~1",
                               "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                             }
                           }
                         },
                         "css": {
                           "version": "1.0.8",
-                          "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                          "from": "css@~1.0.8",
                           "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                           "dependencies": {
                             "css-parse": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                              "from": "css-parse@1.0.4",
                               "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                             },
                             "css-stringify": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                              "from": "css-stringify@1.0.5",
                               "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                             }
                           }
                         },
                         "uglify-js": {
                           "version": "2.2.5",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                          "from": "uglify-js@~2.2.5",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                           "dependencies": {
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "from": "source-map@~0.1.7",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "0.1.0",
-                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                                  "from": "amdefine@>=0.0.4",
                                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                                 }
                               }
                             },
                             "optimist": {
                               "version": "0.3.7",
-                              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                              "from": "optimist@~0.3.5",
                               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                               "dependencies": {
                                 "wordwrap": {
                                   "version": "0.0.2",
-                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "from": "wordwrap@~0.0.2",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                                 }
                               }
@@ -2465,37 +2477,37 @@
                     },
                     "character-parser": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
+                      "from": "character-parser@~1.0.0",
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                     },
                     "monocle": {
                       "version": "0.1.50",
-                      "from": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
+                      "from": "monocle@~0.1.46",
                       "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                       "dependencies": {
                         "readdirp": {
                           "version": "0.2.5",
-                          "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+                          "from": "readdirp@~0.2.3",
                           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                           "dependencies": {
                             "minimatch": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                              "version": "2.0.4",
+                              "from": "minimatch@>=0.2.4",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "from": "brace-expansion@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.2.0",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                                      "from": "balanced-match@^0.2.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -2512,29 +2524,29 @@
             },
             "optimist": {
               "version": "0.3.4",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
+              "from": "optimist@0.3.4",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "plist": {
               "version": "0.4.3",
-              "from": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
+              "from": "plist@0.4.3",
               "resolved": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
               "dependencies": {
                 "xmlbuilder": {
                   "version": "0.4.3",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
+                  "from": "xmlbuilder@0.4.x",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
                 },
                 "xmldom": {
                   "version": "0.1.19",
-                  "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+                  "from": "xmldom@0.1.x",
                   "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
                 }
               }
@@ -2543,68 +2555,68 @@
         },
         "jed": {
           "version": "0.5.4",
-          "from": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz",
+          "from": "jed@0.5.4",
           "resolved": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz"
         },
         "nodemailer": {
           "version": "0.7.1",
-          "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
+          "from": "nodemailer@0.7.1",
           "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
           "dependencies": {
             "mailcomposer": {
               "version": "0.2.12",
-              "from": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
+              "from": "mailcomposer@~0.2.10",
               "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
               "dependencies": {
                 "mimelib": {
                   "version": "0.2.19",
-                  "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+                  "from": "mimelib@~0.2.15",
                   "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                      "from": "encoding@~0.1.7",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.7",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz",
+                          "from": "iconv-lite@~0.4.4",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
                         }
                       }
                     },
                     "addressparser": {
                       "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+                      "from": "addressparser@~0.3.2",
                       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@~1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "follow-redirects": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
+                  "from": "follow-redirects@0.0.3",
                   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.8.2",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz",
+                      "from": "underscore@",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
                     }
                   }
                 },
                 "dkim-signer": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
+                  "from": "dkim-signer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+                      "from": "punycode@~1.2.4",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
@@ -2613,71 +2625,71 @@
             },
             "directmail": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz",
+              "from": "directmail@~0.1.7",
               "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
             },
             "he": {
               "version": "0.3.6",
-              "from": "https://registry.npmjs.org/he/-/he-0.3.6.tgz",
+              "from": "he@~0.3.6",
               "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
             },
             "public-address": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz",
+              "from": "public-address@~0.1.1",
               "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
             },
             "aws-sdk": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
+              "from": "aws-sdk@2.0.5",
               "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
               "dependencies": {
                 "aws-sdk-apis": {
                   "version": "3.1.10",
-                  "from": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz",
+                  "from": "aws-sdk-apis@3.x",
                   "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
                 },
                 "xml2js": {
                   "version": "0.2.6",
-                  "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+                  "from": "xml2js@0.2.6",
                   "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+                      "from": "sax@0.4.2",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                     }
                   }
                 },
                 "xmlbuilder": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+                  "from": "xmlbuilder@0.4.2",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2686,44 +2698,44 @@
         },
         "po2json": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/po2json/-/po2json-0.3.0.tgz",
+          "from": "po2json@0.3.0",
           "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.3.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "nomnom": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+              "from": "nomnom@1.5.2",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+                  "from": "underscore@1.1.x",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                  "from": "colors@0.5.x",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+              "from": "gettext-parser@~0.2.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                  "from": "encoding@~0.1",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz",
+                      "from": "iconv-lite@~0.4.4",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
                     }
                   }
@@ -2734,83 +2746,83 @@
         },
         "rc": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
+          "from": "rc@0.5.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.7",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "from": "deep-extend@~0.2.5",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+              "from": "strip-json-comments@0.1.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "ini": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+              "from": "ini@~1.1.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
             }
           }
         },
         "restify": {
           "version": "2.8.2",
-          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "from": "restify@2.8.2",
           "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@^0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "from": "backoff@^2.3.0",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "from": "precond@0.2",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "from": "bunyan@^0.23.1",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+                  "from": "mv@~2",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "from": "mkdirp@~0.5.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                      "from": "ncp@~0.6.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "from": "rimraf@~2.2.8",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -2819,135 +2831,135 @@
             },
             "csv": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
+              "from": "csv@^0.4.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "dependencies": {
                 "csv-generate": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
+                  "from": "csv-generate@*",
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
-                  "version": "0.0.9",
-                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.9.tgz"
+                  "version": "0.1.0",
+                  "from": "csv-parse@*",
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz",
+                  "from": "stream-transform@*",
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
                 },
                 "csv-stringify": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz",
+                  "from": "csv-stringify@*",
                   "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "from": "deep-equal@^0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "from": "escape-regexp-component@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "from": "formidable@^1.0.14",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@^0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@^0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@^2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@^1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "from": "negotiator@^0.4.5",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+              "version": "1.4.3",
+              "from": "node-uuid@^1.4.1",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "from": "qs@^1.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "from": "semver@^2.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
-              "version": "1.30.2",
-              "from": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz"
+              "version": "1.31.0",
+              "from": "spdy@^1.26.5",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@^0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "from": "verror@^1.4.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "from": "extsprintf@1.2.0",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+              "from": "dtrace-provider@^0.2.8",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -2956,62 +2968,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3020,195 +3032,207 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@~1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@~0.1.1",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
         }
       }
     },
+    "grunt-bump": {
+      "version": "0.3.0",
+      "from": "grunt-bump@0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.0.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.2.2",
+          "from": "semver@~4.2.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+        }
+      }
+    },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "from": "grunt-cli@0.1.13",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3217,56 +3241,56 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "from": "resolve@~0.3.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "from": "grunt-contrib-jshint@0.10.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.5.11",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+          "from": "jshint@~2.5.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+              "from": "cli@0.6.x",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "from": "glob@~ 3.2.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -3277,49 +3301,49 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@1.1.x",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@0.1.x",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "from": "htmlparser2@3.8.x",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "from": "domhandler@2.3",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "from": "dom-serializer@0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "from": "domelementtype@~1.1.1",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                          "from": "entities@~1.1.1",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -3328,117 +3352,117 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@1.0.x",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "from": "shelljs@0.3.x",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+              "from": "strip-json-comments@1.0.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "from": "underscore@1.6.x",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
+      "from": "grunt-copyright@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "from": "cli-color@^0.2.3",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+              "from": "es5-ext@~0.9.2",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "from": "memoizee@~0.2.5",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                  "from": "event-emitter@~0.2.2",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                  "from": "next-tick@0.1.x",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -3447,175 +3471,170 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@^0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "hapi": {
       "version": "8.2.0",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-8.2.0.tgz",
+      "from": "hapi@8.2.0",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.2.0.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "ammo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+          "from": "ammo@1.0.0",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
-        },
-        "boom": {
-          "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "call": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+          "from": "call@2.0.1",
           "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
         },
         "catbox": {
           "version": "4.2.1",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.2.1.tgz",
+          "from": "catbox@4.2.1",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.2.1.tgz"
         },
         "catbox-memory": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+          "from": "catbox-memory@1.1.1",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
+          "from": "h2o2@4.0.0",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz"
         },
         "heavy": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+          "from": "heavy@3.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz"
         },
         "hoek": {
           "version": "2.10.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz",
+          "from": "hoek@2.10.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
         },
         "inert": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/inert/-/inert-2.1.2.tgz",
+          "from": "inert@2.1.2",
           "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.2.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "5.0.2",
-          "from": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
+          "from": "joi@5.0.2",
           "resolved": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.1.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             },
             "moment": {
               "version": "2.8.4",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+              "from": "moment@2.8.4",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+          "from": "mimos@2.0.2",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.6.1",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.6.1.tgz",
+              "from": "mime-db@1.6.1",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.6.1.tgz"
             }
           }
         },
         "peekaboo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+          "from": "peekaboo@1.0.0",
           "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
         },
         "qs": {
           "version": "2.3.3",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "from": "qs@2.3.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "shot": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.4.0.tgz",
+          "from": "shot@1.4.0",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.4.0.tgz"
         },
         "statehood": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
+          "from": "statehood@2.0.0",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz"
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+          "from": "subtext@1.0.2",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -3626,17 +3645,17 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
+          "from": "vision@2.0.0",
           "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz"
         },
         "wreck": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz",
+          "from": "wreck@5.0.1",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz"
         }
       }
@@ -3644,49 +3663,40 @@
     "hapi-auth-hawk": {
       "version": "2.0.0",
       "from": "hapi-auth-hawk@2.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-2.0.0.tgz",
       "dependencies": {
-        "boom": {
-          "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
-        },
         "hoek": {
-          "version": "2.11.1",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+          "version": "2.12.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
         }
       }
     },
     "hawk": {
       "version": "2.3.0",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
+      "from": "hawk@2.3.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.11.1",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
-        },
-        "boom": {
-          "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+          "version": "2.12.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "from": "sntp@1.x.x",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "hkdf": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
+      "from": "hkdf@0.0.2",
       "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "joi": {
@@ -3695,9 +3705,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.0.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.11.1",
+          "version": "2.12.0",
           "from": "hoek@^2.2.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
@@ -3718,54 +3728,54 @@
     },
     "jws": {
       "version": "0.2.6",
-      "from": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
+      "from": "jws@0.2.6",
       "resolved": "https://registry.npmjs.org/jws/-/jws-0.2.6.tgz",
       "dependencies": {
         "base64url": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+          "from": "base64url@0.0.6",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
         },
         "jwa": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/jwa/-/jwa-0.0.1.tgz",
+          "from": "jwa@0.0.1",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-0.0.1.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
+      "from": "load-grunt-tasks@0.6.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3774,46 +3784,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
+          "from": "multimatch@^0.3.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
+              "from": "array-differ@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+              "from": "array-union@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
+                  "from": "array-uniq@^0.1.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@^0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3824,68 +3834,68 @@
     },
     "mailparser": {
       "version": "0.4.6",
-      "from": "https://registry.npmjs.org/mailparser/-/mailparser-0.4.6.tgz",
+      "from": "mailparser@0.4.6",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.4.6.tgz",
       "dependencies": {
         "mimelib": {
           "version": "0.2.19",
-          "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+          "from": "mimelib@>=0.2.17",
           "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+              "from": "addressparser@~0.3.2",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             }
           }
         },
         "encoding": {
           "version": "0.1.11",
-          "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+          "from": "encoding@>=0.1.4",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.7",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz",
+              "from": "iconv-lite@~0.4.4",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             }
           }
         },
         "mime": {
           "version": "1.3.4",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "from": "mime@*",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "uue": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/uue/-/uue-1.0.0.tgz",
+          "from": "uue@~1.0.0",
           "resolved": "https://registry.npmjs.org/uue/-/uue-1.0.0.tgz"
         }
       }
     },
     "nock": {
       "version": "0.48.1",
-      "from": "https://registry.npmjs.org/nock/-/nock-0.48.1.tgz",
+      "from": "nock@0.48.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-0.48.1.tgz",
       "dependencies": {
         "propagate": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+          "from": "propagate@0.3.x",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "debug": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "from": "debug@^1.0.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
@@ -3894,54 +3904,54 @@
     },
     "p-promise": {
       "version": "0.4.8",
-      "from": "https://registry.npmjs.org/p-promise/-/p-promise-0.4.8.tgz",
+      "from": "p-promise@0.4.8",
       "resolved": "https://registry.npmjs.org/p-promise/-/p-promise-0.4.8.tgz"
     },
     "poolee": {
       "version": "0.4.15",
-      "from": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
+      "from": "poolee@0.4.15",
       "resolved": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
       "dependencies": {
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+          "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.45.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
+      "from": "request@2.45.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.45.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.4",
-          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+          "from": "bl@~0.9.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@~1.0.26",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -3950,240 +3960,240 @@
         },
         "caseless": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
+          "from": "caseless@~0.6.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "from": "forever-agent@~0.5.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "qs": {
           "version": "1.2.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "from": "qs@~1.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+          "from": "json-stringify-safe@~5.0.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "from": "mime-types@~1.0.1",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "node-uuid": {
-          "version": "1.4.2",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+          "version": "1.4.3",
+          "from": "node-uuid@~1.4.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "from": "tunnel-agent@~0.4.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "from": "form-data@~0.1.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "from": "combined-stream@~0.0.4",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "from": "mime@~1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@~0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "from": "tough-cookie@>=0.12.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@>=0.2.0",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "from": "http-signature@~0.10.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@^0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+              "from": "ctype@0.5.3",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
+          "from": "oauth-sign@~0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
         },
         "hawk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "from": "hawk@1.1.1",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+              "from": "hoek@0.9.x",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+              "from": "boom@0.4.x",
               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+              "from": "cryptiles@0.2.x",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+              "from": "sntp@0.2.x",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "from": "aws-sign2@~0.5.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+          "from": "stringstream@~0.0.4",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         }
       }
     },
     "scrypt-hash": {
       "version": "1.1.10",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.10.tgz",
+      "from": "scrypt-hash@1.1.10",
       "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.10.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "from": "bindings@1.2.1",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz",
+          "from": "nan@1.5.1",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz"
         }
       }
     },
     "simplesmtp": {
       "version": "0.3.33",
-      "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.33.tgz",
+      "from": "simplesmtp@0.3.33",
       "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.33.tgz",
       "dependencies": {
         "rai": {
           "version": "0.1.12",
-          "from": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz",
+          "from": "rai@~0.1.11",
           "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
         },
         "xoauth2": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
+          "from": "xoauth2@~0.1.8",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
         }
       }
     },
     "sjcl": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.1.tgz",
+      "from": "sjcl@1.0.1",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.1.tgz"
     },
     "tap": {
       "version": "0.4.13",
-      "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+      "from": "tap@0.4.13",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+          "from": "buffer-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+          "from": "deep-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "from": "difflet@~0.2.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+              "from": "traverse@0.6.x",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+              "from": "charm@0.1.x",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@0.1.x",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@~3.2.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -4192,56 +4202,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@~0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "from": "nopt@~2",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "from": "runforcover@~0.0.2",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "from": "bunker@0.1.X",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "from": "burrito@>=0.2.5 <0.3",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                      "from": "traverse@~0.5.1",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                      "from": "uglify-js@~1.1.1",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -4252,24 +4262,24 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
+          "from": "yamlish@*",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
         }
       }
     },
     "through": {
       "version": "2.3.6",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+      "from": "through@2.3.6",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
+      "from": "uuid@1.4.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aws-sdk": "2.0.21",
     "bigint": "0.4.2",
     "binary-split": "0.1.2",
+    "boom": "2.6.1",
     "browserid-crypto": "0.7.0",
     "bunyan": "1.2.0",
     "compute-cluster": "0.0.9",

--- a/server/hawt-auth.js
+++ b/server/hawt-auth.js
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ *  An auth scheme for service-to-service backend requests, using JWTs
+ *  and inspired by Hawk.  Requests are authenticated by icluding the JWT
+ *  directly in the authorization header like so:
+ *
+ *    Authorization: Hawt [JWT]
+ *
+ *  To be accepted, the JWT must be signed by one of a configurable list
+ *  of trusted JKUs, and must reference the relevant JKU in its header.
+ *  The JWT claims must include the following meta-data about the request in
+ *  order to guard against reply etc:
+ *
+ *    - iss:  hostname of the service issuing the request
+ *    - aud:  must match publicly-visible domain of the target server
+ *    - exp:  must be a timestamp within configurable freshness window
+ *    - iat:  if present, must be a timestamp within configurable window
+ *    - nce:  nonce; a random string unique to this request
+ *    - qsh:  query hash; a digest of the request parameters (see below)
+ *    - psh:  payload hash; an optional hash of the request payload (see below)
+ *
+ *  The payload hash is analogous to that used in Hawk, and is the base64
+ *  encoded SHA256 digest of the concatenation of the following strings,
+ *  each followed by a newline:
+ *
+ *     - "hawt.1.payload"
+ *     - the content-type header, in lowercase, without parameters
+ *     - the request payload prior to any content encoding
+ *
+ *  The query hash is analogous to the "mac" field used in Hawk, but is a raw
+ *  hash rather than a HMAC and does not include any fields over which the JWT
+ *  already provides authentication.  It is the base64 encoded SHA256 digest
+ *  of the concatenation of the following strings, each followed by a newline:
+ *
+ *     - "hawt.1.query"
+ *     - the nonce value from the JWT claims
+ *     - the request method, in uppercase
+ *     - the request path, including query string, without normalization
+ *     - the payload hash, or an empty string if there's no payload hash
+ *
+ *  Notes and thoughts:
+ *
+ *     - do we need a `typ` claim, or is it unnecessary given `qsh`?
+ *     - make sure we reject { alg: "none" } JWTs!
+ */
+
+var crypto = require('crypto')
+var url = require('url')
+var jws = require('jws')
+var b64urltohex = require('browserid-crypto/lib/utils').b64urltohex
+var P = require('../promise')
+
+var boom = require('boom')
+
+module.exports = function (error, config) {
+
+  var jwks = require('../jwks')(error, config)
+
+  function Hawt(server, options, next) {
+    server.auth.scheme('hawt', function (server, options) {
+      return {
+
+        authenticate: function (request, reply) {
+          var authz = request.headers.authorization
+          if (!authz || authz.indexOf('Hawt ') !== 0) {
+            // AFAICT, we must return an instance of boom.unauthorized here
+            // to indicate "not our auth scheme" and allow other stragies to
+            // handle the auth.  Returning some other error causes it to
+            // fail out with a 401.
+            return reply(boom.unauthorized(null, 'Hawt'))
+          }
+          var token = authz.split(' ')[1]
+          decodeAndVerifyJWT(token)
+          .then(
+            function (claims) {
+              return verifyQueryHash(request, claims)
+            }
+          )
+          .then(
+            function (claims) {
+              return {
+                credentials: {
+                  jku: claims.jku,
+                  issuer: claims.iss, // XXX TODO: how to verify issuer?
+                },
+                artifacts: {
+                  queryHash: claims.qsh,
+                  payloadHash: claims.psh || '',
+                  audience: claims.aud,
+                  method: request.method,
+                  resource: request.url,
+                  nonce: claims.nce,
+                  exp: claims.exp,
+                },
+              }
+            }
+          )
+          .done(
+            function (result) {
+              return reply.continue(result)
+            },
+            function (err) {
+              return reply(err.code ? err : error.invalidToken())
+            }
+          )
+        },
+
+        payload: function (request, reply) {
+          if (!request.auth.artifacts.payloadLoad) {
+            return reply(boom.unauthorized(null, 'Hawt'))
+          }
+          throw new Error('TODO: payload verification not implemented yet')
+        }
+
+      }
+    })
+    next()
+  }
+
+  function decodeAndVerifyJWT(token) {
+    var d = P.defer()
+    var decoded = jws.decode(token)
+    if (!decoded) {
+      d.reject(error.invalidToken())
+    } else {
+      jwks.get(decoded.header.jku, decoded.header.kid)
+        .then(
+          function (key) {
+            var parts = token.split('.')
+            key.verify(parts[0] + '.' + parts[1], b64urltohex(parts[2]),
+              function (err, result) {
+                if (err) {
+                  return d.reject(err)
+                }
+                if (!result) {
+                  return d.reject(error.invalidSignature())
+                }
+                var claims = parseClaims(parts[1]) 
+                var now = Math.floor(Date.now() / 1000)
+                if (!claims.exp || claims.exp < now) {
+                  return d.reject(error.invalidTimestamp())
+                }
+                if (claims.iat && claims.iat > now) {
+                  return d.reject(error.invalidTimestamp())
+                }
+                if (claims.iat && claims.iat > claims.exp) {
+                  return d.reject(error.invalidTimestamp())
+                }
+                if (!claims.aud || claims.aud !== config.domain) {
+                  return d.reject('TODO: a new errno?')
+                }
+                if (!claims.nce) {
+                  return d.reject(error.invalidNonce())
+                }
+                if (!claims.qsh) {
+                  return d.reject(error.invalidSignature())
+                }
+                claims.jku = decoded.header.jku
+                d.resolve(claims)
+              }
+            )
+          }
+        )
+    }
+    return d.promise
+  }
+
+  function parseClaims(str) {
+    try { return JSON.parse(Buffer(str, 'base64')) } catch (e) { return {} }
+  }
+
+  function calculateQueryHash(request, claims) {
+    var path = request.url || ''
+    if (path && path[0] !== '/') {
+      path = url.parse(path, false).path
+    }
+    var queryStr = 'hawt.1.query\n' +
+                   claims.nonce + '\n' +
+                   request.method.toUpperCase() + '\n' +
+                   path + '\n' +
+                   (claims.psh || '') + '\n'
+    return getHash(queryStr)
+  }
+
+  function verifyQueryHash(request, claims) {
+    var hash = calculateQueryHash(request, claims)
+    // Note: no secrets, no need for constant-time comparison.
+    if (hash !== claims.qsh) {
+      throw error.invalidSignature()
+    }
+    return claims
+  }
+
+  function getHash(data) {
+    var hasher = crypto.createHash('sha256')
+    hasher.update(data)
+    return hasher.digest('base64')
+  }
+
+  Hawt.attributes = {
+    name: 'hawt'
+  }
+
+  Hawt._calculateQueryHash = calculateQueryHash
+
+  return Hawt
+
+}

--- a/server/server.js
+++ b/server/server.js
@@ -144,6 +144,14 @@ module.exports = function (path, url, Hapi) {
       )
     })
 
+    server.register(require('./hawt-auth')(error, config), function (err) {
+      server.auth.strategy(
+        'serviceToken',
+        'hawt',
+        {}
+      )
+    })
+
     server.route(routes)
 
     server.app.log = log

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -17,6 +17,7 @@ function ClientApi(origin) {
   this.origin = origin
   this.baseURL = origin + "/v1"
   this.timeOffset = 0;
+  this.headers = {};
 }
 
 ClientApi.prototype.Token = tokens
@@ -39,6 +40,11 @@ ClientApi.prototype.doRequest = function (method, url, token, payload, headers) 
   var d = P.defer()
   if (typeof headers === 'undefined') {
     headers = {}
+  }
+  for (var k in this.headers) {
+    if (!headers.hasOwnProperty(k)) {
+      headers[k] = this.headers[k];
+    }
   }
   if (token && !headers.Authorization) {
     headers.Authorization = hawkHeader(token, method, url, payload, this.timeOffset)

--- a/test/remote/account_status_service_token_tests.js
+++ b/test/remote/account_status_service_token_tests.js
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var path = require('path')
+var fs = require('fs')
+var crypto = require('crypto')
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var Client = require('../client')
+var bidcrypto = require('browserid-crypto')
+require('browserid-crypto/lib/algs/rs')
+var hex2b64urlencode = require('browserid-crypto/lib/utils').hex2b64urlencode
+var b64 = require('browserid-crypto/lib/utils').base64urlencode
+
+process.env.CONFIG_FILES = path.join(__dirname, '../config/preverify_secret.json')
+var config = require('../../config').root()
+var secretKey = bidcrypto.loadSecretKey(fs.readFileSync(config.secretKeyFile))
+
+var error = require('../../error')
+var Hawt = require('../../server/hawt-auth')(error, config)
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000)
+}
+
+function makeAuthzHeader(opts) {
+  if (!opts) {
+    opts = {}
+  }
+  if (!opts.method) {
+    opts.method = 'GET'
+  }
+  var header = {
+    alg: 'RS256',
+    jku: opts.jku || config.publicUrl + '/.well-known/public-keys',
+    kid: opts.kid || 'dev-1'
+  }
+  header = b64(JSON.stringify(header))
+  var claims =  {
+    iss: opts.iss || 'localhost',
+    aud: opts.aud || config.domain,
+    exp: opts.exp || nowSeconds() + 10,
+    iat: opts.iat || nowSeconds() - 10,
+    nce: opts.nce || crypto.randomBytes(8).toString('base64'),
+    qsh: opts.qsh,
+    psh: opts.psh
+  }
+  if (!claims.qsh) {
+    claims.qsh = Hawt._calculateQueryHash(opts, claims)
+  }
+  claims = b64(JSON.stringify(claims))
+  var sig = opts.sig || secretKey.sign(header + '.' + claims)
+  return 'Hawt ' + header + '.' + claims + '.' + hex2b64urlencode(sig)
+}
+
+TestServer.start(config)
+.then(function main(server) {
+
+  test(
+    'account status authenticated with JWT returns account info',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeAuthzHeader({
+              url: '/v1/account/status?uid=' + c.uid
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function (response) {
+            t.ok(response.exists, 'account exists')
+            t.ok(response.email, 'email address is returned')
+            t.equal(response.locale, 'en-US', 'locale is returned')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with JWT with no uid returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeAuthzHeader({
+              url: '/v1/account/status'
+            })
+            return c.api.accountStatus()
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 400, 'correct error status code')
+            t.equal(e.errno, 108, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with invalid JWT signature returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeAuthzHeader({
+              url: '/v1/account/status?uid=' + c.uid,
+              sig: '00000000'
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with expired JWT returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeAuthzHeader({
+              url: '/v1/account/status?uid=' + c.uid,
+              exp: nowSeconds() - 100
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with JWT for wrong path returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeAuthzHeader({
+              url: '/v1/account/keys',
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
@dcoates here's my sketch-in-progress of how we might do backend service auth using JWTs.  Except it doesn't do any of the actual JWT stuff yet...

The idea is is to add a new auth strategy "backendJWT" that accepts JWTs from trusted sources in some to-be-defined request-signing format, and then use it as another auth option on existing endpoints that we have for querying account data.

A service like basket, upon receiving an account-verified notification, could turn around and make an authenticated backend request to `/account/status?uid=blah` to retrieve the email and locale information in a secure fashion.

Assuming we can model security/permissions appropriate in such a system, what do you think of shaping things this way?  /cc @ckarlof as we've talked about this a few times in the past.