### PR TITLE
fix(server): return isCurrentDevice from /account/devices

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1281,7 +1281,7 @@ with an array of device details in the JSON body:
 [
   {
     "id": "0f7aa00356e5416e82b3bef7bc409eef",
-    "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d",
+    "isCurrentDevice": true,
     "name": "My Phone",
     "type": "mobile",
     "pushCallback": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
@@ -1289,7 +1289,7 @@ with an array of device details in the JSON body:
   },
   {
     "id": "0f7aa00356e5416e82b3bef7bc409eef",
-    "sessionToken": null,
+    "isCurrentDevice": false,
     "name": "My Desktop",
     "type": null,
     "pushCallback": "https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75",

--- a/docs/endpoint_data.md
+++ b/docs/endpoint_data.md
@@ -452,7 +452,7 @@
 * output
   * array of objects
     * id
-    * sessionToken
+    * isCurrentDevice
     * name
     * type
     * pushCallback

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -763,7 +763,7 @@ module.exports = function (
         response: {
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
-            sessionToken: isA.string().length(64).regex(HEX_STRING).required(),
+            isCurrentDevice: isA.boolean().required(),
             name: isA.string().max(255).optional().allow(''),
             type: isA.string().max(16).required(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
@@ -777,7 +777,12 @@ module.exports = function (
         var uid = sessionToken.uid
         db.devices(uid).then(
           function (devices) {
-            reply(devices.map(butil.unbuffer))
+            reply(devices.map(function (device) {
+              device.isCurrentDevice =
+                device.sessionToken.toString('hex') === sessionToken.tokenId.toString('hex')
+              delete device.sessionToken
+              return butil.unbuffer(device)
+            }))
           },
           reply
         )


### PR DESCRIPTION
Fixes #1119.

Previously, `/account/devices` was returning a session token id, something of a chocolate teapot for clients. This change replaces that with a boolean for each device, indicating whether it is the owner of the current session.

The clients need updating after this is merged.