### PR TITLE
fix(db): remove session token updates from status endpoints

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -500,7 +500,6 @@ module.exports = function (
       handler: function (request, reply) {
         var sessionToken = request.auth.credentials
         if (sessionToken) {
-          db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
           reply({ exists: true, locale: sessionToken.locale })
         }
         else if (request.query.uid) {
@@ -571,7 +570,6 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailStatus', request)
         var sessionToken = request.auth.credentials
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         reply(
           {
             email: sessionToken.email,

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -36,7 +36,6 @@ module.exports = function (log, isA, error, db) {
       handler: function (request, reply) {
         log.begin('Session.status', request)
         var sessionToken = request.auth.credentials
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         reply({ uid: sessionToken.uid.toString('hex') })
       }
     }


### PR DESCRIPTION
Apologetic PR for `train-44`; whatever the opposite of the midas touch is, I appear to have it at the moment.

Erring on the side of caution, I've removed the update from all three `/status` endpoints. I know @jrgm's email suggested that `/recovery_email/status` would probably suffice, but I presume that `checkAccountExists` and `isSignedIn` are also pretty frequent operations?

@rfk r?