### PR TITLE
fix(tests): update for some locales that have now translated fxa-auth-mailer strings

### DIFF
--- a/scripts/e2e-email/localeQuirks.js
+++ b/scripts/e2e-email/localeQuirks.js
@@ -21,7 +21,6 @@ var translationQuirks = {
     'dsb',
     'en',
     'hsb',
-    'sq',
     'uk'
   ],
 
@@ -29,18 +28,17 @@ var translationQuirks = {
     'dsb',
     'en',
     'hsb',
-    'sq',
     'uk'
   ],
 
   // A *lot* have not been translated, but a number of broadly
   // spoken languages (e.g., de, zh-TW, zh-TW, ja, ru, pt-BR)
+  // have been.
   'Re-verify your account': [
     'ca',
     'dsb',
     'en',
     'es-AR',
-    'es-CL',
     'et',
     'eu',
     'ff',
@@ -55,9 +53,6 @@ var translationQuirks = {
     'pa',
     'pl',
     'rm',
-    'sq',
-    'sr',
-    'sr-LATN',
     'sv',
     'uk',
   ]


### PR DESCRIPTION
Translations are coming in slowly for `'Re-verify your account'` and some others. (It sucks to have to maintain this meta-list, but it's better than not knowing if things have regressed to untranslated cycle-to-cycle).