### PR TITLE
fix(tokens): extend "freshness" threshold to 6 hours

### DIFF
--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -5,6 +5,10 @@
 var userAgent = require('../userAgent')
 var ONE_HOUR = 60 * 60 * 1000
 
+// Browsers ask for 6 hour duration on certificate sign,
+// so don't bother updating device info any more frequently than that.
+var TOKEN_FRESHNESS_THRESHOLD = 6 * ONE_HOUR
+
 module.exports = function (log, inherits, Token) {
 
   function SessionToken(keys, details) {
@@ -66,7 +70,7 @@ module.exports = function (log, inherits, Token) {
       this.uaOS === freshData.uaOS &&
       this.uaOSVersion === freshData.uaOSVersion &&
       this.uaDeviceType === freshData.uaDeviceType &&
-      this.lastAccessTime + ONE_HOUR > freshData.lastAccessTime
+      this.lastAccessTime + TOKEN_FRESHNESS_THRESHOLD > freshData.lastAccessTime
 
     log.info({
       op: 'SessionToken.isFresh',

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -22,6 +22,8 @@ var DB = require('../../lib/db')(
   Token.PasswordChangeToken
 )
 
+var TOKEN_FRESHNESS_THRESHOLD = require('../../lib/tokens/session_token').TOKEN_FRESHNESS_THRESHOLD
+
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 
@@ -154,7 +156,7 @@ test(
         return sessionToken
       })
       .then(function(sessionToken) {
-        sessionToken.lastAccessTime -= 60 * 60 * 1000
+        sessionToken.lastAccessTime -= TOKEN_FRESHNESS_THRESHOLD
         return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function() {

--- a/test/local/session_token_tests.js
+++ b/test/local/session_token_tests.js
@@ -9,6 +9,8 @@ var log = { trace: function() {}, info: function () {} }
 var tokens = require('../../lib/tokens')(log)
 var SessionToken = tokens.SessionToken
 
+var TOKEN_FRESHNESS_THRESHOLD = require('../../lib/tokens/session_token').TOKEN_FRESHNESS_THREADHOLD
+
 var ACCOUNT = {
   uid: 'xxx',
   email: Buffer('test@example.com').toString('hex'),
@@ -193,8 +195,8 @@ test(
         uaOS: 'baz',
         uaOSVersion: 'qux',
         uaDeviceType: 'wibble',
-        lastAccessTime: 3600000
-      }), false, 'returns false when lastAccessTime is 3,600,000 milliseconds newer')
+        lastAccessTime: TOKEN_FRESHNESS_THRESHOLD
+      }), false, 'returns false when lastAccessTime is TOKEN_FRESHNESS_THRESHOLD milliseconds newer')
       t.equal(token.isFresh({
         uaBrowser: 'foo',
         uaBrowserVersion: 'bar',


### PR DESCRIPTION
Fixes #1159 

A strawman to "fix" #1159. r? - @rfk, @philbooth 

This is targeted to `master`, but I'd actually want this on a branch from tag 0.53.0, the current production version. 

(Could be improve by moving TOKEN_FRESHNESS_THRESHOLD to a config param, but I'm looking for a minimal change to address a current issue).