### PR TITLE
feat(server): support stricter access-control origin on most endpoints

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -345,6 +345,12 @@ var conf = convict({
       default: 0.1,
       env: 'STATSD_SAMPLE_RATE'
     }
+  },
+  corsOrigin: {
+    doc: 'Value for the Access-Control-Allow-Origin response header',
+    format: String,
+    env: 'CORS_ORIGIN',
+    default: '*'
   }
 })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -556,7 +556,7 @@ Not HAWK-authenticated.
 
 Used to submit an account unlock code that was previously sent to a user's recovery email. If correct, the account will be unlocked.
 
-The unlock code will be a random token, delivered in the fragment portion of a URL sent to the user's email address. The URL will lead to a page that extracts the code from the URL fragment, and performs a POST to `/account/unlock/verify_code`. This endpoint should be CORS-enabled, to allow the linked page to be hosted on a different (static) domain. The link can be clicked from any browser, not just the one being attached to the account.
+The unlock code will be a random token, delivered in the fragment portion of a URL sent to the user's email address. The URL will lead to a page that extracts the code from the URL fragment, and performs a POST to `/account/unlock/verify_code`. The link can be clicked from any browser, not just the one being attached to the account.
 
 ### Request
 
@@ -772,7 +772,7 @@ Not HAWK-authenticated.
 
 Used to submit a verification code that was previously sent to a user's recovery email. If correct, the account's recovery email address will be marked as "verified".
 
-The verification code will be a random token, delivered in the fragment portion of a URL sent to the user's email address. The URL will lead to a page that extracts the code from the URL fragment, and performs a POST to `/recovery_email/verify_code`. This endpoint should be CORS-enabled, to allow the linked page to be hosted on a different (static) domain. The link can be clicked from any browser, not just the one being attached to the Firefox account.
+The verification code will be a random token, delivered in the fragment portion of a URL sent to the user's email address. The URL will lead to a page that extracts the code from the URL fragment, and performs a POST to `/recovery_email/verify_code`. The link can be clicked from any browser, not just the one being attached to the Firefox account.
 
 ### Request
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -61,7 +61,8 @@ function create(log, error, config, routes, db) {
     connections: {
       routes: {
         cors: {
-          additionalExposedHeaders: ['Timestamp', 'Accept-Language']
+          additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
+          origin: [config.corsOrigin]
         },
         security: {
           hsts: {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "test": "test"
   },
   "scripts": {
-    "test": "NODE_ENV=dev scripts/test-local.sh && grunt",
+    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo/ scripts/test-local.sh && grunt",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
     "test-quick": "npm run tq",
-    "tq": "NODE_ENV=dev tap test/local 2>/dev/null && NODE_ENV=dev scripts/test-remote-quick.js",
-    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 tap --timeout=300 --tap test/remote"
+    "tq": "NODE_ENV=dev tap test/local 2>/dev/null && NODE_ENV=dev CORS_ORIGIN=https://bar/ scripts/test-remote-quick.js",
+    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz/ tap --timeout=300 --tap test/remote"
   },
   "repository": {
     "type": "git",

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -20,6 +20,8 @@ TestServer.start(config)
       request(config.publicUrl + route, function (err, res, body) {
         t.ok(!err, 'No error fetching ' + route)
 
+        t.equal(res.headers['access-control-allow-origin'], config.corsOrigin, 'Access-Control-Allow-Origin header was set correctly')
+
         var json = JSON.parse(body)
         t.deepEqual(Object.keys(json), ['version', 'commit', 'source'])
         t.equal(json.version, require('../../package.json').version, 'package version')


### PR DESCRIPTION
Fixes #550, adding a config option to set the `Access-Control-Allow-Origin` response header on most endpoints.

~~There are two endpoints that it doesn't affect:~~

* ~~`POST /v1/account/unlock/verify_code`~~
* ~~`POST /v1/recovery_email/verify_code`~~

~~As per [the documentation](https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md#post-v1accountunlockverify_code), those may be accessed from different domains so must always set the header to `*`.~~

~~For the other endpoints,~~ the default setting is ~~also~~ `*` but it can be over-ridden by setting the `CORS_ORIGIN` environment variable.

For the tests, I tried to modify the test client object in the least intrusive way possible, so that I could assert the header was being set correctly without having to update every usage of the client. ~~The client doesn't expose response headers so instead I added a `setAllowedOrigin` method that enables the caller to set expectations of what the header should be. If it's wrong, the promise is rejected and the calling test will fail. I also updated the remote test script to set `CORS_ORIGIN`, so that the stricter option gets properly exercised.~~