### PR TITLE
fix(notifier): calling undefined "log" throws

### DIFF
--- a/bin/notifier.js
+++ b/bin/notifier.js
@@ -15,7 +15,6 @@ var sns = {
 
 function init(config) {
   snsTopicArn = config.snsTopicArn
-  log.level(config.log.level)
   if (snsTopicArn === 'disabled') {
     sns = { publish: function (msg, cb) { cb() }}
     return


### PR DESCRIPTION
So, bad news. When the logging was refactored to mozlog mid-to-late May, this line was left behind, which throws but that exception is caught and swallowed. Things then continue silently from there with a default sns.publish.