### PR TITLE
feat(server): implement device registration api

### DIFF
--- a/docs/endpoint_data.md
+++ b/docs/endpoint_data.md
@@ -428,3 +428,41 @@
 	* PasswordForgotTokens
 	* AccountResetTokens
 	* Accounts
+
+## /account/device
+
+* input
+  * id
+  * name
+  * type
+  * pushCallback
+  * pushPublicKey
+* output
+  * id
+  * createdAt
+  * name
+  * type
+  * pushCallback
+  * pushPublicKey
+* db-write
+  * Devices
+
+## /account/devices
+
+* output
+  * array of objects
+    * id
+    * sessionToken
+    * name
+    * type
+    * pushCallback
+    * pushPublicKey
+
+## /account/device
+
+* input
+  * id
+* db-write
+  * Devices
+  * SessionTokens
+

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -84,3 +84,15 @@
 * authTokens
 * accountResetToken
 * passwordForgotToken
+
+## Devices
+
+* uid
+* id
+* sessionTokenId
+* createdAt
+* name
+* type
+* pushCallback
+* pushPublicKey
+

--- a/lib/error.js
+++ b/lib/error.js
@@ -369,4 +369,26 @@ AppError.accountNotLocked = function (email) {
   )
 }
 
+AppError.unknownDevice = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: 123,
+      message: 'Unknown device'
+    }
+  )
+}
+
+AppError.deviceSessionConflict = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: 124,
+      message: 'Session already registered by another device'
+    }
+  )
+}
+
 module.exports = AppError

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -364,8 +364,8 @@
     },
     "fxa-auth-db-mysql": {
       "version": "0.48.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#2130d4668a3e3586b8f4e5212beba1072217a369",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#2130d4668a3e3586b8f4e5212beba1072217a369",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0b51afe1af7e969e5a515b9e81cb6067a0bf36aa",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0b51afe1af7e969e5a515b9e81cb6067a0bf36aa",
       "dependencies": {
         "clone": {
           "version": "1.0.2",

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -112,7 +112,8 @@ ClientApi.prototype.accountCreate = function (email, authPW, options) {
       service: options.service || undefined,
       redirectTo: options.redirectTo || undefined,
       resume: options.resume || undefined,
-      preVerifyToken: options.preVerifyToken || undefined
+      preVerifyToken: options.preVerifyToken || undefined,
+      device: options.device || undefined
     },
     {
       'accept-language': options.lang
@@ -132,7 +133,8 @@ ClientApi.prototype.accountLogin = function (email, authPW, opts) {
       email: email,
       authPW: authPW.toString('hex'),
       service: opts.service || undefined,
-      reason: opts.reason || undefined
+      reason: opts.reason || undefined,
+      device: opts.device || undefined
     },
     {
       'accept-language': opts.lang
@@ -148,6 +150,49 @@ ClientApi.prototype.accountKeys = function (keyFetchTokenHex) {
           'GET',
           this.baseURL + '/account/keys',
           token
+        )
+      }.bind(this)
+    )
+}
+
+ClientApi.prototype.accountDevices = function (sessionTokenHex) {
+  return tokens.SessionToken.fromHex(sessionTokenHex)
+    .then(
+      function (token) {
+        return this.doRequest(
+          'GET',
+          this.baseURL + '/account/devices',
+          token
+        )
+      }.bind(this)
+    )
+}
+
+ClientApi.prototype.accountDevice = function (sessionTokenHex, info) {
+  return tokens.SessionToken.fromHex(sessionTokenHex)
+    .then(
+      function (token) {
+        return this.doRequest(
+          'POST',
+          this.baseURL + '/account/device',
+          token,
+          info
+        )
+      }.bind(this)
+    )
+}
+
+ClientApi.prototype.deviceDestroy = function (sessionTokenHex, id) {
+  return tokens.SessionToken.fromHex(sessionTokenHex)
+    .then(
+      function (token) {
+        return this.doRequest(
+          'POST',
+          this.baseURL + '/account/device/destroy',
+          token,
+          {
+            id: id
+          }
         )
       }.bind(this)
     )

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -125,6 +125,7 @@ Client.prototype.create = function () {
       this.authAt = a.authAt
       this.sessionToken = a.sessionToken
       this.keyFetchToken = a.keyFetchToken
+      this.device = a.device
       return this
     }.bind(this)
   )
@@ -154,6 +155,7 @@ Client.prototype.auth = function (opts) {
         this.keyFetchToken = data.keyFetchToken || null
         this.emailVerified = data.verified
         this.authAt = data.authAt
+        this.device = data.device
         return this
       }.bind(this)
     )
@@ -270,6 +272,46 @@ Client.prototype.keys = function () {
         throw err
       }.bind(this)
     )
+}
+
+Client.prototype.devices = function () {
+  var o = this.sessionToken ? P.resolve(null) : this.login()
+  return o.then(
+    function () {
+      return this.api.accountDevices(this.sessionToken)
+    }.bind(this)
+  )
+}
+
+Client.prototype.updateDevice = function (info) {
+  var o = this.sessionToken ? P.resolve(null) : this.login()
+  return o.then(
+    function () {
+      return this.api.accountDevice(this.sessionToken, info)
+    }.bind(this)
+  )
+  .then(
+    function (device) {
+      if (! this.device || this.device.id === device.id) {
+        this.device = device
+      }
+      return device
+    }.bind(this)
+  )
+}
+
+Client.prototype.destroyDevice = function (id) {
+  var o = this.sessionToken ? P.resolve(null) : this.login()
+  return o.then(
+    function () {
+      return this.api.deviceDestroy(this.sessionToken, id)
+    }.bind(this)
+  )
+  .then(
+    function () {
+      delete this.sessionToken
+    }.bind(this)
+  )
 }
 
 Client.prototype.sessionStatus = function () {

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var Client = require('../client')
+var config = require('../../config').getProperties()
+var crypto = require('crypto')
+
+TestServer.start(config)
+.then(function main(server) {
+  test(
+    'device registration during account creation',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      var deviceInfo = {
+        name: 'test device',
+        type: 'desktop',
+        pushCallback: 'https://foo/bar',
+        pushPublicKey: crypto.randomBytes(32).toString('hex')
+      }
+      return Client.create(config.publicUrl, email, password, { device: deviceInfo })
+      .then(
+        function (client) {
+          t.ok(client.authAt, 'authAt was set')
+          t.ok(client.device.id, 'device.id was set')
+          t.ok(client.device.createdAt > 0, 'device.createdAt was set')
+          t.equal(client.device.name, deviceInfo.name, 'device.name is correct')
+          t.equal(client.device.type, deviceInfo.type, 'device.type is correct')
+          t.equal(client.device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
+          t.deepEqual(client.device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
+          return client.devices()
+            .then(
+              function (devices) {
+                t.equal(devices.length, 1, 'devices returned one item')
+                t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
+                t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
+                t.deepEqual(devices[0].pushPublicKey, deviceInfo.pushPublicKey, 'devices returned correct pushPublicKey')
+                return client.updateDevice({
+                  id: client.device.id,
+                  name: 'new name'
+                })
+              }
+            )
+            .then(
+              function () {
+                return client.devices()
+              }
+            )
+            .then(
+              function (devices) {
+                t.equal(devices.length, 1, 'devices returned one item')
+                t.equal(devices[0].name, 'new name', 'devices returned correct name')
+                t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
+                t.deepEqual(devices[0].pushPublicKey, deviceInfo.pushPublicKey, 'devices returned correct pushPublicKey')
+                return client.destroyDevice(devices[0].id)
+              }
+            )
+            .then(
+              function () {
+                return client.devices()
+              }
+            )
+            .then(
+              function (devices) {
+                t.equal(devices.length, 0, 'devices returned no items')
+              }
+            )
+        }
+      )
+    }
+  )
+
+  test(
+    'device registration during account login',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      var deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        pushCallback: '',
+        pushPublicKey: ''
+      }
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+        .then(
+          function () {
+            return Client.login(config.publicUrl, email, password, { device: deviceInfo })
+          }
+        )
+        .then(
+          function (client) {
+            t.ok(client.device.id, 'device.id was set')
+            t.ok(client.device.createdAt > 0, 'device.createdAt was set')
+            t.equal(client.device.name, deviceInfo.name, 'device.name is correct')
+            t.equal(client.device.type, deviceInfo.type, 'device.type is correct')
+            t.equal(client.device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
+            t.deepEqual(client.device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
+            return client.devices()
+              .then(
+                function (devices) {
+                  t.equal(devices.length, 1, 'devices returned one item')
+                  t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
+                  t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                  t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
+                  t.deepEqual(devices[0].pushPublicKey, '0000000000000000000000000000000000000000000000000000000000000000', 'devices returned correct pushPublicKey')
+                  return client.destroyDevice(devices[0].id)
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    'device registration after account creation',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            var deviceInfo = {
+              name: 'test device',
+              type: 'mobile',
+              pushCallback: '',
+              pushPublicKey: ''
+            }
+            return client.devices()
+              .then(
+                function (devices) {
+                  t.equal(devices.length, 0, 'devices returned no items')
+                  return client.updateDevice(deviceInfo)
+                }
+              )
+              .then(
+                function (device) {
+                  t.ok(device.id, 'device.id was set')
+                  t.ok(device.createdAt > 0, 'device.createdAt was set')
+                  t.equal(device.name, deviceInfo.name, 'device.name is correct')
+                  t.equal(device.type, deviceInfo.type, 'device.type is correct')
+                  t.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
+                  t.deepEqual(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
+                }
+              )
+              .then(
+                function () {
+                  return client.devices()
+                }
+              )
+              .then(
+                function (devices) {
+                  t.equal(devices.length, 1, 'devices returned one item')
+                  t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
+                  t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                  t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
+                  t.deepEqual(devices[0].pushPublicKey, '0000000000000000000000000000000000000000000000000000000000000000', 'devices returned correct pushPublicKey')
+                  return client.destroyDevice(devices[0].id)
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    'teardown',
+    function (t) {
+      server.stop()
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
This change is entirely predicated on the acceptance (or otherwise) of https://github.com/mozilla/fxa-auth-db-mysql/pull/116, hence the `WIP` label. However, because I'm keen to try and get this into train 50 if at all possible, I'm opening the PR now in the hope of getting the review process underway ASAP.

Just to be ultra-clear, **these changes can't be merged until after https://github.com/mozilla/fxa-auth-db-mysql/pull/116 is merged**.

For detailed requirements concerning this API, see [the feature readme](https://github.com/mozilla/fxa/blob/master/features/FxA-45-device-registration-api/README.md).

@rfk and/or @dannycoates, if either of you have time it would be awesome to get some feedback on this. Also, @shane-tomlinson, you may or may not be interested depending on other, far more important matters. :)

* Fixes #1094
* Fixes #1095
* Fixes #1096
* Fixes #1097
* Fixes #1098
* Fixes #1099
* Fixes #1100
* Fixes #1101

