### PR TITLE
WIP feat(auth): allow backend server access to our API via oauth tokens

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -241,6 +241,23 @@ module.exports = function (fs, path, url, convict) {
       doc: 'Is account lockout enabled',
       format: Boolean,
       default: false
+    },
+    oauth: {
+      host: {
+        doc: 'OAuth host for verifying tokens',
+        default: 'localhost',
+        env: 'OAUTH_HOST'
+      },
+      port: {
+        doc: 'OAuth port for veryfing tokens',
+        default: 9010,
+        env: 'OAUTH_PORT'
+      },
+      insecure: {
+        doc: 'Connect to OAuth server via insecure plain http',
+        default: false,
+        env: 'OAUTH_INSECURE'
+      }
     }
   })
 

--- a/error.js
+++ b/error.js
@@ -70,8 +70,15 @@ AppError.translate = function (response) {
     else if (payload.message === 'Invalid nonce') {
       error = AppError.invalidNonce()
     }
-    else {
+    else if (payload.message === 'Bad mac' ||
+             payload.message === 'Unknown algorithm' ||
+             payload.message === 'Missing required payload hash' ||
+             payload.message === 'Payload is invalid' ||
+             payload.message === 'Bad payload hash') {
       error = AppError.invalidSignature(payload.message)
+    }
+    else {
+      error = AppError.invalidToken(payload.message)
     }
   }
   else if (payload.validation) {
@@ -232,12 +239,12 @@ AppError.invalidSignature = function (message) {
   })
 }
 
-AppError.invalidToken = function () {
+AppError.invalidToken = function (message) {
   return new AppError({
     code: 401,
     error: 'Unauthorized',
     errno: 110,
-    message: 'Invalid authentication token in request signature'
+    message: message || 'Invalid authentication token in request signature'
   })
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,27 +9,27 @@
       "dependencies": {
         "blanket": {
           "version": "1.1.6",
-          "from": "blanket@>=1.1.5 <1.2.0",
+          "from": "blanket@~1.1.5",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@~1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@>=0.1.6 <0.2.0",
+              "from": "falafel@~0.1.6",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@>=2.1.1 <2.2.0",
+              "from": "xtend@~2.1.1",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "from": "object-keys@~0.4.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -38,17 +38,17 @@
         },
         "temp": {
           "version": "0.6.0",
-          "from": "temp@>=0.6.0 <0.7.0",
+          "from": "temp@~0.6.0",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
-              "from": "rimraf@>=2.1.4 <2.2.0",
+              "from": "rimraf@~2.1.4",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                  "from": "graceful-fs@~1",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
@@ -62,12 +62,12 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
           "version": "0.12.4",
-          "from": "cheerio@>=0.12.4 <0.13.0",
+          "from": "cheerio@~0.12.4",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
@@ -77,34 +77,34 @@
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
-                  "from": "CSSselect@>=0.0.0 <1.0.0",
+                  "from": "CSSselect@0.x",
                   "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "CSSwhat@>=0.4.0 <0.5.0",
+                      "from": "CSSwhat@0.4",
                       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
-                      "from": "domutils@>=1.4.0 <1.5.0",
+                      "from": "domutils@1.4",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.3.0",
-                          "from": "domelementtype@>=1.0.0 <2.0.0",
+                          "from": "domelementtype@1",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "boolbase@>=1.0.0 <1.1.0",
+                      "from": "boolbase@~1.0.0",
                       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
                     },
                     "nth-check": {
                       "version": "1.0.1",
-                      "from": "nth-check@>=1.0.0 <1.1.0",
+                      "from": "nth-check@~1.0.0",
                       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
                     }
                   }
@@ -118,27 +118,27 @@
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "domhandler@>=2.0.0 <2.1.0",
+                  "from": "domhandler@2.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "domutils@>=1.1.0 <1.2.0",
+                  "from": "domutils@1.1",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.0 <1.1.0",
+                  "from": "readable-stream@1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -148,12 +148,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -162,12 +162,12 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@>=1.4.0 <1.5.0",
+              "from": "underscore@~1.4",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@>=0.0.0 <1.0.0",
+              "from": "entities@0.x",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             }
           }
@@ -227,6 +227,18 @@
         }
       }
     },
+    "boom": {
+      "version": "2.6.1",
+      "from": "boom@2.6.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "2.12.0",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+        }
+      }
+    },
     "browserid-crypto": {
       "version": "0.7.0",
       "from": "browserid-crypto@0.7.0",
@@ -239,7 +251,7 @@
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.3 <0.9.0",
+              "from": "JSONStream@~0.8.3",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
@@ -251,27 +263,27 @@
             },
             "assert": {
               "version": "1.1.2",
-              "from": "assert@>=1.1.0 <1.2.0",
+              "from": "assert@~1.1.0",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
             },
             "browser-pack": {
               "version": "3.2.0",
-              "from": "browser-pack@>=3.0.0 <4.0.0",
+              "from": "browser-pack@^3.0.0",
               "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
               "dependencies": {
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "combine-source-map@>=0.3.0 <0.4.0",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "inline-source-map@>=0.3.0 <0.4.0",
+                      "from": "inline-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "source-map@>=0.3.0 <0.4.0",
+                          "from": "source-map@~0.3.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
@@ -285,12 +297,12 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "convert-source-map@>=0.3.0 <0.4.0",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.31 <0.2.0",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -304,15 +316,15 @@
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "browser-resolve": {
-              "version": "1.8.2",
-              "from": "browser-resolve@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz",
+              "version": "1.8.1",
+              "from": "browser-resolve@^1.3.0",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.1.tgz",
               "dependencies": {
                 "resolve": {
                   "version": "1.1.6",
@@ -323,19 +335,19 @@
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.2 <0.2.0",
+              "from": "browserify-zlib@~0.1.2",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.6",
-                  "from": "pako@>=0.2.0 <0.3.0",
+                  "from": "pako@~0.2.0",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
                 }
               }
             },
             "buffer": {
               "version": "2.8.2",
-              "from": "buffer@>=2.3.0 <3.0.0",
+              "from": "buffer@^2.3.0",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "dependencies": {
                 "base64-js": {
@@ -345,19 +357,19 @@
                 },
                 "ieee754": {
                   "version": "1.1.4",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "from": "ieee754@^1.1.4",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
-                  "from": "is-array@>=1.0.1 <2.0.0",
+                  "from": "is-array@^1.0.1",
                   "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "builtins": {
               "version": "0.0.7",
-              "from": "builtins@>=0.0.3 <0.1.0",
+              "from": "builtins@~0.0.3",
               "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
             },
             "commondir": {
@@ -366,28 +378,28 @@
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
-              "version": "1.4.8",
-              "from": "concat-stream@>=1.4.1 <1.5.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "version": "1.4.7",
+              "from": "concat-stream@~1.4.1",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "typedarray@~0.0.5",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -396,29 +408,29 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "from": "console-browserify@^1.1.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "constants-browserify@>=0.0.1 <0.1.0",
+              "from": "constants-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
               "version": "3.9.13",
-              "from": "crypto-browserify@>=3.0.0 <4.0.0",
+              "from": "crypto-browserify@^3.0.0",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
               "dependencies": {
                 "browserify-aes": {
                   "version": "1.0.0",
-                  "from": "browserify-aes@>=1.0.0 <2.0.0",
+                  "from": "browserify-aes@^1.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
                 },
                 "browserify-sign": {
@@ -428,51 +440,51 @@
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@>=1.0.0 <2.0.0",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "1.1.1",
-                      "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                      "from": "browserify-rsa@^1.1.0",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "elliptic@>=1.0.0 <2.0.0",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
                       "version": "2.0.0",
-                      "from": "parse-asn1@>=2.0.0 <3.0.0",
+                      "from": "parse-asn1@^2.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "asn1.js@>=1.0.0 <2.0.0",
+                          "from": "asn1.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "asn1.js-rfc3280": {
                           "version": "1.0.0",
-                          "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                          "from": "asn1.js-rfc3280@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                         },
                         "pemstrip": {
@@ -486,27 +498,27 @@
                 },
                 "create-ecdh": {
                   "version": "2.0.0",
-                  "from": "create-ecdh@>=2.0.0 <3.0.0",
+                  "from": "create-ecdh@^2.0.0",
                   "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@>=1.0.0 <2.0.0",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
-                      "from": "elliptic@>=1.0.0 <2.0.0",
+                      "from": "elliptic@^1.0.0",
                       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.2",
-                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "from": "hash.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                         }
                       }
@@ -515,44 +527,44 @@
                 },
                 "create-hash": {
                   "version": "1.1.1",
-                  "from": "create-hash@>=1.1.0 <2.0.0",
+                  "from": "create-hash@^1.1.0",
                   "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "dependencies": {
                     "ripemd160": {
                       "version": "1.0.0",
-                      "from": "ripemd160@>=1.0.0 <2.0.0",
+                      "from": "ripemd160@^1.0.0",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                     },
                     "sha.js": {
-                      "version": "2.4.0",
-                      "from": "sha.js@>=2.3.6 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+                      "version": "2.3.6",
+                      "from": "sha.js@^2.3.6",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                     }
                   }
                 },
                 "create-hmac": {
                   "version": "1.1.3",
-                  "from": "create-hmac@>=1.1.0 <2.0.0",
+                  "from": "create-hmac@^1.1.0",
                   "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
                 },
                 "diffie-hellman": {
                   "version": "3.0.1",
-                  "from": "diffie-hellman@>=3.0.1 <4.0.0",
+                  "from": "diffie-hellman@^3.0.1",
                   "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@>=1.0.0 <2.0.0",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "miller-rabin": {
                       "version": "1.1.5",
-                      "from": "miller-rabin@>=1.1.2 <2.0.0",
+                      "from": "miller-rabin@^1.1.2",
                       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.0.5",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "brorand@^1.0.1",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                         }
                       }
@@ -561,37 +573,37 @@
                 },
                 "pbkdf2-compat": {
                   "version": "3.0.2",
-                  "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+                  "from": "pbkdf2-compat@^3.0.1",
                   "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                 },
                 "public-encrypt": {
                   "version": "2.0.0",
-                  "from": "public-encrypt@>=2.0.0 <3.0.0",
+                  "from": "public-encrypt@^2.0.0",
                   "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
-                      "from": "bn.js@>=1.0.0 <2.0.0",
+                      "from": "bn.js@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
                       "version": "2.0.0",
-                      "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                      "from": "browserify-rsa@^2.0.0",
                       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "parse-asn1": {
                       "version": "3.0.0",
-                      "from": "parse-asn1@>=3.0.0 <4.0.0",
+                      "from": "parse-asn1@^3.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "1.0.3",
-                          "from": "asn1.js@>=1.0.0 <2.0.0",
+                          "from": "asn1.js@^1.0.0",
                           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "from": "minimalistic-assert@^1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
@@ -602,61 +614,61 @@
                 },
                 "randombytes": {
                   "version": "2.0.1",
-                  "from": "randombytes@>=2.0.0 <3.0.0",
+                  "from": "randombytes@^2.0.0",
                   "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
+              "from": "deep-equal@~0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "defined": {
               "version": "0.0.0",
-              "from": "defined@>=0.0.0 <0.1.0",
+              "from": "defined@~0.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
             },
             "deps-sort": {
               "version": "1.3.5",
-              "from": "deps-sort@>=1.3.0 <2.0.0",
+              "from": "deps-sort@^1.3.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@>=0.2.0 <0.3.0",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "domain-browser": {
               "version": "1.1.4",
-              "from": "domain-browser@>=1.1.0 <1.2.0",
+              "from": "domain-browser@~1.1.0",
               "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
             },
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@>=0.0.2 <0.1.0",
+              "from": "duplexer2@~0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -665,27 +677,27 @@
             },
             "events": {
               "version": "1.0.2",
-              "from": "events@>=1.0.0 <1.1.0",
+              "from": "events@~1.0.0",
               "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.8 <3.3.0",
+              "from": "glob@~3.2.8",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.2",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -694,22 +706,22 @@
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https-browserify@>=0.0.0 <0.1.0",
+              "from": "https-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
               "version": "6.2.1",
-              "from": "insert-module-globals@>=6.1.0 <7.0.0",
+              "from": "insert-module-globals@^6.1.0",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@>=0.7.1 <0.8.0",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
@@ -721,17 +733,17 @@
                 },
                 "combine-source-map": {
                   "version": "0.3.0",
-                  "from": "combine-source-map@>=0.3.0 <0.4.0",
+                  "from": "combine-source-map@~0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                   "dependencies": {
                     "inline-source-map": {
                       "version": "0.3.1",
-                      "from": "inline-source-map@>=0.3.0 <0.4.0",
+                      "from": "inline-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.3.0",
-                          "from": "source-map@>=0.3.0 <0.4.0",
+                          "from": "source-map@~0.3.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                           "dependencies": {
                             "amdefine": {
@@ -745,12 +757,12 @@
                     },
                     "convert-source-map": {
                       "version": "0.3.5",
-                      "from": "convert-source-map@>=0.3.0 <0.4.0",
+                      "from": "convert-source-map@~0.3.0",
                       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.31 <0.2.0",
+                      "from": "source-map@~0.1.31",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
@@ -764,12 +776,12 @@
                 },
                 "lexical-scope": {
                   "version": "1.1.0",
-                  "from": "lexical-scope@>=1.1.0 <1.2.0",
+                  "from": "lexical-scope@~1.1.0",
                   "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
                   "dependencies": {
                     "astw": {
                       "version": "1.1.0",
-                      "from": "astw@>=1.1.0 <1.2.0",
+                      "from": "astw@~1.1.0",
                       "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                       "dependencies": {
                         "esprima-fb": {
@@ -783,7 +795,7 @@
                 },
                 "process": {
                   "version": "0.6.0",
-                  "from": "process@>=0.6.0 <0.7.0",
+                  "from": "process@~0.6.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 }
               }
@@ -795,34 +807,34 @@
             },
             "labeled-stream-splicer": {
               "version": "1.0.2",
-              "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+              "from": "labeled-stream-splicer@^1.0.0",
               "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
               "dependencies": {
                 "stream-splicer": {
                   "version": "1.3.1",
-                  "from": "stream-splicer@>=1.1.0 <2.0.0",
+                  "from": "stream-splicer@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.13-1 <2.0.0",
+                      "from": "readable-stream@^1.1.13-1",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "readable-wrap@>=1.0.0 <2.0.0",
+                      "from": "readable-wrap@^1.0.0",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     },
                     "indexof": {
@@ -835,13 +847,13 @@
               }
             },
             "module-deps": {
-              "version": "3.7.6",
-              "from": "module-deps@>=3.5.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.6.tgz",
+              "version": "3.7.3",
+              "from": "module-deps@^3.5.0",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.7.4",
-                  "from": "JSONStream@>=0.7.1 <0.8.0",
+                  "from": "JSONStream@~0.7.1",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
                   "dependencies": {
                     "jsonparse": {
@@ -853,74 +865,74 @@
                 },
                 "detective": {
                   "version": "4.0.0",
-                  "from": "detective@>=4.0.0 <5.0.0",
+                  "from": "detective@^4.0.0",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "0.9.0",
-                      "from": "acorn@>=0.9.0 <0.10.0",
+                      "from": "acorn@~0.9.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                     },
                     "escodegen": {
                       "version": "1.6.1",
-                      "from": "escodegen@>=1.4.1 <2.0.0",
+                      "from": "escodegen@^1.4.1",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "1.9.3",
-                          "from": "estraverse@>=1.9.1 <2.0.0",
+                          "from": "estraverse@^1.9.1",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                         },
                         "esutils": {
                           "version": "1.1.6",
-                          "from": "esutils@>=1.1.6 <2.0.0",
+                          "from": "esutils@^1.1.6",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                         },
                         "esprima": {
                           "version": "1.2.5",
-                          "from": "esprima@>=1.2.2 <2.0.0",
+                          "from": "esprima@^1.2.2",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                         },
                         "optionator": {
                           "version": "0.5.0",
-                          "from": "optionator@>=0.5.0 <0.6.0",
+                          "from": "optionator@^0.5.0",
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                           "dependencies": {
                             "prelude-ls": {
                               "version": "1.1.1",
-                              "from": "prelude-ls@>=1.1.1 <1.2.0",
+                              "from": "prelude-ls@~1.1.1",
                               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                             },
                             "deep-is": {
                               "version": "0.1.3",
-                              "from": "deep-is@>=0.1.2 <0.2.0",
+                              "from": "deep-is@~0.1.2",
                               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@>=0.0.2 <0.1.0",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             },
                             "type-check": {
                               "version": "0.3.1",
-                              "from": "type-check@>=0.3.1 <0.4.0",
+                              "from": "type-check@~0.3.1",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                             },
                             "levn": {
                               "version": "0.2.5",
-                              "from": "levn@>=0.2.5 <0.3.0",
+                              "from": "levn@~0.2.5",
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                             },
                             "fast-levenshtein": {
                               "version": "1.0.6",
-                              "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                              "from": "fast-levenshtein@~1.0.0",
                               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "from": "source-map@~0.1.40",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
@@ -936,39 +948,39 @@
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@>=0.2.0 <0.3.0",
+                  "from": "minimist@~0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "parents": {
                   "version": "1.0.1",
-                  "from": "parents@>=1.0.0 <2.0.0",
+                  "from": "parents@^1.0.0",
                   "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
                   "dependencies": {
                     "path-platform": {
                       "version": "0.11.15",
-                      "from": "path-platform@>=0.11.15 <0.12.0",
+                      "from": "path-platform@~0.11.15",
                       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                     }
                   }
                 },
                 "resolve": {
                   "version": "1.1.6",
-                  "from": "resolve@>=1.1.3 <2.0.0",
+                  "from": "resolve@^1.1.3",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
                 },
                 "stream-combiner2": {
                   "version": "1.0.2",
-                  "from": "stream-combiner2@>=1.0.0 <1.1.0",
+                  "from": "stream-combiner2@~1.0.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                   "dependencies": {
                     "through2": {
                       "version": "0.5.1",
-                      "from": "through2@>=0.5.1 <0.6.0",
+                      "from": "through2@~0.5.1",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                       "dependencies": {
                         "xtend": {
                           "version": "3.0.0",
-                          "from": "xtend@>=3.0.0 <3.1.0",
+                          "from": "xtend@~3.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                         }
                       }
@@ -977,17 +989,17 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "through2@~0.4.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "xtend@~2.1.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "object-keys@~0.4.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -996,68 +1008,68 @@
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "os-browserify@>=0.1.1 <0.2.0",
+              "from": "os-browserify@~0.1.1",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
             },
             "parents": {
               "version": "0.0.3",
-              "from": "parents@>=0.0.1 <0.1.0",
+              "from": "parents@~0.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
               "dependencies": {
                 "path-platform": {
                   "version": "0.0.1",
-                  "from": "path-platform@>=0.0.1 <0.0.2",
+                  "from": "path-platform@^0.0.1",
                   "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
                 }
               }
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "path-browserify@>=0.0.0 <0.1.0",
+              "from": "path-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.7.0",
-              "from": "process@>=0.7.0 <0.8.0",
+              "from": "process@^0.7.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
             },
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@>=1.2.3 <1.3.0",
+              "from": "punycode@~1.2.3",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "from": "querystring-es3@~0.2.0",
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.27-1 <2.0.0",
+              "from": "readable-stream@^1.0.27-1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@>=0.7.1 <0.8.0",
+              "from": "resolve@~0.7.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "shallow-copy": {
@@ -1067,53 +1079,53 @@
             },
             "shasum": {
               "version": "1.0.1",
-              "from": "shasum@>=1.0.0 <2.0.0",
+              "from": "shasum@^1.0.0",
               "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
               "dependencies": {
                 "json-stable-stringify": {
                   "version": "0.0.1",
-                  "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+                  "from": "json-stable-stringify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "from": "jsonify@~0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
                 },
                 "sha.js": {
                   "version": "2.3.6",
-                  "from": "sha.js@>=2.3.0 <2.4.0",
+                  "from": "sha.js@~2.3.0",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "shell-quote": {
               "version": "0.0.1",
-              "from": "shell-quote@>=0.0.1 <0.1.0",
+              "from": "shell-quote@~0.0.1",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "from": "stream-browserify@^1.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "stream-combiner@>=0.0.2 <0.1.0",
+              "from": "stream-combiner@~0.0.2",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "dependencies": {
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "from": "duplexer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.0.1",
-              "from": "string_decoder@>=0.0.0 <0.1.0",
+              "from": "string_decoder@~0.0.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
             },
             "subarg": {
@@ -1123,41 +1135,41 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "minimist@~0.0.7",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "syntax-error": {
               "version": "1.1.2",
-              "from": "syntax-error@>=1.1.1 <2.0.0",
+              "from": "syntax-error@^1.1.1",
               "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "from": "acorn@~0.9.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "through2@^1.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -1171,56 +1183,56 @@
             },
             "timers-browserify": {
               "version": "1.4.0",
-              "from": "timers-browserify@>=1.0.1 <2.0.0",
+              "from": "timers-browserify@^1.0.1",
               "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
               "dependencies": {
                 "process": {
                   "version": "0.10.1",
-                  "from": "process@>=0.10.0 <0.11.0",
+                  "from": "process@~0.10.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
                 }
               }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "tty-browserify@>=0.0.0 <0.1.0",
+              "from": "tty-browserify@~0.0.0",
               "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "umd": {
               "version": "2.1.0",
-              "from": "umd@>=2.1.0 <2.2.0",
+              "from": "umd@~2.1.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
               "dependencies": {
                 "rfile": {
                   "version": "1.0.0",
-                  "from": "rfile@>=1.0.0 <1.1.0",
+                  "from": "rfile@~1.0.0",
                   "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
                   "dependencies": {
                     "callsite": {
                       "version": "1.0.0",
-                      "from": "callsite@>=1.0.0 <1.1.0",
+                      "from": "callsite@~1.0.0",
                       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                     },
                     "resolve": {
                       "version": "0.3.1",
-                      "from": "resolve@>=0.3.0 <0.4.0",
+                      "from": "resolve@~0.3.0",
                       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                     }
                   }
                 },
                 "ruglify": {
                   "version": "1.0.0",
-                  "from": "ruglify@>=1.0.0 <1.1.0",
+                  "from": "ruglify@~1.0.0",
                   "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
                   "dependencies": {
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "uglify-js@>=2.2.0 <2.3.0",
+                      "from": "uglify-js@~2.2",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "from": "source-map@~0.1.7",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
@@ -1232,12 +1244,12 @@
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@>=0.3.5 <0.4.0",
+                          "from": "optimist@~0.3.5",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@>=0.0.2 <0.1.0",
+                              "from": "wordwrap@~0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
@@ -1250,7 +1262,7 @@
             },
             "url": {
               "version": "0.10.3",
-              "from": "url@>=0.10.1 <0.11.0",
+              "from": "url@~0.10.1",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
@@ -1267,12 +1279,12 @@
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.1 <0.11.0",
+              "from": "util@~0.10.1",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@>=0.0.1 <0.1.0",
+              "from": "vm-browserify@~0.0.1",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
@@ -1284,7 +1296,7 @@
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "xtend@>=3.0.0 <4.0.0",
+              "from": "xtend@^3.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
@@ -1296,12 +1308,12 @@
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "Base64@~0.2.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -1318,7 +1330,7 @@
             },
             "diff": {
               "version": "1.0.8",
-              "from": "diff@>=1.0.3 <1.1.0",
+              "from": "diff@~1.0.3",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             }
           }
@@ -1330,12 +1342,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -1347,7 +1359,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -1364,19 +1376,19 @@
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.5 <0.4.0",
+              "from": "optimist@~0.3",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "uglify-to-browserify@~1.0.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
@@ -1395,19 +1407,19 @@
           "dependencies": {
             "nan": {
               "version": "1.3.0",
-              "from": "nan@>=1.3.0 <1.4.0",
+              "from": "nan@~1.3.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
             }
           }
         },
         "mv": {
           "version": "2.0.3",
-          "from": "mv@>=2.0.0 <3.0.0",
+          "from": "mv@~2",
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "mkdirp@~0.5.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -1419,12 +1431,12 @@
             },
             "ncp": {
               "version": "0.6.0",
-              "from": "ncp@>=0.6.0 <0.7.0",
+              "from": "ncp@~0.6.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.8 <2.3.0",
+              "from": "rimraf@~2.2.8",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -1467,32 +1479,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>=1.5.0",
+                  "from": "nomnom@>= 1.5.x",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@>=1.6.0 <1.7.0",
+                      "from": "underscore@~1.6.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@>=0.4.0 <0.5.0",
+                      "from": "chalk@~0.4.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@>=0.1.0 <0.2.0",
+                          "from": "has-color@~0.1.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@>=1.0.0 <1.1.0",
+                          "from": "ansi-styles@~1.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@>=0.1.0 <0.2.0",
+                          "from": "strip-ansi@~0.1.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -1501,7 +1513,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>=4.0.0",
+                  "from": "JSV@>= 4.0.x",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -1525,12 +1537,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -1544,8 +1556,8 @@
     },
     "fxa-auth-db-mem": {
       "version": "0.33.0",
-      "from": "../../../../var/folders/rv/6mf4_t5x169fdxtrnd14y7500000gq/T/npm-89723-5419a2e5/git-cache-49796c534e40/9a122f8bad7b22c49319b373b8c07ab0d1e4c3f9",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mem.git#9a122f8bad7b22c49319b373b8c07ab0d1e4c3f9",
+      "from": "fxa-auth-db-mem@git+https://github.com/mozilla/fxa-auth-db-mem.git#master",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mem.git#a3219f1a8e5d4ed441220e2de805482ba67cd7a0",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
@@ -1554,8 +1566,8 @@
         },
         "fxa-auth-db-server": {
           "version": "0.35.0",
-          "from": "../../../../var/folders/rv/6mf4_t5x169fdxtrnd14y7500000gq/T/npm-89723-5419a2e5/git-cache-07d588b5aad9/e4473c622e8e260c2e80e8972bdd105fca6b4738",
-          "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#e4473c622e8e260c2e80e8972bdd105fca6b4738",
+          "from": "fxa-auth-db-server@git://github.com/mozilla/fxa-auth-db-server.git",
+          "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#93d1bca3a4fb723773c46c7a7bdc9b2667782efb",
           "dependencies": {
             "restify": {
               "version": "2.8.2",
@@ -1564,34 +1576,34 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "backoff": {
                   "version": "2.4.1",
-                  "from": "backoff@>=2.3.0 <3.0.0",
+                  "from": "backoff@^2.3.0",
                   "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
                   "dependencies": {
                     "precond": {
                       "version": "0.2.3",
-                      "from": "precond@>=0.2.0 <0.3.0",
+                      "from": "precond@0.2",
                       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                     }
                   }
                 },
                 "bunyan": {
                   "version": "0.23.1",
-                  "from": "bunyan@>=0.23.1 <0.24.0",
+                  "from": "bunyan@^0.23.1",
                   "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
                   "dependencies": {
                     "mv": {
                       "version": "2.0.3",
-                      "from": "mv@>=2.0.0 <3.0.0",
+                      "from": "mv@~2",
                       "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                       "dependencies": {
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "from": "mkdirp@~0.5.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
@@ -1603,12 +1615,12 @@
                         },
                         "ncp": {
                           "version": "0.6.0",
-                          "from": "ncp@>=0.6.0 <0.7.0",
+                          "from": "ncp@~0.6.0",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                         },
                         "rimraf": {
                           "version": "2.2.8",
-                          "from": "rimraf@>=2.2.8 <2.3.0",
+                          "from": "rimraf@~2.2.8",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
@@ -1617,7 +1629,7 @@
                 },
                 "csv": {
                   "version": "0.4.1",
-                  "from": "csv@>=0.4.0 <0.5.0",
+                  "from": "csv@^0.4.0",
                   "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
                   "dependencies": {
                     "csv-generate": {
@@ -1626,9 +1638,9 @@
                       "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                     },
                     "csv-parse": {
-                      "version": "0.1.0",
+                      "version": "0.1.1",
                       "from": "csv-parse@*",
-                      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz"
                     },
                     "stream-transform": {
                       "version": "0.0.7",
@@ -1644,22 +1656,22 @@
                 },
                 "deep-equal": {
                   "version": "0.2.2",
-                  "from": "deep-equal@>=0.2.1 <0.3.0",
+                  "from": "deep-equal@^0.2.1",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
                 },
                 "escape-regexp-component": {
                   "version": "1.0.2",
-                  "from": "escape-regexp-component@>=1.0.2 <2.0.0",
+                  "from": "escape-regexp-component@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
                 },
                 "formidable": {
                   "version": "1.0.17",
-                  "from": "formidable@>=1.0.14 <2.0.0",
+                  "from": "formidable@^1.0.14",
                   "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "http-signature@^0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "asn1": {
@@ -1676,64 +1688,64 @@
                 },
                 "keep-alive-agent": {
                   "version": "0.0.1",
-                  "from": "keep-alive-agent@>=0.0.1 <0.0.2",
+                  "from": "keep-alive-agent@^0.0.1",
                   "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
                 },
                 "lru-cache": {
-                  "version": "2.5.2",
-                  "from": "lru-cache@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                  "version": "2.6.1",
+                  "from": "lru-cache@^2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@>=1.2.11 <2.0.0",
+                  "from": "mime@^1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "negotiator": {
                   "version": "0.4.9",
-                  "from": "negotiator@>=0.4.5 <0.5.0",
+                  "from": "negotiator@^0.4.5",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.1 <2.0.0",
+                  "from": "node-uuid@^1.4.1",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "qs@>=1.0.0 <2.0.0",
+                  "from": "qs@^1.0.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "semver": {
                   "version": "2.3.2",
-                  "from": "semver@>=2.3.0 <3.0.0",
+                  "from": "semver@^2.3.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
                 },
                 "spdy": {
-                  "version": "1.31.0",
-                  "from": "spdy@>=1.26.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
+                  "version": "1.32.0",
+                  "from": "spdy@^1.26.5",
+                  "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@^0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "verror": {
                   "version": "1.6.0",
-                  "from": "verror@>=1.4.0 <2.0.0",
+                  "from": "verror@^1.4.0",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
                   "dependencies": {
                     "extsprintf": {
@@ -1745,7 +1757,7 @@
                 },
                 "dtrace-provider": {
                   "version": "0.2.8",
-                  "from": "dtrace-provider@>=0.2.8 <0.3.0",
+                  "from": "dtrace-provider@^0.2.8",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
                 }
               }
@@ -1759,85 +1771,85 @@
           "dependencies": {
             "intel": {
               "version": "1.0.0",
-              "from": "intel@>=1.0.0 <2.0.0",
+              "from": "intel@^1.0.0",
               "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "from": "chalk@~0.5.1",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "from": "ansi-styles@^1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "from": "escape-string-regexp@^1.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "from": "has-ansi@^0.1.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@^0.2.1",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "from": "strip-ansi@^0.3.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@^0.2.1",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "from": "supports-color@^0.2.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "dbug": {
                   "version": "0.4.2",
-                  "from": "dbug@>=0.4.2 <0.5.0",
+                  "from": "dbug@~0.4.2",
                   "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
                 },
                 "stack-trace": {
                   "version": "0.0.9",
-                  "from": "stack-trace@>=0.0.9 <0.1.0",
+                  "from": "stack-trace@~0.0.9",
                   "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                 },
                 "strftime": {
                   "version": "0.8.4",
-                  "from": "strftime@>=0.8.2 <0.9.0",
+                  "from": "strftime@~0.8.2",
                   "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
                 },
                 "symbol": {
                   "version": "0.2.1",
-                  "from": "symbol@>=0.2.0 <0.3.0",
+                  "from": "symbol@~0.2.0",
                   "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
                 },
                 "utcstring": {
                   "version": "0.1.0",
-                  "from": "utcstring@>=0.1.0 <0.2.0",
+                  "from": "utcstring@~0.1.0",
                   "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
                 }
               }
             },
             "merge": {
               "version": "1.2.0",
-              "from": "merge@>=1.2.0 <2.0.0",
+              "from": "merge@^1.2.0",
               "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
             }
           }
@@ -1846,8 +1858,8 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.7",
-      "from": "../../../../var/folders/rv/6mf4_t5x169fdxtrnd14y7500000gq/T/npm-89723-5419a2e5/git-cache-a2a399657592/31470ec0361a773688d2a295f7f5a39686909ed1",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#31470ec0361a773688d2a295f7f5a39686909ed1",
+      "from": "fxa-auth-mailer@git+https://github.com/mozilla/fxa-auth-mailer.git#master",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#ea6e505c0ab086019e572883a8a71804c7f94801",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
@@ -1861,12 +1873,12 @@
           "dependencies": {
             "mv": {
               "version": "2.0.3",
-              "from": "mv@>=2.0.0 <3.0.0",
+              "from": "mv@~2",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "mkdirp@~0.5.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
@@ -1878,12 +1890,12 @@
                 },
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "ncp@>=0.6.0 <0.7.0",
+                  "from": "ncp@~0.6.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@>=2.2.8 <2.3.0",
+                  "from": "rimraf@~2.2.8",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
@@ -1892,8 +1904,8 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "../../../../var/folders/rv/6mf4_t5x169fdxtrnd14y7500000gq/T/npm-89723-5419a2e5/git-cache-da9fa95abbe5/7efb426f00f280ad2ec97622990e25632cd89150",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#7efb426f00f280ad2ec97622990e25632cd89150"
+          "from": "fxa-content-server-l10n@git://github.com/mozilla/fxa-content-server-l10n.git",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#7e0bf097f8c128582c3865a7e4afbead459e6654"
         },
         "handlebars": {
           "version": "1.3.0",
@@ -1902,29 +1914,29 @@
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
+              "from": "optimist@~0.3",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "from": "uglify-js@~2.3",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "async@~0.2.6",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "from": "source-map@~0.1.7",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -1970,13 +1982,13 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "encoding@>=0.1.0 <0.2.0",
+                      "from": "encoding@~0.1",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.7",
-                          "from": "iconv-lite@>=0.4.4 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+                          "version": "0.4.8",
+                          "from": "iconv-lite@~0.4.4",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                         }
                       }
                     }
@@ -1989,12 +2001,12 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.1.7",
-                      "from": "underscore@>=1.1.0 <1.2.0",
+                      "from": "underscore@1.1.x",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                     },
                     "colors": {
                       "version": "0.5.1",
-                      "from": "colors@>=0.5.0 <0.6.0",
+                      "from": "colors@0.5.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     }
                   }
@@ -2006,41 +2018,41 @@
                   "dependencies": {
                     "commander": {
                       "version": "1.1.1",
-                      "from": "commander@>=1.1.1 <1.2.0",
+                      "from": "commander@~1.1.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                       "dependencies": {
                         "keypress": {
                           "version": "0.1.0",
-                          "from": "keypress@>=0.1.0 <0.2.0",
+                          "from": "keypress@0.1.x",
                           "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "mkdirp@>=0.3.0 <0.4.0",
+                      "from": "mkdirp@0.3.x",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     },
                     "transformers": {
                       "version": "2.0.1",
-                      "from": "transformers@>=2.0.1 <2.1.0",
+                      "from": "transformers@~2.0.1",
                       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                       "dependencies": {
                         "promise": {
                           "version": "2.0.0",
-                          "from": "promise@>=2.0.0 <2.1.0",
+                          "from": "promise@~2.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                           "dependencies": {
                             "is-promise": {
                               "version": "1.0.1",
-                              "from": "is-promise@>=1.0.0 <2.0.0",
+                              "from": "is-promise@~1",
                               "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                             }
                           }
                         },
                         "css": {
                           "version": "1.0.8",
-                          "from": "css@>=1.0.8 <1.1.0",
+                          "from": "css@~1.0.8",
                           "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                           "dependencies": {
                             "css-parse": {
@@ -2057,12 +2069,12 @@
                         },
                         "uglify-js": {
                           "version": "2.2.5",
-                          "from": "uglify-js@>=2.2.5 <2.3.0",
+                          "from": "uglify-js@~2.2.5",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                           "dependencies": {
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "source-map@>=0.1.7 <0.2.0",
+                              "from": "source-map@~0.1.7",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
@@ -2074,12 +2086,12 @@
                             },
                             "optimist": {
                               "version": "0.3.7",
-                              "from": "optimist@>=0.3.5 <0.4.0",
+                              "from": "optimist@~0.3.5",
                               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                               "dependencies": {
                                 "wordwrap": {
                                   "version": "0.0.2",
-                                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                                  "from": "wordwrap@~0.0.2",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                                 }
                               }
@@ -2090,17 +2102,17 @@
                     },
                     "character-parser": {
                       "version": "1.0.2",
-                      "from": "character-parser@>=1.0.0 <1.1.0",
+                      "from": "character-parser@~1.0.0",
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                     },
                     "monocle": {
                       "version": "0.1.50",
-                      "from": "monocle@>=0.1.46 <0.2.0",
+                      "from": "monocle@~0.1.46",
                       "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                       "dependencies": {
                         "readdirp": {
                           "version": "0.2.5",
-                          "from": "readdirp@>=0.2.3 <0.3.0",
+                          "from": "readdirp@~0.2.3",
                           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                           "dependencies": {
                             "minimatch": {
@@ -2110,12 +2122,12 @@
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.0",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "from": "brace-expansion@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.2.0",
-                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                      "from": "balanced-match@^0.2.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                     },
                                     "concat-map": {
@@ -2142,7 +2154,7 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
@@ -2154,12 +2166,12 @@
               "dependencies": {
                 "xmlbuilder": {
                   "version": "0.4.3",
-                  "from": "xmlbuilder@>=0.4.0 <0.5.0",
+                  "from": "xmlbuilder@0.4.x",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
                 },
                 "xmldom": {
                   "version": "0.1.19",
-                  "from": "xmldom@>=0.1.0 <0.2.0",
+                  "from": "xmldom@0.1.x",
                   "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
                 }
               }
@@ -2178,36 +2190,36 @@
           "dependencies": {
             "mailcomposer": {
               "version": "0.2.12",
-              "from": "mailcomposer@>=0.2.10 <0.3.0",
+              "from": "mailcomposer@~0.2.10",
               "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
               "dependencies": {
                 "mimelib": {
                   "version": "0.2.19",
-                  "from": "mimelib@>=0.2.15 <0.3.0",
+                  "from": "mimelib@~0.2.15",
                   "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "encoding@>=0.1.7 <0.2.0",
+                      "from": "encoding@~0.1.7",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.7",
-                          "from": "iconv-lite@>=0.4.4 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+                          "version": "0.4.8",
+                          "from": "iconv-lite@~0.4.4",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                         }
                       }
                     },
                     "addressparser": {
                       "version": "0.3.2",
-                      "from": "addressparser@>=0.3.2 <0.4.0",
+                      "from": "addressparser@~0.3.2",
                       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
+                  "from": "mime@~1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "follow-redirects": {
@@ -2217,19 +2229,19 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.8.3",
-                      "from": "underscore@*",
+                      "from": "underscore@",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
                     }
                   }
                 },
                 "dkim-signer": {
                   "version": "0.1.2",
-                  "from": "dkim-signer@>=0.1.1 <0.2.0",
+                  "from": "dkim-signer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.2.4",
-                      "from": "punycode@>=1.2.4 <1.3.0",
+                      "from": "punycode@~1.2.4",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
@@ -2238,17 +2250,17 @@
             },
             "directmail": {
               "version": "0.1.8",
-              "from": "directmail@>=0.1.7 <0.2.0",
+              "from": "directmail@~0.1.7",
               "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
             },
             "he": {
               "version": "0.3.6",
-              "from": "he@>=0.3.6 <0.4.0",
+              "from": "he@~0.3.6",
               "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
             },
             "public-address": {
               "version": "0.1.1",
-              "from": "public-address@>=0.1.1 <0.2.0",
+              "from": "public-address@~0.1.1",
               "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
             },
             "aws-sdk": {
@@ -2258,7 +2270,7 @@
               "dependencies": {
                 "aws-sdk-apis": {
                   "version": "3.1.10",
-                  "from": "aws-sdk-apis@>=3.0.0 <4.0.0",
+                  "from": "aws-sdk-apis@3.x",
                   "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
                 },
                 "xml2js": {
@@ -2282,12 +2294,12 @@
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -2297,12 +2309,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2316,7 +2328,7 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "nomnom": {
@@ -2326,30 +2338,30 @@
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@>=1.1.0 <1.2.0",
+                  "from": "underscore@1.1.x",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@>=0.5.0 <0.6.0",
+                  "from": "colors@0.5.x",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@>=0.2.0 <0.3.0",
+              "from": "gettext-parser@~0.2.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "encoding@>=0.1.0 <0.2.0",
+                  "from": "encoding@~0.1",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.7",
-                      "from": "iconv-lite@>=0.4.4 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+                      "version": "0.4.8",
+                      "from": "iconv-lite@~0.4.4",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                     }
                   }
                 }
@@ -2364,22 +2376,22 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.7 <0.1.0",
+              "from": "minimist@~0.0.7",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "deep-extend@>=0.2.5 <0.3.0",
+              "from": "deep-extend@~0.2.5",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+              "from": "strip-json-comments@0.1.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "ini": {
               "version": "1.1.0",
-              "from": "ini@>=1.1.0 <1.2.0",
+              "from": "ini@~1.1.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
             }
           }
@@ -2391,34 +2403,34 @@
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "assert-plus@^0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "backoff@>=2.3.0 <3.0.0",
+              "from": "backoff@^2.3.0",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "precond@>=0.2.0 <0.3.0",
+                  "from": "precond@0.2",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "bunyan@>=0.23.1 <0.24.0",
+              "from": "bunyan@^0.23.1",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "mv@>=2.0.0 <3.0.0",
+                  "from": "mv@~2",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "mkdirp@~0.5.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
@@ -2430,12 +2442,12 @@
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "ncp@>=0.6.0 <0.7.0",
+                      "from": "ncp@~0.6.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@>=2.2.8 <2.3.0",
+                      "from": "rimraf@~2.2.8",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -2444,7 +2456,7 @@
             },
             "csv": {
               "version": "0.4.1",
-              "from": "csv@>=0.4.0 <0.5.0",
+              "from": "csv@^0.4.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "dependencies": {
                 "csv-generate": {
@@ -2453,9 +2465,9 @@
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
-                  "version": "0.1.0",
+                  "version": "0.1.1",
                   "from": "csv-parse@*",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
@@ -2471,22 +2483,22 @@
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
+              "from": "deep-equal@^0.2.1",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
+              "from": "escape-regexp-component@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "formidable@>=1.0.14 <2.0.0",
+              "from": "formidable@^1.0.14",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "http-signature@^0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
@@ -2503,64 +2515,64 @@
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
+              "from": "keep-alive-agent@^0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
-              "version": "2.5.2",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+              "version": "2.6.1",
+              "from": "lru-cache@^2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
+              "from": "mime@^1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "negotiator@>=0.4.5 <0.5.0",
+              "from": "negotiator@^0.4.5",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "node-uuid@^1.4.1",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.0.0 <2.0.0",
+              "from": "qs@^1.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
+              "from": "semver@^2.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
-              "version": "1.31.0",
-              "from": "spdy@>=1.26.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
+              "version": "1.32.0",
+              "from": "spdy@^1.26.5",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@^0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "verror@>=1.4.0 <2.0.0",
+              "from": "verror@^1.4.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
@@ -2572,7 +2584,7 @@
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@>=0.2.8 <0.3.0",
+              "from": "dtrace-provider@^0.2.8",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -2586,17 +2598,17 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -2606,37 +2618,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.2",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2645,144 +2657,144 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.2",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "underscore@~1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "exit@~0.1.1",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -2796,7 +2808,7 @@
       "dependencies": {
         "semver": {
           "version": "4.2.2",
-          "from": "semver@>=4.2.2 <4.3.0",
+          "from": "semver@~4.2.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
         }
       }
@@ -2808,44 +2820,44 @@
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.2",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2854,14 +2866,14 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@>=0.3.1 <0.4.0",
+          "from": "resolve@~0.3.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
@@ -2873,37 +2885,37 @@
       "dependencies": {
         "jshint": {
           "version": "2.5.11",
-          "from": "jshint@>=2.5.0 <2.6.0",
+          "from": "jshint@~2.5.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
-              "version": "0.6.6",
-              "from": "cli@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "version": "0.6.5",
+              "from": "cli@0.6.x",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "glob@~ 3.2.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.2",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -2914,49 +2926,49 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "from": "console-browserify@1.1.x",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.0 <0.2.0",
+              "from": "exit@0.1.x",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "from": "htmlparser2@3.8.x",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "from": "domhandler@2.3",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "from": "dom-serializer@0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "from": "domelementtype@~1.1.1",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
+                          "from": "entities@~1.1.1",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -2965,17 +2977,17 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -2985,60 +2997,60 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <1.1.0",
+              "from": "minimatch@1.0.x",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.2",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
+              "from": "shelljs@0.3.x",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "from": "strip-json-comments@1.0.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@>=1.6.0 <1.7.0",
+              "from": "underscore@1.6.x",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
@@ -3055,27 +3067,27 @@
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@>=0.2.3 <0.3.0",
+          "from": "cli-color@^0.2.3",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@>=0.9.2 <0.10.0",
+              "from": "es5-ext@~0.9.2",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@>=0.2.5 <0.3.0",
+              "from": "memoizee@~0.2.5",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@>=0.2.2 <0.3.0",
+                  "from": "event-emitter@~0.2.2",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@>=0.1.0 <0.2.0",
+                  "from": "next-tick@0.1.x",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -3084,12 +3096,12 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@^0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -3109,11 +3121,6 @@
           "from": "ammo@1.0.0",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
         },
-        "boom": {
-          "version": "2.6.1",
-          "from": "boom@2.6.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
-        },
         "call": {
           "version": "2.0.1",
           "from": "call@2.0.1",
@@ -3131,7 +3138,7 @@
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.0.4",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
@@ -3263,7 +3270,7 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.0.2",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
@@ -3283,17 +3290,17 @@
       "from": "hapi-auth-hawk@2.0.0",
       "resolved": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-2.0.0.tgz",
       "dependencies": {
-        "boom": {
-          "version": "2.7.0",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
-        },
         "hoek": {
           "version": "2.12.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "hoek@^2.2.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
         }
       }
+    },
+    "hapi-fxa-oauth": {
+      "version": "2.0.1",
+      "from": "hapi-fxa-oauth@2.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.0.1.tgz"
     },
     "hawk": {
       "version": "2.3.0",
@@ -3302,22 +3309,17 @@
       "dependencies": {
         "hoek": {
           "version": "2.12.0",
-          "from": "hoek@>=2.2.0 <3.0.0",
+          "from": "hoek@^2.2.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
-        },
-        "boom": {
-          "version": "2.7.0",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
+          "from": "sntp@1.x.x",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
@@ -3334,23 +3336,23 @@
       "dependencies": {
         "hoek": {
           "version": "2.12.0",
-          "from": "hoek@>=2.2.0 <3.0.0",
+          "from": "hoek@^2.2.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@>=1.0.0 <2.0.0",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "isemail@>=1.0.0 <2.0.0",
+          "from": "isemail@1.x.x",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
-          "version": "2.10.2",
-          "from": "moment@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.2.tgz"
+          "version": "2.9.0",
+          "from": "moment@2.x.x",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         }
       }
     },
@@ -3378,32 +3380,32 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@~3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.2",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3412,46 +3414,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "multimatch@>=0.3.0 <0.4.0",
+          "from": "multimatch@^0.3.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "array-differ@>=0.1.0 <0.2.0",
+              "from": "array-differ@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "array-union@>=0.1.0 <0.2.0",
+              "from": "array-union@^0.1.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "array-uniq@>=0.1.0 <0.2.0",
+                  "from": "array-uniq@^0.1.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "minimatch@^0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.2",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3472,7 +3474,7 @@
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "addressparser@>=0.3.2 <0.4.0",
+              "from": "addressparser@~0.3.2",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             }
           }
@@ -3484,7 +3486,7 @@
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.7",
-              "from": "iconv-lite@>=0.4.4 <0.5.0",
+              "from": "iconv-lite@~0.4.4",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             }
           }
@@ -3496,7 +3498,7 @@
         },
         "uue": {
           "version": "1.0.0",
-          "from": "uue@>=1.0.0 <1.1.0",
+          "from": "uue@~1.0.0",
           "resolved": "https://registry.npmjs.org/uue/-/uue-1.0.0.tgz"
         }
       }
@@ -3508,17 +3510,17 @@
       "dependencies": {
         "propagate": {
           "version": "0.3.1",
-          "from": "propagate@>=0.3.0 <0.4.0",
+          "from": "propagate@0.3.x",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@>=1.0.4 <2.0.0",
+          "from": "debug@^1.0.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
@@ -3554,17 +3556,17 @@
       "dependencies": {
         "bl": {
           "version": "0.9.4",
-          "from": "bl@>=0.9.0 <0.10.0",
+          "from": "bl@~0.9.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "from": "readable-stream@~1.0.26",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -3574,12 +3576,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -3588,47 +3590,47 @@
         },
         "caseless": {
           "version": "0.6.0",
-          "from": "caseless@>=0.6.0 <0.7.0",
+          "from": "caseless@~0.6.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@>=0.5.0 <0.6.0",
+          "from": "forever-agent@~0.5.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "qs": {
           "version": "1.2.2",
-          "from": "qs@>=1.2.0 <1.3.0",
+          "from": "qs@~1.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+          "from": "json-stringify-safe@~5.0.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
-          "from": "mime-types@>=1.0.1 <1.1.0",
+          "from": "mime-types@~1.0.1",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "from": "node-uuid@~1.4.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "from": "tunnel-agent@~0.4.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "form-data@>=0.1.0 <0.2.0",
+          "from": "form-data@~0.1.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.4 <0.1.0",
+              "from": "combined-stream@~0.0.4",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -3640,12 +3642,12 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@>=1.2.11 <1.3.0",
+              "from": "mime@~1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "async@~0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
@@ -3664,12 +3666,12 @@
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
+          "from": "http-signature@~0.10.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "assert-plus@^0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
@@ -3686,7 +3688,7 @@
         },
         "oauth-sign": {
           "version": "0.4.0",
-          "from": "oauth-sign@>=0.4.0 <0.5.0",
+          "from": "oauth-sign@~0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
         },
         "hawk": {
@@ -3696,34 +3698,34 @@
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@>=0.9.0 <0.10.0",
+              "from": "hoek@0.9.x",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@>=0.4.0 <0.5.0",
+              "from": "boom@0.4.x",
               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@>=0.2.0 <0.3.0",
+              "from": "cryptiles@0.2.x",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@>=0.2.0 <0.3.0",
+              "from": "sntp@0.2.x",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "from": "aws-sign2@~0.5.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "stringstream@~0.0.4",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         }
       }
@@ -3752,12 +3754,12 @@
       "dependencies": {
         "rai": {
           "version": "0.1.12",
-          "from": "rai@>=0.1.11 <0.2.0",
+          "from": "rai@~0.1.11",
           "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
         },
         "xoauth2": {
           "version": "0.1.8",
-          "from": "xoauth2@>=0.1.8 <0.2.0",
+          "from": "xoauth2@~0.1.8",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
         }
       }
@@ -3774,54 +3776,54 @@
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "buffer-equal@>=0.0.0 <0.1.0",
+          "from": "buffer-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@>=0.0.0 <0.1.0",
+          "from": "deep-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "difflet@>=0.2.0 <0.3.0",
+          "from": "difflet@~0.2.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@>=0.6.0 <0.7.0",
+              "from": "traverse@0.6.x",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@>=0.1.0 <0.2.0",
+              "from": "charm@0.1.x",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@>=0.1.0 <0.2.0",
+              "from": "deep-is@0.1.x",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.1 <3.3.0",
+          "from": "glob@~3.2.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.2",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3835,7 +3837,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+          "from": "mkdirp@~0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
@@ -3847,39 +3849,39 @@
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "nopt@>=2.0.0 <3.0.0",
+          "from": "nopt@~2",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "runforcover@>=0.0.2 <0.1.0",
+          "from": "runforcover@~0.0.2",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "bunker@>=0.1.0 <0.2.0",
+              "from": "bunker@0.1.X",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "burrito@>=0.2.5 <0.3.0",
+                  "from": "burrito@>=0.2.5 <0.3",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@>=0.5.1 <0.6.0",
+                      "from": "traverse@~0.5.1",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@>=1.1.1 <1.2.0",
+                      "from": "uglify-js@~1.1.1",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fxa-auth-mailer": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
     "hapi": "8.2.0",
     "hapi-auth-hawk": "2.0.0",
+    "hapi-fxa-oauth": "2.0.1",
     "hkdf": "0.0.2",
     "joi": "6.0.0",
     "jws": "0.2.6",

--- a/server/server.js
+++ b/server/server.js
@@ -144,6 +144,23 @@ module.exports = function (path, url, Hapi) {
       )
     })
 
+    server.register(
+      {
+        register: require('hapi-fxa-oauth'),
+        options: config.oauth
+      },
+      function (err) {
+        server.auth.strategy(
+          'oauthToken',
+          'fxa-oauth'
+          // TODO: push scope-checking down into hapi-fxa-oauth?
+          //{
+          //  scope: "profile"
+          //}
+        )
+      }
+    )
+
     server.route(routes)
 
     server.app.log = log

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -16,7 +16,8 @@ function ClientApi(origin) {
   EventEmitter.call(this)
   this.origin = origin
   this.baseURL = origin + "/v1"
-  this.timeOffset = 0;
+  this.timeOffset = 0
+  this.headers = {}
 }
 
 ClientApi.prototype.Token = tokens
@@ -39,6 +40,11 @@ ClientApi.prototype.doRequest = function (method, url, token, payload, headers) 
   var d = P.defer()
   if (typeof headers === 'undefined') {
     headers = {}
+  }
+  for (var k in this.headers) {
+    if (!headers.hasOwnProperty(k)) {
+      headers[k] = this.headers[k]
+    }
   }
   if (token && !headers.Authorization) {
     headers.Authorization = hawkHeader(token, method, url, payload, this.timeOffset)

--- a/test/config/mock_oauth.json
+++ b/test/config/mock_oauth.json
@@ -1,0 +1,7 @@
+{
+  "oauth": {
+    "host": "localhost",
+    "port": 9010,
+    "insecure": true
+  }
+}

--- a/test/oauth_helper.js
+++ b/test/oauth_helper.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var config = require('../config').root()
+
+var hapi = require('hapi')
+var api = new hapi.Server()
+api.connection({
+  host: config.oauth.host,
+  port: config.oauth.port
+})
+
+api.route(
+  [
+    {
+      method: 'POST',
+      path: '/v1/verify',
+      handler: function (request, reply) {
+        var data = JSON.parse(Buffer(request.payload.token, 'hex'))
+        return reply(data).code(data.code || 200)
+      }
+    }
+  ]
+)
+
+api.start()

--- a/test/remote/account_status_oauth_token_tests.js
+++ b/test/remote/account_status_oauth_token_tests.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var path = require('path')
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var Client = require('../client')
+
+process.env.CONFIG_FILES = path.join(__dirname, '../config/mock_oauth.json')
+var config = require('../../config').root()
+
+function makeMockOAuthHeader(opts) {
+  var token = new Buffer(JSON.stringify(opts)).toString('hex')
+  return 'Bearer ' + token
+}
+
+TestServer.start(config)
+.then(function main(server) {
+
+  test(
+    'account status authenticated with oauth returns account info',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeMockOAuthHeader({
+              user: c.uid,
+              scopes: ['profile']
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function (response) {
+            t.ok(response.exists, 'account exists')
+            t.ok(response.email, 'email address is returned')
+            t.equal(response.locale, 'en-US', 'locale is returned')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with oauth with no uid returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeMockOAuthHeader({
+              user: c.uid,
+              scopes: ['profile']
+            })
+            return c.api.accountStatus()
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 400, 'correct error status code')
+            t.equal(e.errno, 108, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with invalid oauth token returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeMockOAuthHeader({
+              code: 401,
+              errno: 108
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with oauth for wrong uid returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeMockOAuthHeader({
+              user: 'abcdef123456',
+              scopes: ['profile']
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status authenticated with oauth for wrong scope returns an error',
+    function (t) {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(
+          function (c) {
+            c.api.headers.Authorization = makeMockOAuthHeader({
+              user: c.uid,
+              scopes: ['readinglist', 'payments']
+            })
+            return c.api.accountStatus(c.uid)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should get an error')
+          },
+          function (e) {
+            t.equal(e.code, 401, 'correct error status code')
+            t.equal(e.errno, 110, 'correct errno')
+          }
+        )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -239,7 +239,6 @@ TestServer.start(config)
         .then(
           t.fail,
           function (err) {
-            console.log(err)
             t.equal(err.errno, 109, 'Missing payload authentication')
           }
         )

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -11,8 +11,10 @@ var createDBServer = require('fxa-auth-db-mem')
 
 function TestServer(config, printLogs) {
   this.printLogs = printLogs === false ? false : true
+  this.config = config
   this.server = null
   this.mail = null
+  this.oauth = null
   this.mailbox = mailbox(config.smtp.api.host, config.smtp.api.port)
 }
 
@@ -82,6 +84,21 @@ TestServer.prototype.start = function () {
     this.mail.stdout.on('data', process.stdout.write.bind(process.stdout))
     this.mail.stderr.on('data', process.stderr.write.bind(process.stderr))
   }
+
+  if (this.config.oauth.host) {
+    this.oauth = cp.spawn(
+      'node',
+      ['./oauth_helper.js'],
+      {
+        cwd: __dirname,
+        stdio: this.printLogs ? 'pipe' : 'ignore'
+      }
+    )
+    if (this.printLogs) {
+      this.oauth.stdout.on('data', process.stdout.write.bind(process.stdout))
+      this.oauth.stderr.on('data', process.stderr.write.bind(process.stderr))
+    }
+  }
 }
 
 TestServer.prototype.stop = function () {
@@ -89,6 +106,9 @@ TestServer.prototype.stop = function () {
   if (this.server) {
     this.server.kill('SIGINT')
     this.mail.kill()
+    if (this.oauth) {
+      this.oauth.kill()
+    }
   }
 }
 


### PR DESCRIPTION
Here's a sketch of how we might allow backend service access to our API via oauth tokens.  It's basically #901 re-cast to consume oauth tokens rather than a custom auth scheme.  We'll need to think about the necessary scopes and permission model, and probably iterate on hapi-fxa-oauth to e.g. do the proper scope checking automatically.

@dannycoates @ckarlof thoughts?

