### PR TITLE
fix(server): require device name to be set explicitly

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1190,6 +1190,12 @@ Either registers a new device for this user/session
 or updates existing device details for this user/session
 (if a device `id` is specified).
 
+If no device `id` is specified,
+both `name` and `type` must be provided.
+If a device `id` is specified,
+at least one of `name`, `type`, `pushCallback` and `pushPublicKey`
+must be present.
+
 ### Request
 
 ___Headers___

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -59,7 +59,7 @@ module.exports = function (
             resume: isA.string().max(2048).optional(),
             preVerifyToken: isA.string().max(2048).regex(BASE64_JWT).optional(),
             device: isA.object({
-              name: isA.string().max(255).optional().allow(''),
+              name: isA.string().max(255).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -76,7 +76,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().required(),
-              name: isA.string().max(255).optional().allow(''),
+              name: isA.string().max(255).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -287,7 +287,7 @@ module.exports = function (
             reason: isA.string().max(16).optional(),
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).optional(),
-              name: isA.string().max(255).optional().allow(''),
+              name: isA.string().max(255).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -305,7 +305,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().optional(),
-              name: isA.string().max(255).optional().allow(''),
+              name: isA.string().max(255).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -721,19 +721,27 @@ module.exports = function (
           strategy: 'sessionToken'
         },
         validate: {
-          payload: isA.object({
-            id: isA.string().length(32).regex(HEX_STRING).optional(),
-            name: isA.string().max(255).optional().allow(''),
-            type: isA.string().max(16).optional(),
-            pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-            pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
-          })
+          payload: isA.alternatives().try(
+            isA.object({
+              id: isA.string().length(32).regex(HEX_STRING).required(),
+              name: isA.string().max(255).optional(),
+              type: isA.string().max(16).optional(),
+              pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+            }).or('name', 'type', 'pushCallback', 'pushPublicKey'),
+            isA.object({
+              name: isA.string().max(255).required(),
+              type: isA.string().max(16).required(),
+              pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+            })
+          )
         },
         response: {
           schema: {
             id: isA.string().length(32).regex(HEX_STRING).required(),
             createdAt: isA.number().positive().optional(),
-            name: isA.string().max(255).optional().allow(''),
+            name: isA.string().max(255).optional(),
             type: isA.string().max(16).optional(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
             pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -764,7 +772,7 @@ module.exports = function (
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
             isCurrentDevice: isA.boolean().required(),
-            name: isA.string().max(255).optional().allow('').allow(null),
+            name: isA.string().max(255).required(),
             type: isA.string().max(16).required(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow('').allow(null),
             pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow(null)

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -83,7 +83,7 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'test password'
       var deviceInfo = {
-        name: 'test device',
+        name: 'a different device name',
         type: 'mobile',
         pushCallback: '',
         pushPublicKey: ''
@@ -127,7 +127,7 @@ TestServer.start(config)
         .then(
           function (client) {
             var deviceInfo = {
-              name: '',
+              name: 'test device',
               type: 'mobile',
               pushCallback: '',
               pushPublicKey: ''
@@ -157,7 +157,7 @@ TestServer.start(config)
               .then(
                 function (devices) {
                   t.equal(devices.length, 1, 'devices returned one item')
-                  t.equal(devices[0].name, '', 'devices returned empty name')
+                  t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
                   t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
                   t.equal(devices[0].pushCallback, '', 'devices returned empty pushCallback')
                   t.deepEqual(devices[0].pushPublicKey, '0000000000000000000000000000000000000000000000000000000000000000', 'devices returned correct pushPublicKey')
@@ -178,6 +178,7 @@ TestServer.start(config)
         .then(
           function (client) {
             var deviceInfo = {
+              name: 'test device',
               type: 'mobile'
             }
             return client.devices()
@@ -191,7 +192,7 @@ TestServer.start(config)
                 function (device) {
                   t.ok(device.id, 'device.id was set')
                   t.ok(device.createdAt > 0, 'device.createdAt was set')
-                  t.equal(device.name, undefined, 'device.name is undefined')
+                  t.equal(device.name, deviceInfo.name, 'device.name is correct')
                   t.equal(device.type, deviceInfo.type, 'device.type is correct')
                   t.equal(device.pushCallback, undefined, 'device.pushCallback is undefined')
                   t.deepEqual(device.pushPublicKey, undefined, 'device.pushPublicKey is undefined')
@@ -205,11 +206,62 @@ TestServer.start(config)
               .then(
                 function (devices) {
                   t.equal(devices.length, 1, 'devices returned one item')
-                  t.equal(devices[0].name, null, 'devices returned undefined name')
+                  t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
                   t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
                   t.equal(devices[0].pushCallback, null, 'devices returned undefined pushCallback')
                   t.deepEqual(devices[0].pushPublicKey, null, 'devices returned undefined pushPublicKey')
                   return client.destroyDevice(devices[0].id)
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    'device registration without required name parameter',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            return client.updateDevice({ type: 'mobile' })
+              .then(
+                function (r) {
+                  console.error('!!!!! PHIL !!!!! ' + Object.keys(r))
+                  t.fail('request should have failed')
+                }
+              )
+              .catch(
+                function (err) {
+                  t.equal(err.code, 400, 'err.code was 400')
+                  t.equal(err.errno, 108, 'err.errno was 108')
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
+    'device registration without required type parameter',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            return client.updateDevice({ name: 'test device' })
+              .then(
+                function () {
+                  t.fail('request should have failed')
+                }
+              )
+              .catch(
+                function (err) {
+                  t.equal(err.code, 400, 'err.code was 400')
+                  t.equal(err.errno, 108, 'err.errno was 108')
                 }
               )
           }


### PR DESCRIPTION
Fixes #1118, enforcing the presence of the `name` parameter in device information.

@rfk or @dannycoates: r?