### PR TITLE
fix(api): accept service as a query parameter

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -162,7 +162,7 @@ module.exports = function (
             function (response) {
               if (!response.account.emailVerified) {
                 mailer.sendVerifyCode(response.account, response.account.emailCode, {
-                  service: form.service,
+                  service: form.service || request.query.service,
                   redirectTo: form.redirectTo,
                   resume: form.resume,
                   acceptLanguage: request.app.acceptLanguage
@@ -221,6 +221,7 @@ module.exports = function (
         var form = request.payload
         var email = form.email
         var authPW = Buffer(form.authPW, 'hex')
+        var service = request.payload.service || request.query.service
         customs.check(
           request.app.clientAddress,
           email,
@@ -290,7 +291,7 @@ module.exports = function (
               )
               .then(
                 function (tokens) {
-                  if (request.payload.service === 'sync' && request.payload.reason === 'signin') {
+                  if (service === 'sync' && request.payload.reason === 'signin') {
                     return mailer.sendNewSyncDeviceNotification(
                       emailRecord.email,
                       {
@@ -440,6 +441,7 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailResend', request)
         var sessionToken = request.auth.credentials
+        var service = request.payload.service || request.query.service
         if (sessionToken.emailVerified ||
             Date.now() - sessionToken.verifierSetAt < resendBlackoutPeriod) {
           return reply({})
@@ -454,7 +456,7 @@ module.exports = function (
               sessionToken,
               sessionToken.emailCode,
               {
-                service: request.payload.service,
+                service: service,
                 redirectTo: request.payload.redirectTo,
                 resume: request.payload.resume,
                 acceptLanguage: request.app.acceptLanguage
@@ -524,6 +526,7 @@ module.exports = function (
         log.begin('Account.UnlockCodeResend', request)
         var email = request.payload.email
         var emailRecord
+        var service = request.payload.service || request.query.service
 
         customs.check(
           request.app.clientAddress,
@@ -548,7 +551,7 @@ module.exports = function (
                 emailRecord,
                 unlockCode,
                 {
-                  service: request.payload.service,
+                  service: service,
                   redirectTo: request.payload.redirectTo,
                   resume: request.payload.resume,
                   acceptLanguage: request.app.acceptLanguage

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -201,6 +201,7 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Password.forgotSend', request)
         var email = request.payload.email
+        var service = request.payload.service || request.query.service
         customs.check(
           request.app.clientAddress,
           email,
@@ -217,7 +218,7 @@ module.exports = function (
                 passwordForgotToken,
                 passwordForgotToken.passCode,
                 {
-                  service: request.payload.service,
+                  service: service,
                   redirectTo: request.payload.redirectTo,
                   resume: request.payload.resume,
                   acceptLanguage: request.app.acceptLanguage
@@ -272,6 +273,7 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Password.forgotResend', request)
         var passwordForgotToken = request.auth.credentials
+        var service = request.payload.service || request.query.service
         customs.check(
           request.app.clientAddress,
           passwordForgotToken.email,
@@ -282,7 +284,7 @@ module.exports = function (
               passwordForgotToken,
               passwordForgotToken.passCode,
               {
-                service: request.payload.service,
+                service: service,
                 redirectTo: request.payload.redirectTo,
                 resume: request.payload.resume,
                 acceptLanguage: request.app.acceptLanguage

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -89,8 +89,7 @@ ClientApi.prototype.doRequest = function (method, url, token, payload, headers) 
  */
 ClientApi.prototype.accountCreate = function (email, authPW, options) {
   options = options || {}
-  var url = this.baseURL + '/account/create'
-  if (options.keys) { url += '?keys=true' }
+  var url = this.baseURL + '/account/create' + getQueryString(options)
   return this.doRequest(
     'POST',
     url,
@@ -116,7 +115,7 @@ ClientApi.prototype.accountLogin = function (email, authPW, opts) {
   }
   return this.doRequest(
     'POST',
-    this.baseURL + '/account/login' + (opts.keys ? '?keys=true' : ''),
+    this.baseURL + '/account/login' + getQueryString(opts),
     null,
     {
       email: email,
@@ -298,7 +297,7 @@ ClientApi.prototype.passwordForgotSendCode = function (email, options) {
   options = options || {}
   return this.doRequest(
     'POST',
-    this.baseURL + '/password/forgot/send_code',
+    this.baseURL + '/password/forgot/send_code' + getQueryString(options),
     null,
     {
       email: email,
@@ -316,7 +315,7 @@ ClientApi.prototype.passwordForgotResendCode = function (passwordForgotTokenHex,
       function (token) {
         return this.doRequest(
           'POST',
-          this.baseURL + '/password/forgot/resend_code',
+          this.baseURL + '/password/forgot/resend_code' + getQueryString(options),
           token,
           {
             email: email,
@@ -425,6 +424,20 @@ ClientApi.prototype.sessionStatus = function (sessionTokenHex) {
 
 ClientApi.heartbeat = function (origin) {
   return (new ClientApi(origin)).doRequest('GET', origin + '/__heartbeat__')
+}
+
+function getQueryString (options) {
+  var qs = '?'
+
+  if (options.keys) {
+    qs += 'keys=true&'
+  }
+
+  if (options.serviceQuery) {
+    qs += 'service=' + options.serviceQuery
+  }
+
+  return qs
 }
 
 module.exports = ClientApi

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -350,6 +350,20 @@ TestServer.start(config)
   )
 
   test(
+    'create account with service query parameter',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', { serviceQuery: 'bar' })
+        .then(function () {
+          return server.mailbox.waitForEmail(email)
+        })
+        .then(function (emailData) {
+          t.equal(emailData.headers['x-service-id'], 'bar', 'service query parameter was propagated')
+        })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -329,6 +329,36 @@ TestServer.start(config)
   )
 
   test(
+    'forgot password with service query parameter',
+    function (t) {
+      var email = server.uniqueEmail()
+      var options = {
+        redirectTo: 'https://sync.firefox.com',
+        serviceQuery: 'sync'
+      }
+      var client
+      return Client.create(config.publicUrl, email, 'wibble', options)
+        .then(function (c) {
+          client = c
+        })
+        .then(function () {
+          return server.mailbox.waitForEmail(email)
+        })
+        .then(function () {
+          return client.forgotPassword()
+        })
+        .then(function () {
+          return server.mailbox.waitForEmail(email)
+        })
+        .then(function (emailData) {
+          var link = emailData.headers['x-link']
+          var query = url.parse(link, true).query
+          t.equal(query.service, options.serviceQuery, 'service is in link')
+        })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
Fixes #961.

Accepts a `service` query parameter on the following endpoints:

* `/account/create`
* `/account/login`
* `/password/forgot/send_code`

Note that a new test hasn't been added for `/account/login`, because I couldn't find anything to assert against. I'm happy to add one if somebody can point out a good way to assert that the parameter worked. Tests are added for the other two routes.