### PR TITLE
fix(travis-ci): check that auth-db-mysql reports "MySql" as constructor class name

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -363,9 +363,9 @@
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
     },
     "fxa-auth-db-mysql": {
-      "version": "0.48.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#c526bd4d815f61817a3416aeba3dbf314d9bbece",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#c526bd4d815f61817a3416aeba3dbf314d9bbece",
+      "version": "0.50.0",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#939f04e1ab22a924ec328293bc62ea8e19caedb3",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#939f04e1ab22a924ec328293bc62ea8e19caedb3",
       "dependencies": {
         "clone": {
           "version": "1.0.2",

--- a/scripts/start-travis-auth-db-mysql.sh
+++ b/scripts/start-travis-auth-db-mysql.sh
@@ -16,6 +16,7 @@ nohup node ./node_modules/fxa-auth-db-mysql/bin/server.js &>>/var/tmp/db-mysql.o
 # Give auth-db-mysql a moment to start up
 sleep 5
 
-# This curl will cause a test fail if no connection
-# TODO: in the future, check that response contains "implementation: 'MySql'"
-curl http://127.0.0.1:8000/; echo
+# If either the curl fails to get a response, or the grep fails to match, this
+# script will exit non-zero and fail the test run.
+authdb_version=$(curl -s http://127.0.0.1:8000/__version__)
+echo $authdb_version | grep '"implementation":"MySql"'


### PR DESCRIPTION
Make the travis-ci check a bit more definite by checking that `"implementation":"MySql"` is in the `/__version__` response. 

(Note: while failing this check will cause the overall travis-ci check to fail, travis-ci will continue on to run `npm test`. It doesn't abort on the first failure. Just the way travis-ci works).