### PR TITLE
fix(travis): install/use g++-4.8 for node 4.x build of scrypt-hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,23 @@ env:
 node_js:
  - "0.10"
  - "0.12"
- - "iojs-v2"
+ - "4"
 
 sudo: false
 
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+
 env:
-  - NODE_ENV=test DB=memory
-  - NODE_ENV=test DB=mysql
+  global:
+    - NODE_ENV=test
+  matrix:
+    - DB=memory
+    - DB=mysql
 
 notifications:
   email:
@@ -32,6 +42,10 @@ notifications:
 before_install:
   - npm install -g npm@2
   - npm config set spin false
+
+install:
+  # use c++-11 with node4, default compiler on downlevel versions
+  - if [ $TRAVIS_NODE_VERSION == "4" ]; then CXX=g++-4.8 npm install; else npm install; fi
 
 script:
   - if [ $DB == "mysql" ]; then ./scripts/start-travis-auth-db-mysql.sh; fi


### PR DESCRIPTION
Perhaps over-thinking, but this will build on node-4.x with g++-4.8, and on node 0.10 and 0.12 with the default g++-4.6. 

r? @dannycoates 