### PR TITLE
tests(preverify): add 321done to trusted jkus for dev

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -20,7 +20,10 @@
     "region": "us-east-1"
   },
   "customsUrl": "none",
-  "trustedJKUs": ["http://127.0.0.1:8080/.well-known/public-keys"],
+  "trustedJKUs": [
+    "http://127.0.0.1:8080/.well-known/public-keys",
+    "http://127.0.0.1:10139/.well-known/public-keys"
+  ],
   "lockoutEnabled": true,
   "snsTopicArn": "disabled"
 }


### PR DESCRIPTION
We need this to test the permission screen in the preVerified signup flow.

@vladikoff r? Do we need to configure something like this for fxa-dev too?