### PR TITLE
fix(pool): Stop retrying requests to db-server

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -26,7 +26,7 @@ function Pool(url, options) {
     {
       timeout: options.timeout || 5000,
       keepAlive: true,
-      maxRetries: 2
+      maxRetries: 0
     }
   )
 }


### PR DESCRIPTION
Following https://github.com/mozilla/fxa-auth-db-mysql/issues/9 we
should stop retrying requests to the db-server so we're more explicit
about what is happening.

Fixes #921.