### PR TITLE
fix(l10n): pass config.i18n.defaultLanguage to fxa-auth-mailer

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -12,6 +12,7 @@ module.exports = function (config, log) {
     log,
     {
       locales: config.i18n.locales,
+      defaultLanguage: defaultLanguage,
       mail: config.smtp
     }
   )


### PR DESCRIPTION
To match https://github.com/mozilla/fxa-auth-mailer/pull/40/.