### PR TITLE
fix(tests): run mysql tests on travis, moar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 node_js:
  - "0.10"
  - "0.12"
- - "iojs-v1"
  - "iojs-v2"
 
 sudo: false
@@ -23,6 +22,7 @@ notifications:
     - dcoates@mozilla.com
     - jbonacci@mozilla.com
     - rfkelly@mozilla.com
+    - jrgm@mozilla.com
   irc:
     channels:
       - "irc.mozilla.org#fxa-bots"
@@ -33,6 +33,6 @@ before_install:
   - npm config set spin false
 
 script:
-  - if [ DB == "mysql" ]; then npm run start-mysql; fi
+  - if [ $DB == "mysql" ]; then echo '~*~ Starting auth-db-mysql'; (./scripts/start-local-test-mysql.sh &>/dev/null &); fi
   - npm test
   - grunt validate-shrinkwrap --force

--- a/scripts/start-local-test-mysql.sh
+++ b/scripts/start-local-test-mysql.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+node ./scripts/gen_keys.js
+
+ls ./node_modules/fxa-auth-db-mysql/node_modules/mysql-patcher || npm i ./node_modules/fxa-auth-db-mysql
+node ./node_modules/fxa-auth-db-mysql/bin/db_patcher.js
+node ./node_modules/fxa-auth-db-mysql/bin/server.js

--- a/test/local/verifier_upgrade_tests.js
+++ b/test/local/verifier_upgrade_tests.js
@@ -106,7 +106,14 @@ createDBServer().then(
         }
       )
       .then(
-        function () { db_server.close() }
+        function () {
+          try {
+            db_server.close()
+          } catch (e) {
+            // This connection may already be dead if a real mysql server is
+            // already bound to :8000.
+          }
+        }
       )
     })
   })


### PR DESCRIPTION
Hey, @vladikoff. I was reviewing your GH-1047, and there were a problem: $DB, not DB (so it wasn't actually running against the database ;-) A way to test the test is to add `sleep 20; mysql -uroot 'drop database if exists fxa'`; that better fail if the tests are using the database).

But running against the database revealed that test/local/verifier_upgrade_tests.js is flaky on travis (passes on my local osx with a database; maybe it shouldn't but it does). Adding this try-catch corrects one definitely failure I reproduced running tests on linux, but that test is still flaky. I've taken several approaches in re-writing that test to not be as flaky on travis, and some were better, but still not solid. 

Anyways, this is a PR to your PR. You may just want to merge this in manually and close this, or whichever. We'll still need to track down the failures with that test before this all lands though.

This also drops testing on iojs-v1, and adds me to email.