### PR TITLE
fix(server): eliminate device validation discrepancies

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -59,7 +59,7 @@ module.exports = function (
             resume: isA.string().max(2048).optional(),
             preVerifyToken: isA.string().max(2048).regex(BASE64_JWT).optional(),
             device: isA.object({
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).optional().allow(''),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -76,7 +76,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().required(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).optional().allow(''),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -287,7 +287,7 @@ module.exports = function (
             reason: isA.string().max(16).optional(),
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).optional(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).optional().allow(''),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -305,7 +305,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().optional(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).optional().allow(''),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -723,7 +723,7 @@ module.exports = function (
         validate: {
           payload: isA.object({
             id: isA.string().length(32).regex(HEX_STRING).optional(),
-            name: isA.string().max(255).optional(),
+            name: isA.string().max(255).optional().allow(''),
             type: isA.string().max(16).optional(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
             pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -733,7 +733,7 @@ module.exports = function (
           schema: {
             id: isA.string().length(32).regex(HEX_STRING).required(),
             createdAt: isA.number().positive().optional(),
-            name: isA.string().max(255).optional(),
+            name: isA.string().max(255).optional().allow(''),
             type: isA.string().max(16).optional(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
             pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -764,10 +764,10 @@ module.exports = function (
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
             sessionToken: isA.string().length(64).regex(HEX_STRING).required(),
-            name: isA.string().max(255).required().allow(''),
+            name: isA.string().max(255).optional().allow(''),
             type: isA.string().max(16).required(),
-            pushCallback: isA.string().uri({ scheme: 'https' }).max(255).required().allow(''),
-            pushPublicKey: isA.string().length(64).regex(HEX_STRING).required()
+            pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
+            pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional()
           }))
         }
       },

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -125,7 +125,7 @@ TestServer.start(config)
         .then(
           function (client) {
             var deviceInfo = {
-              name: 'test device',
+              name: '',
               type: 'mobile',
               pushCallback: '',
               pushPublicKey: ''
@@ -155,10 +155,58 @@ TestServer.start(config)
               .then(
                 function (devices) {
                   t.equal(devices.length, 1, 'devices returned one item')
-                  t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
+                  t.equal(devices[0].name, '', 'devices returned empty name')
                   t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
-                  t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
+                  t.equal(devices[0].pushCallback, '', 'devices returned empty pushCallback')
                   t.deepEqual(devices[0].pushPublicKey, '0000000000000000000000000000000000000000000000000000000000000000', 'devices returned correct pushPublicKey')
+                  return client.destroyDevice(devices[0].id)
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    'device registration without optional parameters',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            var deviceInfo = {
+              type: 'mobile'
+            }
+            return client.devices()
+              .then(
+                function (devices) {
+                  t.equal(devices.length, 0, 'devices returned no items')
+                  return client.updateDevice(deviceInfo)
+                }
+              )
+              .then(
+                function (device) {
+                  t.ok(device.id, 'device.id was set')
+                  t.ok(device.createdAt > 0, 'device.createdAt was set')
+                  t.equal(device.name, undefined, 'device.name is undefined')
+                  t.equal(device.type, deviceInfo.type, 'device.type is correct')
+                  t.equal(device.pushCallback, undefined, 'device.pushCallback is undefined')
+                  t.deepEqual(device.pushPublicKey, undefined, 'device.pushPublicKey is undefined')
+                }
+              )
+              .then(
+                function () {
+                  return client.devices()
+                }
+              )
+              .then(
+                function (devices) {
+                  t.equal(devices.length, 1, 'devices returned one item')
+                  t.equal(devices[0].name, undefined, 'devices returned undefined name')
+                  t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                  t.equal(devices[0].pushCallback, undefined, 'devices returned undefined pushCallback')
+                  t.deepEqual(devices[0].pushPublicKey, undefined, 'devices returned undefined pushPublicKey')
                   return client.destroyDevice(devices[0].id)
                 }
               )


### PR DESCRIPTION
There were a couple gaps in the device registration tests that allowed inconsistent validation to fail `GET /account/devices` requests, if fields were unset or had been set to the empty string.

This PR adds the appropriate tests and harmonises the validation rules across all endpoints so that the tests succeed.

Apologies for this slipping through in the original device registration PR, I'm annoyed with myself about it. I had a bit of a blind spot because the schemata started out stricter than they are now, so the new tests only became necessary later on.
