### PR TITLE
fix(test): use a version of node-ass with updated node-temp

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,172 +3,162 @@
   "version": "1.37.0",
   "dependencies": {
     "ass": {
-      "version": "0.0.4",
-      "from": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
+      "version": "1.0.0",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+        },
         "blanket": {
-          "version": "1.1.7",
-          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.7.tgz",
+          "version": "1.1.6",
+          "from": "blanket@1.1.6",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
-              "version": "1.2.5",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.1.0-dev",
-                  "from": "git://github.com/substack/esprima#is-keyword",
-                  "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290"
-                }
-              }
+              "version": "0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            }
-          }
-        },
-        "temp": {
-          "version": "0.6.0",
-          "from": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
-          "dependencies": {
-            "rimraf": {
-              "version": "2.1.4",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
-            },
-            "osenv": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
-          "version": "0.12.4",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+          "version": "0.14.0",
+          "from": "cheerio@0.14.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "dependencies": {
-            "cheerio-select": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
-              "dependencies": {
-                "CSSselect": {
-                  "version": "0.7.0",
-                  "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
-                  "dependencies": {
-                    "CSSwhat": {
-                      "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-                      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                        }
-                      }
-                    },
-                    "boolbase": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-                    },
-                    "nth-check": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "htmlparser2": {
-              "version": "3.1.4",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+              "version": "3.7.3",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
+                  "version": "2.2.1",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
-                  "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
               }
             },
-            "underscore": {
-              "version": "1.4.4",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-            },
             "entities": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            },
+            "CSSselect": {
+              "version": "0.4.1",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "dependencies": {
+                "CSSwhat": {
+                  "version": "0.4.7",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@0.8.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.8 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         }
@@ -176,44 +166,44 @@
     },
     "aws-sdk": {
       "version": "2.1.26",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.26.tgz",
+      "from": "aws-sdk@2.1.26",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.26.tgz",
       "dependencies": {
         "sax": {
           "version": "0.5.3",
-          "from": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
+          "from": "sax@0.5.3",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
         },
         "xml2js": {
           "version": "0.2.8",
-          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+          "from": "xml2js@0.2.8",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
         },
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+          "from": "xmlbuilder@0.4.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "binary-split": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
+      "from": "binary-split@0.1.2",
       "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
       "dependencies": {
         "bops": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+          "from": "bops@0.0.6",
           "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+              "from": "base64-js@0.0.2",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
             },
             "to-utf8": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+              "from": "to-utf8@0.0.1",
               "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz"
             }
           }
@@ -222,52 +212,52 @@
     },
     "bluebird": {
       "version": "2.9.25",
-      "from": "bluebird@*",
+      "from": "bluebird@2.9.25",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
     },
     "convict": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+      "from": "convict@0.6.1",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+          "from": "cjson@0.3.0",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -276,7 +266,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -285,34 +275,34 @@
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
           "version": "2.8.4",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+          "from": "moment@2.8.4",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.26.0",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz",
+          "from": "validator@3.26.0",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
         }
       }
@@ -338,12 +328,12 @@
     },
     "fxa-auth-db-mem": {
       "version": "0.33.0",
-      "from": "git://github.com/mozilla/fxa-auth-db-mem.git#219faab1345a7ae45c1c83e9a3d97a4424df8dcc",
-      "resolved": "git://github.com/mozilla/fxa-auth-db-mem.git#219faab1345a7ae45c1c83e9a3d97a4424df8dcc",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mem.git#219faab1345a7ae45c1c83e9a3d97a4424df8dcc",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mem.git#219faab1345a7ae45c1c83e9a3d97a4424df8dcc",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+          "from": "bluebird@2.2.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "fxa-auth-db-server": {
@@ -353,56 +343,56 @@
           "dependencies": {
             "restify": {
               "version": "2.8.2",
-              "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+              "from": "restify@2.8.2",
               "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "backoff": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+                  "from": "backoff@>=2.3.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
                   "dependencies": {
                     "precond": {
                       "version": "0.2.3",
-                      "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                      "from": "precond@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                     }
                   }
                 },
                 "bunyan": {
                   "version": "0.23.1",
-                  "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+                  "from": "bunyan@>=0.23.1 <0.24.0",
                   "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
                   "dependencies": {
                     "mv": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+                      "from": "mv@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                       "dependencies": {
                         "mkdirp": {
-                          "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "from": "minimist@0.0.8",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
                         "ncp": {
                           "version": "0.6.0",
-                          "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                          "from": "ncp@>=0.6.0 <0.7.0",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                         },
                         "rimraf": {
                           "version": "2.2.8",
-                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "from": "rimraf@>=2.2.8 <2.3.0",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
@@ -411,131 +401,136 @@
                 },
                 "csv": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/csv/-/csv-0.4.2.tgz",
+                  "from": "csv@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.2.tgz",
                   "dependencies": {
                     "csv-generate": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
+                      "from": "csv-generate@>=0.0.4 <0.0.5",
                       "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                     },
                     "csv-parse": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz",
+                      "from": "csv-parse@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz"
                     },
                     "stream-transform": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz",
+                      "from": "stream-transform@>=0.0.7 <0.0.8",
                       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
                     },
                     "csv-stringify": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz",
+                      "from": "csv-stringify@>=0.0.6 <0.0.7",
                       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
                     }
                   }
                 },
                 "deep-equal": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+                  "from": "deep-equal@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
                 },
                 "escape-regexp-component": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+                  "from": "escape-regexp-component@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
                 },
                 "formidable": {
                   "version": "1.0.17",
-                  "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+                  "from": "formidable@>=1.0.14 <2.0.0",
                   "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "keep-alive-agent": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+                  "from": "keep-alive-agent@>=0.0.1 <0.0.2",
                   "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
                 },
                 "lru-cache": {
-                  "version": "2.6.2",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.5.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "from": "mime@>=1.2.11 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "negotiator": {
                   "version": "0.4.9",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                  "from": "negotiator@>=0.4.5 <0.5.0",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+                  "from": "qs@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "semver": {
                   "version": "2.3.2",
-                  "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+                  "from": "semver@>=2.3.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
                 },
                 "spdy": {
                   "version": "1.32.0",
-                  "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz",
+                  "from": "spdy@>=1.26.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "verror": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+                  "from": "verror@>=1.4.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                      "from": "extsprintf@1.2.0",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                     }
                   }
+                },
+                "dtrace-provider": {
+                  "version": "0.2.8",
+                  "from": "dtrace-provider@>=0.2.8 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
                 }
               }
             }
@@ -543,90 +538,90 @@
         },
         "mozlog": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
+          "from": "mozlog@2.0.0",
           "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
           "dependencies": {
             "intel": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
+              "from": "intel@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "from": "chalk@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "dbug": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+                  "from": "dbug@>=0.4.2 <0.5.0",
                   "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
                 },
                 "stack-trace": {
                   "version": "0.0.9",
-                  "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                  "from": "stack-trace@>=0.0.9 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                 },
                 "strftime": {
                   "version": "0.8.4",
-                  "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz",
+                  "from": "strftime@>=0.8.2 <0.9.0",
                   "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
                 },
                 "symbol": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+                  "from": "symbol@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
                 },
                 "utcstring": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+                  "from": "utcstring@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
                 }
               }
             },
             "merge": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+              "from": "merge@>=1.2.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
             }
           }
@@ -635,44 +630,44 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.7",
-      "from": "git://github.com/mozilla/fxa-auth-mailer.git#d2eb3b298464455c8fe18fd964141ba89a0d1a0e",
-      "resolved": "git://github.com/mozilla/fxa-auth-mailer.git#d2eb3b298464455c8fe18fd964141ba89a0d1a0e",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#d2eb3b298464455c8fe18fd964141ba89a0d1a0e",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#d2eb3b298464455c8fe18fd964141ba89a0d1a0e",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+          "from": "bluebird@2.2.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "bunyan": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.0.0.tgz",
+          "from": "bunyan@1.0.0",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.0.0.tgz",
           "dependencies": {
             "mv": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+              "from": "mv@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
               "dependencies": {
                 "mkdirp": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                  "from": "ncp@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "from": "rimraf@>=2.2.8 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
@@ -681,44 +676,44 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#d6d263acccbf27df194e2b53f0bc7bbdb811ea22",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#d6d263acccbf27df194e2b53f0bc7bbdb811ea22"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#fe27fbc4f4ae80f5ccae81599699c868c2123a8d",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#fe27fbc4f4ae80f5ccae81599699c868c2123a8d"
         },
         "handlebars": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+          "from": "handlebars@1.3.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -729,12 +724,12 @@
         },
         "i18n-abide": {
           "version": "0.0.22",
-          "from": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
+          "from": "i18n-abide@0.0.22",
           "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+              "from": "async@0.1.22",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "gobbledygook": {
@@ -744,27 +739,27 @@
             },
             "jsxgettext": {
               "version": "0.3.9",
-              "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
+              "from": "jsxgettext@0.3.9",
               "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz",
+                  "from": "acorn@0.4.2",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz"
                 },
                 "gettext-parser": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+                  "from": "gettext-parser@0.2.0",
                   "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                      "from": "encoding@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.8",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+                          "from": "iconv-lite@>=0.4.4 <0.5.0",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                         }
                       }
@@ -773,102 +768,102 @@
                 },
                 "nomnom": {
                   "version": "1.5.2",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+                  "from": "nomnom@1.5.2",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.1.7",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+                      "from": "underscore@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                     },
                     "colors": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                      "from": "colors@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     }
                   }
                 },
                 "jade": {
                   "version": "0.30.0",
-                  "from": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
+                  "from": "jade@0.30.0",
                   "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+                      "from": "commander@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                       "dependencies": {
                         "keypress": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+                          "from": "keypress@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                      "from": "mkdirp@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     },
                     "transformers": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
+                      "from": "transformers@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                       "dependencies": {
                         "promise": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                          "from": "promise@>=2.0.0 <2.1.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                           "dependencies": {
                             "is-promise": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                              "from": "is-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                             }
                           }
                         },
                         "css": {
                           "version": "1.0.8",
-                          "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                          "from": "css@>=1.0.8 <1.1.0",
                           "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                           "dependencies": {
                             "css-parse": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                              "from": "css-parse@1.0.4",
                               "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                             },
                             "css-stringify": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                              "from": "css-stringify@1.0.5",
                               "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                             }
                           }
                         },
                         "uglify-js": {
                           "version": "2.2.5",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                          "from": "uglify-js@>=2.2.5 <2.3.0",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                           "dependencies": {
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "from": "source-map@>=0.1.7 <0.2.0",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "0.1.0",
-                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                                  "from": "amdefine@>=0.0.4",
                                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                                 }
                               }
                             },
                             "optimist": {
                               "version": "0.3.7",
-                              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                              "from": "optimist@>=0.3.5 <0.4.0",
                               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                               "dependencies": {
                                 "wordwrap": {
                                   "version": "0.0.3",
-                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                                  "from": "wordwrap@>=0.0.2 <0.1.0",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                                 }
                               }
@@ -879,37 +874,37 @@
                     },
                     "character-parser": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
+                      "from": "character-parser@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                     },
                     "monocle": {
                       "version": "0.1.50",
-                      "from": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
+                      "from": "monocle@>=0.1.46 <0.2.0",
                       "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                       "dependencies": {
                         "readdirp": {
                           "version": "0.2.5",
-                          "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+                          "from": "readdirp@>=0.2.3 <0.3.0",
                           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                           "dependencies": {
                             "minimatch": {
-                              "version": "2.0.7",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+                              "version": "2.0.8",
+                              "from": "minimatch@>=0.2.4",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.2.0",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                                      "from": "balanced-match@>=0.2.0 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -926,29 +921,29 @@
             },
             "optimist": {
               "version": "0.3.4",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
+              "from": "optimist@0.3.4",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
             "plist": {
               "version": "0.4.3",
-              "from": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
+              "from": "plist@0.4.3",
               "resolved": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
               "dependencies": {
                 "xmlbuilder": {
                   "version": "0.4.3",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
+                  "from": "xmlbuilder@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
                 },
                 "xmldom": {
                   "version": "0.1.19",
-                  "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+                  "from": "xmldom@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
                 }
               }
@@ -957,68 +952,68 @@
         },
         "jed": {
           "version": "0.5.4",
-          "from": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz",
+          "from": "jed@0.5.4",
           "resolved": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz"
         },
         "nodemailer": {
           "version": "0.7.1",
-          "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
+          "from": "nodemailer@0.7.1",
           "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
           "dependencies": {
             "mailcomposer": {
               "version": "0.2.12",
-              "from": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
+              "from": "mailcomposer@>=0.2.10 <0.3.0",
               "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
               "dependencies": {
                 "mimelib": {
                   "version": "0.2.19",
-                  "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+                  "from": "mimelib@>=0.2.15 <0.3.0",
                   "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                      "from": "encoding@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.8",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+                          "from": "iconv-lite@>=0.4.4 <0.5.0",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                         }
                       }
                     },
                     "addressparser": {
                       "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+                      "from": "addressparser@>=0.3.2 <0.4.0",
                       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@>=1.2.11 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "follow-redirects": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
+                  "from": "follow-redirects@0.0.3",
                   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.8.3",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                      "from": "underscore@*",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
                     }
                   }
                 },
                 "dkim-signer": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
+                  "from": "dkim-signer@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+                      "from": "punycode@>=1.2.4 <1.3.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
@@ -1027,71 +1022,71 @@
             },
             "directmail": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz",
+              "from": "directmail@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
             },
             "he": {
               "version": "0.3.6",
-              "from": "https://registry.npmjs.org/he/-/he-0.3.6.tgz",
+              "from": "he@>=0.3.6 <0.4.0",
               "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
             },
             "public-address": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz",
+              "from": "public-address@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
             },
             "aws-sdk": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
+              "from": "aws-sdk@2.0.5",
               "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
               "dependencies": {
                 "aws-sdk-apis": {
                   "version": "3.1.10",
-                  "from": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz",
+                  "from": "aws-sdk-apis@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
                 },
                 "xml2js": {
                   "version": "0.2.6",
-                  "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+                  "from": "xml2js@0.2.6",
                   "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+                      "from": "sax@0.4.2",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                     }
                   }
                 },
                 "xmlbuilder": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+                  "from": "xmlbuilder@0.4.2",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1100,44 +1095,44 @@
         },
         "po2json": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/po2json/-/po2json-0.3.0.tgz",
+          "from": "po2json@0.3.0",
           "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.3.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "nomnom": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+              "from": "nomnom@1.5.2",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+                  "from": "underscore@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                  "from": "colors@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+              "from": "gettext-parser@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+                  "from": "encoding@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.8",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+                      "from": "iconv-lite@>=0.4.4 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                     }
                   }
@@ -1148,83 +1143,83 @@
         },
         "rc": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
+          "from": "rc@0.5.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.7 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "from": "deep-extend@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+              "from": "strip-json-comments@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "ini": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+              "from": "ini@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
             }
           }
         },
         "restify": {
           "version": "2.8.2",
-          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "from": "restify@2.8.2",
           "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "from": "backoff@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "from": "precond@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "from": "bunyan@>=0.23.1 <0.24.0",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+                  "from": "mv@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                      "from": "ncp@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "from": "rimraf@>=2.2.8 <2.3.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -1233,131 +1228,136 @@
             },
             "csv": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/csv/-/csv-0.4.2.tgz",
+              "from": "csv@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.2.tgz",
               "dependencies": {
                 "csv-generate": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
+                  "from": "csv-generate@>=0.0.4 <0.0.5",
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz",
+                  "from": "csv-parse@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.1.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz",
+                  "from": "stream-transform@>=0.0.7 <0.0.8",
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
                 },
                 "csv-stringify": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz",
+                  "from": "csv-stringify@>=0.0.6 <0.0.7",
                   "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "from": "deep-equal@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "from": "formidable@>=1.0.14 <2.0.0",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
-              "version": "2.6.2",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@>=1.2.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "from": "negotiator@>=0.4.5 <0.5.0",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "from": "qs@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "from": "semver@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
               "version": "1.32.0",
-              "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz",
+              "from": "spdy@>=1.26.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "from": "verror@>=1.4.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "from": "extsprintf@1.2.0",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
+            },
+            "dtrace-provider": {
+              "version": "0.2.8",
+              "from": "dtrace-provider@>=0.2.8 <0.3.0",
+              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
         }
@@ -1365,27 +1365,27 @@
     },
     "fxa-jwtool": {
       "version": "0.7.1",
-      "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
+      "from": "fxa-jwtool@0.7.1",
       "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.9.15",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
+          "from": "bluebird@2.9.15",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
         },
         "fetch": {
           "version": "0.3.6",
-          "from": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
+          "from": "fetch@0.3.6",
           "resolved": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
           "dependencies": {
             "encoding": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+              "from": "encoding@*",
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.8",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+                  "from": "iconv-lite@>=0.4.4 <0.5.0",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                 }
               }
@@ -1396,62 +1396,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.2",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -1460,144 +1460,144 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.2",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -1606,61 +1606,61 @@
     },
     "grunt-bump": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
+      "from": "grunt-bump@0.3.1",
       "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.4",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
+          "from": "semver@>=4.3.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
         }
       }
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "from": "grunt-cli@0.1.13",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.2",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -1669,61 +1669,61 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "from": "resolve@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.11.2",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
+      "from": "grunt-contrib-jshint@0.11.2",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jshint": {
           "version": "2.7.0",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.7.0.tgz",
+          "from": "jshint@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.7.0.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "from": "cli@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "from": "glob@>=3.2.1 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.2",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1734,49 +1734,49 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "from": "domutils@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                          "from": "entities@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -1785,61 +1785,61 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.7",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1848,17 +1848,17 @@
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "from": "shelljs@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "lodash": {
               "version": "3.6.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
+              "from": "lodash@>=3.6.0 <3.7.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
             }
           }
@@ -1867,37 +1867,37 @@
     },
     "grunt-copyright": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz",
+      "from": "grunt-copyright@0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "from": "cli-color@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "from": "memoizee@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1906,74 +1906,74 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "hapi": {
       "version": "8.4.0",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-8.4.0.tgz",
+      "from": "hapi@8.4.0",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.4.0.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "ammo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+          "from": "ammo@1.0.0",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
         },
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.6.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "call": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+          "from": "call@2.0.1",
           "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
         },
         "catbox": {
           "version": "4.2.2",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.2.2.tgz",
+          "from": "catbox@4.2.2",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.2.2.tgz"
         },
         "catbox-memory": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+          "from": "catbox-memory@1.1.1",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
+          "from": "h2o2@4.0.0",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
           "dependencies": {
             "joi": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "from": "joi@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "from": "isemail@1.1.1",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.10.3",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
                 }
               }
@@ -1982,22 +1982,22 @@
         },
         "heavy": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+          "from": "heavy@3.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
           "dependencies": {
             "joi": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "from": "joi@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "from": "isemail@1.1.1",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.10.3",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
                 }
               }
@@ -2006,98 +2006,98 @@
         },
         "hoek": {
           "version": "2.11.1",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz",
+          "from": "hoek@2.11.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
         },
         "inert": {
           "version": "2.1.4",
-          "from": "https://registry.npmjs.org/inert/-/inert-2.1.4.tgz",
+          "from": "inert@2.1.4",
           "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.4.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "6.0.8",
-          "from": "https://registry.npmjs.org/joi/-/joi-6.0.8.tgz",
+          "from": "joi@6.0.8",
           "resolved": "https://registry.npmjs.org/joi/-/joi-6.0.8.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.1.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             },
             "moment": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz",
+              "from": "moment@2.9.0",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+          "from": "mimos@2.0.2",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
+              "from": "mime-db@1.7.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
             }
           }
         },
         "peekaboo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+          "from": "peekaboo@1.0.0",
           "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
         },
         "qs": {
           "version": "2.4.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.4.0.tgz",
+          "from": "qs@2.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.0.tgz"
         },
         "shot": {
           "version": "1.4.2",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.4.2.tgz",
+          "from": "shot@1.4.2",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.4.2.tgz"
         },
         "statehood": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
+          "from": "statehood@2.0.0",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
           "dependencies": {
             "joi": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "from": "joi@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "from": "isemail@1.1.1",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.10.3",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
                 }
               }
@@ -2106,32 +2106,32 @@
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+          "from": "subtext@1.0.2",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -2142,27 +2142,27 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.0.2",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
+          "from": "vision@2.0.0",
           "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
           "dependencies": {
             "joi": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "from": "joi@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "from": "isemail@1.1.1",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.10.3",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
                 }
               }
@@ -2171,147 +2171,147 @@
         },
         "wreck": {
           "version": "5.2.0",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz",
+          "from": "wreck@5.2.0",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz"
         }
       }
     },
     "hapi-auth-hawk": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-2.0.0.tgz",
+      "from": "hapi-auth-hawk@2.0.0",
       "resolved": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-2.0.0.tgz",
       "dependencies": {
         "boom": {
           "version": "2.7.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
+          "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
         },
         "hoek": {
           "version": "2.13.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
         }
       }
     },
     "hawk": {
       "version": "2.3.1",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "from": "hawk@2.3.1",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.13.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
         },
         "boom": {
           "version": "2.7.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
+          "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "from": "sntp@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "hkdf": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
+      "from": "hkdf@0.0.2",
       "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "joi": {
       "version": "6.4.1",
-      "from": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+      "from": "joi@6.4.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.13.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
           "version": "2.10.3",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+          "from": "moment@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
         }
       }
     },
     "jws": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
+      "from": "jws@3.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
       "dependencies": {
         "jwa": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.0.tgz",
+          "from": "jwa@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.0.tgz",
           "dependencies": {
             "base64url": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+              "from": "base64url@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
             },
             "buffer-equal-constant-time": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+              "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
             }
           }
         },
         "base64url": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+          "from": "base64url@>=1.0.4 <1.1.0",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.4.8",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "from": "concat-stream@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -2320,54 +2320,54 @@
             },
             "meow": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+              "from": "meow@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "repeating": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                         },
                         "meow": {
                           "version": "3.1.0",
-                          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                          "from": "meow@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                           "dependencies": {
                             "object-assign": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                             }
                           }
@@ -2378,12 +2378,12 @@
                 },
                 "minimist": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                  "from": "object-assign@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                 }
               }
@@ -2394,54 +2394,54 @@
     },
     "load-grunt-tasks": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
+      "from": "load-grunt-tasks@3.1.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
           "dependencies": {
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.0 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.7",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -2450,12 +2450,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -2466,44 +2466,44 @@
         },
         "multimatch": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "from": "multimatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.7",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2516,51 +2516,51 @@
     },
     "mailparser": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mailparser/-/mailparser-0.5.1.tgz",
+      "from": "mailparser@0.5.1",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.5.1.tgz",
       "dependencies": {
         "mimelib": {
           "version": "0.2.19",
-          "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+          "from": "mimelib@>=0.2.19 <0.3.0",
           "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+              "from": "addressparser@>=0.3.2 <0.4.0",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             }
           }
         },
         "encoding": {
           "version": "0.1.11",
-          "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+          "from": "encoding@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.8",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+              "from": "iconv-lite@>=0.4.4 <0.5.0",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
             }
           }
         },
         "mime": {
           "version": "1.3.4",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "from": "mime@>=1.3.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "uue": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/uue/-/uue-2.1.0.tgz",
+          "from": "uue@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uue/-/uue-2.1.0.tgz",
           "dependencies": {
             "array.prototype.findindex": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz",
+              "from": "array.prototype.findindex@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz"
             },
             "extend": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+              "from": "extend@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             }
           }
@@ -2569,117 +2569,117 @@
     },
     "mozlog": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.1.tgz",
+      "from": "mozlog@2.0.1",
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.1.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.4",
-              "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz",
+              "from": "strftime@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "nock": {
       "version": "1.7.1",
-      "from": "https://registry.npmjs.org/nock/-/nock-1.7.1.tgz",
+      "from": "nock@1.7.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.7.1.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+          "from": "chai@>=1.9.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+              "from": "assertion-error@1.0.0",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "from": "deep-eql@0.1.3",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "from": "type-detect@0.1.1",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -2688,63 +2688,63 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "from": "debug@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+          "from": "propagate@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
     },
     "pem-jwk": {
       "version": "1.5.1",
-      "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
+      "from": "pem-jwk@1.5.1",
       "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
       "dependencies": {
         "asn1.js": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+          "from": "asn1.js@1.0.3",
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@*",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimalistic-assert": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
             },
             "bn.js": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+              "from": "bn.js@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
             }
           }
@@ -2753,49 +2753,49 @@
     },
     "poolee": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
+      "from": "poolee@1.0.0",
       "resolved": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
       "dependencies": {
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+          "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.55.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+      "from": "request@2.55.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.4",
-          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+          "from": "bl@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2804,220 +2804,215 @@
         },
         "caseless": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "from": "caseless@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "from": "forever-agent@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "from": "form-data@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
             "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             }
           }
         },
         "json-stringify-safe": {
-          "version": "5.0.0",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.0.11",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.11.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.11.tgz",
+          "version": "2.0.12",
+          "from": "mime-types@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.9.1",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.9.1.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.9.1.tgz"
+              "version": "1.10.0",
+              "from": "mime-db@>=1.10.0 <1.11.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "qs": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "from": "qs@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "tough-cookie": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
+          "from": "tough-cookie@>=0.12.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+              "from": "ctype@0.5.3",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "from": "oauth-sign@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "from": "combined-stream@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+              "from": "delayed-stream@0.0.5",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "from": "isstream@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "har-validator": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+          "from": "har-validator@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
           "dependencies": {
-            "bluebird": {
-              "version": "2.9.25",
-              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
-            },
             "chalk": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.8.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "from": "commander@>=2.8.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.11.0",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.11.0.tgz",
+              "version": "2.12.0",
+              "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                  "from": "jsonpointer@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
@@ -3028,115 +3023,115 @@
     },
     "scrypt-hash": {
       "version": "1.1.12",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.12.tgz",
+      "from": "scrypt-hash@1.1.12",
       "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.12.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "from": "bindings@1.2.1",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
           "version": "1.8.4",
-          "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+          "from": "nan@1.8.4",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
         }
       }
     },
     "simplesmtp": {
       "version": "0.3.35",
-      "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
+      "from": "simplesmtp@0.3.35",
       "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
       "dependencies": {
         "rai": {
           "version": "0.1.12",
-          "from": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz",
+          "from": "rai@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
         },
         "xoauth2": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
+          "from": "xoauth2@>=0.1.8 <0.2.0",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
         }
       }
     },
     "sjcl": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.2.tgz",
+      "from": "sjcl@1.0.2",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.2.tgz"
     },
     "tap": {
       "version": "0.7.1",
-      "from": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
+      "from": "tap@0.7.1",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "from": "difflet@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+              "from": "traverse@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+              "from": "charm@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "from": "glob@>=4.3.5 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.7",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3145,12 +3140,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -3159,56 +3154,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+          "version": "3.0.2",
+          "from": "nopt@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "from": "runforcover@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "from": "bunker@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "from": "burrito@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                      "from": "traverse@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -3219,24 +3214,24 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
+          "from": "yamlish@*",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
         }
       }
     },
     "through": {
       "version": "2.3.7",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+      "from": "through@2.3.7",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
+      "from": "uuid@1.4.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "uuid": "1.4.1"
   },
   "devDependencies": {
-    "ass": "0.0.4",
+    "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
     "fxa-auth-db-mem": "git+https://github.com/mozilla/fxa-auth-db-mem.git#master",
     "grunt": "0.4.5",
     "grunt-bump": "0.3.1",


### PR DESCRIPTION
update the version of node-ass that we use to the same as used in fxa-auth-db-server and fxa-auth-db-mysql (which I should make the npm available version, but for now...). 

Fixes #938 and the problem in general if you don't have a `~/tmp` directory or `$TMPDIR` or `$TEMP` defined.

