### PR TITLE
chore(version): display source repo last in {/ver.json,/__version__}

### DIFF
--- a/lib/routes/defaults.js
+++ b/lib/routes/defaults.js
@@ -32,9 +32,9 @@ module.exports = function (log, P, db, error) {
     function sendReply() {
       reply(
         {
-          source: sourceRepo,
           version: version,
-          commit: commitHash
+          commit: commitHash,
+          source: sourceRepo
         }
       )
     }

--- a/test/local/base_path_tests.js
+++ b/test/local/base_path_tests.js
@@ -22,7 +22,7 @@ TestServer.start(config)
           if (err) { d.reject(err) }
           t.equal(res.statusCode, 200)
           var json = JSON.parse(body)
-          t.deepEqual(Object.keys(json), ['source', 'version', 'commit'])
+          t.deepEqual(Object.keys(json), ['version', 'commit', 'source'])
           t.equal(json.version, require('../../package.json').version, 'package version')
           t.ok(json.source && json.source !== 'unknown', 'source repository')
 

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -21,7 +21,7 @@ TestServer.start(config)
         t.ok(!err, 'No error fetching ' + route)
 
         var json = JSON.parse(body)
-        t.deepEqual(Object.keys(json), ['source', 'version', 'commit'])
+        t.deepEqual(Object.keys(json), ['version', 'commit', 'source'])
         t.equal(json.version, require('../../package.json').version, 'package version')
         t.ok(json.source && json.source !== 'unknown', 'source repository')
 
@@ -43,12 +43,12 @@ TestServer.start(config)
   )
 
   test(
-    '/ returns source repo, version and git hash',
+    '/ returns version, git hash and source repo',
     testVersionRoute('/')
   )
 
   test(
-    '/__version__ returns source repo, version and git hash',
+    '/__version__ returns version, git hash and source repo',
     testVersionRoute('/__version__')
   )
 


### PR DESCRIPTION
I know I just added this, but seeing this in practice, the source is (usually) the least interesting information in this output compared to versions/shas, so it should be last.

Before:
```
{"source":"https://github.com/mozilla/fxa-auth-server.git","version":"1.42.0","commit":"94745ee21541be27e2308fe0c677aa49f8c3bd7b"}`
```
After:
```
{"version":"1.42.0","commit":"94745ee21541be27e2308fe0c677aa49f8c3bd7b","source":"https://github.com/mozilla/fxa-auth-server.git"}
```