### PR TITLE
feat(metrics): send account verification time to statsd

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -135,6 +135,10 @@ Lug.prototype.summary = function (request, response) {
   }
 }
 
+Lug.prototype.timing = function(name, timing, tags) {
+  this.statsd.timing(name, timing, tags)
+}
+
 module.exports = function (level, name) {
   var log = new Lug(
     {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -678,6 +678,7 @@ module.exports = function (
               if (!butil.buffersAreEqual(code, account.emailCode)) {
                 throw error.invalidVerificationCode()
               }
+              log.timing('account.verified', Date.now() - account.createdAt)
               log.event('verified', { email: account.email, uid: account.uid, locale: account.locale })
               log.increment('account.verified')
               return db.verifyEmail(account)


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/3046.

The existing log functions are unsuitable for this event because we want to send the data to statsd as a timing. Hence I've added new `timing` methods to `lib/log.js` and `lib/metrics/statsd.js`, following a similar approach to `log.increment`.
