### PR TITLE
fix(errors): convert missing parameter errors correctly

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var inherits = require('util').inherits
+var messages = require('joi/lib/language').errors
 
 var DEFAULTS = {
   code: 500,
@@ -75,7 +76,11 @@ AppError.translate = function (response) {
     }
   }
   else if (payload.validation) {
-    error = AppError.invalidRequestParameter(payload.validation)
+    if (payload.message && payload.message.indexOf(messages.any.required) >= 0) {
+      error = AppError.missingRequestParameter(payload.validation.keys[0])
+    } else {
+      error = AppError.invalidRequestParameter(payload.validation)
+    }
   }
   else if (payload.statusCode === 400 && TOO_LARGE.test(payload.message)) {
     error = AppError.requestBodyTooLarge()

--- a/test/local/error_tests.js
+++ b/test/local/error_tests.js
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var messages = require('joi/lib/language')
+var AppError = require('../../lib/error')
+
+test(
+  'tightly-coupled joi message hack is okay',
+  function (t) {
+    t.equal(typeof messages.errors.any.required, 'string')
+    t.not(messages.errors.any.required, '')
+    t.end()
+  }
+)
+
+test(
+  'exported functions exist',
+  function (t) {
+    t.equal(typeof AppError, 'function')
+    t.equal(AppError.length, 3)
+    t.equal(typeof AppError.translate, 'function')
+    t.equal(AppError.translate.length, 1)
+    t.equal(typeof AppError.invalidRequestParameter, 'function')
+    t.equal(AppError.invalidRequestParameter.length, 1)
+    t.equal(typeof AppError.missingRequestParameter, 'function')
+    t.equal(AppError.missingRequestParameter.length, 1)
+    t.end()
+  }
+)
+
+test(
+  'error.translate with missing required parameters',
+  function (t) {
+    var result = AppError.translate({
+      output: {
+        payload: {
+          message: 'foo' + messages.errors.any.required,
+          validation: {
+            keys: [ 'bar', 'baz' ]
+          }
+        }
+      }
+    })
+    t.ok(result instanceof AppError, 'instanceof AppError')
+    t.equal(result.errno, 108)
+    t.equal(result.message, 'Missing parameter in request body: bar')
+    t.equal(result.output.statusCode, 400)
+    t.equal(result.output.payload.error, 'Bad Request')
+    t.equal(result.output.payload.errno, result.errno)
+    t.equal(result.output.payload.message, result.message)
+    t.equal(result.output.payload.param, 'bar')
+    t.end()
+  }
+)
+
+test(
+  'error.translate with invalid parameter',
+  function (t) {
+    var result = AppError.translate({
+      output: {
+        payload: {
+          validation: 'foo'
+        }
+      }
+    })
+    t.ok(result instanceof AppError, 'instanceof AppError')
+    t.equal(result.errno, 107)
+    t.equal(result.message, 'Invalid parameter in request body')
+    t.equal(result.output.statusCode, 400)
+    t.equal(result.output.payload.error, 'Bad Request')
+    t.equal(result.output.payload.errno, result.errno)
+    t.equal(result.output.payload.message, result.message)
+    t.equal(result.output.payload.validation, 'foo')
+    t.end()
+  }
+)
+


### PR DESCRIPTION
Fixes #419.

The issue just mentions Joi errors but it turns out the invalid parameter case was already handled, so this changeset only adds handling for the missing parameter case.

The change works by checking the `message` property of the Joi error. It is definitely a hackish approach, but I can't see another way to do it without modifying Joi itself.

I've limited the hackishness as much as possible by importing the comparison string from Joi directly, rather than hard-coding it ourselves. I've also added a unit test that ensures the relied-upon string actually exists in Joi, which further mitigates the hack (I think).

There were no tests at all for the error module before this. I've added some to cover what I've done here, but I haven't gone further to test the rest of the module.