### PR TITLE
feat(db): store user agent and last-access time in sessionTokens

### DIFF
--- a/lib/crypto/butil.js
+++ b/lib/crypto/butil.js
@@ -40,12 +40,23 @@ module.exports.unbuffer = function unbuffer(object, inplace) {
   return copy
 }
 
-module.exports.bufferize = function bufferize(object, inplace) {
+module.exports.bufferize = function bufferize(object, options) {
   var keys = Object.keys(object)
-  var copy = inplace ? object : {}
+  options = options || {}
+  var copy = options.inplace ? object : {}
+  var ignore = options.ignore || []
   for (var i = 0; i < keys.length; i++) {
-    var x = object[keys[i]]
-    copy[keys[i]] = (typeof(x) === 'string' && HEX.test(x)) ? Buffer(x, 'hex') : x
+    var key = keys[i]
+    var value = object[key]
+    if (
+      ignore.indexOf(key) === -1 &&
+      typeof value === 'string' &&
+      HEX.test(value)
+    ) {
+      copy[key] = Buffer(value, 'hex')
+    } else {
+      copy[key] = value
+    }
   }
   return copy
 }

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -36,6 +36,7 @@ module.exports = function (log, isA, error, db) {
       handler: function (request, reply) {
         log.begin('Session.status', request)
         var sessionToken = request.auth.credentials
+        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         reply({ uid: sessionToken.uid.toString('hex') })
       }
     }

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -37,6 +37,8 @@ module.exports = function (log, isA, error, signer, db, domain) {
         var publicKey = request.payload.publicKey
         var duration = request.payload.duration
 
+        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
+
         if (!sessionToken.emailVerified) {
           return reply(error.unverifiedAccount())
         }

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -6,6 +6,12 @@ module.exports = function (log, inherits, Token) {
 
   function SessionToken(keys, details) {
     Token.call(this, keys, details)
+    this.uaBrowser = details.uaBrowser
+    this.uaBrowserVersion = details.uaBrowserVersion
+    this.uaOS = details.uaOS
+    this.uaOSVersion = details.uaOSVersion
+    this.uaDeviceType = details.uaDeviceType
+    this.lastAccessTime = details.lastAccessTime
     this.email = details.email || null
     this.emailCode = details.emailCode || null
     this.emailVerified = !!details.emailVerified

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var ua = require('ua-parser')
+
+module.exports = function (userAgentString) {
+  var userAgentData = ua.parse(userAgentString)
+
+  this.uaBrowser = getFamily(userAgentData.ua)
+  this.uaBrowserVersion = getVersion(userAgentData.ua)
+  this.uaOS = getFamily(userAgentData.os)
+  this.uaOSVersion = getVersion(userAgentData.os)
+  this.uaDeviceType = getDeviceType(userAgentData)
+
+  return this
+}
+
+function getFamily (data) {
+  if (data.family && data.family !== 'Other') {
+    return data.family
+  }
+}
+
+function getVersion (data) {
+  if (! data.major) {
+    return
+  }
+
+  if (! data.minor || parseInt(data.minor) === 0) {
+    return data.major
+  }
+
+  return data.major + '.' + data.minor
+}
+
+function getDeviceType (data) {
+  if (getFamily(data.device)) {
+    return 'mobile'
+  }
+}
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -351,58 +351,63 @@
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
     },
     "fxa-auth-db-mysql": {
-      "version": "0.33.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#63a8ba4714d2b105ddc7396f72f99e743df4bdf5",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#63a8ba4714d2b105ddc7396f72f99e743df4bdf5",
+      "version": "0.42.0",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#b415b35340f8586919ec7080f8797be37416893c",
       "dependencies": {
         "bluebird": {
-          "version": "2.2.2",
-          "from": "bluebird@2.2.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
+          "version": "2.1.3",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "convict": {
-          "version": "0.6.1",
-          "from": "convict@0.6.1",
-          "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
           "dependencies": {
             "cjson": {
               "version": "0.3.0",
-              "from": "cjson@0.3.0",
+              "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
               "dependencies": {
                 "jsonlint": {
                   "version": "1.6.0",
-                  "from": "jsonlint@1.6.0",
+                  "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
                   "dependencies": {
                     "nomnom": {
                       "version": "1.8.1",
-                      "from": "nomnom@>=1.5.0",
+                      "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                       "dependencies": {
                         "underscore": {
                           "version": "1.6.0",
-                          "from": "underscore@>=1.6.0 <1.7.0",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                         },
                         "chalk": {
                           "version": "0.4.0",
-                          "from": "chalk@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                           "dependencies": {
                             "has-color": {
                               "version": "0.1.7",
-                              "from": "has-color@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                               "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                             },
                             "ansi-styles": {
                               "version": "1.0.0",
-                              "from": "ansi-styles@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                             },
                             "strip-ansi": {
                               "version": "0.1.1",
-                              "from": "strip-ansi@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                             }
                           }
@@ -411,297 +416,358 @@
                     },
                     "JSV": {
                       "version": "4.0.2",
-                      "from": "JSV@>=4.0.0",
+                      "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                     }
                   }
                 }
               }
             },
-            "depd": {
-              "version": "1.0.0",
-              "from": "depd@1.0.0",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+            "validator": {
+              "version": "1.5.1",
+              "from": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
             },
             "moment": {
-              "version": "2.8.4",
-              "from": "moment@2.8.4",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
             },
             "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
-            },
-            "validator": {
-              "version": "3.26.0",
-              "from": "validator@3.26.0",
-              "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
             }
           }
         },
-        "fxa-auth-db-server": {
-          "version": "0.42.0",
-          "from": "git://github.com/mozilla/fxa-auth-db-server.git#3d5f649de3324be6c9c37076ea094b2fe3b7bdcd",
-          "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#3d5f649de3324be6c9c37076ea094b2fe3b7bdcd",
+        "fxa-jwtool": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
           "dependencies": {
-            "restify": {
-              "version": "2.8.2",
-              "from": "restify@2.8.2",
-              "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+            "bluebird": {
+              "version": "2.9.14",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz"
+            },
+            "jws": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
               "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "backoff": {
-                  "version": "2.4.1",
-                  "from": "backoff@>=2.3.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+                "jwa": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
                   "dependencies": {
-                    "precond": {
-                      "version": "0.2.3",
-                      "from": "precond@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
-                    }
-                  }
-                },
-                "bunyan": {
-                  "version": "0.23.1",
-                  "from": "bunyan@>=0.23.1 <0.24.0",
-                  "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
-                  "dependencies": {
-                    "mv": {
-                      "version": "2.1.1",
-                      "from": "mv@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                    "base64url": {
+                      "version": "0.0.6",
+                      "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
+                    },
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
                       "dependencies": {
-                        "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "mkdirp@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                        "asn1.js": {
+                          "version": "2.1.3",
+                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz",
                           "dependencies": {
-                            "minimist": {
-                              "version": "0.0.8",
-                              "from": "minimist@0.0.8",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            "bn.js": {
+                              "version": "2.2.0",
+                              "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
-                        "ncp": {
-                          "version": "2.0.0",
-                          "from": "ncp@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
-                        },
-                        "rimraf": {
-                          "version": "2.4.2",
-                          "from": "rimraf@>=2.4.0 <2.5.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-                          "dependencies": {
-                            "glob": {
-                              "version": "5.0.14",
-                              "from": "glob@>=5.0.14 <6.0.0",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                              "dependencies": {
-                                "inflight": {
-                                  "version": "1.0.4",
-                                  "from": "inflight@>=1.0.4 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "minimatch": {
-                                  "version": "2.0.10",
-                                  "from": "minimatch@>=2.0.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                                  "dependencies": {
-                                    "brace-expansion": {
-                                      "version": "1.1.0",
-                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                                      "dependencies": {
-                                        "balanced-match": {
-                                          "version": "0.2.0",
-                                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                        },
-                                        "concat-map": {
-                                          "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "path-is-absolute": {
-                                  "version": "1.0.0",
-                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
+                        "base64-url": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                         }
                       }
                     }
                   }
                 },
-                "csv": {
-                  "version": "0.4.5",
-                  "from": "csv@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",
+                "base64url": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
                   "dependencies": {
-                    "csv-generate": {
-                      "version": "0.0.6",
-                      "from": "csv-generate@>=0.0.6 <0.0.7",
-                      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
-                    "csv-parse": {
-                      "version": "0.1.3",
-                      "from": "csv-parse@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.3.tgz"
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "pem-jwk": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
+              "dependencies": {
+                "asn1.js": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
-                    "stream-transform": {
-                      "version": "0.1.0",
-                      "from": "stream-transform@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz"
+                    "minimalistic-assert": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                     },
-                    "csv-stringify": {
-                      "version": "0.0.8",
-                      "from": "csv-stringify@>=0.0.8 <0.0.9",
-                      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
+                    "bn.js": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     }
                   }
                 },
-                "deep-equal": {
-                  "version": "0.2.2",
-                  "from": "deep-equal@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
-                },
-                "escape-regexp-component": {
-                  "version": "1.0.2",
-                  "from": "escape-regexp-component@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
-                },
-                "formidable": {
-                  "version": "1.0.17",
-                  "from": "formidable@>=1.0.14 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                "base64url": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
                   "dependencies": {
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
                     }
                   }
-                },
-                "keep-alive-agent": {
-                  "version": "0.0.1",
-                  "from": "keep-alive-agent@>=0.0.1 <0.0.2",
-                  "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
-                },
-                "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "lru-cache@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                },
-                "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@>=1.2.11 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.9",
-                  "from": "negotiator@>=0.4.5 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "1.2.2",
-                  "from": "qs@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-                },
-                "semver": {
-                  "version": "2.3.2",
-                  "from": "semver@>=2.3.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-                },
-                "spdy": {
-                  "version": "1.32.4",
-                  "from": "spdy@>=1.26.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "verror": {
-                  "version": "1.6.0",
-                  "from": "verror@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.2.0",
-                      "from": "extsprintf@1.2.0",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
-                    }
-                  }
-                },
-                "dtrace-provider": {
-                  "version": "0.2.8",
-                  "from": "dtrace-provider@>=0.2.8 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
                 }
               }
             }
@@ -709,91 +775,532 @@
         },
         "mozlog": {
           "version": "2.0.0",
-          "from": "mozlog@2.0.0",
+          "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
           "dependencies": {
             "intel": {
               "version": "1.0.0",
-              "from": "intel@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "dbug": {
                   "version": "0.4.2",
-                  "from": "dbug@>=0.4.2 <0.5.0",
+                  "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
                 },
                 "stack-trace": {
                   "version": "0.0.9",
-                  "from": "stack-trace@>=0.0.9 <0.1.0",
+                  "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                 },
                 "strftime": {
                   "version": "0.8.4",
-                  "from": "strftime@>=0.8.2 <0.9.0",
+                  "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
                 },
                 "symbol": {
                   "version": "0.2.1",
-                  "from": "symbol@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
                 },
                 "utcstring": {
                   "version": "0.1.0",
-                  "from": "utcstring@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
                 }
               }
             },
             "merge": {
               "version": "1.2.0",
-              "from": "merge@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+            }
+          }
+        },
+        "mysql": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+          "dependencies": {
+            "bignumber.js": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "require-all": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
+            }
+          }
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            }
+          }
+        },
+        "restify": {
+          "version": "2.8.2",
+          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "backoff": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "dependencies": {
+                "precond": {
+                  "version": "0.2.3",
+                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+                }
+              }
+            },
+            "bunyan": {
+              "version": "0.23.1",
+              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "dependencies": {
+                "mv": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "ncp": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.4.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.14",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "2.0.10",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "csv": {
+              "version": "0.4.5",
+              "from": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",
+              "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",
+              "dependencies": {
+                "csv-generate": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
+                },
+                "csv-parse": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.4.tgz"
+                },
+                "stream-transform": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz"
+                },
+                "csv-stringify": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
+            },
+            "escape-regexp-component": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "keep-alive-agent": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+            },
+            "lru-cache": {
+              "version": "2.6.5",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "negotiator": {
+              "version": "0.4.9",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            },
+            "spdy": {
+              "version": "1.32.4",
+              "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "verror": {
+              "version": "1.6.0",
+              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
+                }
+              }
             }
           }
         }
@@ -801,7 +1308,7 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.7",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#6aac195ff6d1692b239c7906fd1becd95ee85ebf",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
       "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#6aac195ff6d1692b239c7906fd1becd95ee85ebf",
       "dependencies": {
         "bluebird": {
@@ -914,8 +1421,8 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#31fe9e530eca4656ea044377cd96fdd9e3e63ec4",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#31fe9e530eca4656ea044377cd96fdd9e3e63ec4"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#72c1bb4864abb948b9a71ae6e45ea580615d816a"
         },
         "handlebars": {
           "version": "1.3.0",
@@ -1530,9 +2037,9 @@
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
                 },
                 "csv-parse": {
-                  "version": "0.1.3",
+                  "version": "0.1.4",
                   "from": "csv-parse@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.3.tgz"
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.4.tgz"
                 },
                 "stream-transform": {
                   "version": "0.1.0",
@@ -1646,11 +2153,6 @@
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
-            },
-            "dtrace-provider": {
-              "version": "0.2.8",
-              "from": "dtrace-provider@>=0.2.8 <0.3.0",
-              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
         }
@@ -1719,7 +2221,7 @@
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
@@ -1943,7 +2445,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -2140,7 +2642,7 @@
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-symbol": {
@@ -2152,7 +2654,7 @@
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.1 <0.2.0",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "es6-symbol": {
@@ -2191,12 +2693,12 @@
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.1 <0.2.0",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
@@ -2234,9 +2736,9 @@
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
-              "version": "8.2.0",
+              "version": "8.3.0",
               "from": "globals@>=8.0.0 <9.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
@@ -2259,9 +2761,9 @@
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
-                  "version": "3.10.0",
+                  "version": "3.10.1",
                   "from": "lodash@>=3.3.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
@@ -2288,9 +2790,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.0",
+              "version": "2.12.1",
               "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -2332,9 +2834,9 @@
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.10.0",
+                      "version": "3.10.1",
                       "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -2434,9 +2936,9 @@
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
-              "version": "1.0.2",
+              "version": "1.0.4",
               "from": "strip-json-comments@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
@@ -2559,9 +3061,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
-                  "version": "2.10.3",
+                  "version": "2.10.6",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
                 }
               }
             }
@@ -2583,9 +3085,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
-                  "version": "2.10.3",
+                  "version": "2.10.6",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
                 }
               }
             }
@@ -2683,9 +3185,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
-                  "version": "2.10.3",
+                  "version": "2.10.6",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
                 }
               }
             }
@@ -2748,9 +3250,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
-                  "version": "2.10.3",
+                  "version": "2.10.6",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
                 }
               }
             }
@@ -2823,9 +3325,9 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
         },
         "topo": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "from": "topo@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
         },
         "isemail": {
           "version": "1.1.1",
@@ -2833,9 +3335,9 @@
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
-          "version": "2.10.3",
+          "version": "2.10.6",
           "from": "moment@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
         }
       }
     },
@@ -2950,9 +3452,9 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
+                      "version": "1.2.1",
                       "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
@@ -2993,9 +3495,9 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "1.0.0",
@@ -3037,7 +3539,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -3149,7 +3651,7 @@
         },
         "encoding": {
           "version": "0.1.11",
-          "from": "encoding@*",
+          "from": "encoding@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
           "dependencies": {
             "iconv-lite": {
@@ -3379,6 +3881,35 @@
         }
       }
     },
+    "proxyquire": {
+      "version": "1.6.0",
+      "from": "proxyquire@1.6.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.6.0.tgz",
+      "dependencies": {
+        "fill-keys": {
+          "version": "1.0.1",
+          "from": "fill-keys@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.1.tgz",
+          "dependencies": {
+            "is-object": {
+              "version": "1.0.1",
+              "from": "is-object@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.0",
+              "from": "merge-descriptors@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+            }
+          }
+        },
+        "module-not-found-error": {
+          "version": "1.0.1",
+          "from": "module-not-found-error@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
+        }
+      }
+    },
     "request": {
       "version": "2.55.0",
       "from": "request@2.55.0",
@@ -3600,9 +4131,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.0",
+              "version": "2.12.1",
               "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -3668,6 +4199,40 @@
           "version": "0.1.8",
           "from": "xoauth2@>=0.1.8 <0.2.0",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
+        }
+      }
+    },
+    "sinon": {
+      "version": "1.15.4",
+      "from": "sinon@1.15.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "from": "formatio@1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.3 <1.0.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "from": "lolex@1.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "from": "samsam@1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
         }
       }
     },
@@ -3770,7 +4335,7 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <3.0.0",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
@@ -3844,6 +4409,18 @@
       "version": "2.3.7",
       "from": "through@2.3.7",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+    },
+    "ua-parser": {
+      "version": "0.3.5",
+      "from": "ua-parser@0.3.5",
+      "resolved": "https://registry.npmjs.org/ua-parser/-/ua-parser-0.3.5.tgz",
+      "dependencies": {
+        "yamlparser": {
+          "version": "0.0.2",
+          "from": "yamlparser@>=0.0.2",
+          "resolved": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz"
+        }
+      }
     },
     "uuid": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "request": "2.55.0",
     "scrypt-hash": "1.1.12",
     "through": "2.3.7",
+    "ua-parser": "0.3.5",
     "uuid": "1.4.1"
   },
   "devDependencies": {
@@ -59,7 +60,9 @@
     "mailparser": "0.5.1",
     "nock": "1.7.1",
     "pem-jwk": "1.5.1",
+    "proxyquire": "1.6.0",
     "simplesmtp": "0.3.35",
+    "sinon": "1.15.4",
     "sjcl": "1.0.2",
     "tap": "0.7.1"
   }

--- a/test/local/butil_tests.js
+++ b/test/local/butil_tests.js
@@ -46,3 +46,57 @@ test(
     t.end()
   }
 )
+
+test(
+  'bufferize works',
+  function (t) {
+    var argument = { foo: 'bar', baz: 'f00d' }
+    var result = butil.bufferize(argument)
+    t.notEqual(result, argument)
+    t.equal(Object.keys(result).length, Object.keys(argument).length)
+    t.equal(typeof result.foo, 'string')
+    t.equal(result.foo, argument.foo)
+    t.ok(Buffer.isBuffer(result.baz))
+    t.equal(result.baz.length, 2)
+    t.equal(result.baz[0], 0xf0)
+    t.equal(result.baz[1], 0x0d)
+    t.end()
+  }
+)
+
+test(
+  'bufferize works in-place',
+  function (t) {
+    var argument = { foo: 'beef', bar: 'baz' }
+    var result = butil.bufferize(argument, { inplace: true })
+    t.equal(result, argument)
+    t.equal(Object.keys(result).length, 2)
+    t.ok(Buffer.isBuffer(result.foo))
+    t.equal(result.foo.length, 2)
+    t.equal(result.foo[0], 0xbe)
+    t.equal(result.foo[1], 0xef)
+    t.equal(typeof result.bar, 'string')
+    t.equal(result.bar, 'baz')
+    t.end()
+  }
+)
+
+test(
+  'bufferize ignores exceptions',
+  function (t) {
+    var argument = { foo: 'bar', baz: 'f00d', qux: 'beef' }
+    var result = butil.bufferize(argument, { ignore: [ 'baz' ] })
+    t.notEqual(argument, result)
+    t.equal(Object.keys(result).length, Object.keys(argument).length)
+    t.equal(typeof result.foo, 'string')
+    t.equal(result.foo, argument.foo)
+    t.equal(typeof result.baz, 'string')
+    t.equal(result.baz, argument.baz)
+    t.ok(Buffer.isBuffer(result.qux))
+    t.equal(result.qux.length, 2)
+    t.equal(result.qux[0], 0xbe)
+    t.equal(result.qux[1], 0xef)
+    t.end()
+  }
+)
+

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -100,7 +100,7 @@ test(
       var tokenId
       return db.emailRecord(ACCOUNT.email)
       .then(function(emailRecord) {
-        return db.createSessionToken(emailRecord)
+        return db.createSessionToken(emailRecord, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function(sessionToken) {
         t.deepEqual(sessionToken.uid, ACCOUNT.uid)
@@ -111,10 +111,32 @@ test(
       })
       .then(function(sessionToken) {
         t.deepEqual(sessionToken.tokenId, tokenId, 'token id matches')
+        t.equal(sessionToken.uaBrowser, 'Firefox')
+        t.equal(sessionToken.uaBrowserVersion, '41')
+        t.equal(sessionToken.uaOS, 'Mac OS X')
+        t.equal(sessionToken.uaOSVersion, '10.10')
+        t.equal(sessionToken.uaDeviceType, undefined)
+        t.equal(sessionToken.lastAccessTime, sessionToken.createdAt)
         t.deepEqual(sessionToken.uid, ACCOUNT.uid)
         t.equal(sessionToken.email, ACCOUNT.email)
         t.deepEqual(sessionToken.emailCode, ACCOUNT.emailCode)
         t.equal(sessionToken.emailVerified, ACCOUNT.emailVerified)
+        return sessionToken
+      })
+      .then(function(sessionToken) {
+        return db.updateSessionTokenInBackground(sessionToken, 'Mozilla/5.0 (Android; Linux armv7l; rv:9.0) Gecko/20111216 Firefox/9.0 Fennec/9.0')
+      })
+      .then(function() {
+        return db.sessionToken(tokenId)
+      })
+      .then(function(sessionToken) {
+        t.equal(sessionToken.uaBrowser, 'Firefox Mobile')
+        t.equal(sessionToken.uaBrowserVersion, '9')
+        t.equal(sessionToken.uaOS, 'Android')
+        t.equal(sessionToken.uaOSVersion, undefined)
+        t.equal(sessionToken.uaDeviceType, undefined)
+        t.ok(sessionToken.lastAccessTime >= sessionToken.createdAt)
+        t.ok(sessionToken.lastAccessTime <= Date.now())
         return sessionToken
       })
       .then(function(sessionToken) {
@@ -314,7 +336,7 @@ test(
     return dbConn.then(function(db) {
       return db.emailRecord(ACCOUNT.email)
       .then(function(emailRecord) {
-        return db.createSessionToken(emailRecord)
+        return db.createSessionToken(emailRecord, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function(sessionToken) {
         return db.createAccountResetToken(sessionToken)

--- a/test/local/user_agent_tests.js
+++ b/test/local/user_agent_tests.js
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var test = require('../ptaptest')
+var proxyquire = require('proxyquire')
+var sinon = require('sinon')
+
+var parserResult
+
+var uaParser = {
+  parse: sinon.spy(function () {
+    return parserResult
+  })
+}
+
+var userAgent = proxyquire('../../lib/userAgent', {
+  'ua-parser': uaParser
+})
+
+test(
+  'exports function',
+  function (t) {
+    t.equal(typeof userAgent, 'function')
+    t.equal(userAgent.length, 1)
+    t.end()
+  }
+)
+
+test(
+  'sets data correctly',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'bar',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'baz'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context, 'qux')
+    t.equal(uaParser.parse.callCount, 1)
+    t.ok(uaParser.parse.calledWithExactly('qux'))
+    t.equal(result, context)
+    t.equal(Object.keys(result).length, 5)
+    t.equal(result.uaBrowser, 'foo')
+    t.equal(result.uaBrowserVersion, '1')
+    t.equal(result.uaOS, 'bar')
+    t.equal(result.uaOSVersion, '2')
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'ignores family:Other',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'Other',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Other',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context, 'wibble')
+    t.equal(uaParser.parse.callCount, 1)
+    t.ok(uaParser.parse.calledWithExactly('wibble'))
+    t.equal(result, context)
+    t.equal(Object.keys(result).length, 5)
+    t.equal(result.uaBrowser, undefined)
+    t.equal(result.uaOS, undefined)
+    t.equal(result.uaDeviceType, undefined)
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'appends minor version if set',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '1'
+      },
+      os: {
+        family: 'bar',
+        major: '2',
+        minor: '34567'
+      },
+      device: {
+        family: 'baz'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context, 'qux')
+    t.equal(result.uaBrowserVersion, '1.1')
+    t.equal(result.uaOSVersion, '2.34567')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/983.

Depends on #1000 and https://github.com/mozilla/fxa-auth-db-mysql/pull/65, requires a dependency-update and a rebase after those are fixed and then the tests should all pass.

Creates session tokens with the new `uaBrowser`, `uaBrowserVersion`, `uaOS`, `uaOSVersion`, `deviceType` and `lastAccessTime` fields and updates those fields whenever the session token is used.
