### PR TITLE
fix(email): disable new sync device email

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -74,12 +74,8 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendNewSyncDeviceNotification = function (email, opts) {
-        return P.resolve(mailer.newSyncDeviceEmail(
-          {
-            email: email,
-            acceptLanguage: opts.acceptLanguage || defaultLanguage
-          }
-        ))
+        // XXX: disabled for now, see github.com/mozilla/fxa-auth-mailer/issues/96
+        return P.resolve()
       }
       mailer.sendPostVerifyEmail = function (email, opts) {
         return P.resolve(mailer.postVerifyEmail(


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-mailer/issues/96