### PR TITLE
fix(db): decrease session token update frequency

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -500,7 +500,6 @@ module.exports = function (
       handler: function (request, reply) {
         var sessionToken = request.auth.credentials
         if (sessionToken) {
-          db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
           reply({ exists: true, locale: sessionToken.locale })
         }
         else if (request.query.uid) {
@@ -571,7 +570,6 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailStatus', request)
         var sessionToken = request.auth.credentials
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         reply(
           {
             email: sessionToken.email,
@@ -598,7 +596,6 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailResend', request)
         var sessionToken = request.auth.credentials
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         var service = request.payload.service || request.query.service
         if (sessionToken.emailVerified ||
             Date.now() - sessionToken.verifierSetAt < config.smtp.resendBlackoutPeriod) {

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -36,7 +36,6 @@ module.exports = function (log, isA, error, db) {
       handler: function (request, reply) {
         log.begin('Session.status', request)
         var sessionToken = request.auth.credentials
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
         reply({ uid: sessionToken.uid.toString('hex') })
       }
     }

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -28,11 +28,11 @@ var MOBILE_OS_FAMILIES = {
 module.exports = function (userAgentString) {
   var userAgentData = ua.parse(userAgentString)
 
-  this.uaBrowser = getFamily(userAgentData.ua)
-  this.uaBrowserVersion = getVersion(userAgentData.ua)
-  this.uaOS = getFamily(userAgentData.os)
-  this.uaOSVersion = getVersion(userAgentData.os)
-  this.uaDeviceType = getDeviceType(userAgentData)
+  this.uaBrowser = getFamily(userAgentData.ua) || null
+  this.uaBrowserVersion = getVersion(userAgentData.ua) || null
+  this.uaOS = getFamily(userAgentData.os) || null
+  this.uaOSVersion = getVersion(userAgentData.os) || null
+  this.uaDeviceType = getDeviceType(userAgentData) || null
 
   return this
 }

--- a/test/local/user_agent_tests.js
+++ b/test/local/user_agent_tests.js
@@ -87,9 +87,9 @@ test(
     t.ok(uaParser.parse.calledWithExactly('wibble'))
     t.equal(result, context)
     t.equal(Object.keys(result).length, 5)
-    t.equal(result.uaBrowser, undefined)
-    t.equal(result.uaOS, undefined)
-    t.equal(result.uaDeviceType, undefined)
+    t.equal(result.uaBrowser, null)
+    t.equal(result.uaOS, null)
+    t.equal(result.uaDeviceType, null)
     uaParser.parse.reset()
     t.end()
   }
@@ -272,7 +272,7 @@ test(
     }
     var context = {}
     var result = userAgent.call(context)
-    t.equal(result.uaDeviceType, undefined)
+    t.equal(result.uaDeviceType, null)
     uaParser.parse.reset()
     t.end()
   }
@@ -298,7 +298,7 @@ test(
     }
     var context = {}
     var result = userAgent.call(context)
-    t.equal(result.uaDeviceType, undefined)
+    t.equal(result.uaDeviceType, null)
     uaParser.parse.reset()
     t.end()
   }
@@ -324,7 +324,7 @@ test(
     }
     var context = {}
     var result = userAgent.call(context)
-    t.equal(result.uaDeviceType, undefined)
+    t.equal(result.uaDeviceType, null)
     uaParser.parse.reset()
     t.end()
   }


### PR DESCRIPTION
This is a continuation from https://github.com/mozilla/fxa-auth-server/pull/1039, which was opened against the `train-44` branch.

As per discussion in that PR, this change limits session token updates to just the `/certificate/sign` endpoint, and only in the case where the user agent has changed or they've not been updated in the past hour.

The changes to `lib/userAgent.js` were necessary to make the new comparisons work with null fields from the database.

@rfk & @jrgm r?