### PR TITLE
fix(tests): make smtp.redirectDomain configurable in remote tests

### DIFF
--- a/test/remote/account_unlock_tests.js
+++ b/test/remote/account_unlock_tests.js
@@ -60,7 +60,7 @@ TestServer.start(config)
       var password = 'something'
       var client = null
       var options = {
-        redirectTo: 'https://sync.firefox.com',
+        redirectTo: 'https://sync.' + config.smtp.redirectDomain,
         service: 'sync'
       }
       return Client.create(config.publicUrl, email, password, options)

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -200,7 +200,7 @@ TestServer.start(config)
       var password = 'something'
       var client = null
       var options = {
-        redirectTo: 'https://sync.firefox.com',
+        redirectTo: 'https://sync.' + config.smtp.redirectDomain,
         service: 'sync'
       }
       return Client.create(config.publicUrl, email, password, options)
@@ -333,7 +333,7 @@ TestServer.start(config)
     function (t) {
       var email = server.uniqueEmail()
       var options = {
-        redirectTo: 'https://sync.firefox.com',
+        redirectTo: 'https://sync.' + config.smtp.redirectDomain,
         serviceQuery: 'sync'
       }
       var client

--- a/test/remote/recovery_email_verify_tests.js
+++ b/test/remote/recovery_email_verify_tests.js
@@ -68,7 +68,7 @@ TestServer.start(config)
       var password = 'something'
       var client = null // eslint-disable-line no-unused-vars
       var options = {
-        redirectTo: 'https://sync.firefox.com',
+        redirectTo: 'https://sync.'  + config.smtp.redirectDomain,
         service: 'sync'
       }
       return Client.create(config.publicUrl, email, password, options)


### PR DESCRIPTION
I've had this on a branch for eons and keep neglecting to make this PR.  This is used as REDIRECT_DOMAIN=my.test.domain tap ...

@dannycoates - r?