### PR TITLE
build(travis): Test on both io.js v1 and v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
 node_js:
  - "0.10"
  - "0.12"
- - "iojs"
+ - "iojs-v1"
+ - "iojs-v2"
 
 sudo: false
 


### PR DESCRIPTION
Since Travis uses the same semantics as nvm we can test on both
io.js v1.x and v2.x: https://github.com/creationix/nvm#usage