### PR TITLE
fix(oauth): look for the correct 'scope' param in oauth response, not 'scopes'

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -584,7 +584,7 @@ module.exports = function (
           if (auth.strategy === 'sessionToken') {
             return true
           }
-          var scopes = auth.credentials.scopes
+          var scopes = auth.credentials.scope
           for (var i = 0; i < scopes.length; i++) {
             if (scopes[i] === 'profile') {
               return true

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -45,7 +45,7 @@ TestServer.start(config)
             return c.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: c.uid,
-                scopes: ['profile']
+                scope: ['profile']
               })
             })
           }
@@ -96,7 +96,7 @@ TestServer.start(config)
             return c.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: UNKNOWN_UID,
-                scopes: ['profile']
+                scope: ['profile']
               })
             })
           }
@@ -122,7 +122,7 @@ TestServer.start(config)
             return c.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: c.uid,
-                scopes: ['readinglist', 'payments']
+                scope: ['readinglist', 'payments']
               })
             })
           }
@@ -146,7 +146,7 @@ TestServer.start(config)
             return client.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: client.uid,
-                scopes: ['profile:email']
+                scope: ['profile:email']
               })
             })
           }
@@ -162,7 +162,7 @@ TestServer.start(config)
             return client.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: client.uid,
-                scopes: ['profile:locale']
+                scope: ['profile:locale']
               })
             })
           }
@@ -187,7 +187,7 @@ TestServer.start(config)
             return client.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: client.uid,
-                scopes: ['profile:write']
+                scope: ['profile:write']
               })
             })
           }
@@ -203,7 +203,7 @@ TestServer.start(config)
             return client.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: client.uid,
-                scopes: ['profile:locale:write', 'readinglist']
+                scope: ['profile:locale:write', 'readinglist']
               })
             })
           }
@@ -219,7 +219,7 @@ TestServer.start(config)
             return client.api.accountProfile(null, {
               Authorization: makeMockOAuthHeader({
                 user: client.uid,
-                scopes: ['storage', 'profile:email:write']
+                scope: ['storage', 'profile:email:write']
               })
             })
           }


### PR DESCRIPTION
Part of the fix for the backout in https://github.com/mozilla/fxa-profile-server/pull/171.  @seanmonstar r?