### PR TITLE
feat(i18n): Enable Romainian `ro` support.

### DIFF
--- a/config/supportedLanguages.js
+++ b/config/supportedLanguages.js
@@ -37,6 +37,7 @@ module.exports = [
   'pl',
   'pt',
   'pt-BR',
+  'ro',
   'rm',
   'ru',
   'sk',


### PR DESCRIPTION
fixes mozilla/fxa-content-server#3125, ref mozilla/fxa-content-server#3126

@jrgm - r?