### PR TITLE
fix(server): add missing lastAccessTime field to devices response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1288,6 +1288,7 @@ with an array of device details in the JSON body:
   {
     "id": "0f7aa00356e5416e82b3bef7bc409eef",
     "isCurrentDevice": true,
+    "lastAccessTime": 1449235471335,
     "name": "My Phone",
     "type": "mobile",
     "pushCallback": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
@@ -1296,6 +1297,7 @@ with an array of device details in the JSON body:
   {
     "id": "0f7aa00356e5416e82b3bef7bc409eef",
     "isCurrentDevice": false,
+    "lastAccessTime": 1417699471335,
     "name": "My Desktop",
     "type": null,
     "pushCallback": "https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75",

--- a/lib/db.js
+++ b/lib/db.js
@@ -434,6 +434,7 @@ module.exports = function (
             return bufferize({
               id: item.id,
               sessionToken: item.sessionTokenId,
+              lastAccessTime: item.lastAccessTime,
               name: item.name,
               type: item.type,
               pushCallback: item.callbackURL,

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -772,6 +772,7 @@ module.exports = function (
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
             isCurrentDevice: isA.boolean().required(),
+            lastAccessTime: isA.number().positive(),
             name: isA.string().max(255).required(),
             type: isA.string().max(16).required(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow('').allow(null),

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -279,6 +279,7 @@ test(
         })
         .then(function (device) {
           t.ok(Buffer.isBuffer(device.id), 'device.id is set')
+          t.ok(device.lastAccessTime > 0, 'device.lastAccessTime is set')
           t.equal(device.name, deviceInfo.name, 'device.name is correct')
           t.equal(device.type, deviceInfo.type, 'device.type is correct')
           t.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -37,6 +37,7 @@ TestServer.start(config)
               function (devices) {
                 t.equal(devices.length, 1, 'devices returned one item')
                 t.equal(devices[0].isCurrentDevice, true, 'devices returned true isCurrentDevice')
+                t.ok(devices[0].lastAccessTime > 0, 'devices returned positive lastAccessTime')
                 t.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
                 t.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
                 t.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')


### PR DESCRIPTION
Fixes #1117.

For some reason I forgot the `lastConnectedAt` field the first time round. Here it is.