### PR TITLE
fix(server): improve identification of mobile user agents

### DIFF
--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -6,6 +6,25 @@
 
 var ua = require('ua-parser')
 
+var MOBILE_OS_FAMILIES = {
+  'Android': null,
+  'Bada': null,
+  'BlackBerry OS': null,
+  'BlackBerry Tablet OS': null,
+  'Brew MP': null,
+  'Firefox OS': null,
+  'iOS': null,
+  'Maemo': null,
+  'MeeGo': null,
+  'Symbian OS': null,
+  'Symbian^3': null,
+  'Symbian^3 Anna': null,
+  'Symbian^3 Belle': null,
+  'Windows CE': null,
+  'Windows Mobile': null,
+  'Windows Phone': null
+}
+
 module.exports = function (userAgentString) {
   var userAgentData = ua.parse(userAgentString)
 
@@ -37,8 +56,12 @@ function getVersion (data) {
 }
 
 function getDeviceType (data) {
-  if (getFamily(data.device)) {
+  if (getFamily(data.device) || isMobileOS(data.os)) {
     return 'mobile'
   }
+}
+
+function isMobileOS (os) {
+  return os.family in MOBILE_OS_FAMILIES
 }
 

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -134,7 +134,7 @@ test(
         t.equal(sessionToken.uaBrowserVersion, '9')
         t.equal(sessionToken.uaOS, 'Android')
         t.equal(sessionToken.uaOSVersion, undefined)
-        t.equal(sessionToken.uaDeviceType, undefined)
+        t.equal(sessionToken.uaDeviceType, 'mobile')
         t.ok(sessionToken.lastAccessTime >= sessionToken.createdAt)
         t.ok(sessionToken.lastAccessTime <= Date.now())
         return sessionToken

--- a/test/local/user_agent_tests.js
+++ b/test/local/user_agent_tests.js
@@ -114,9 +114,217 @@ test(
       }
     }
     var context = {}
-    var result = userAgent.call(context, 'qux')
+    var result = userAgent.call(context)
     t.equal(result.uaBrowserVersion, '1.1')
     t.equal(result.uaOSVersion, '2.34567')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'recognises Android as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Android',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'recognises iOS as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'iOS',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'recognises Firefox OS as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Firefox OS',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'recognises Windows Phone as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Windows Phone',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'recognises BlackBerry OS as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'BlackBerry OS',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, 'mobile')
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'does not recognise Mac OS X as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Mac OS X',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, undefined)
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'does not recognise Linux as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Linux',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, undefined)
+    uaParser.parse.reset()
+    t.end()
+  }
+)
+
+test(
+  'does not recognise Windows as a mobile OS',
+  function (t) {
+    parserResult = {
+      ua: {
+        family: 'foo',
+        major: '1',
+        minor: '0'
+      },
+      os: {
+        family: 'Windows',
+        major: '2',
+        minor: '0'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    var context = {}
+    var result = userAgent.call(context)
+    t.equal(result.uaDeviceType, undefined)
     uaParser.parse.reset()
     t.end()
   }


### PR DESCRIPTION
Fixes #1010.

If `ua-parser` doesn't return a device type, compare the OS to a list of known mobile OS' to determine whether or not the user agent is on a mobile device.

I derived the list of operating systems in `isMobileOS` from tests of `ua-parser` against [this list of mobile user-agent strings](http://www.useragentstring.com/pages/Mobile%20Browserlist/). I then added `iOS`, `Firefox OS`  and `BlackBerry OS` to the list of failing cases for completeness / just to be on the safe side.

The thing I'm most worried about is that I may have gone too far in my quest for correctness. What is the sane cut-off point between ensuring we have good enough metrics and unnecessarily performing string comparisons against operating systems nobody has ever heard of? I'm happy to chop some. :smile: