### PR TITLE
tests(e2e-email): updates to reflect current l10n state in train-41

### DIFF
--- a/scripts/e2e-email/index.js
+++ b/scripts/e2e-email/index.js
@@ -81,9 +81,9 @@ function assertSubjectLang(subject, lang, expectSubject) {
   // If it's listed in quirks, expect en-US content
   var quirks = localeQuirks[expectSubject]
   if (quirks && quirks[lang]) {
-    assert.equal(subject, expectSubject)
+    assert.equal(subject, expectSubject, lang + ' -> ' + subject)
   } else {
-    assert.notEqual(subject, expectSubject)
+    assert.notEqual(subject, expectSubject, lang + ' -> ' + subject)
   }
 }
 
@@ -100,11 +100,11 @@ function checkSubjects(subject, lang, headers, link) {
   }
 
   if (link.pathname === VERIFY_PATH) {
-    checkByType('Verify your account', ['x-verify-code', 'x-uid'], '["code","uid"]')
+    checkByType('Verify your Firefox Account', ['x-verify-code', 'x-uid'], '["code","uid"]')
   } else if (link.pathname === RESET_PATH) {
-    checkByType('Reset your password', ['x-recovery-code'], '["code","email","token"]')
+    checkByType('Reset your Firefox Account password', ['x-recovery-code'], '["code","email","token"]')
   } else if (link.pathname === UNLOCK_PATH) {
-    checkByType('Re-verify your account', ['x-unlock-code', 'x-uid'], '["code","uid"]')
+    checkByType('Re-verify your Firefox Account', ['x-unlock-code', 'x-uid'], '["code","uid"]')
   }
 }
 

--- a/scripts/e2e-email/localeQuirks.js
+++ b/scripts/e2e-email/localeQuirks.js
@@ -12,23 +12,17 @@ var translationQuirks = {
   'content-language': [
   ],
 
-  'Verify your account': [
-    'en'
-  ],
-
-  'Reset your password': [
-    'en'
-  ],
-
-  // A *lot* have not been translated, but a number of broadly
-  // spoken languages (e.g., de, zh-TW, zh-TW, ja, ru, pt-BR)
-  // have been.
-  'Re-verify your account': [
+  'Verify your Firefox Account': [
     'ca',
+    'cs',
+    'cy',
     'en',
     'es-AR',
+    'es-CL',
+    'eu',
     'ff',
     'he',
+    'hu',
     'id',
     'ko',
     'lt',
@@ -36,7 +30,70 @@ var translationQuirks = {
     'pa',
     'pl',
     'rm',
+    'sk',
+    'sq',
+    'sr',
+    'sr-LATN',
     'sv',
+    'sv-SE',
+    'tr'
+  ],
+
+  'Reset your Firefox Account password': [
+    'ca',
+    'cs',
+    'cy',
+    'en',
+    'es-AR',
+    'es-CL',
+    'eu',
+    'ff',
+    'he',
+    'hu',
+    'id',
+    'ko',
+    'lt',
+    'nb-NO',
+    'pa',
+    'pl',
+    'rm',
+    'sk',
+    'sq',
+    'sr',
+    'sr-LATN',
+    'sv',
+    'sv-SE',
+    'tr'
+  ],
+
+  // A *lot* have not been translated, but a number of broadly
+  // spoken languages (e.g., de, zh-TW, zh-TW, ja, ru, pt-BR)
+  // have been.
+  'Re-verify your Firefox Account': [
+    'ca',
+    'cs',
+    'cy',
+    'en',
+    'es-AR',
+    'es-CL',
+    'eu',
+    'ff',
+    'he',
+    'hu',
+    'id',
+    'ko',
+    'lt',
+    'nb-NO',
+    'pa',
+    'pl',
+    'rm',
+    'sk',
+    'sq',
+    'sr',
+    'sr-LATN',
+    'sv',
+    'sv-SE',
+    'tr'
   ]
 }
 

--- a/scripts/e2e-email/localeQuirks.js
+++ b/scripts/e2e-email/localeQuirks.js
@@ -14,11 +14,9 @@ var translationQuirks = {
 
   'Verify your Firefox Account': [
     'ca',
-    'cs',
     'cy',
     'en',
     'es-AR',
-    'es-CL',
     'eu',
     'ff',
     'he',
@@ -29,23 +27,19 @@ var translationQuirks = {
     'nb-NO',
     'pa',
     'pl',
-    'rm',
     'sk',
     'sq',
     'sr',
     'sr-LATN',
     'sv',
-    'sv-SE',
     'tr'
   ],
 
   'Reset your Firefox Account password': [
     'ca',
-    'cs',
     'cy',
     'en',
     'es-AR',
-    'es-CL',
     'eu',
     'ff',
     'he',
@@ -56,13 +50,11 @@ var translationQuirks = {
     'nb-NO',
     'pa',
     'pl',
-    'rm',
     'sk',
     'sq',
     'sr',
     'sr-LATN',
     'sv',
-    'sv-SE',
     'tr'
   ],
 
@@ -71,11 +63,9 @@ var translationQuirks = {
   // have been.
   'Re-verify your Firefox Account': [
     'ca',
-    'cs',
     'cy',
     'en',
     'es-AR',
-    'es-CL',
     'eu',
     'ff',
     'he',
@@ -86,13 +76,11 @@ var translationQuirks = {
     'nb-NO',
     'pa',
     'pl',
-    'rm',
     'sk',
     'sq',
     'sr',
     'sr-LATN',
     'sv',
-    'sv-SE',
     'tr'
   ]
 }


### PR DESCRIPTION
Kinda ugly with the number of locales not up to date, but it's the current state. r? @rfk 