### PR TITLE
chore(version): add /__version__ route; add source repo based on origin; simplify routes/default

### DIFF
--- a/lib/routes/defaults.js
+++ b/lib/routes/defaults.js
@@ -12,51 +12,58 @@ var commitHash
 
 module.exports = function (log, P, db, error) {
 
+  function versionHandler(request, reply) {
+    log.begin('Defaults.root', request)
+
+    function sendReply() {
+      reply(
+        {
+          version: version,
+          commit: commitHash
+        }
+      )
+    }
+
+    // if we already have the commitHash, send the reply and return
+    if (commitHash) {
+      return sendReply()
+    }
+
+    // Note: we figure out the Git hash in the following order:
+    //
+    // (1) read config/version.json if exists (ie. staging, production)
+    // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
+
+    // (1) read config/version.json if exists (ie. staging, production)
+    var configFile = path.join(__dirname, '..', '..', 'config', 'version.json')
+    if ( fs.existsSync(configFile) ) {
+      commitHash = require(configFile).version.hash
+      return sendReply()
+    }
+
+    // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
+    var gitDir
+    if ( !fs.existsSync(path.join(__dirname, '..', '..', '.git')) ) {
+      // try at '/home/app/git' for AwsBox deploys
+      gitDir = path.sep + path.join('home', 'app', 'git')
+    }
+    var cmd = util.format('git %s rev-parse HEAD', gitDir ? '--git-dir=' + gitDir : '')
+    child_process.exec(cmd, function(err, stdout) {
+      commitHash = stdout.replace(/\s+/, '')
+      return sendReply()
+    })
+  }
+
   var routes = [
     {
       method: 'GET',
       path: '/',
-      handler: function index(request, reply) {
-        log.begin('Defaults.root', request)
-
-        function sendReply() {
-          reply(
-            {
-              version: version,
-              commit: commitHash
-            }
-          )
-        }
-
-        // if we already have the commitHash, send the reply and return
-        if (commitHash) {
-          return sendReply()
-        }
-
-        // Note: we figure out the Git hash in the following order:
-        //
-        // (1) read config/version.json if exists (ie. staging, production)
-        // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
-
-        // (1) read config/version.json if exists (ie. staging, production)
-        var configFile = path.join(__dirname, '..', '..', 'config', 'version.json')
-        if ( fs.existsSync(configFile) ) {
-          commitHash = require(configFile).version.hash
-          return sendReply()
-        }
-
-        // (2) figure it out from git (either regular '.git', or '/home/app/git' for AwsBox)
-        var gitDir
-        if ( !fs.existsSync(path.join(__dirname, '..', '..', '.git')) ) {
-          // try at '/home/app/git' for AwsBox deploys
-          gitDir = path.sep + path.join('home', 'app', 'git')
-        }
-        var cmd = util.format('git %s rev-parse HEAD', gitDir ? '--git-dir=' + gitDir : '')
-        child_process.exec(cmd, function(err, stdout) {
-          commitHash = stdout.replace(/\s+/, '')
-          return sendReply()
-        })
-      }
+      handler: versionHandler
+    },
+    {
+      method: 'GET',
+      path: '/__version__',
+      handler: versionHandler
     },
     {
       method: 'GET',


### PR DESCRIPTION
Adds the source repo to '/' and a new '/__version__' route. Fixes #1005 

Became a bit of a yak shave. Easier to review as two commits, https://github.com/mozilla/fxa-auth-server/commit/a79d2b027b8a94ee81ec2b3774cfa84f850ccbb9?w=1 (with `diff -w`), and https://github.com/mozilla/fxa-auth-server/commit/842799f7d32ca3b7b32658f1e3ac77ce31189af6 (with --yak-shave).
