### PR TITLE
feat(versions): pull version number from fxa-auth-db-mysql server

### DIFF
--- a/lib/routes/defaults.js
+++ b/lib/routes/defaults.js
@@ -5,9 +5,11 @@
 var path = require('path')
 var cp = require('child_process')
 const util = require('util')
+var httprequest = require('request')
 
 var version = require('../../package.json').version
 var commitHash
+var dbVersion
 var sourceRepo
 
 // Production and stage provide './config/version.json'. Try to load this at
@@ -27,33 +29,66 @@ module.exports = function (log, P, db, error) {
   function versionHandler(request, reply) {
     log.begin('Defaults.root', request)
 
+    // Get the version from fxa-auth-db-mysql server
+    function getDBVersion() {
+      return new P(function (resolve, reject) {
+        if (!dbVersion) {
+          var config = require('../../config').root()
+          httprequest.get({url: config.httpdb.url, json: true, timeout: 10000}, function (err, response, body) {
+            if (err) reject(err)
+            if (response.statusCode !== 200) {
+              // Just in case httpdb isn't sending plain 200, reject with explicit HTTP code
+              reject(response.statusCode)
+            } else {
+              resolve(dbVersion = response.body.version)
+            }
+          })
+        } else {
+          resolve() // dbVersion is already set, so just resolve
+        }
+      }) // end of promise
+    }
+
+    function getCommitVersion() {
+      return new P(function (resolve, reject) {
+        if (!commitHash) {
+          // ignore errors and default to 'unknown' if not found
+          var gitDir = path.resolve(__dirname, '..', '..', '.git')
+          var cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir)
+          cp.exec(cmd, function(err, stdout1) {
+            if (err) reject(err)
+            var configPath = path.join(gitDir, 'config')
+            var cmd = util.format('git config --file %s --get remote.origin.url', configPath)
+            cp.exec(cmd, function(err, stdout2) {
+              if (err) reject(err)
+              commitHash = (stdout1 && stdout1.trim()) || 'unknown'
+              sourceRepo = (stdout2 && stdout2.trim()) || 'unknown'
+              resolve()
+            })
+          })
+        } else {
+          resolve() // commitHash is already set, e.g. on staging or production
+        }
+      }) // end of promise
+    }
+
     function sendReply() {
       reply(
         {
           version: version,
           commit: commitHash,
+          dbVersion: dbVersion,
           source: sourceRepo
         }
       ).spaces(2).suffix('\n')
     }
 
-    // if we already have the commitHash, send the reply and return
-    if (commitHash) {
-      return sendReply()
-    }
-
-    // ignore errors and default to 'unknown' if not found
-    var gitDir = path.resolve(__dirname, '..', '..', '.git')
-    var cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir)
-    cp.exec(cmd, function(err, stdout1) {
-      var configPath = path.join(gitDir, 'config')
-      var cmd = util.format('git config --file %s --get remote.origin.url', configPath)
-      cp.exec(cmd, function(err, stdout2) {
-        commitHash = (stdout1 && stdout1.trim()) || 'unknown'
-        sourceRepo = (stdout2 && stdout2.trim()) || 'unknown'
-        return sendReply()
+    P.all([getDBVersion(), getCommitVersion()])
+      .then(sendReply)
+      .catch(function(err) {
+        log.error({ op: 'get versions', err: err })
+        reply(error.serviceUnavailable())
       })
-    })
   }
 
   var routes = [
@@ -73,10 +108,11 @@ module.exports = function (log, P, db, error) {
       handler: function heartbeat(request, reply) {
         log.begin('Defaults.heartbeat', request)
         db.ping()
-          .done(
+          .then(
             function () {
               reply({})
-            },
+            })
+          .catch(
             function (err) {
               log.error({ op: 'heartbeat', err: err })
               reply(error.serviceUnavailable())

--- a/test/local/base_path_tests.js
+++ b/test/local/base_path_tests.js
@@ -22,12 +22,14 @@ TestServer.start(config)
           if (err) { d.reject(err) }
           t.equal(res.statusCode, 200)
           var json = JSON.parse(body)
-          t.deepEqual(Object.keys(json), ['version', 'commit', 'source'])
+          t.deepEqual(Object.keys(json), ['version', 'commit', 'dbVersion', 'source'])
           t.equal(json.version, require('../../package.json').version, 'package version')
           t.ok(json.source && json.source !== 'unknown', 'source repository')
 
           // check that the git hash just looks like a hash
           t.ok(json.commit.match(/^[0-9a-f]{40}$/), 'The git hash actually looks like one')
+          // check the dbVersion looks like a semver
+          t.ok(json.dbVersion.match(/^([0-9]+\.|[0-9]+$){3}/), 'The dbVer exists and looks like a semver')
           d.resolve(json)
         }
       )

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -21,12 +21,15 @@ TestServer.start(config)
         t.ok(!err, 'No error fetching ' + route)
 
         var json = JSON.parse(body)
-        t.deepEqual(Object.keys(json), ['version', 'commit', 'source'])
+        t.deepEqual(Object.keys(json), ['version', 'commit', 'dbVersion', 'source'])
         t.equal(json.version, require('../../package.json').version, 'package version')
         t.ok(json.source && json.source !== 'unknown', 'source repository')
 
         // check that the git hash just looks like a hash
         t.ok(json.commit.match(/^[0-9a-f]{40}$/), 'The git hash actually looks like one')
+
+        // check the dbVersion looks like a semver
+        t.ok(json.dbVersion.match(/^([0-9]+\.|[0-9]+$){3}/), 'The dbVer exists and looks like a semver')
         t.end()
       })
     }


### PR DESCRIPTION
Reopening this after #908 went stale a while back, please check that PR for context.

When run against my local fxa-auth-server in docker I get the following:
```
curl http://127.0.0.1:9000
{
  "version": "1.47.0",
  "commit": "c29a7c3e4bd6ff5e925c9820b7033d1c99ef5424",
  "dbVersion": "0.45.0",
  "source": "git@github.com:jamonation/fxa-auth-server.git"
}
```