### PR TITLE
fix(db): properly encapsulate session token update logic

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -11,8 +11,6 @@ var butil = require('./crypto/butil')
 var unbuffer = butil.unbuffer
 var bufferize = butil.bufferize
 
-var ONE_HOUR = 60 * 60 * 1000
-
 module.exports = function (
   backend,
   log,
@@ -418,36 +416,21 @@ module.exports = function (
     )
   }
 
-  DB.prototype.updateSessionTokenInBackground = function (token, userAgentString) {
-    log.trace({ op: 'DB.updateSessionTokenInBackground', uid: token && token.uid })
+  DB.prototype.updateSessionToken = function (token, userAgentString) {
+    log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
 
-    var freshData = userAgent.call({
-      lastAccessTime: Date.now()
-    }, userAgentString)
-
-    if (isSessionTokenFresh(token, freshData)) {
+    if (! token.update(userAgentString)) {
       return P.resolve()
     }
 
-    return this.pool.post('/sessionToken/' + token.id + '/update', freshData)
-  }
-
-  function isSessionTokenFresh (token, freshData) {
-    var fresh = (token.uaBrowser === freshData.uaBrowser &&
-                 token.uaBrowserVersion === freshData.uaBrowserVersion &&
-                 token.uaOS === freshData.uaOS &&
-                 token.uaOSVersion === freshData.uaOSVersion &&
-                 token.uaDeviceType === freshData.uaDeviceType &&
-                 token.lastAccessTime + ONE_HOUR > freshData.lastAccessTime)
-
-    log.info({
-      op: 'DB.isSessionTokenFresh',
-      uid: token && token.uid,
-      tokenAge: freshData.lastAccessTime - token.lastAccessTime,
-      fresh: fresh
+    return this.pool.post('/sessionToken/' + token.id + '/update', {
+      uaBrowser: token.uaBrowser,
+      uaBrowserVersion: token.uaBrowserVersion,
+      uaOS: token.uaOS,
+      uaOSVersion: token.uaOSVersion,
+      uaDeviceType: token.uaDeviceType,
+      lastAccessTime: token.lastAccessTime
     })
-
-    return fresh
   }
 
   // DELETE

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -37,7 +37,8 @@ module.exports = function (log, isA, error, signer, db, domain) {
         var publicKey = request.payload.publicKey
         var duration = request.payload.duration
 
-        db.updateSessionTokenInBackground(sessionToken, request.headers['user-agent'])
+        // No need to wait for a response, update in the background.
+        db.updateSessionToken(sessionToken, request.headers['user-agent'])
 
         if (!sessionToken.emailVerified) {
           return reply(error.unverifiedAccount())

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -126,7 +126,7 @@ test(
       })
       .then(function(sessionToken) {
         sessionToken.lastAccessTime -= 59 * 60 * 1000
-        return db.updateSessionTokenInBackground(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
+        return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function() {
         return db.sessionToken(tokenId)
@@ -137,7 +137,7 @@ test(
       })
       .then(function(sessionToken) {
         sessionToken.lastAccessTime -= 60 * 60 * 1000
-        return db.updateSessionTokenInBackground(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
+        return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function() {
         return db.sessionToken(tokenId)
@@ -147,7 +147,7 @@ test(
         return sessionToken
       })
       .then(function(sessionToken) {
-        return db.updateSessionTokenInBackground(sessionToken, 'Mozilla/5.0 (Android; Linux armv7l; rv:9.0) Gecko/20111216 Firefox/9.0 Fennec/9.0')
+        return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Android; Linux armv7l; rv:9.0) Gecko/20111216 Firefox/9.0 Fennec/9.0')
       })
       .then(function() {
         return db.sessionToken(tokenId)

--- a/test/local/session_token_tests.js
+++ b/test/local/session_token_tests.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var sinon = require('sinon')
 var test = require('../ptaptest')
-var log = { trace: function() {} }
+var log = { trace: function() {}, info: function () {} }
 
 var tokens = require('../../lib/tokens')(log)
 var SessionToken = tokens.SessionToken
-
 
 var ACCOUNT = {
   uid: 'xxx',
@@ -16,6 +16,18 @@ var ACCOUNT = {
   emailVerified: true
 }
 
+test(
+  'interface is correct',
+  function (t) {
+    return SessionToken.create(ACCOUNT)
+      .then(function (token) {
+        t.equal(typeof token.lastAuthAt, 'function', 'lastAuthAt method is defined')
+        t.equal(typeof token.update, 'function', 'update method is defined')
+        t.equal(typeof token.isFresh, 'function', 'isFresh method is defined')
+        t.equal(typeof token.forceUpdate, 'function', 'forceUpdate method is defined')
+      })
+  }
+)
 
 test(
   're-creation from tokenData works',
@@ -47,7 +59,6 @@ test(
   }
 )
 
-
 test(
   'sessionToken key derivations are test-vector compliant',
   function (t) {
@@ -64,3 +75,204 @@ test(
       )
   }
 )
+
+test(
+  'SessionToken.forceUpdate',
+  function (t) {
+    return SessionToken.create(ACCOUNT)
+      .then(function (token) {
+        token.forceUpdate({
+          data: 'foo',
+          tokenId: 'foo',
+          authKey: 'foo',
+          bundleKey: 'foo',
+          algorithm: 'foo',
+          uid: 'foo',
+          lifetime: 'foo',
+          createdAt: 'foo',
+          email: 'foo',
+          emailCode: 'foo',
+          emailVerified: 'foo',
+          verifierSetAt: 'foo',
+          locale: 'foo',
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar',
+          uaOS: 'baz',
+          uaOSVersion: 'qux',
+          uaDeviceType: 'wibble',
+          lastAccessTime: 'mnngh'
+        })
+        t.notEqual(token.data, 'foo', 'data was not updated')
+        t.notEqual(token.tokenId, 'foo', 'tokenId was not updated')
+        t.notEqual(token.authKey, 'foo', 'authKey was not updated')
+        t.notEqual(token.bundleKey, 'foo', 'bundleKey was not updated')
+        t.notEqual(token.algorithm, 'foo', 'algorithm was not updated')
+        t.notEqual(token.uid, 'foo', 'uid was not updated')
+        t.notEqual(token.lifetime, 'foo', 'lifetime was not updated')
+        t.notEqual(token.createdAt, 'foo', 'createdAt was not updated')
+        t.notEqual(token.email, 'foo', 'email was not updated')
+        t.notEqual(token.emailVerified, 'foo', 'emailVerified was not updated')
+        t.notEqual(token.verifierSetAt, 'foo', 'verifierSetAt was not updated')
+        t.notEqual(token.locale, 'foo', 'locale was not updated')
+        t.equal(token.uaBrowser, 'foo', 'uaBrowser was updated')
+        t.equal(token.uaBrowserVersion, 'bar', 'uaBrowserVersion was updated')
+        t.equal(token.uaOS, 'baz', 'uaOS was updated')
+        t.equal(token.uaOSVersion, 'qux', 'uaOSVersion was updated')
+        t.equal(token.uaDeviceType, 'wibble', 'uaDeviceType was updated')
+        t.equal(token.lastAccessTime, 'mnngh', 'lastAccessTime was updated')
+      })
+  }
+)
+
+test(
+  'SessionToken.isFresh',
+  function (t) {
+    return SessionToken.create({
+      uaBrowser: 'foo',
+      uaBrowserVersion: 'bar',
+      uaOS: 'baz',
+      uaOSVersion: 'qux',
+      uaDeviceType: 'wibble',
+      lastAccessTime: 0
+    }).then(function (token) {
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 0
+      }), true, 'returns true when all fields are the same')
+      t.equal(token.isFresh({
+        uaBrowser: 'Foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 0
+      }), false, 'returns false when uaBrowser is different')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'baR',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 0
+      }), false, 'returns false when uaBrowserVersion is different')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'foo',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 0
+      }), false, 'returns false when uaOS is different')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'QUX',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 0
+      }), false, 'returns false when uaOSVersion is different')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wobble',
+        lastAccessTime: 0
+      }), false, 'returns false when uaDeviceType is different')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 3600000
+      }), false, 'returns false when lastAccessTime is 3,600,000 milliseconds newer')
+      t.equal(token.isFresh({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: 'wibble',
+        lastAccessTime: 3599999
+      }), true, 'returns true when lastAccessTime is 3,599,999 milliseconds newer')
+    })
+  }
+)
+
+test(
+  'SessionToken.update on fresh token',
+  function (t) {
+    return SessionToken.create(
+    ).then(function (token) {
+      sinon.stub(SessionToken.prototype, 'isFresh', function () {
+        return true
+      })
+      sinon.spy(SessionToken.prototype, 'forceUpdate')
+
+      t.equal(
+        token.update(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0'
+        ), false, 'returns'
+      )
+
+      t.equal(SessionToken.prototype.isFresh.callCount, 1, 'isFresh was called once')
+      t.equal(SessionToken.prototype.isFresh.thisValues[0], token, 'isFresh context was token')
+      var isFreshArgs = SessionToken.prototype.isFresh.args[0]
+      t.equal(isFreshArgs.length, 1, 'isFresh was passed one argument')
+      var isFreshData = isFreshArgs[0]
+      t.equal(typeof isFreshData, 'object', 'isFresh was passed an object')
+      t.equal(Object.keys(isFreshData).length, 6, 'isFresh data had six properties')
+      t.equal(isFreshData.uaBrowser, 'Firefox', 'uaBrowser was correct')
+      t.equal(isFreshData.uaBrowserVersion, '41', 'uaBrowserVersion was correct')
+      t.equal(isFreshData.uaOS, 'Mac OS X', 'uaOS was correct')
+      t.equal(isFreshData.uaOSVersion, '10.10', 'uaOSVersion was correct')
+      t.equal(isFreshData.uaDeviceType, null, 'uaDeviceType was correct')
+      t.ok(isFreshData.lastAccessTime > Date.now() - 10000, 'lastAccessTime was greater than 10 seconds ago')
+      t.ok(isFreshData.lastAccessTime < Date.now(), 'lastAccessTime was less then Date.now()')
+
+      t.equal(SessionToken.prototype.forceUpdate.callCount, 0, 'forceUpdate was not called')
+    })
+    .finally(function () {
+      SessionToken.prototype.isFresh.restore()
+      SessionToken.prototype.forceUpdate.restore()
+    })
+  }
+)
+
+test(
+  'SessionToken.update on stale token',
+  function (t) {
+    return SessionToken.create()
+      .then(function (token) {
+        sinon.stub(SessionToken.prototype, 'isFresh', function () {
+          return false
+        })
+        sinon.spy(SessionToken.prototype, 'forceUpdate')
+
+        t.equal(
+          token.update(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0'
+          ), true, 'returns true'
+        )
+
+        t.equal(SessionToken.prototype.isFresh.callCount, 1, 'isFresh was called once')
+        var isFreshArgs = SessionToken.prototype.forceUpdate.args[0]
+        t.equal(isFreshArgs.length, 1, 'isFresh was passed one argument')
+
+        t.equal(SessionToken.prototype.forceUpdate.callCount, 1, 'forceUpdate called once')
+        t.equal(SessionToken.prototype.forceUpdate.thisValues[0], token, 'forceUpdate context was token')
+        var forceUpdateArgs = SessionToken.prototype.forceUpdate.args[0]
+        t.equal(forceUpdateArgs.length, 1, 'forceUpdate was passed one argument')
+        t.deepEqual(forceUpdateArgs[0], isFreshArgs[0], 'forceUpdate was passed correct argument')
+      })
+      .finally(function () {
+        SessionToken.prototype.isFresh.restore()
+        SessionToken.prototype.forceUpdate.restore()
+      })
+  }
+)
+


### PR DESCRIPTION
This addresses [feedback](https://github.com/mozilla/fxa-auth-server/pull/1042#discussion_r38881438) from #1042, refactoring the checks around session token updates to the `SessionToken` object.

Fwiw, the name of `DB.prototype.updateSessionTokenInBackground` bothers me, now that it is only called from one place. I felt a bit iffy about it before because the backgroundness doesn't come from the function itself, which returns a promise like the other `DB` methods, but from the caller choosing to ignore said promise.

Now that only one of those callers remains, it strikes me that some commentary at the call site might be a more appropriate place to point out that we're not waiting for a response. Would it be okay to rename it to `updateSessionToken` in this commit and add such a comment instead?