### PR TITLE
WIP: Add session revocation tokens to support device manager

### DIFF
--- a/bin/email_bouncer.js
+++ b/bin/email_bouncer.js
@@ -14,6 +14,7 @@ var DB = require('../lib/db')(
   error,
   Token.SessionToken,
   Token.KeyFetchToken,
+  Token.SessionRevokeToken,
   Token.AccountResetToken,
   Token.PasswordForgotToken,
   Token.PasswordChangeToken

--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -53,6 +53,7 @@ function main() {
           error,
           Token.SessionToken,
           Token.KeyFetchToken,
+          Token.SessionRevokeToken,
           Token.AccountResetToken,
           Token.PasswordForgotToken,
           Token.PasswordChangeToken

--- a/lib/db.js
+++ b/lib/db.js
@@ -16,6 +16,7 @@ module.exports = function (
   error,
   SessionToken,
   KeyFetchToken,
+  SessionRevokeToken,
   AccountResetToken,
   PasswordForgotToken,
   PasswordChangeToken) {
@@ -78,6 +79,31 @@ module.exports = function (
         throw err
       }
     )
+  }
+
+  DB.prototype.createSessionRevokeToken = function (data) {
+    return SessionRevokeToken.create(data)
+      .then(
+        function (sessionRevokeToken) {
+          return this.pool.put(
+            '/sessionRevokeToken/' + sessionRevokeToken.id,
+            unbuffer(
+              {
+                tokenId: sessionRevokeToken.tokenId,
+                data: sessionRevokeToken.data,
+                uid: sessionRevokeToken.uid,
+                sessionData: sessionRevokeToken.sessionData,
+                keyFetchId: sessionRevokeToken.keyFetchId,
+                createdAt: sessionRevokeToken.createdAt
+              },
+              'inplace'
+            )
+          )
+          .then(function () {
+            return sessionRevokeToken
+          })
+        }.bind(this)
+      )
   }
 
   DB.prototype.createSessionToken = function (authToken) {
@@ -265,6 +291,23 @@ module.exports = function (
       )
   }
 
+  DB.prototype.sessionRevokeToken = function (id) {
+    log.trace({ op: 'DB.sessionRevokeToken', id: id })
+    return this.pool.get('/sessionRevokeToken/' + id.toString('hex'))
+      .then(
+        function (body) {
+          var data = bufferize(body)
+          return SessionRevokeToken.fromHex(data.tokenData, data)
+        },
+        function (err) {
+          if (err.statusCode === 404) {
+            err = error.invalidToken()
+          }
+          throw err
+        }
+      )
+  }
+
   DB.prototype.accountResetToken = function (id) {
     log.trace({ op: 'DB.accountResetToken', id: id })
     return this.pool.get('/accountResetToken/' + id.toString('hex'))
@@ -391,6 +434,17 @@ module.exports = function (
       }
     )
     return this.pool.del('/keyFetchToken/' + keyFetchToken.id)
+  }
+
+  DB.prototype.deleteSessionRevokeToken = function (sessionRevokeToken) {
+    log.trace(
+      {
+        op: 'DB.deleteSessionRevokeToken',
+        id: sessionRevokeToken && sessionRevokeToken.id,
+        uid: sessionRevokeToken && sessionRevokeToken.uid
+      }
+    )
+    return this.pool.del('/sessionRevokeToken/' + sessionRevokeToken.id)
   }
 
   DB.prototype.deleteAccountResetToken = function (accountResetToken) {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -28,6 +28,17 @@ module.exports = function (
   checkPassword
   ) {
 
+  function createRevokeToken(account, sessionToken, keyFetchToken) {
+    var data = {
+      uid: account.uid,
+      sessionData: sessionToken.data
+    }
+    if (keyFetchToken) {
+      data.keyFetchId = keyFetchToken.tokenId
+    }
+    return db.createSessionRevokeToken(data)
+  }
+
   var routes = [
     {
       method: 'POST',
@@ -122,10 +133,15 @@ module.exports = function (
                       .then(
                         function (sessionToken) {
                           if (request.query.keys !== 'true') {
-                            return P({
-                              account: account,
-                              sessionToken: sessionToken
-                            })
+                            return createRevokeToken(account, sessionToken)
+                              .then(function (sessionRevokeToken) {
+                                return {
+                                  account: account,
+                                  sessionToken: sessionToken,
+                                  sessionRevokeToken: sessionRevokeToken
+                                }
+                              }
+                            )
                           }
                           return password.unwrap(account.wrapWrapKb)
                             .then(
@@ -142,11 +158,16 @@ module.exports = function (
                             )
                             .then(
                               function (keyFetchToken) {
-                                return {
-                                  account: account,
-                                  sessionToken: sessionToken,
-                                  keyFetchToken: keyFetchToken
-                                }
+                                return createRevokeToken(account, sessionToken, keyFetchToken)
+                                  .then(function (sessionRevokeToken) {
+                                    return {
+                                      account: account,
+                                      sessionToken: sessionToken,
+                                      keyFetchToken: keyFetchToken,
+                                      sessionRevokeToken: sessionRevokeToken
+                                    }
+                                  }
+                                )
                               }
                             )
                         }
@@ -185,6 +206,7 @@ module.exports = function (
                   keyFetchToken: response.keyFetchToken ?
                     response.keyFetchToken.data.toString('hex')
                     : undefined,
+                  sessionRevokeToken: response.sessionRevokeToken.data.toString('hex'),
                   authAt: response.sessionToken.lastAuthAt()
                 }
               )
@@ -208,6 +230,7 @@ module.exports = function (
             uid: isA.string().regex(HEX_STRING).required(),
             sessionToken: isA.string().regex(HEX_STRING).required(),
             keyFetchToken: isA.string().regex(HEX_STRING).optional(),
+            sessionRevokeToken: isA.string().regex(HEX_STRING).required(),
             verified: isA.boolean().required(),
             authAt: isA.number().integer()
           }
@@ -248,9 +271,14 @@ module.exports = function (
                 .then(
                   function (sessionToken) {
                     if (request.query.keys !== 'true') {
-                      return P({
-                        sessionToken: sessionToken
-                      })
+                      return createRevokeToken(emailRecord, sessionToken)
+                        .then(function (sessionRevokeToken) {
+                          return {
+                            sessionToken: sessionToken,
+                            sessionRevokeToken: sessionRevokeToken
+                          }
+                        }
+                      )
                     }
                     var password = new Password(
                       authPW,
@@ -272,10 +300,15 @@ module.exports = function (
                     )
                     .then(
                       function (keyFetchToken) {
-                        return {
-                          sessionToken: sessionToken,
-                          keyFetchToken: keyFetchToken
-                        }
+                        return createRevokeToken(emailRecord, sessionToken, keyFetchToken)
+                          .then(function (sessionRevokeToken) {
+                            return {
+                              sessionToken: sessionToken,
+                              keyFetchToken: keyFetchToken,
+                              sessionRevokeToken: sessionRevokeToken
+                            }
+                          }
+                        )
                       }
                     )
                 }
@@ -291,6 +324,7 @@ module.exports = function (
                   keyFetchToken: tokens.keyFetchToken ?
                     tokens.keyFetchToken.data.toString('hex')
                     : undefined,
+                  sessionRevokeToken: tokens.sessionRevokeToken.data.toString('hex'),
                   verified: tokens.sessionToken.emailVerified,
                   authAt: tokens.sessionToken.lastAuthAt()
                 }

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -4,7 +4,79 @@
 
 module.exports = function (log, isA, error, db) {
 
+  function destroySession(sessionRevokeToken) {
+    return sessionRevokeToken.sessionToken()
+      .then(
+        function(sessionToken) {
+          if (!sessionToken) {
+            return null
+          }
+          return db.deleteSessionToken(sessionToken)
+            .then(
+              null,
+              function (err) {
+                if (err.statusCode === 404) {
+                  return null
+                }
+                throw err
+              }
+            )
+        }
+      )
+  }
+
+  function destroyKeyFetch(sessionRevokeToken) {
+    return sessionRevokeToken.keyFetchToken()
+      .then(
+        function (keyFetchToken) {
+          if (!keyFetchToken) {
+            return null
+          }
+          return db.deleteKeyFetchToken(keyFetchToken)
+            .then(
+              null,
+              function (err) {
+                if (err.statusCode === 404) {
+                  return null
+                }
+                throw err
+              }
+            )
+        }
+      )
+  }
+
   var routes = [
+    {
+      method: 'POST',
+      path: '/session/revoke',
+      config: {
+        auth: {
+          strategy: 'sessionRevokeToken'
+        }
+      },
+      handler: function (request, reply) {
+        log.begin('Session.revoke', request)
+        var sessionRevokeToken = request.auth.credentials
+        destroySession(sessionRevokeToken)
+          .then(
+            function () {
+              return destroyKeyFetch(sessionRevokeToken)
+            }
+          )
+          .then(
+            function() {
+              return db.deleteSessionRevokeToken(sessionRevokeToken)
+            }
+          )
+          .done(
+            function () {
+              reply({})
+            },
+            reply
+          )
+      }
+    },
     {
       method: 'POST',
       path: '/session/destroy',

--- a/lib/server.js
+++ b/lib/server.js
@@ -121,6 +121,14 @@ function create(log, error, config, routes, db) {
       }
     )
     server.auth.strategy(
+      'sessionRevokeToken',
+      'hawk',
+      {
+        getCredentialsFunc: makeCredentialFn(db.sessionRevokeToken.bind(db)),
+        hawk: hawkOptions
+      }
+    )
+    server.auth.strategy(
       'accountResetToken',
       'hawk',
       {

--- a/lib/tokens/index.js
+++ b/lib/tokens/index.js
@@ -29,6 +29,15 @@ module.exports = function (log, lifetimes) {
     lifetimes.accountResetToken
   )
   var SessionToken = require('./session_token')(log, inherits, Token)
+  var SessionRevokeToken = require('./session_revoke_token')(
+    log,
+    inherits,
+    Token,
+    P,
+    SessionToken,
+    KeyFetchToken
+  )
+
   var PasswordForgotToken = require('./password_forgot_token')(
     log,
     inherits,
@@ -49,6 +58,7 @@ module.exports = function (log, lifetimes) {
   Token.AccountResetToken = AccountResetToken
   Token.KeyFetchToken = KeyFetchToken
   Token.SessionToken = SessionToken
+  Token.SessionRevokeToken = SessionRevokeToken
   Token.PasswordForgotToken = PasswordForgotToken
   Token.PasswordChangeToken = PasswordChangeToken
 

--- a/lib/tokens/session_revoke_token.js
+++ b/lib/tokens/session_revoke_token.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (log, inherits, Token, P, SessionToken, KeyFetchToken) {
+
+  function SessionRevokeToken(keys, details) {
+    Token.call(this, keys, details)
+    this.sessionData = details.sessionData
+    this.keyFetchId = details.keyFetchId
+  }
+  inherits(SessionRevokeToken, Token)
+
+  SessionRevokeToken.tokenTypeID = 'sessionRevokeToken'
+
+  SessionRevokeToken.prototype.sessionToken = function () {
+    return SessionToken.fromHex(this.sessionData, { uid: this.uid })
+  }
+
+  SessionRevokeToken.prototype.keyFetchToken = function () {
+    if (!this.keyFetchId) {
+      return P(null)
+    }
+    return KeyFetchToken.fromId(this.keyFetchId, { uid: this.uid })
+  }
+
+  SessionRevokeToken.create = function (details) {
+    log.trace({ op: 'SessionRevokeToken.create', uid: details && details.uid })
+    return Token.createNewToken(SessionRevokeToken, details || {})
+  }
+
+  SessionRevokeToken.fromHex = function (string, details) {
+    log.trace({ op: 'SessionRevokeToken.fromHex' })
+    return Token.createTokenFromHexData(SessionRevokeToken, string, details || {})
+  }
+
+  return SessionRevokeToken
+}

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -408,6 +408,19 @@ ClientApi.prototype.sessionDestroy = function (sessionTokenHex) {
     )
 }
 
+ClientApi.prototype.sessionRevoke = function (sessionRevokeTokenHex) {
+  return tokens.SessionRevokeToken.fromHex(sessionRevokeTokenHex)
+    .then(
+      function (token) {
+        return this.doRequest(
+          'POST',
+          this.baseURL + '/session/revoke',
+          token
+        )
+      }.bind(this)
+    )
+}
+
 ClientApi.prototype.sessionStatus = function (sessionTokenHex) {
   return tokens.SessionToken.fromHex(sessionTokenHex)
     .then(

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -17,6 +17,7 @@ function Client(origin) {
   this.emailVerified = false
   this.authToken = null
   this.sessionToken = null
+  this.sessionRevokeToken = null
   this.accountResetToken = null
   this.keyFetchToken = null
   this.passwordForgotToken = null
@@ -119,6 +120,7 @@ Client.prototype.create = function () {
       this.authAt = a.authAt
       this.sessionToken = a.sessionToken
       this.keyFetchToken = a.keyFetchToken
+      this.sessionRevokeToken = a.sessionRevokeToken
       return this
     }.bind(this)
   )
@@ -127,6 +129,7 @@ Client.prototype.create = function () {
 Client.prototype._clear = function () {
   this.authToken = null
   this.sessionToken = null
+  this.sessionRevokeToken = null
   this.srpSession = null
   this.accountResetToken = null
   this.keyFetchToken = null
@@ -146,6 +149,7 @@ Client.prototype.auth = function (opts) {
         this.uid = data.uid
         this.sessionToken = data.sessionToken
         this.keyFetchToken = data.keyFetchToken || null
+        this.sessionRevokeToken = data.sessionRevokeToken
         this.emailVerified = data.verified
         this.authAt = data.authAt
         return this
@@ -164,6 +168,22 @@ Client.prototype.destroySession = function () {
       .then(
         function () {
           this.sessionToken = null
+          return {}
+        }.bind(this)
+      )
+  }
+  return p
+}
+
+Client.prototype.revokeSession = function () {
+  var p = P(null)
+  if (this.sessionRevokeToken) {
+    p = this.api.sessionRevoke(this.sessionRevokeToken)
+      .then(
+        function () {
+          this.sessionRevokeToken = null
+          this.sessionToken = null
+          this.keyFetchToken = null
           return {}
         }.bind(this)
       )

--- a/test/remote/session_revoke_tests.js
+++ b/test/remote/session_revoke_tests.js
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var Client = require('../client')
+
+var config = require('../../config').root()
+
+TestServer.start(config)
+.then(function main(server) {
+
+  test(
+    'revoke without key fetch token',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'foobar'
+      var client = null
+      var sessionToken = null
+      var sessionRevokeToken = null
+      t.plan(6)
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, { keys: false })
+        .then(
+          function (x) {
+            client = x
+
+            sessionToken = client.sessionToken
+            t.ok(sessionToken, 'did not issue session token')
+
+            t.ok(!client.keyFetchToken, 'issued key fetch token')
+
+            sessionRevokeToken = client.sessionRevokeToken
+            t.ok(sessionRevokeToken, 'did not issue revocation token')
+
+            return client.revokeSession()
+          }
+        )
+        .then(
+          function (x) {
+            t.equal(client.sessionToken, null, 'did not clear session token')
+            t.equal(client.sessionRevokeToken, null, 'did not clear revocation token')
+
+            client.sessionToken = sessionToken
+            return client.sessionStatus()
+          }
+        )
+        .then(
+          function (status) {
+            t.fail('got status with revoked session token')
+          },
+          function (err) {
+            t.equal(err.errno, 110, 'session token is revoked')
+          }
+        )
+    }
+  )
+
+  test(
+    'revoke with key fetch token',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'foobar'
+      var client = null
+      var sessionToken = null
+      var keyFetchToken = null
+      var sessionRevokeToken = null
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, { keys: true })
+        .then(
+          function (x) {
+            client = x
+
+            sessionToken = client.sessionToken
+            t.ok(sessionToken, 'did not issue session token')
+
+            keyFetchToken = client.keyFetchToken
+            t.ok(keyFetchToken, 'did not issue key fetch token')
+
+            sessionRevokeToken = client.sessionRevokeToken
+            t.ok(sessionRevokeToken, 'did not issue revocation token')
+
+            return client.revokeSession()
+          }
+        )
+        .then(
+          function (x) {
+            t.equal(client.sessionToken, null, 'did not clear session token')
+            t.equal(client.keyFetchToken, null, 'did not clear key fetch token')
+            t.equal(client.sessionRevokeToken, null, 'did not clear revocation token')
+
+            client.keyFetchToken = keyFetchToken
+            return client.keys()
+          }
+        )
+        .then(
+          function (keys) {
+            t.fail('got keys with revoked key fetch token')
+          },
+          function (err) {
+            t.equal(err.errno, 110, 'key fetch token is revoked')
+
+            client.sessionToken = sessionToken
+            return client.sessionStatus().then(
+              function () {
+                t.fail('got status with revoked session token')
+              },
+              function (err) {
+                t.equal(err.errno, 110, 'session token is revoked')
+              }
+            )
+          }
+        )
+    }
+  )
+
+  test(
+    'revoke consumed tokens',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'foobar'
+      var client = null
+      var sessionRevokeToken = null
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, { keys: true })
+        .then(
+          function (x) {
+            client = x
+            sessionRevokeToken = client.sessionRevokeToken
+
+            // Consume the key fetch token.
+            return client.keys()
+          }
+        )
+        .then(
+          function (keys) {
+            t.ok(Buffer.isBuffer(keys.kA), 'kA exists')
+            t.ok(Buffer.isBuffer(keys.wrapKb), 'wrapKb exists')
+            t.equal(client.kB.length, 32, 'kB exists, has the right length')
+
+            // Consume the session token.
+            return client.destroySession()
+          }
+        )
+        .then(
+          function (x) {
+            return client.revokeSession()
+          }
+        )
+        .then(
+          function (x) {
+            t.equal(client.sessionRevokeToken, null, 'did not clear revocation token')
+
+            client.sessionRevokeToken = sessionRevokeToken
+            return client.revokeSession()
+          }
+        )
+        .then(
+          function (x) {
+            t.fail('did not consume revocation token')
+          },
+          function (err) {
+            t.equal(err.errno, 110, 'revocation token is consumed')
+          }
+        )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
We're currently working on enabling Sync (or a Sync-like microservice?) to use Push. As part of that work, we're building a device manager that associates accounts with a user's devices. There are precedents, but we'd like to unify them under a common service. There's a [vague plan](https://docs.google.com/document/d/1kG3Zmpt_AYoZd1bqbcMwyZYd1OXMzZ0IlqoNdv9S4jM) that describes the motivation and some of the scenarios.

One requirement is for a user to be able to log out remotely in case her device is lost or stolen. There's currently a `/v1/session/destroy` call for this, but it requires a full session token. We'd like to avoid having the device manager store session tokens, to avoid duplication and issues if the token is compromised.

This PR is a cobbled-together proposal for a low-privilege token that can only be used to destroy an active session (and the key fetch token for that session, if one was requested). There are changes to the database backends, too (kitcambridge/fxa-auth-db-server@782e8972434f5e663b587e773f667e06a9bc0b10, kitcambridge/fxa-auth-db-mem@d9127476948732c01576d4573b82be669a932467, kitcambridge/fxa-auth-db-mysql@cff05abe0af9d1bbb0cc9ab5167c2076ce58b58b).

@rfk, @dannycoates I'd love your feedback on the general approach, or specific improvements to the code. :smile_cat: