### PR TITLE
Renaming toolbusy config option to maxEventLoopDelay

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -155,12 +155,10 @@ var conf = convict({
       default: 1000 * 60 * 10
     }
   },
-  toobusy: {
-    maxLag: {
-      doc: "Max event-loop lag before toobusy reports failure",
-      default: 0,
-      env: 'TOOBUSY_MAX_LAG'
-    }
+  maxEventLoopDelay: {
+    doc: "Max event-loop delay before which incoming requests are rejected",
+    default: 0,
+    env: 'MAX_EVENT_LOOP_DELAY'
   },
   scrypt: {
     maxPending: {

--- a/lib/server.js
+++ b/lib/server.js
@@ -79,7 +79,7 @@ function create(log, error, config, routes, db) {
         }
       },
       load: {
-        maxEventLoopDelay: config.toobusy.maxLag
+        maxEventLoopDelay: config.maxEventLoopDelay
       }
     },
     load: {


### PR DESCRIPTION
This is to fix https://github.com/mozilla/fxa-auth-server/issues/741