### PR TITLE
Update shrinkwrap and fix test expectation for new l10n content

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,168 @@
   "name": "fxa-auth-server",
   "version": "1.47.0",
   "dependencies": {
+    "ass": {
+      "version": "1.0.0",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+        },
+        "blanket": {
+          "version": "1.1.6",
+          "from": "blanket@1.1.6",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "falafel": {
+              "version": "0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "cheerio": {
+          "version": "0.14.0",
+          "from": "cheerio@0.14.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+          "dependencies": {
+            "htmlparser2": {
+              "version": "3.7.3",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.2.1",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            },
+            "CSSselect": {
+              "version": "0.4.1",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "dependencies": {
+                "CSSwhat": {
+                  "version": "0.4.7",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@0.8.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        }
+      }
+    },
     "aws-sdk": {
       "version": "2.1.26",
       "from": "aws-sdk@2.1.26",
@@ -52,6 +214,18 @@
       "version": "2.9.25",
       "from": "bluebird@2.9.25",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+    },
+    "commander": {
+      "version": "2.8.1",
+      "from": "commander@2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "dependencies": {
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "from": "graceful-readlink@>=1.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        }
+      }
     },
     "convict": {
       "version": "1.0.1",
@@ -183,10 +357,976 @@
         }
       }
     },
+    "eslint-config-fxa": {
+      "version": "1.6.0",
+      "from": "eslint-config-fxa@1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
+    },
+    "fxa-auth-db-mysql": {
+      "version": "0.46.0",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#462981acb897fedbae0f6527abc7e30a30ba0faf",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#462981acb897fedbae0f6527abc7e30a30ba0faf",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.1.3",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "convict": {
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
+          "dependencies": {
+            "cjson": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+              "dependencies": {
+                "jsonlint": {
+                  "version": "1.6.0",
+                  "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                  "dependencies": {
+                    "nomnom": {
+                      "version": "1.8.1",
+                      "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.6.0",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                        },
+                        "chalk": {
+                          "version": "0.4.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                          "dependencies": {
+                            "has-color": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                            },
+                            "ansi-styles": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                            },
+                            "strip-ansi": {
+                              "version": "0.1.1",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "JSV": {
+                      "version": "4.0.2",
+                      "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "validator": {
+              "version": "1.5.1",
+              "from": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
+            },
+            "moment": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fxa-jwtool": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "2.9.14",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz"
+            },
+            "jws": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
+              "dependencies": {
+                "jwa": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                  "dependencies": {
+                    "base64url": {
+                      "version": "0.0.6",
+                      "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
+                    },
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "2.2.0",
+                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "2.2.0",
+                              "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "base64-url": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "base64url": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "pem-jwk": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
+              "dependencies": {
+                "asn1.js": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimalistic-assert": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                    },
+                    "bn.js": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                    }
+                  }
+                },
+                "base64url": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mozlog": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
+          "dependencies": {
+            "intel": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/intel/-/intel-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.1.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "dbug": {
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
+                },
+                "stack-trace": {
+                  "version": "0.0.9",
+                  "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                },
+                "strftime": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
+                },
+                "symbol": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
+                },
+                "utcstring": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
+                }
+              }
+            },
+            "merge": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+            }
+          }
+        },
+        "mysql": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+          "dependencies": {
+            "bignumber.js": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "require-all": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
+            }
+          }
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            }
+          }
+        },
+        "restify": {
+          "version": "2.8.2",
+          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "backoff": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "dependencies": {
+                "precond": {
+                  "version": "0.2.3",
+                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+                }
+              }
+            },
+            "bunyan": {
+              "version": "0.23.1",
+              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "dependencies": {
+                "mv": {
+                  "version": "2.1.1",
+                  "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "ncp": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.4.3",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.14",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "2.0.10",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "csv": {
+              "version": "0.4.6",
+              "from": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
+              "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
+              "dependencies": {
+                "csv-generate": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
+                },
+                "csv-parse": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.0.tgz"
+                },
+                "stream-transform": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz"
+                },
+                "csv-stringify": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
+            },
+            "escape-regexp-component": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "keep-alive-agent": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+            },
+            "lru-cache": {
+              "version": "2.6.5",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "negotiator": {
+              "version": "0.4.9",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            },
+            "spdy": {
+              "version": "1.32.4",
+              "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "verror": {
+              "version": "1.6.0",
+              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
+                }
+              }
+            },
+            "dtrace-provider": {
+              "version": "0.2.8",
+              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
+            }
+          }
+        }
+      }
+    },
     "fxa-auth-mailer": {
       "version": "1.0.8",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#62c023efbf9d4bffac326d1a8c03fa79c132b4e9",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#62c023efbf9d4bffac326d1a8c03fa79c132b4e9",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#93b0f3100482130d2f7e874c4d72124e6493198b",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#93b0f3100482130d2f7e874c4d72124e6493198b",
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",
@@ -226,9 +1366,9 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
                   "dependencies": {
                     "glob": {
-                      "version": "5.0.14",
+                      "version": "5.0.15",
                       "from": "glob@>=5.0.14 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -248,14 +1388,14 @@
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
-                          "version": "2.0.10",
-                          "from": "minimatch@>=2.0.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "version": "3.0.0",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.0",
+                              "version": "1.1.1",
                               "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.2.0",
@@ -298,8 +1438,1144 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#6e9093757b3a5bf720c2eb7ab771df303fca98e5",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#6e9093757b3a5bf720c2eb7ab771df303fca98e5"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#fa01545e896e403cd849f61a7ecb43e0aed5a3a9",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#fa01545e896e403cd849f61a7ecb43e0aed5a3a9"
+        },
+        "grunt-nunjucks-2-html": {
+          "version": "0.3.4",
+          "from": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
+          "resolved": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
+          "dependencies": {
+            "async": {
+              "version": "1.4.2",
+              "from": "async@>=1.4.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+            },
+            "nunjucks": {
+              "version": "2.1.0",
+              "from": "nunjucks@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.1.0.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "from": "asap@>=2.0.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                },
+                "chokidar": {
+                  "version": "1.2.0",
+                  "from": "chokidar@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.2.0.tgz",
+                  "dependencies": {
+                    "anymatch": {
+                      "version": "1.3.0",
+                      "from": "anymatch@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                      "dependencies": {
+                        "micromatch": {
+                          "version": "2.2.0",
+                          "from": "micromatch@>=2.1.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
+                          "dependencies": {
+                            "arr-diff": {
+                              "version": "1.1.0",
+                              "from": "arr-diff@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                              "dependencies": {
+                                "arr-flatten": {
+                                  "version": "1.0.1",
+                                  "from": "arr-flatten@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                                },
+                                "array-slice": {
+                                  "version": "0.2.3",
+                                  "from": "array-slice@>=0.2.3 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                                }
+                              }
+                            },
+                            "array-unique": {
+                              "version": "0.2.1",
+                              "from": "array-unique@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                            },
+                            "braces": {
+                              "version": "1.8.1",
+                              "from": "braces@>=1.8.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.1.tgz",
+                              "dependencies": {
+                                "expand-range": {
+                                  "version": "1.8.1",
+                                  "from": "expand-range@>=1.8.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                                  "dependencies": {
+                                    "fill-range": {
+                                      "version": "2.2.2",
+                                      "from": "fill-range@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "1.1.2",
+                                          "from": "is-number@>=1.1.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                        },
+                                        "isobject": {
+                                          "version": "1.0.2",
+                                          "from": "isobject@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                        },
+                                        "randomatic": {
+                                          "version": "1.1.0",
+                                          "from": "randomatic@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "0.2.3",
+                                  "from": "lazy-cache@>=0.2.3 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.3.tgz"
+                                },
+                                "preserve": {
+                                  "version": "0.2.0",
+                                  "from": "preserve@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                                },
+                                "repeat-element": {
+                                  "version": "1.1.2",
+                                  "from": "repeat-element@>=1.1.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "expand-brackets": {
+                              "version": "0.1.4",
+                              "from": "expand-brackets@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                            },
+                            "extglob": {
+                              "version": "0.3.1",
+                              "from": "extglob@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                              "dependencies": {
+                                "ansi-green": {
+                                  "version": "0.1.1",
+                                  "from": "ansi-green@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                                  "dependencies": {
+                                    "ansi-wrap": {
+                                      "version": "0.1.0",
+                                      "from": "ansi-wrap@0.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "is-extglob": {
+                                  "version": "1.0.0",
+                                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                                },
+                                "success-symbol": {
+                                  "version": "0.1.0",
+                                  "from": "success-symbol@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "filename-regex": {
+                              "version": "2.0.0",
+                              "from": "filename-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                            },
+                            "is-glob": {
+                              "version": "1.1.3",
+                              "from": "is-glob@>=1.1.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+                            },
+                            "kind-of": {
+                              "version": "1.1.0",
+                              "from": "kind-of@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                            },
+                            "object.omit": {
+                              "version": "1.1.0",
+                              "from": "object.omit@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+                              "dependencies": {
+                                "for-own": {
+                                  "version": "0.1.3",
+                                  "from": "for-own@>=0.1.3 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                                  "dependencies": {
+                                    "for-in": {
+                                      "version": "0.1.4",
+                                      "from": "for-in@>=0.1.4 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                    }
+                                  }
+                                },
+                                "isobject": {
+                                  "version": "1.0.2",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "parse-glob": {
+                              "version": "3.0.4",
+                              "from": "parse-glob@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.3.0",
+                                  "from": "glob-base@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                                },
+                                "is-dotfile": {
+                                  "version": "1.0.1",
+                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                                },
+                                "is-extglob": {
+                                  "version": "1.0.0",
+                                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                                },
+                                "is-glob": {
+                                  "version": "2.0.1",
+                                  "from": "is-glob@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "regex-cache": {
+                              "version": "0.4.2",
+                              "from": "regex-cache@>=0.4.2 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                              "dependencies": {
+                                "is-equal-shallow": {
+                                  "version": "0.1.3",
+                                  "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                                },
+                                "is-primitive": {
+                                  "version": "2.0.0",
+                                  "from": "is-primitive@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "arrify": {
+                      "version": "1.0.0",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                    },
+                    "async-each": {
+                      "version": "0.1.6",
+                      "from": "async-each@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                    },
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "from": "glob-parent@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                    },
+                    "is-binary-path": {
+                      "version": "1.0.1",
+                      "from": "is-binary-path@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                      "dependencies": {
+                        "binary-extensions": {
+                          "version": "1.3.1",
+                          "from": "binary-extensions@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "from": "is-glob@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                      "dependencies": {
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "lodash.flatten": {
+                      "version": "3.0.2",
+                      "from": "lodash.flatten@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
+                      "dependencies": {
+                        "lodash._baseflatten": {
+                          "version": "3.1.4",
+                          "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.0.4",
+                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                            },
+                            "lodash.isarray": {
+                              "version": "3.0.4",
+                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                            }
+                          }
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
+                    "readdirp": {
+                      "version": "2.0.0",
+                      "from": "readdirp@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "minimatch@>=2.0.10 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.0.2",
+                          "from": "readable-stream@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "fsevents": {
+                      "version": "1.0.2",
+                      "from": "fsevents@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.2.tgz",
+                      "dependencies": {
+                        "nan": {
+                          "version": "2.1.0",
+                          "from": "nan@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+                        },
+                        "node-pre-gyp": {
+                          "version": "0.6.12",
+                          "from": "node-pre-gyp@0.6.12",
+                          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.12.tgz",
+                          "dependencies": {
+                            "nopt": {
+                              "version": "3.0.4",
+                              "from": "nopt@~3.0.1",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.7",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                                }
+                              }
+                            },
+                            "npmlog": {
+                              "version": "1.2.1",
+                              "from": "npmlog@~1.2.0",
+                              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                              "dependencies": {
+                                "ansi": {
+                                  "version": "0.3.0",
+                                  "from": "ansi@~0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                                },
+                                "are-we-there-yet": {
+                                  "version": "1.0.4",
+                                  "from": "are-we-there-yet@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                                  "dependencies": {
+                                    "delegates": {
+                                      "version": "0.1.0",
+                                      "from": "delegates@^0.1.0",
+                                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                                    },
+                                    "readable-stream": {
+                                      "version": "1.1.13",
+                                      "from": "readable-stream@^1.1.13",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@~1.0.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@~0.10.x",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@2",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gauge": {
+                                  "version": "1.2.2",
+                                  "from": "gauge@~1.2.0",
+                                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                                  "dependencies": {
+                                    "has-unicode": {
+                                      "version": "1.0.0",
+                                      "from": "has-unicode@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                                    },
+                                    "lodash.pad": {
+                                      "version": "3.1.1",
+                                      "from": "lodash.pad@^3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._createpadding": {
+                                          "version": "3.6.1",
+                                          "from": "lodash._createpadding@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                                          "dependencies": {
+                                            "lodash.repeat": {
+                                              "version": "3.0.1",
+                                              "from": "lodash.repeat@^3.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash.padleft": {
+                                      "version": "3.1.1",
+                                      "from": "lodash.padleft@^3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._createpadding": {
+                                          "version": "3.6.1",
+                                          "from": "lodash._createpadding@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                                          "dependencies": {
+                                            "lodash.repeat": {
+                                              "version": "3.0.1",
+                                              "from": "lodash.repeat@^3.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash.padright": {
+                                      "version": "3.1.1",
+                                      "from": "lodash.padright@^3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._createpadding": {
+                                          "version": "3.6.1",
+                                          "from": "lodash._createpadding@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                                          "dependencies": {
+                                            "lodash.repeat": {
+                                              "version": "3.0.1",
+                                              "from": "lodash.repeat@^3.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "request": {
+                              "version": "2.64.0",
+                              "from": "request@2.x",
+                              "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
+                              "dependencies": {
+                                "bl": {
+                                  "version": "1.0.0",
+                                  "from": "bl@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@~2.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@~1.0.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@~2.0.1",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.3",
+                                          "from": "process-nextick-args@~1.0.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@~0.10.x",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@~1.0.1",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "caseless": {
+                                  "version": "0.11.0",
+                                  "from": "caseless@~0.11.0",
+                                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                                },
+                                "extend": {
+                                  "version": "3.0.0",
+                                  "from": "extend@~3.0.0",
+                                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                                },
+                                "forever-agent": {
+                                  "version": "0.6.1",
+                                  "from": "forever-agent@~0.6.0",
+                                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                                },
+                                "form-data": {
+                                  "version": "1.0.0-rc3",
+                                  "from": "form-data@~1.0.0-rc1",
+                                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                                  "dependencies": {
+                                    "async": {
+                                      "version": "1.4.2",
+                                      "from": "async@^1.4.0",
+                                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                                    }
+                                  }
+                                },
+                                "json-stringify-safe": {
+                                  "version": "5.0.1",
+                                  "from": "json-stringify-safe@~5.0.0",
+                                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                                },
+                                "mime-types": {
+                                  "version": "2.1.7",
+                                  "from": "mime-types@~2.1.2",
+                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.19.0",
+                                      "from": "mime-db@~1.19.0",
+                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                                    }
+                                  }
+                                },
+                                "node-uuid": {
+                                  "version": "1.4.3",
+                                  "from": "node-uuid@~1.4.0",
+                                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                                },
+                                "qs": {
+                                  "version": "5.1.0",
+                                  "from": "qs@~5.1.0",
+                                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@~0.4.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                },
+                                "tough-cookie": {
+                                  "version": "2.1.0",
+                                  "from": "tough-cookie@>=0.12.0",
+                                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.1.0.tgz"
+                                },
+                                "http-signature": {
+                                  "version": "0.11.0",
+                                  "from": "http-signature@~0.11.0",
+                                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "0.1.5",
+                                      "from": "assert-plus@^0.1.5",
+                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                    },
+                                    "asn1": {
+                                      "version": "0.1.11",
+                                      "from": "asn1@0.1.11",
+                                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                    },
+                                    "ctype": {
+                                      "version": "0.5.3",
+                                      "from": "ctype@0.5.3",
+                                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                    }
+                                  }
+                                },
+                                "oauth-sign": {
+                                  "version": "0.8.0",
+                                  "from": "oauth-sign@~0.8.0",
+                                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                                },
+                                "hawk": {
+                                  "version": "3.1.0",
+                                  "from": "hawk@~3.1.0",
+                                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                                  "dependencies": {
+                                    "hoek": {
+                                      "version": "2.16.3",
+                                      "from": "hoek@2.x.x",
+                                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                    },
+                                    "boom": {
+                                      "version": "2.9.0",
+                                      "from": "boom@^2.8.x",
+                                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                                    },
+                                    "cryptiles": {
+                                      "version": "2.0.5",
+                                      "from": "cryptiles@2.x.x",
+                                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                                    },
+                                    "sntp": {
+                                      "version": "1.0.9",
+                                      "from": "sntp@1.x.x",
+                                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                    }
+                                  }
+                                },
+                                "aws-sign2": {
+                                  "version": "0.5.0",
+                                  "from": "aws-sign2@~0.5.0",
+                                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                                },
+                                "stringstream": {
+                                  "version": "0.0.4",
+                                  "from": "stringstream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                                },
+                                "combined-stream": {
+                                  "version": "1.0.5",
+                                  "from": "combined-stream@~1.0.1",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "1.0.0",
+                                      "from": "delayed-stream@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "isstream": {
+                                  "version": "0.1.2",
+                                  "from": "isstream@~0.1.1",
+                                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                                },
+                                "har-validator": {
+                                  "version": "1.8.0",
+                                  "from": "har-validator@^1.6.1",
+                                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                                  "dependencies": {
+                                    "bluebird": {
+                                      "version": "2.10.2",
+                                      "from": "bluebird@^2.9.30",
+                                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                                    },
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "from": "chalk@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "from": "ansi-styles@^2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "from": "escape-string-regexp@^1.0.2",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "from": "has-ansi@^2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "from": "ansi-regex@^2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "from": "strip-ansi@^3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "from": "ansi-regex@^2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "from": "supports-color@^2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "commander": {
+                                      "version": "2.8.1",
+                                      "from": "commander@^2.8.1",
+                                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1",
+                                          "from": "graceful-readlink@>= 1.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-my-json-valid": {
+                                      "version": "2.12.2",
+                                      "from": "is-my-json-valid@^2.12.0",
+                                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                                      "dependencies": {
+                                        "generate-function": {
+                                          "version": "2.0.0",
+                                          "from": "generate-function@^2.0.0",
+                                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                                        },
+                                        "generate-object-property": {
+                                          "version": "1.2.0",
+                                          "from": "generate-object-property@^1.1.0",
+                                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                          "dependencies": {
+                                            "is-property": {
+                                              "version": "1.0.2",
+                                              "from": "is-property@^1.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "jsonpointer": {
+                                          "version": "2.0.0",
+                                          "from": "jsonpointer@2.0.0",
+                                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                                        },
+                                        "xtend": {
+                                          "version": "4.0.0",
+                                          "from": "xtend@^4.0.0",
+                                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.0.3",
+                              "from": "semver@~5.0.1",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                            },
+                            "tar": {
+                              "version": "2.2.1",
+                              "from": "tar@~2.2.0",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.8",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                                },
+                                "fstream": {
+                                  "version": "1.0.8",
+                                  "from": "fstream@^1.0.2",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@^4.1.2",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar-pack": {
+                              "version": "2.0.0",
+                              "from": "tar-pack@~2.0.0",
+                              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                              "dependencies": {
+                                "uid-number": {
+                                  "version": "0.0.3",
+                                  "from": "uid-number@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                                },
+                                "once": {
+                                  "version": "1.1.1",
+                                  "from": "once@~1.1.1",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                                },
+                                "debug": {
+                                  "version": "0.7.4",
+                                  "from": "debug@~0.7.2",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                                },
+                                "rimraf": {
+                                  "version": "2.2.8",
+                                  "from": "rimraf@~2.2.0",
+                                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                                },
+                                "fstream": {
+                                  "version": "0.1.31",
+                                  "from": "fstream@~0.1.22",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "3.0.8",
+                                      "from": "graceful-fs@~3.0.2",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@~0.1.17",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.8",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "fstream-ignore": {
+                                  "version": "0.0.7",
+                                  "from": "fstream-ignore@0.0.7",
+                                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                                  "dependencies": {
+                                    "minimatch": {
+                                      "version": "0.2.14",
+                                      "from": "minimatch@~0.2.0",
+                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                      "dependencies": {
+                                        "lru-cache": {
+                                          "version": "2.7.0",
+                                          "from": "lru-cache@2",
+                                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                        },
+                                        "sigmund": {
+                                          "version": "1.0.1",
+                                          "from": "sigmund@~1.0.0",
+                                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "1.0.33",
+                                  "from": "readable-stream@~1.0.2",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "graceful-fs": {
+                                  "version": "1.2.3",
+                                  "from": "graceful-fs@1.2",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                }
+                              }
+                            },
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "from": "mkdirp@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8",
+                                  "from": "minimist@0.0.8",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                }
+                              }
+                            },
+                            "rc": {
+                              "version": "1.1.2",
+                              "from": "rc@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "1.2.0",
+                                  "from": "minimist@^1.1.2",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                },
+                                "deep-extend": {
+                                  "version": "0.2.11",
+                                  "from": "deep-extend@~0.2.5",
+                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                },
+                                "strip-json-comments": {
+                                  "version": "0.1.3",
+                                  "from": "strip-json-comments@0.1.x",
+                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                },
+                                "ini": {
+                                  "version": "1.3.4",
+                                  "from": "ini@~1.3.0",
+                                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                }
+                              }
+                            },
+                            "rimraf": {
+                              "version": "2.4.3",
+                              "from": "rimraf@~2.4.0",
+                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "5.0.15",
+                                  "from": "glob@^5.0.14",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                                  "dependencies": {
+                                    "inflight": {
+                                      "version": "1.0.4",
+                                      "from": "inflight@^1.0.4",
+                                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@1",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "minimatch": {
+                                      "version": "3.0.0",
+                                      "from": "minimatch@2 || 3",
+                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                                      "dependencies": {
+                                        "brace-expansion": {
+                                          "version": "1.1.1",
+                                          "from": "brace-expansion@^1.0.0",
+                                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                          "dependencies": {
+                                            "balanced-match": {
+                                              "version": "0.2.0",
+                                              "from": "balanced-match@^0.2.0",
+                                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                            },
+                                            "concat-map": {
+                                              "version": "0.0.1",
+                                              "from": "concat-map@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "once": {
+                                      "version": "1.3.2",
+                                      "from": "once@^1.3.0",
+                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@1",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "path-is-absolute": {
+                                      "version": "1.0.0",
+                                      "from": "path-is-absolute@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@*",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "handlebars": {
           "version": "1.3.0",
@@ -370,9 +2646,9 @@
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
                 },
                 "gettext-parser": {
-                  "version": "1.1.1",
+                  "version": "1.1.2",
                   "from": "gettext-parser@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.11",
@@ -380,9 +2656,9 @@
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.11",
+                          "version": "0.4.13",
                           "from": "iconv-lite@>=0.4.4 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                         }
                       }
                     }
@@ -404,9 +2680,9 @@
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
                     },
                     "clean-css": {
-                      "version": "3.4.4",
+                      "version": "3.4.5",
                       "from": "clean-css@>=3.1.9 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.4.tgz",
+                      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.5.tgz",
                       "dependencies": {
                         "commander": {
                           "version": "2.8.1",
@@ -555,9 +2831,9 @@
                       }
                     },
                     "uglify-js": {
-                      "version": "2.4.24",
+                      "version": "2.5.0",
                       "from": "uglify-js@>=2.4.19 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.5.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
@@ -565,16 +2841,9 @@
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "source-map": {
-                          "version": "0.1.34",
-                          "from": "source-map@0.1.34",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
+                          "version": "0.5.1",
+                          "from": "source-map@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
                         },
                         "uglify-to-browserify": {
                           "version": "1.0.2",
@@ -727,9 +2996,9 @@
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.11",
+                          "version": "0.4.13",
                           "from": "iconv-lite@>=0.4.4 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                         }
                       }
                     },
@@ -768,23 +3037,6 @@
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
-                }
-              }
-            },
-            "simplesmtp": {
-              "version": "0.3.35",
-              "from": "simplesmtp@>=0.2.0 <0.3.0||>=0.3.30 <0.4.0",
-              "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
-              "dependencies": {
-                "rai": {
-                  "version": "0.1.12",
-                  "from": "rai@>=0.1.11 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
-                },
-                "xoauth2": {
-                  "version": "0.1.8",
-                  "from": "xoauth2@>=0.1.8 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
                 }
               }
             },
@@ -911,9 +3163,9 @@
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.11",
+                      "version": "0.4.13",
                       "from": "iconv-lite@>=0.4.4 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
                 }
@@ -1003,9 +3255,9 @@
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
                       "dependencies": {
                         "glob": {
-                          "version": "5.0.14",
+                          "version": "5.0.15",
                           "from": "glob@>=5.0.14 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
@@ -1025,14 +3277,14 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "minimatch": {
-                              "version": "2.0.10",
-                              "from": "minimatch@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "version": "3.0.0",
+                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.0",
+                                  "version": "1.1.1",
                                   "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.2.0",
@@ -1219,42 +3471,858 @@
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.11",
+                  "version": "0.4.13",
                   "from": "iconv-lite@>=0.4.4 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "from": "grunt@0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.2",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.12 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.2",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-bump": {
+      "version": "0.3.1",
+      "from": "grunt-bump@0.3.1",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.3.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "from": "grunt-cli@0.1.13",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.3.1",
+          "from": "resolve@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
+        }
+      }
+    },
+    "grunt-copyright": {
+      "version": "0.2.0",
+      "from": "grunt-copyright@0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
+    },
+    "grunt-eslint": {
+      "version": "15.0.0",
+      "from": "grunt-eslint@15.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "eslint": {
+          "version": "0.23.0",
+          "from": "eslint@>=0.23.0 <0.24.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.0",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "doctrine": {
+              "version": "0.6.4",
+              "from": "doctrine@>=0.6.2 <0.7.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "escope": {
+              "version": "3.2.0",
+              "from": "escope@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.1",
+                  "from": "es6-map@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.8",
+                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "2.0.0",
+                          "from": "es6-iterator@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "3.0.0",
+                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-set": {
+                      "version": "0.1.2",
+                      "from": "es6-set@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "2.0.0",
+                          "from": "es6-iterator@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "3.0.0",
+                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "es6-symbol": {
+                      "version": "0.1.1",
+                      "from": "es6-symbol@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.4",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "0.1.4",
+                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.8",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "2.0.0",
+                          "from": "es6-iterator@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "3.0.0",
+                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                },
+                "estraverse": {
+                  "version": "3.1.0",
+                  "from": "estraverse@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                }
+              }
+            },
+            "espree": {
+              "version": "2.2.5",
+              "from": "espree@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+            },
+            "estraverse": {
+              "version": "2.0.0",
+              "from": "estraverse@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+            },
+            "estraverse-fb": {
+              "version": "1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+            },
+            "globals": {
+              "version": "8.11.0",
+              "from": "globals@>=8.0.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
+            },
+            "inquirer": {
+              "version": "0.8.5",
+              "from": "inquirer@>=0.8.2 <0.9.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "cli-width": {
+                  "version": "1.0.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                },
+                "figures": {
+                  "version": "1.4.0",
+                  "from": "figures@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.3.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.5.3",
+                  "from": "rx@>=2.4.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.2",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0",
+                  "from": "jsonpointer@2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.3",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.6.0",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-nsp-shrinkwrap": {
+      "version": "0.0.3",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "dependencies": {
+        "cli-color": {
+          "version": "0.2.3",
+          "from": "cli-color@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.9.2",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
+            },
+            "memoizee": {
+              "version": "0.2.6",
+              "from": "memoizee@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "dependencies": {
+                "event-emitter": {
+                  "version": "0.2.2",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
+                },
+                "next-tick": {
+                  "version": "0.1.0",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
             }
           }
         },
-        "pem-jwk": {
-          "version": "1.5.1",
-          "from": "pem-jwk@1.5.1",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
-          "dependencies": {
-            "asn1.js": {
-              "version": "1.0.3",
-              "from": "asn1.js@1.0.3",
-              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimalistic-assert": {
-                  "version": "1.0.0",
-                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                },
-                "bn.js": {
-                  "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
-                }
-              }
-            }
-          }
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
@@ -1532,23 +4600,33 @@
           "version": "2.16.3",
           "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        }
+      }
+    },
+    "hawk": {
+      "version": "2.3.1",
+      "from": "hawk@2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
-        "hawk": {
-          "version": "2.3.1",
-          "from": "hawk@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "dependencies": {
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-          }
+        "boom": {
+          "version": "2.9.0",
+          "from": "boom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "from": "sntp@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
@@ -1568,9 +4646,9 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
-          "version": "1.0.3",
+          "version": "1.1.0",
           "from": "topo@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
           "version": "1.2.0",
@@ -1581,6 +4659,350 @@
           "version": "2.10.6",
           "from": "moment@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+        }
+      }
+    },
+    "jws": {
+      "version": "3.0.0",
+      "from": "jws@3.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
+      "dependencies": {
+        "jwa": {
+          "version": "1.0.2",
+          "from": "jwa@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+          "dependencies": {
+            "base64url": {
+              "version": "0.0.6",
+              "from": "base64url@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
+            },
+            "buffer-equal-constant-time": {
+              "version": "1.0.1",
+              "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+            },
+            "ecdsa-sig-formatter": {
+              "version": "1.0.2",
+              "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+              "dependencies": {
+                "asn1.js": {
+                  "version": "2.2.1",
+                  "from": "asn1.js@>=2.0.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "2.2.0",
+                      "from": "bn.js@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimalistic-assert": {
+                      "version": "1.0.0",
+                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                    }
+                  }
+                },
+                "base64-url": {
+                  "version": "1.2.1",
+                  "from": "base64-url@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "base64url": {
+          "version": "1.0.4",
+          "from": "base64url@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.4.10",
+              "from": "concat-stream@>=1.4.7 <1.5.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "meow": {
+              "version": "2.0.0",
+              "from": "meow@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "1.0.0",
+                  "from": "object-assign@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "load-grunt-tasks": {
+      "version": "3.1.0",
+      "from": "load-grunt-tasks@3.1.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mailparser": {
+      "version": "0.5.1",
+      "from": "mailparser@0.5.1",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.5.1.tgz",
+      "dependencies": {
+        "mimelib": {
+          "version": "0.2.19",
+          "from": "mimelib@>=0.2.19 <0.3.0",
+          "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+          "dependencies": {
+            "addressparser": {
+              "version": "0.3.2",
+              "from": "addressparser@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
+            }
+          }
+        },
+        "encoding": {
+          "version": "0.1.11",
+          "from": "encoding@>=0.1.11 <0.2.0",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.13",
+              "from": "iconv-lite@>=0.4.4 <0.5.0",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.3.4",
+          "from": "mime@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "uue": {
+          "version": "2.1.1",
+          "from": "uue@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uue/-/uue-2.1.1.tgz",
+          "dependencies": {
+            "array.prototype.findindex": {
+              "version": "1.0.0",
+              "from": "array.prototype.findindex@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            }
+          }
         }
       }
     },
@@ -1674,6 +5096,71 @@
         }
       }
     },
+    "nock": {
+      "version": "1.7.1",
+      "from": "nock@1.7.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-1.7.1.tgz",
+      "dependencies": {
+        "chai": {
+          "version": "1.10.0",
+          "from": "chai@>=1.9.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+          "dependencies": {
+            "assertion-error": {
+              "version": "1.0.0",
+              "from": "assertion-error@1.0.0",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "from": "deep-eql@0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "from": "type-detect@0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "1.0.4",
+          "from": "debug@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "propagate": {
+          "version": "0.3.1",
+          "from": "propagate@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+        }
+      }
+    },
     "node-statsd": {
       "version": "0.1.1",
       "from": "node-statsd@0.1.1",
@@ -1684,6 +5171,35 @@
       "from": "openid@0.5.13",
       "resolved": "https://registry.npmjs.org/openid/-/openid-0.5.13.tgz"
     },
+    "pem-jwk": {
+      "version": "1.5.1",
+      "from": "pem-jwk@1.5.1",
+      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
+      "dependencies": {
+        "asn1.js": {
+          "version": "1.0.3",
+          "from": "asn1.js@1.0.3",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimalistic-assert": {
+              "version": "1.0.0",
+              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+            },
+            "bn.js": {
+              "version": "1.3.0",
+              "from": "bn.js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "poolee": {
       "version": "1.0.0",
       "from": "poolee@1.0.0",
@@ -1693,6 +5209,35 @@
           "version": "0.0.1",
           "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+        }
+      }
+    },
+    "proxyquire": {
+      "version": "1.6.0",
+      "from": "proxyquire@1.6.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.6.0.tgz",
+      "dependencies": {
+        "fill-keys": {
+          "version": "1.0.2",
+          "from": "fill-keys@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+          "dependencies": {
+            "is-object": {
+              "version": "1.0.1",
+              "from": "is-object@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.0",
+              "from": "merge-descriptors@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+            }
+          }
+        },
+        "module-not-found-error": {
+          "version": "1.0.1",
+          "from": "module-not-found-error@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
         }
       }
     },
@@ -1790,9 +5335,9 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
         },
         "tough-cookie": {
-          "version": "2.0.0",
+          "version": "2.2.0",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
@@ -1820,33 +5365,6 @@
           "version": "0.6.0",
           "from": "oauth-sign@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "from": "hawk@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "boom": {
-              "version": "2.9.0",
-              "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-          }
         },
         "aws-sign2": {
           "version": "0.5.0",
@@ -1881,9 +5399,9 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "dependencies": {
             "bluebird": {
-              "version": "2.10.1",
+              "version": "2.10.2",
               "from": "bluebird@>=2.9.30 <3.0.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz"
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
             },
             "chalk": {
               "version": "1.1.1",
@@ -1928,18 +5446,6 @@
                   "version": "2.0.0",
                   "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "commander": {
-              "version": "2.8.1",
-              "from": "commander@>=2.8.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
@@ -1995,6 +5501,226 @@
           "version": "1.8.4",
           "from": "nan@1.8.4",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+        }
+      }
+    },
+    "simplesmtp": {
+      "version": "0.3.35",
+      "from": "simplesmtp@0.3.35",
+      "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
+      "dependencies": {
+        "rai": {
+          "version": "0.1.12",
+          "from": "rai@>=0.1.11 <0.2.0",
+          "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
+        },
+        "xoauth2": {
+          "version": "0.1.8",
+          "from": "xoauth2@>=0.1.8 <0.2.0",
+          "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
+        }
+      }
+    },
+    "sinon": {
+      "version": "1.15.4",
+      "from": "sinon@1.15.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "from": "formatio@1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.3 <1.0.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "from": "lolex@1.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "from": "samsam@1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+        }
+      }
+    },
+    "sjcl": {
+      "version": "1.0.2",
+      "from": "sjcl@1.0.2",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.2.tgz"
+    },
+    "tap": {
+      "version": "0.7.1",
+      "from": "tap@0.7.1",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
+      "dependencies": {
+        "buffer-equal": {
+          "version": "0.0.1",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+        },
+        "difflet": {
+          "version": "0.2.6",
+          "from": "difflet@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "dependencies": {
+            "traverse": {
+              "version": "0.6.6",
+              "from": "traverse@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+            },
+            "charm": {
+              "version": "0.1.2",
+              "from": "charm@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "from": "deep-is@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.3.5 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@*",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.4",
+          "from": "nopt@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "runforcover": {
+          "version": "0.0.2",
+          "from": "runforcover@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "dependencies": {
+            "bunker": {
+              "version": "0.1.2",
+              "from": "bunker@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "dependencies": {
+                "burrito": {
+                  "version": "0.2.12",
+                  "from": "burrito@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.5.2",
+                      "from": "traverse@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
+                    },
+                    "uglify-js": {
+                      "version": "1.1.1",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "from": "slide@*",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+        },
+        "yamlish": {
+          "version": "0.0.7",
+          "from": "yamlish@*",
+          "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
         }
       }
     },

--- a/test/local/mailer_locales_tests.js
+++ b/test/local/mailer_locales_tests.js
@@ -16,9 +16,9 @@ require('../../lib/mailer')(config, log)
         function (t) {
           var locales = config.i18n.supportedLanguages
           locales.forEach(function(lang) {
+            // sr-LATN is sr, but in Latin characters, not Cyrillic
             if (lang === 'sr-LATN') {
-              // sr-LATN is sr, but in Latin characters, not Cyrillic
-              t.equal('sr', mailer.translator(lang).language)
+              t.equal('sr-Latn', mailer.translator(lang).language)
             } else {
               t.equal(lang, mailer.translator(lang).language)
             }


### PR DESCRIPTION
Update shrinkwrap, principally for
  fxa-auth-mailer.git : from 62c023e to 93b0f31
  fxa-content-server-l10n.git : from 6e90937 to fa01545

r? - @rfk 