### PR TITLE
feat(basket): send sync login events to basket

### DIFF
--- a/bin/basket.js
+++ b/bin/basket.js
@@ -4,7 +4,7 @@
 
 /*/
 
-This process reads fxa 'verified' auth-server events and sends them
+This process reads fxa 'verified' and 'login' auth-server events and sends them
 to the [basket API](https://github.com/mozilla/basket) for user engagement.
 
 /*/
@@ -14,88 +14,98 @@ var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'fxa-basket-sender')
 var SQSReceiver = require('../lib/sqs')(log)
 
-
-function shouldIgnoreEmail(email) {
-  if (email.match(/@restmail.net$/)) {
-    return true
-  }
-  if (email.match(/@restmail.lcip.org$/)) {
-    return true
-  }
-  return false
+var messageHandlers = {
+  verified: onVerified,
+  login: onLogin
 }
-
 
 var basketQueue = new SQSReceiver(config.basket.region, [config.basket.queueUrl])
 basketQueue.on(
   'data',
   function basketRequest(message) {
     log.trace({ op: 'basketRequest', sqs: message })
-    if (message.event === 'verified') {
-      // Ignore email addresses that are clearly from dev testing.
-      if (shouldIgnoreEmail(message.email)) {
-        message.del()
-        return
-      }
-      // Forward all others to basket API.
-      request(
-        {
-          url: config.basket.apiUrl + '/fxa-register/',
-          strictSSL: true,
-          method: 'POST',
-          headers: {
-            'X-API-Key': config.basket.apiKey
-          },
-          form: {
-            fxa_id: message.uid,
-            email: message.email,
-            // Basket won't accept empty or null `accept_lang` field,
-            // so we default to en-US.  This should only happen if
-            // the user has not sent an explicit Accept-Language header.
-            accept_lang: message.locale || 'en-US'
-          }
-        },
-        function (err, res, body) {
-          // Log and retry for network-level errors.
-          if (err) {
-            log.error(
-              {
-                op: 'basketRequest',
-                uid: message.uid,
-                locale: message.locale,
-                err: err
-              }
-            )
-            return
-          }
-          // Log at error level for HTTP-level errors, info level otherwise.
-          if (res.statusCode < 200 || res.statusCode >= 300) {
-            log.error(
-              {
-                op: 'basketRequest',
-                status: res.statusCode,
-                uid: message.uid,
-                locale: message.locale,
-                body: body
-              }
-            )
-          } else {
-            log.info(
-              {
-                op: 'basketRequest',
-                status: res.statusCode,
-                locale: message.locale,
-                body: body
-              }
-            )
-          }
-          message.del()
-        }
-      )
+
+    var messageHandler = messageHandlers[message.event]
+    if (messageHandler) {
+      return messageHandler(message)
     }
-    else {
-      message.del()
-    }
+
+    message.del()
   }
 )
 basketQueue.start()
+
+function onVerified (message) {
+  forwardEvent(message, '/fxa-register/', {
+    fxa_id: message.uid,
+    email: message.email,
+    // Basket won't accept empty or null `accept_lang` field,
+    // so we default to en-US.  This should only happen if
+    // the user has not sent an explicit Accept-Language header.
+    accept_lang: message.locale || 'en-US'
+  }, 'form')
+}
+
+function onLogin (message) {
+  forwardEvent(message, '/fxa-activity/', {
+    activity: 'account.login',
+    service: message.service,
+    fxa_id: message.uid,
+    first_device: message.deviceCount === 1,
+    user_agent: message.userAgent
+  }, 'json')
+}
+
+function forwardEvent (message, endpoint, data, dataFormat) {
+  // Ignore email addresses that are clearly from dev testing.
+  if (shouldIgnoreEmail(message.email)) {
+    message.del()
+    return
+  }
+
+  // Forward all others to basket API.
+  var requestData = {
+    url: config.basket.apiUrl + endpoint,
+    strictSSL: true,
+    method: 'POST',
+    headers: {
+      'X-API-Key': config.basket.apiKey
+    }
+  }
+  requestData[dataFormat] = data
+  request(requestData, function (err, res, body) {
+    message.op = 'basketRequest'
+    message.endpoint = endpoint
+
+    // Log and retry for network-level errors.
+    if (err) {
+      message.err = err
+      return log.error(message)
+    }
+
+    message.status = res.statusCode
+    message.body = body
+
+    // Log at error level for HTTP-level errors, info level otherwise.
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      log.error(message)
+    } else {
+      log.info(message)
+    }
+
+    message.del()
+  })
+}
+
+function shouldIgnoreEmail (email) {
+  if (email.match(/@restmail.net$/)) {
+    return true
+  }
+
+  if (email.match(/@restmail.lcip.org$/)) {
+    return true
+  }
+
+  return false
+}
+

--- a/lib/db.js
+++ b/lib/db.js
@@ -257,6 +257,26 @@ module.exports = function (
       )
   }
 
+  DB.prototype.sessions = function (uid) {
+    log.trace({ op: 'DB.sessions', uid: uid })
+    return this.pool.get('/account/' + uid.toString('hex') + '/sessions')
+      .then(
+        function (body) {
+          return body.map(function (sessionToken) {
+            return bufferize(sessionToken, {
+              ignore: [
+                'uaBrowser',
+                'uaBrowserVersion',
+                'uaOS',
+                'uaOSVersion',
+                'uaDeviceType'
+              ]
+            })
+          })
+        }
+      )
+  }
+
   DB.prototype.sessionToken = function (id) {
     log.trace({ op: 'DB.sessionToken', id: id })
     return this.pool.get('/sessionToken/' + id.toString('hex'))

--- a/test/local/basket_tests.js
+++ b/test/local/basket_tests.js
@@ -1,0 +1,216 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var path = require('path')
+var test = require('../ptaptest')
+var proxyquire = require('proxyquire')
+var sinon = require('sinon')
+var config = require('../../config').getProperties()
+
+var request = sinon.spy()
+var basketQueue = {
+  on: sinon.spy(),
+  start: sinon.spy()
+}
+var SQSReceiver = sinon.spy(function () {
+  return basketQueue
+})
+
+var dependencies = {
+  request: request
+}
+dependencies[path.resolve(__dirname, '../../bin') + '/../lib/sqs'] = function () {
+  return SQSReceiver
+}
+proxyquire('../../bin/basket.js', dependencies)
+
+test(
+  'basket tests',
+  function (t) {
+    // queue initialisation
+    t.equal(SQSReceiver.callCount, 1, 'SQSReceiver was called once')
+    var args = SQSReceiver.args[0]
+    t.equal(args.length, 2, 'SQSReceiver was passed two arguments')
+    t.equal(args[0], config.basket.region, 'region argument was correct')
+    t.ok(Array.isArray(args[1]), 'urls argument was array')
+    t.equal(args[1].length, 1, 'urls array contained one item')
+    t.equal(args[1][0], config.basket.queueUrl, 'urls item was correct')
+
+    t.equal(basketQueue.on.callCount, 1, 'basketQueue.on was called once')
+    args = basketQueue.on.args[0]
+    t.equal(args.length, 2, 'basketQueue.on was passed two arguments')
+    t.equal(args[0], 'data', 'event argument was correct')
+    t.equal(typeof args[1], 'function', 'listener argument was function')
+    var messageHandler = args[1]
+
+    t.equal(basketQueue.start.callCount, 1, 'basketQueue.start was called once')
+    t.equal(basketQueue.start.args[0].length, 0, 'basketQueue.start was passed no arguments')
+
+    t.equal(request.callCount, 0, 'request was not called')
+
+    // verified event
+    var message = {
+      event: 'verified',
+      uid: 'foo',
+      email: 'bar@example.org',
+      locale: 'baz',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 1, 'request was called once')
+
+    args = request.args[0]
+    t.equal(args.length, 2, 'request was passed two arguments')
+    t.equal(Object.keys(args[0]).length, 5, 'data argument had five properties')
+    t.equal(args[0].url, config.basket.apiUrl + '/fxa-register/', 'url property was correct')
+    t.ok(args[0].strictSSL, 'strictSSL property was correct')
+    t.equal(args[0].method, 'POST', 'method property was correct')
+    t.equal(Object.keys(args[0].headers).length, 1, 'one header was defined')
+    t.equal(args[0].headers['X-API-Key'], config.basket.apiKey, 'X-API-Key header was correct')
+
+    var data = args[0].form
+    t.equal(Object.keys(data).length, 3, 'body data had three properties')
+    t.equal(data.fxa_id, 'foo', 'fxa_id property was correct')
+    t.equal(data.email, 'bar@example.org', 'email property was correct')
+    t.equal(data.accept_lang, 'baz', 'accept_lang property was correct')
+
+    t.equal(typeof args[1], 'function', 'callback argument was function')
+    t.equal(message.del.callCount, 0, 'message.del was not called')
+    args[1](null, { statusCode: 200})
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+    t.equal(message.del.args[0].length, 0, 'message.del was passed no arguments')
+
+    // verified event with restmail.net email address
+    message = {
+      event: 'verified',
+      uid: 'foo',
+      email: 'bar@restmail.net',
+      locale: 'baz',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 1, 'request was not called')
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+
+    // verified event with restmail.lcip.org email address
+    message = {
+      event: 'verified',
+      uid: 'foo',
+      email: 'bar@restmail.lcip.org',
+      locale: 'baz',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 1, 'request was not called')
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+
+    // verified event with default locale
+    message = {
+      event: 'verified',
+      uid: 'foo',
+      email: 'bar',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 2, 'request was called once')
+    t.equal(request.args[1][0].form.accept_lang, 'en-US', 'accept_lang property was correct')
+
+    // login event
+    message = {
+      event: 'login',
+      service: 'a',
+      uid: 'b',
+      email: 'c',
+      deviceCount: 1,
+      userAgent: 'e',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 3, 'request was called once')
+
+    args = request.args[2]
+    t.equal(Object.keys(args[0]).length, 5, 'data argument had five properties')
+    t.equal(args[0].url, config.basket.apiUrl + '/fxa-activity/', 'url property was correct')
+    t.ok(args[0].strictSSL, 'strictSSL property was correct')
+    t.equal(args[0].method, 'POST', 'method property was correct')
+    t.equal(args[0].headers['X-API-Key'], config.basket.apiKey, 'X-API-Key header was correct')
+
+    data = args[0].json
+    t.equal(Object.keys(data).length, 5, 'body data had five properties')
+    t.equal(data.activity, 'account.login', 'activity property was correct')
+    t.equal(data.service, 'a', 'service property was correct')
+    t.equal(data.fxa_id, 'b', 'fxa_id property was correct')
+    t.strictEqual(data.first_device, true, 'first_device property was correct')
+    t.equal(data.user_agent, 'e', 'user_agent property was correct')
+
+    t.equal(typeof args[1], 'function', 'callback argument was function')
+    t.equal(message.del.callCount, 0, 'message.del was not called')
+    args[1](null, { statusCode: 200})
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+
+    // login event with restmail.net email address
+    message = {
+      event: 'login',
+      service: 'a',
+      uid: 'b',
+      email: 'c@restmail.net',
+      deviceCount: 1,
+      userAgent: 'e',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 3, 'request was not called')
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+
+    // login event with restmail.lcip.org email address
+    message = {
+      event: 'login',
+      service: 'a',
+      uid: 'b',
+      email: 'c@restmail.lcip.org',
+      deviceCount: 1,
+      userAgent: 'e',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 3, 'request was not called')
+    t.equal(message.del.callCount, 1, 'message.del was called once')
+
+    // login event with multiple devices
+    message = {
+      event: 'login',
+      service: 'foo',
+      uid: 'bar',
+      email: 'baz',
+      deviceCount: 2,
+      userAgent: 'qux',
+      del: sinon.spy()
+    }
+    messageHandler(message)
+
+    t.equal(request.callCount, 4, 'request was called once')
+
+    data = request.args[3][0].json
+    t.equal(Object.keys(data).length, 5, 'body data had five properties')
+    t.equal(data.activity, 'account.login', 'activity property was correct')
+    t.equal(data.service, 'foo', 'service property was correct')
+    t.equal(data.fxa_id, 'bar', 'fxa_id property was correct')
+    t.strictEqual(data.first_device, false, 'first_device property was correct')
+    t.equal(data.user_agent, 'qux', 'user_agent property was correct')
+
+    t.equal(typeof args[1], 'function', 'callback argument was function')
+
+    t.end()
+  }
+)
+


### PR DESCRIPTION
Fixes #1038.

`bin/basket.js` has been fairly heavily refactored so that the two message handlers can share common code. I've called the new message `login` but I was a bit unsure about it because there is some `login`/`signin` duality in the surrounding code. Are those terms completely interchangeable or is there some subtle contextual difference between the two? Is one of them generally preferable to the other?

There is a small gap in the test coverage but plugging it is going to be time-consuming, so I wanted to check here first: there are no assertions that the call to `log.event` is made correctly from the route handler. Fwiw, there are also no equivalent assertions for existing calls to `log.event`.

Elsewhere, there were no tests at all for the basket stuff previously and this PR adds some pretty comprehensive ones, so I think overall it puts us in a much stronger position than we were, tests-wise.