### PR TITLE
Fix travis-ci to actually run fxa-auth-db-mysql when $DB = 'mysql'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,10 @@ notifications:
     skip_join: false
 
 before_install:
+  - npm install -g npm@2
   - npm config set spin false
 
 script:
-  - if [ $DB == "mysql" ]; then echo '~*~ Starting auth-db-mysql'; (./scripts/start-local-test-mysql.sh &>/dev/null &); fi
+  - if [ $DB == "mysql" ]; then ./scripts/start-travis-auth-db-mysql.sh; fi
   - npm test
   - grunt nsp --force

--- a/scripts/start-local-test-mysql.sh
+++ b/scripts/start-local-test-mysql.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-node ./scripts/gen_keys.js
-
-ls ./node_modules/fxa-auth-db-mysql/node_modules/mysql-patcher || npm i ./node_modules/fxa-auth-db-mysql
-node ./node_modules/fxa-auth-db-mysql/bin/db_patcher.js
-node ./node_modules/fxa-auth-db-mysql/bin/server.js

--- a/scripts/start-travis-auth-db-mysql.sh
+++ b/scripts/start-travis-auth-db-mysql.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ev
+
+node ./scripts/gen_keys.js
+
+# Force install of mysql-patcher
+(cd node_modules/fxa-auth-db-mysql && npm install &>/var/tmp/db-mysql.out)
+
+mysql -e 'DROP DATABASE IF EXISTS fxa'
+node ./node_modules/fxa-auth-db-mysql/bin/db_patcher.js
+
+# Start backgrounded fxa-auth-db-mysql server
+nohup node ./node_modules/fxa-auth-db-mysql/bin/server.js &>>/var/tmp/db-mysql.out &
+
+# Give auth-db-mysql a moment to start up
+sleep 5
+
+# This curl will cause a test fail if no connection
+# TODO: in the future, check that response contains "implementation: 'MySql'"
+curl http://127.0.0.1:8000/; echo

--- a/test/local/verifier_upgrade_tests.js
+++ b/test/local/verifier_upgrade_tests.js
@@ -25,6 +25,7 @@ var DB = require('../../lib/db')(
 createDBServer().then(
   function (db_server) {
     db_server.listen(config.httpdb.url.split(':')[2])
+    db_server.on('error', function () {})
 
     var email = Math.random() + '@example.com'
     var password = 'ok'


### PR DESCRIPTION
Fixes #1125 

The backgrounded fxa-auth-db-mysql server was failing to start because the install was failing to install db-patcher (npm install quirk). This changes the npm install to run *in* the directory, which installs all the devDependencies including mysql-patcher. 

Also, there was an inherent race condition in the previous script. (It would try to complete the npm install/database update and be up and running before the actual tests would start). There is now a pause  and a check that the server started before continuing with the actual tests. (The check will be updated in a later PR to check that the implementation says 'MySql').

Also, updates to use npm@2.