### PR TITLE
fix(server): permit null values in devices response

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -764,10 +764,10 @@ module.exports = function (
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
             isCurrentDevice: isA.boolean().required(),
-            name: isA.string().max(255).optional().allow(''),
+            name: isA.string().max(255).optional().allow('').allow(null),
             type: isA.string().max(16).required(),
-            pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-            pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional()
+            pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow('').allow(null),
+            pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow(null)
           }))
         }
       },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -364,8 +364,8 @@
     },
     "fxa-auth-db-mysql": {
       "version": "0.48.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0b51afe1af7e969e5a515b9e81cb6067a0bf36aa",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0b51afe1af7e969e5a515b9e81cb6067a0bf36aa",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#c526bd4d815f61817a3416aeba3dbf314d9bbece",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#c526bd4d815f61817a3416aeba3dbf314d9bbece",
       "dependencies": {
         "clone": {
           "version": "1.0.2",

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -205,10 +205,10 @@ TestServer.start(config)
               .then(
                 function (devices) {
                   t.equal(devices.length, 1, 'devices returned one item')
-                  t.equal(devices[0].name, undefined, 'devices returned undefined name')
+                  t.equal(devices[0].name, null, 'devices returned undefined name')
                   t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
-                  t.equal(devices[0].pushCallback, undefined, 'devices returned undefined pushCallback')
-                  t.deepEqual(devices[0].pushPublicKey, undefined, 'devices returned undefined pushPublicKey')
+                  t.equal(devices[0].pushCallback, null, 'devices returned undefined pushCallback')
+                  t.deepEqual(devices[0].pushPublicKey, null, 'devices returned undefined pushPublicKey')
                   return client.destroyDevice(devices[0].id)
                 }
               )
@@ -258,6 +258,15 @@ TestServer.start(config)
               .then(
                 function (devices) {
                   t.equal(devices.length, 2, 'devices returned two items')
+                  if (devices[0].name === deviceInfo[1].name) {
+                    // database results are unordered, swap them if necessary
+                    var swap = {}
+                    Object.keys(devices[0]).forEach(function (key) {
+                      swap[key] = devices[0][key]
+                      devices[0][key] = devices[1][key]
+                      devices[1][key] = swap[key]
+                    })
+                  }
                   t.equal(devices[0].isCurrentDevice, false, 'devices returned false isCurrentDevice for first item')
                   t.equal(devices[0].name, deviceInfo[0].name, 'devices returned correct name for first item')
                   t.equal(devices[0].type, deviceInfo[0].type, 'devices returned correct type for first item')


### PR DESCRIPTION
Fixes #1123 but depends on changes in https://github.com/mozilla/fxa-auth-db-mysql/pull/117 so **do not merge until after that PR has been accepted**.

This issue was caused by my misunderstanding of Joi's `optional()`, which doesn't permit `null` values. It was exacerbated by yet another gaping hole in my test coverage, this time in `fxa-auth-db-mysql`, which meant the memory backend and the MySQL backend were behaving differently with regards to the initialisation of missing fields in the `devices` table.

And then I stupidly to forgot to test device registration against the MySQL backend, so the aforementioned discrepancy masked this bug until @jrgm found it when he deployed train 50. Apologies @jrgm (and everybody else).

I've updated `npm-shrinkwrap.json` here for the purposes of making travis pass, but it will need to be updated properly when the db change is in `master`.