### PR TITLE
chore(deps): switch from db-mem to db-mysql

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -350,10 +350,10 @@
       "from": "eslint-config-fxa@1.6.0",
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
     },
-    "fxa-auth-db-mem": {
+    "fxa-auth-db-mysql": {
       "version": "0.33.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mem.git#33803409adce8cb8c31a4c292238698b1a435e16",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mem.git#33803409adce8cb8c31a4c292238698b1a435e16",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#63a8ba4714d2b105ddc7396f72f99e743df4bdf5",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#63a8ba4714d2b105ddc7396f72f99e743df4bdf5",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
     "eslint-config-fxa": "1.6.0",
-    "fxa-auth-db-mem": "git+https://github.com/mozilla/fxa-auth-db-mem.git#master",
+    "fxa-auth-db-mysql": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
     "grunt": "0.4.5",
     "grunt-bump": "0.3.1",
     "grunt-cli": "0.1.13",

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -2,7 +2,7 @@
 node ./scripts/gen_keys.js
 node ./test/mail_helper.js &
 MH=$!
-node ./node_modules/fxa-auth-db-mem/bin/server.js &
+node ./node_modules/fxa-auth-db-mysql/bin/mem.js &
 DB=$!
 
 node ./bin/key_server.js | node ./bin/notifier.js >/dev/null

--- a/test/local/verifier_upgrade_tests.js
+++ b/test/local/verifier_upgrade_tests.js
@@ -5,7 +5,7 @@
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
 var Client = require('../client')
-var createDBServer = require('fxa-auth-db-mem')
+var createDBServer = require('fxa-auth-db-mysql')
 var log = { trace: console.log }
 
 process.env.VERIFIER_VERSION = '0'

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -7,7 +7,7 @@ var crypto = require('crypto')
 var P = require('../lib/promise')
 var request = require('request')
 var mailbox = require('./mailbox')
-var createDBServer = require('fxa-auth-db-mem')
+var createDBServer = require('fxa-auth-db-mysql')
 
 function TestServer(config, printLogs) {
   this.printLogs = printLogs === false ? false : true


### PR DESCRIPTION
This is a pre-requisite for any changes that depend on incoming db changes, now that the db repos have been merged into `fxa-auth-db-mysql`.