### PR TITLE
fix(server): flatten account promise chains

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -70,6 +70,7 @@ module.exports = function (
         var locale = request.app.acceptLanguage
         var userAgentString = request.headers['user-agent']
         var service = form.service || request.query.service
+        var preverified, password, account
         customs.check(
           request.app.clientAddress,
           email,
@@ -90,102 +91,104 @@ module.exports = function (
           )
           .then(isPreVerified.bind(null, form.email, form.preVerifyToken))
           .then(
-            function (preverified) {
-              var password = new Password(authPW, authSalt, config.verifierVersion)
+            function (result) {
+              preverified = result
+              password = new Password(authPW, authSalt, config.verifierVersion)
               return password.verifyHash()
-              .then(
-                function (verifyHash) {
-                  // We're seeing a surprising number of accounts created
-                  // without a proper locale.  Log details to help debug this.
-                  if (!locale) {
-                    log.info({
-                      op: 'account.create.emptyLocale',
-                      email: email,
-                      locale: locale,
-                      agent: userAgentString
-                    })
-                  }
-                  return db.createAccount(
-                    {
-                      uid: uuid.v4('binary'),
-                      createdAt: Date.now(),
-                      email: email,
-                      emailCode: crypto.randomBytes(16),
-                      emailVerified: form.preVerified || preverified,
-                      kA: crypto.randomBytes(32),
-                      wrapWrapKb: crypto.randomBytes(32),
-                      accountResetToken: null,
-                      passwordForgotToken: null,
-                      authSalt: authSalt,
-                      verifierVersion: password.version,
-                      verifyHash: verifyHash,
-                      verifierSetAt: Date.now(),
-                      locale: locale
-                    }
-                  )
-                  .then(
-                    function (account) {
-                      log.activityEvent('account.created', request, {
-                        uid: account.uid.toString('hex')
-                      })
-                      if (account.emailVerified) {
-                        log.event('verified', { email: account.email, uid: account.uid, locale: account.locale })
-                      }
-                      if (service === 'sync') {
-                        log.event('login', {
-                          service: 'sync',
-                          uid: account.uid,
-                          email: account.email,
-                          deviceCount: 1,
-                          userAgent: request.headers['user-agent']
-                        })
-                      }
-                      return db.createSessionToken(
-                        {
-                          uid: account.uid,
-                          email: account.email,
-                          emailCode: account.emailCode,
-                          emailVerified: account.emailVerified,
-                          verifierSetAt: account.verifierSetAt
-                        },
-                        userAgentString
-                      )
-                      .then(
-                        function (sessionToken) {
-                          if (request.query.keys !== 'true') {
-                            return P.resolve({
-                              account: account,
-                              sessionToken: sessionToken
-                            })
-                          }
-                          return password.unwrap(account.wrapWrapKb)
-                            .then(
-                              function (wrapKb) {
-                                return db.createKeyFetchToken(
-                                  {
-                                    uid: account.uid,
-                                    kA: account.kA,
-                                    wrapKb: wrapKb,
-                                    emailVerified: account.emailVerified
-                                  }
-                                )
-                              }
-                            )
-                            .then(
-                              function (keyFetchToken) {
-                                return {
-                                  account: account,
-                                  sessionToken: sessionToken,
-                                  keyFetchToken: keyFetchToken
-                                }
-                              }
-                            )
-                        }
-                      )
-                    }
-                  )
+            }
+          )
+          .then(
+            function (verifyHash) {
+              // We're seeing a surprising number of accounts created
+              // without a proper locale.  Log details to help debug this.
+              if (!locale) {
+                log.info({
+                  op: 'account.create.emptyLocale',
+                  email: email,
+                  locale: locale,
+                  agent: userAgentString
+                })
+              }
+              return db.createAccount(
+                {
+                  uid: uuid.v4('binary'),
+                  createdAt: Date.now(),
+                  email: email,
+                  emailCode: crypto.randomBytes(16),
+                  emailVerified: form.preVerified || preverified,
+                  kA: crypto.randomBytes(32),
+                  wrapWrapKb: crypto.randomBytes(32),
+                  accountResetToken: null,
+                  passwordForgotToken: null,
+                  authSalt: authSalt,
+                  verifierVersion: password.version,
+                  verifyHash: verifyHash,
+                  verifierSetAt: Date.now(),
+                  locale: locale
                 }
               )
+            }
+          )
+          .then(
+            function (result) {
+              account = result
+              log.activityEvent('account.created', request, {
+                uid: account.uid.toString('hex')
+              })
+              if (account.emailVerified) {
+                log.event('verified', { email: account.email, uid: account.uid, locale: account.locale })
+              }
+              if (service === 'sync') {
+                log.event('login', {
+                  service: 'sync',
+                  uid: account.uid,
+                  email: account.email,
+                  deviceCount: 1,
+                  userAgent: request.headers['user-agent']
+                })
+              }
+              return db.createSessionToken(
+                {
+                  uid: account.uid,
+                  email: account.email,
+                  emailCode: account.emailCode,
+                  emailVerified: account.emailVerified,
+                  verifierSetAt: account.verifierSetAt
+                },
+                userAgentString
+              )
+            }
+          )
+          .then(
+            function (sessionToken) {
+              if (request.query.keys !== 'true') {
+                return P.resolve({
+                  account: account,
+                  sessionToken: sessionToken
+                })
+              }
+              return password.unwrap(account.wrapWrapKb)
+                .then(
+                  function (wrapKb) {
+                    return db.createKeyFetchToken(
+                      {
+                        uid: account.uid,
+                        kA: account.kA,
+                        wrapKb: wrapKb,
+                        emailVerified: account.emailVerified
+                      }
+                    )
+                  }
+                )
+                .then(
+                  function (keyFetchToken) {
+                    return {
+                      account: account,
+                      sessionToken: sessionToken,
+                      keyFetchToken: keyFetchToken
+                    }
+                  }
+                )
             }
           )
           .then(
@@ -252,13 +255,15 @@ module.exports = function (
         var email = form.email
         var authPW = Buffer(form.authPW, 'hex')
         var service = request.payload.service || request.query.service
+        var emailRecord
         customs.check(
           request.app.clientAddress,
           email,
           'accountLogin')
           .then(db.emailRecord.bind(db, email))
           .then(
-            function (emailRecord) {
+            function (result) {
+              emailRecord = result
               if(email !== emailRecord.email) {
                 throw error.incorrectPassword(emailRecord.email, email)
               }
@@ -266,80 +271,80 @@ module.exports = function (
                 throw error.lockedAccount()
               }
               return checkPassword(emailRecord, authPW, request.app.clientAddress)
+            }
+          )
+          .then(
+            function (match) {
+              if (!match) {
+                throw error.incorrectPassword(emailRecord.email, email)
+              }
+              var uid = emailRecord.uid.toString('hex')
+              log.activityEvent('account.login', request, {
+                uid: uid
+              })
+              return db.createSessionToken(
+                {
+                  uid: emailRecord.uid,
+                  email: emailRecord.email,
+                  emailCode: emailRecord.emailCode,
+                  emailVerified: emailRecord.emailVerified,
+                  verifierSetAt: emailRecord.verifierSetAt
+                },
+                request.headers['user-agent']
+              )
+            }
+          )
+          .then(
+            function (sessionToken) {
+              if (request.query.keys !== 'true') {
+                return P.resolve({
+                  sessionToken: sessionToken
+                })
+              }
+              var password = new Password(
+                authPW,
+                emailRecord.authSalt,
+                emailRecord.verifierVersion
+              )
+              return password.unwrap(emailRecord.wrapWrapKb)
                 .then(
-                  function (match) {
-                    if (!match) {
-                      throw error.incorrectPassword(emailRecord.email, email)
-                    }
-                    var uid = emailRecord.uid.toString('hex')
-                    log.activityEvent('account.login', request, {
-                      uid: uid
-                    })
-                    return db.createSessionToken(
+                  function (wrapKb) {
+                    return db.createKeyFetchToken(
                       {
                         uid: emailRecord.uid,
-                        email: emailRecord.email,
-                        emailCode: emailRecord.emailCode,
-                        emailVerified: emailRecord.emailVerified,
-                        verifierSetAt: emailRecord.verifierSetAt
-                      },
-                      request.headers['user-agent']
+                        kA: emailRecord.kA,
+                        wrapKb: wrapKb,
+                        emailVerified: emailRecord.emailVerified
+                      }
                     )
                   }
                 )
                 .then(
-                  function (sessionToken) {
-                    if (request.query.keys !== 'true') {
-                      return P.resolve({
-                        sessionToken: sessionToken
-                      })
+                  function (keyFetchToken) {
+                    return {
+                      sessionToken: sessionToken,
+                      keyFetchToken: keyFetchToken
                     }
-                    var password = new Password(
-                      authPW,
-                      emailRecord.authSalt,
-                      emailRecord.verifierVersion
-                    )
-                    return password.unwrap(emailRecord.wrapWrapKb)
-                    .then(
-                      function (wrapKb) {
-                        return db.createKeyFetchToken(
-                          {
-                            uid: emailRecord.uid,
-                            kA: emailRecord.kA,
-                            wrapKb: wrapKb,
-                            emailVerified: emailRecord.emailVerified
-                          }
-                        )
-                      }
-                    )
-                    .then(
-                      function (keyFetchToken) {
-                        return {
-                          sessionToken: sessionToken,
-                          keyFetchToken: keyFetchToken
-                        }
-                      }
-                    )
                   }
-              )
-              .then(
-                function (tokens) {
-                  if (service === 'sync' && request.payload.reason === 'signin') {
-                    db.sessions(emailRecord.uid)
-                      .then(function (sessions) {
-                        log.event('login', {
-                          service: 'sync',
-                          uid: emailRecord.uid,
-                          email: emailRecord.email,
-                          deviceCount: sessions.length,
-                          userAgent: request.headers['user-agent']
-                        })
-                      })
-                  }
+                )
+            }
+          )
+          .then(
+            function (tokens) {
+              if (service === 'sync' && request.payload.reason === 'signin') {
+                db.sessions(emailRecord.uid)
+                  .then(function (sessions) {
+                    log.event('login', {
+                      service: 'sync',
+                      uid: emailRecord.uid,
+                      email: emailRecord.email,
+                      deviceCount: sessions.length,
+                      userAgent: request.headers['user-agent']
+                    })
+                  })
+              }
 
-                  return tokens
-                }
-              )
+              return tokens
             }
           )
           .done(


### PR DESCRIPTION
Not sure how you guys will feel about this but the `account` promise chains were annoying me while working on the device API stuff, which was otherwise introducing yet another level of indentation. I've pulled it out as a separate PR so that you can reject it separately if it offends you.

I recommend reviewing with `?w=1` for a saner diff.

The tests all pass although CI is failing because of a problem with `grunt validate-shrinkwrap`:

```
$ grunt validate-shrinkwrap --force

Running "validate-shrinkwrap" task

/home/travis/build/mozilla/fxa-auth-server/npm-shrinkwrap.json

Fatal error: Cannot read property 'patched_versions' of undefined

The command "grunt validate-shrinkwrap --force" exited with 3.
```

@dannycoates or @rfk, r?