### PR TITLE
Lazily initialize test servers; report unhandled rejections as failures

### DIFF
--- a/test/local/account_preverified_token_tests.js
+++ b/test/local/account_preverified_token_tests.js
@@ -24,12 +24,12 @@ function nowSeconds() {
   return Math.floor(Date.now() / 1000)
 }
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    'a valid preVerifyToken creates a verified account',
-    function (t) {
+test(
+  'a valid preVerifyToken creates a verified account',
+  function (t) {
+    return testServer.then(function(server) {
       var email = server.uniqueEmail()
       var password = 'ok'
       var token = secretKey.signSync(
@@ -51,12 +51,14 @@ TestServer.start(config)
             t.ok(Buffer.isBuffer(keys.wrapKb), 'wrapKb exists')
           }
         )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'an invalid preVerifyToken return an invalid verification code error',
-    function (t) {
+test(
+  'an invalid preVerifyToken return an invalid verification code error',
+  function (t) {
+    return testServer.then(function(server) {
       var email = server.uniqueEmail()
       var password = 'ok'
       var token = secretKey.signSync(
@@ -73,12 +75,14 @@ TestServer.start(config)
             t.equal(err.errno, 105, 'invalid verification code')
           }
         )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    're-signup against an unverified email',
-    function (t) {
+test(
+  're-signup against an unverified email',
+  function (t) {
+    return testServer.then(function(server) {
       var email = server.uniqueEmail()
       var password = 'abcdef'
       return Client.create(config.publicUrl, email, password)
@@ -112,14 +116,15 @@ TestServer.start(config)
             t.ok(Buffer.isBuffer(keys.wrapKb), 'wrapKb exists')
           }
         )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)

--- a/test/local/base_path_tests.js
+++ b/test/local/base_path_tests.js
@@ -12,22 +12,24 @@ var request = require('request')
 process.env.CONFIG_FILES = path.join(__dirname, '../config/base_path.json')
 var config = require('../../config').root()
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    'alternate base path',
-    function (t) {
+test(
+  'alternate base path',
+  function (t) {
+    return testServer.then(function(server) {
       var email = Math.random() + "@example.com"
       var password = 'ok'
       // if this doesn't crash, we're all good
       return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
-    }
-  )
+    })
+  }
+)
 
-  test(
-    '.well-known did not move',
-    function (t) {
+test(
+  '.well-known did not move',
+  function (t) {
+    return testServer.then(function(server) {
       var d = P.defer()
       request('http://127.0.0.1:9000/.well-known/browserid',
         function (err, res, body) {
@@ -39,12 +41,14 @@ TestServer.start(config)
         }
       )
       return d.promise
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'default routes are prefixed',
-    function (t) {
+test(
+  'default routes are prefixed',
+  function (t) {
+    return testServer.then(function(server) {
       var d = P.defer()
       request(config.publicUrl + '/',
         function (err, res, body) {
@@ -56,14 +60,15 @@ TestServer.start(config)
         }
       )
       return d.promise
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)

--- a/test/local/concurrent_tests.js
+++ b/test/local/concurrent_tests.js
@@ -12,12 +12,12 @@ var P = require('../../lib/promise')
 process.env.CONFIG_FILES = path.join(__dirname, '../config/scrypt.json')
 var config = require('../../config').root()
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    'concurrent create requests',
-    function (t) {
+test(
+  'concurrent create requests',
+  function (t) {
+    return testServer.then(function(server) {
       var email = server.uniqueEmail()
       var password = 'abcdef'
       // Two shall enter, only one shall survive!
@@ -33,14 +33,15 @@ TestServer.start(config)
           t.equal(err.errno, 101, 'account exists')
         }
       )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)

--- a/test/local/email_validity_tests.js
+++ b/test/local/email_validity_tests.js
@@ -12,12 +12,12 @@ var P = require('../../lib/promise')
 process.env.CONFIG_FILES = path.join(__dirname, '../config/scrypt.json')
 var config = require('../../config').root()
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    '/account/create with a variety of malformed email addresses',
-    function (t) {
+test(
+  '/account/create with a variety of malformed email addresses',
+  function (t) {
+    return testServer.then(function(server) {
       var pwd = '123456'
 
       var emails = [
@@ -42,12 +42,14 @@ TestServer.start(config)
       })
 
       return P.all(emails)
-    }
-  )
+    })
+  }
+)
 
-  test(
-    '/account/create with a variety of unusual but valid email addresses',
-    function (t) {
+test(
+  '/account/create with a variety of unusual but valid email addresses',
+  function (t) {
+    return testServer.then(function(server) {
       var pwd = '123456'
 
       var emails = [
@@ -72,14 +74,15 @@ TestServer.start(config)
       })
 
       return P.all(emails)
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)

--- a/test/local/mailer_locales_tests.js
+++ b/test/local/mailer_locales_tests.js
@@ -3,84 +3,82 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 require('ass')
-var test = require('tap').test
+var test = require('../ptaptest')
 var config = require('../../config').root()
 var log = {}
 
-require('../../lib/mailer')(config, log)
-  .done(
-    function(mailer) {
+var testMailer = require('../../lib/mailer')(config, log)
 
-      test(
-        'All configured supportedLanguages are available',
-        function (t) {
-          var locales = config.i18n.supportedLanguages
-          locales.forEach(function(lang) {
-            if (lang === 'sr-LATN') {
-              // sr-LATN is sr, but in Latin characters, not Cyrillic
-              t.equal('sr', mailer.translator(lang).language)
-            } else {
-              t.equal(lang, mailer.translator(lang).language)
-            }
-          })
-          t.end()
+test(
+  'All configured supportedLanguages are available',
+  function (t) {
+    return testMailer.then(function(mailer) {
+      var locales = config.i18n.supportedLanguages
+      locales.forEach(function(lang) {
+        if (lang === 'sr-LATN') {
+          // sr-LATN is sr, but in Latin characters, not Cyrillic
+          t.equal('sr', mailer.translator(lang).language)
+        } else {
+          t.equal(lang, mailer.translator(lang).language)
         }
-      )
+      })
+    })
+  }
+)
 
-      test(
-        'unsupported languages get default/fallback content',
-        function (t) {
-          // These are locales for which we do not have explicit translations
-          var locales = [
-            // [ locale, expected result ]
-            [ '',      'en' ],
-            [ 'en-US', 'en' ],
-            [ 'en-CA', 'en' ],
-            [ 'db-LB', 'en' ],
-            [ 'el-GR', 'en' ],
-            [ 'es-BO', 'es' ],
-            [ 'fr-FR', 'fr' ],
-            [ 'fr-CA', 'fr' ],
-          ]
+test(
+  'unsupported languages get default/fallback content',
+  function (t) {
+    return testMailer.then(function(mailer) {
+      // These are locales for which we do not have explicit translations
+      var locales = [
+        // [ locale, expected result ]
+        [ '',      'en' ],
+        [ 'en-US', 'en' ],
+        [ 'en-CA', 'en' ],
+        [ 'db-LB', 'en' ],
+        [ 'el-GR', 'en' ],
+        [ 'es-BO', 'es' ],
+        [ 'fr-FR', 'fr' ],
+        [ 'fr-CA', 'fr' ],
+      ]
 
-          locales.forEach(function(lang) {
-            t.equal(lang[1], mailer.translator(lang[0]).language)
-          })
-          t.end()
-        }
-      )
+      locales.forEach(function(lang) {
+        t.equal(lang[1], mailer.translator(lang[0]).language)
+      })
+    })
+  }
+)
 
-      test(
-        'accept-language handled correctly',
-        function (t) {
-          // These are the Accept-Language headers from Firefox 37 L10N builds
-          var locales = [
-            // [ accept-language, expected result ]
-            [ 'bogus-value',                         'en'    ],
-            [ 'en-US,en;q=0.5',                      'en'    ],
-            [ 'es-AR,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es-AR' ],
-            [ 'es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es'    ],
-            [ 'sv-SE,sv;q=0.8,en-US;q=0.5,en;q=0.3', 'sv-SE' ],
-            [ 'zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3', 'zh-CN' ],
-            // Yes, this line is the official accept-language in the nb-NO build
-            [ 'nb-NO,nb;q=0.9,no-NO;q=0.8,no;q=0.6,nn-NO;q=0.5,nn;q=0.4,en-US;q=0.3,en;q=0.1', 'nb-NO' ],
-          ]
+test(
+  'accept-language handled correctly',
+  function (t) {
+    return testMailer.then(function(mailer) {
+      // These are the Accept-Language headers from Firefox 37 L10N builds
+      var locales = [
+        // [ accept-language, expected result ]
+        [ 'bogus-value',                         'en'    ],
+        [ 'en-US,en;q=0.5',                      'en'    ],
+        [ 'es-AR,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es-AR' ],
+        [ 'es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es'    ],
+        [ 'sv-SE,sv;q=0.8,en-US;q=0.5,en;q=0.3', 'sv-SE' ],
+        [ 'zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3', 'zh-CN' ],
+        // Yes, this line is the official accept-language in the nb-NO build
+        [ 'nb-NO,nb;q=0.9,no-NO;q=0.8,no;q=0.6,nn-NO;q=0.5,nn;q=0.4,en-US;q=0.3,en;q=0.1', 'nb-NO' ],
+      ]
 
-          locales.forEach(function(lang) {
-            t.equal(lang[1], mailer.translator(lang[0]).language)
-          })
-          t.end()
-        }
-      )
+      locales.forEach(function(lang) {
+        t.equal(lang[1], mailer.translator(lang[0]).language)
+      })
+    })
+  }
+)
 
-      test(
-        'teardown',
-        function (t) {
-          mailer.stop()
-          t.end()
-        }
-      )
-    }
-  )
-
-
+test(
+  'teardown',
+  function (t) {
+    return testMailer.then(function(mailer) {
+      return mailer.stop()
+    })
+  }
+)

--- a/test/local/resend_blackout_tests.js
+++ b/test/local/resend_blackout_tests.js
@@ -11,12 +11,12 @@ var P = require('../../lib/promise')
 process.env.CONFIG_FILES = path.join(__dirname, '../config/resend_blackout.json')
 var config = require('../../config').root()
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    'resend blackout period',
-    function (t) {
+test(
+  'resend blackout period',
+  function (t) {
+    return testServer.then(function(server) {
       // FYI config.tokenLifetimes.passwordChangeToken = -1
       var email = Math.random() + "@example.com"
       var password = 'ok'
@@ -51,14 +51,15 @@ TestServer.start(config)
             return server.mailbox.waitForCode(email)
           }
         )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)

--- a/test/local/token_expiry_tests.js
+++ b/test/local/token_expiry_tests.js
@@ -12,12 +12,12 @@ var config = require('../../config').root()
 
 function fail() { throw new Error() }
 
-TestServer.start(config)
-.then(function main(server) {
+var testServer = TestServer.start(config)
 
-  test(
-    'token expiry',
-    function (t) {
+test(
+  'token expiry',
+  function (t) {
+    return testServer.then(function(server) {
       // FYI config.tokenLifetimes.passwordChangeToken = -1
       var email = Math.random() + "@example.com"
       var password = 'ok'
@@ -33,14 +33,15 @@ TestServer.start(config)
             t.equal(err.errno, 110, 'invalid token')
           }
         )
-    }
-  )
+    })
+  }
+)
 
-  test(
-    'teardown',
-    function (t) {
-      server.stop()
-      t.end()
-    }
-  )
-})
+test(
+  'teardown',
+  function (t) {
+    return testServer.then(function(server) {
+      return server.stop()
+    })
+  }
+)


### PR DESCRIPTION
Follow-up to #933. Any errors starting the test server (e.g., port already in use) will now be reported as test failures.

I found this out when I accidentally left a different `fxa-auth-db-server` instance running in the background, and `TestServer` tried to listen on the same port. A lot of the tests timed out, so there was definitely a clear indication something went wrong...just wasn't sure what at first.

@dannycoates r?