### PR TITLE
fix(tokens): extend token freshness threshold to 6 hours

### DIFF
--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -4,6 +4,8 @@
 
 var userAgent = require('../userAgent')
 var ONE_HOUR = 60 * 60 * 1000
+// browsers ask for 6 hour duration on certificate sign
+var TOKEN_FRESHNESS_THRESHOLD = 6 * ONE_HOUR
 
 module.exports = function (log, inherits, Token) {
 
@@ -66,7 +68,7 @@ module.exports = function (log, inherits, Token) {
       this.uaOS === freshData.uaOS &&
       this.uaOSVersion === freshData.uaOSVersion &&
       this.uaDeviceType === freshData.uaDeviceType &&
-      this.lastAccessTime + ONE_HOUR > freshData.lastAccessTime
+      this.lastAccessTime + TOKEN_FRESHNESS_THRESHOLD > freshData.lastAccessTime
 
     log.info({
       op: 'SessionToken.isFresh',

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -25,6 +25,9 @@ var DB = require('../../lib/db')(
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 
+// browsers ask for 6 hour duration on certificate sign
+var TOKEN_FRESHNESS_THRESHOLD = 6 * 60 * 60 * 1000
+
 var ACCOUNT = {
   uid: uuid.v4('binary'),
   email: 'foo@bar.com',
@@ -154,7 +157,7 @@ test(
         return sessionToken
       })
       .then(function(sessionToken) {
-        sessionToken.lastAccessTime -= 60 * 60 * 1000
+        sessionToken.lastAccessTime -= TOKEN_FRESHNESS_THRESHOLD
         return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function() {

--- a/test/local/session_token_tests.js
+++ b/test/local/session_token_tests.js
@@ -9,6 +9,9 @@ var log = { trace: function() {}, info: function () {} }
 var tokens = require('../../lib/tokens')(log)
 var SessionToken = tokens.SessionToken
 
+// browsers ask for 6 hour duration on certificate sign
+var TOKEN_FRESHNESS_THRESHOLD = 6 * 60 * 60 * 1000
+
 var ACCOUNT = {
   uid: 'xxx',
   email: Buffer('test@example.com').toString('hex'),
@@ -193,8 +196,8 @@ test(
         uaOS: 'baz',
         uaOSVersion: 'qux',
         uaDeviceType: 'wibble',
-        lastAccessTime: 3600000
-      }), false, 'returns false when lastAccessTime is 3,600,000 milliseconds newer')
+        lastAccessTime: TOKEN_FRESHNESS_THRESHOLD
+      }), false, 'returns false when lastAccessTime is TOKEN_FRESHNESS_THRESHOLD milliseconds newer')
       t.equal(token.isFresh({
         uaBrowser: 'foo',
         uaBrowserVersion: 'bar',


### PR DESCRIPTION
This is the same as https://github.com/mozilla/fxa-auth-server/pull/1160, but targeted at current production version v1.53.0. 

It seems that CPU has suprisingly returned to normal-ish. But I'm going to continue to get this built and tested in stage in case the problem returns.