### PR TITLE
WIP: feat(versions): pull version number from fxa-auth-db-mysql server

### DIFF
--- a/routes/defaults.js
+++ b/routes/defaults.js
@@ -6,9 +6,12 @@ var path = require('path')
 var fs = require('fs')
 var util = require('util')
 var child_process = require('child_process')
+var httprequest = require('request')
 
+var config = require('../config').root()
 var version = require('../package.json').version
-var commitHash;
+var commitHash
+var dbVer;
 
 module.exports = function (log, P, db, error) {
 
@@ -23,39 +26,65 @@ module.exports = function (log, P, db, error) {
           reply(
             {
               version: version,
-              commit: commitHash
+              commit: commitHash,
+              dbVer: dbVer
             }
           )
         }
 
-        // if we already have the commitHash, send the reply and return
-        if (commitHash) {
-          return sendReply()
+        // Get the version from fxa-auth-db-mysql server
+        function getDBVer() {
+          var d = P.defer()
+          httprequest.get({url: config.httpdb.url, json: true}, function (err, response, body) {
+            if (err) {
+              d.reject(err)
+            } else if (response.statusCode === 200) {
+              dbVer = response.body.version
+              d.resolve()
+            } else {
+              // Just in case httpdb isn't sending plain 200, reject with explicit HTTP code
+              d.reject(response.statusCode)
+            }
+          })
+          return d.promise
+        }
+     
+        function getCommitVer() {
+          // Note: we figure out the Git hash in the following order:
+          //
+          // (1) read config/version.json if exists (ie. staging, production)
+          // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
+
+          var d = P.defer()
+          // (1) read config/version.json if exists (ie. staging, production)
+          var configFile = path.join(__dirname, '..', 'config', 'version.json')
+          if ( fs.existsSync(configFile) ) {
+            commitHash = require(configFile).version.hash
+            d.resolve()
+          }
+
+          // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
+          var gitDir
+          if ( !fs.existsSync(path.join(__dirname, '..', '.git')) ) {
+            // try at '/home/app/git' for AwsBox deploys
+            gitDir = path.sep + path.join('home', 'app', 'git')
+          }
+          var cmd = util.format('git %s rev-parse HEAD', gitDir ? '--git-dir=' + gitDir : '')
+          child_process.exec(cmd, function(err, stdout) {
+              if (err) {
+                d.reject(err)
+              } else {
+                commitHash = stdout.replace(/\s+/, '')
+                d.resolve()  
+              }
+          })
+          return d.promise
         }
 
-        // Note: we figure out the Git hash in the following order:
-        //
-        // (1) read config/version.json if exists (ie. staging, production)
-        // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
+        // collect version info via as many varying functions/methods as are needed
+        // use .spread to ensure every promise is fulfilled before sending reply
+        P.spread([getDBVer(), getCommitVer()], sendReply)
 
-        // (1) read config/version.json if exists (ie. staging, production)
-        var configFile = path.join(__dirname, '..', 'config', 'version.json')
-        if ( fs.existsSync(configFile) ) {
-          commitHash = require(configFile).version.hash
-          return sendReply()
-        }
-
-        // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
-        var gitDir
-        if ( !fs.existsSync(path.join(__dirname, '..', '.git')) ) {
-          // try at '/home/app/git' for AwsBox deploys
-          gitDir = path.sep + path.join('home', 'app', 'git')
-        }
-        var cmd = util.format('git %s rev-parse HEAD', gitDir ? '--git-dir=' + gitDir : '')
-        child_process.exec(cmd, function(err, stdout) {
-          commitHash = stdout.replace(/\s+/, '')
-          return sendReply()
-        })
       }
     },
     {

--- a/routes/defaults.js
+++ b/routes/defaults.js
@@ -11,9 +11,64 @@ var httprequest = require('request')
 var config = require('../config').root()
 var version = require('../package.json').version
 var commitHash
-var dbVer;
+var dbVersion
 
 module.exports = function (log, P, db, error) {
+
+  // Get the version from fxa-auth-db-mysql server
+  function getDBVersion() {
+    var d = P.defer()
+    if (!dbVersion) {
+      httprequest.get({url: config.httpdb.url, json: true, timeout: 10000}, function (err, response, body) {
+        if (err) {
+          d.reject(err)
+        } else if (response.statusCode !== 200) {
+          // Just in case httpdb isn't sending plain 200, reject with explicit HTTP code
+          d.reject(response.statusCode)
+        } else {
+          dbVersion = response.body.version
+          d.resolve()
+        }
+      })
+    } else {
+      // dbVersion is already set, so just resolve
+      d.resolve()
+    }
+    return d.promise
+  }
+
+  function getCommitVersion() {
+    // Note: we figure out the Git hash in the following order:
+    //
+    // (1) read config/version.json if exists (ie. staging, production)
+    // (2) figure it out from git ('.git' for dev)
+
+    var d = P.defer()
+    if (!commitHash) {
+      // (1) read config/version.json if exists (ie. staging, production)
+      var configFile = path.join(__dirname, '..', 'config', 'version.json')
+      if ( fs.existsSync(configFile) ) {
+        commitHash = require(configFile).version.hash
+        d.resolve()
+      }
+      // (2) figure it out from git ('.git' for dev)
+      if ( fs.existsSync(path.join(__dirname, '..', '.git')) ) {
+          var cmd = util.format('git %s rev-parse HEAD', '')
+        child_process.exec(cmd, function(err, stdout) {
+            if (err) {
+              d.reject(err)
+            } else {
+              commitHash = stdout.replace(/\s+/, '')
+              d.resolve()  
+            }
+        })
+      }
+    } else {
+        // commitHash is already set so just resolve
+        d.resolve()
+    }
+    return d.promise
+  }
 
   var routes = [
     {
@@ -27,63 +82,14 @@ module.exports = function (log, P, db, error) {
             {
               version: version,
               commit: commitHash,
-              dbVer: dbVer
+              dbVersion: dbVersion
             }
           )
         }
 
-        // Get the version from fxa-auth-db-mysql server
-        function getDBVer() {
-          var d = P.defer()
-          httprequest.get({url: config.httpdb.url, json: true}, function (err, response, body) {
-            if (err) {
-              d.reject(err)
-            } else if (response.statusCode === 200) {
-              dbVer = response.body.version
-              d.resolve()
-            } else {
-              // Just in case httpdb isn't sending plain 200, reject with explicit HTTP code
-              d.reject(response.statusCode)
-            }
-          })
-          return d.promise
-        }
-     
-        function getCommitVer() {
-          // Note: we figure out the Git hash in the following order:
-          //
-          // (1) read config/version.json if exists (ie. staging, production)
-          // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
-
-          var d = P.defer()
-          // (1) read config/version.json if exists (ie. staging, production)
-          var configFile = path.join(__dirname, '..', 'config', 'version.json')
-          if ( fs.existsSync(configFile) ) {
-            commitHash = require(configFile).version.hash
-            d.resolve()
-          }
-
-          // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
-          var gitDir
-          if ( !fs.existsSync(path.join(__dirname, '..', '.git')) ) {
-            // try at '/home/app/git' for AwsBox deploys
-            gitDir = path.sep + path.join('home', 'app', 'git')
-          }
-          var cmd = util.format('git %s rev-parse HEAD', gitDir ? '--git-dir=' + gitDir : '')
-          child_process.exec(cmd, function(err, stdout) {
-              if (err) {
-                d.reject(err)
-              } else {
-                commitHash = stdout.replace(/\s+/, '')
-                d.resolve()  
-              }
-          })
-          return d.promise
-        }
-
         // collect version info via as many varying functions/methods as are needed
         // use .spread to ensure every promise is fulfilled before sending reply
-        P.spread([getDBVer(), getCommitVer()], sendReply)
+        P.spread([getDBVersion(), getCommitVersion()], sendReply)
 
       }
     },

--- a/test/local/base_path_tests.js
+++ b/test/local/base_path_tests.js
@@ -51,7 +51,7 @@ TestServer.start(config)
           if (err) { d.reject(err) }
           t.equal(res.statusCode, 200)
           var json = JSON.parse(body)
-          t.deepEqual(Object.keys(json), ['version', 'commit'])
+          t.deepEqual(Object.keys(json), ['version', 'commit', 'dbVer'])
           d.resolve(json)
         }
       )

--- a/test/local/base_path_tests.js
+++ b/test/local/base_path_tests.js
@@ -51,7 +51,7 @@ TestServer.start(config)
           if (err) { d.reject(err) }
           t.equal(res.statusCode, 200)
           var json = JSON.parse(body)
-          t.deepEqual(Object.keys(json), ['version', 'commit', 'dbVer'])
+          t.deepEqual(Object.keys(json), ['version', 'commit', 'dbVersion'])
           d.resolve(json)
         }
       )

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -28,14 +28,14 @@ TestServer.start(config)
   test(
     '/ returns version and git hash',
     function (t) {
-        request(config.publicUrl + '/', function (err, res, body) {
+      request(config.publicUrl + '/', function (err, res, body) {
         t.ok(!err, 'No error fetching /')
 
         var json = JSON.parse(body)
         t.equal(json.version, require('../../package.json').version, 'package version')
 
         // check that the db version returns something like a semver
-        t.ok(json.dbVer.match(/^[0-9]+\.[0-9]+\.[0-9]+$/), 'The dbVer exists and looks like a semver')
+        t.ok(json.dbVersion.match(/^[0-9]+\.[0-9]+\.[0-9]+$/), 'The dbVer exists and looks like a semver')
 
         // check that the git hash just looks like a hash
         t.ok(json.commit.match(/^[0-9a-f]{40}$/), 'The git hash actually looks like one')

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -28,11 +28,14 @@ TestServer.start(config)
   test(
     '/ returns version and git hash',
     function (t) {
-      request(config.publicUrl + '/', function (err, res, body) {
+        request(config.publicUrl + '/', function (err, res, body) {
         t.ok(!err, 'No error fetching /')
 
         var json = JSON.parse(body)
         t.equal(json.version, require('../../package.json').version, 'package version')
+
+        // check that the db version returns something like a semver
+        t.ok(json.dbVer.match(/^[0-9]+\.[0-9]+\.[0-9]+$/), 'The dbVer exists and looks like a semver')
 
         // check that the git hash just looks like a hash
         t.ok(json.commit.match(/^[0-9a-f]{40}$/), 'The git hash actually looks like one')


### PR DESCRIPTION
Here's a pull request to handle issue #871 - it uses request and async libraries to handle collection of both filesystem and remote http based version numbers. It can be extended to collect an indefinite number of versions by adding more parallel async functions.

Any thoughts, something I've missed or fxa specific convention that I should take into account?