### PR TITLE
feat(metrics): record anonymized network and device information from /cert/sign

### DIFF
--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var crypto = require('crypto')
+
 module.exports = function (log, isA, error, signer, db, domain) {
 
   const HOUR = 1000 * 60 * 60
@@ -101,10 +103,25 @@ module.exports = function (log, isA, error, signer, db, domain) {
         ).then(function(certResult) {
           log.activityEvent('account.signed', request, {
             uid: uid,
+            network: getNetworkHash(uid, request.info.remoteAddress),
+            device: getDeviceHash(sessionToken.id),
             account_created_at: sessionToken.accountCreatedAt
           })
           reply(certResult)
         }, reply)
+
+        function getNetworkHash(uid, ip) {
+          var hash = crypto.createHash('sha-256')
+          hash.update(Buffer(uid, 'hex'))
+          hash.update(Buffer(ip, 'utf-8'))
+          return hash.digest('base64')
+        }
+
+        function getDeviceHash(id) {
+          var hash = crypto.createHash('sha-256')
+          hash.update(Buffer(id, 'hex'))
+          return hash.digest('base64')
+        }
       }
     }
   ]


### PR DESCRIPTION
This information will be useful in knowing if users have multiple connected devices on the same local network. Sean, why would we possibly want that? Glad you asked. We might be interested in improving the interaction of Firefox across multiple devices on the same network, but before investing, we want to know if that circumstance is common, such as having a laptop and a phone both using FxA, or if instead people setup FxA on a home laptop, and at a work computer, and thus never use the same network.

This may seem scary, but the data is scrubbed so as to not be identifiable. The IP addresses are hased with the userid, so we are unable to determine the IP address again from this.

-------

I can include tests if this seems like something that we could do.

/cc @rfk 