### PR TITLE
fix(httpdb): Set verifierSetAt for resetAccount()

### DIFF
--- a/db/httpdb.js
+++ b/db/httpdb.js
@@ -434,6 +434,7 @@ module.exports = function (
 
   DB.prototype.resetAccount = function (accountResetToken, data) {
     log.trace({ op: 'DB.resetAccount', uid: accountResetToken && accountResetToken.uid })
+    data.verifierSetAt = Date.now()
     return this.pool.post(
       '/account/' + accountResetToken.uid.toString('hex') + '/reset',
       unbuffer(data)


### PR DESCRIPTION
Currently we set `verifierSetAt` inside createAccount() but we don't
for resetAccount(). This change mirrors that. Furthermore, the db-mem
and db-mysql backends set this field but that logic should be contained
here, rather than in the dumb backends.