### PR TITLE
fxa-deviceId in signed cert

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -453,6 +453,22 @@ module.exports = function (
       )
   }
 
+  DB.prototype.sessionDevice = function (id) {
+    log.trace({ op: 'DB.sessionDevice', id: id })
+    return this.pool.get('/sessionToken/' + id.toString('hex') + '/device')
+      .then(
+        function (body) {
+          return bufferize(body)
+        },
+        function (err) {
+          if (isNotFoundError(err)) {
+            return null
+          }
+          throw err
+        }
+      )
+  }
+
   // UPDATE
 
   DB.prototype.updatePasswordForgotToken = function (token) {

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -88,23 +88,38 @@ module.exports = function (log, isA, error, signer, db, domain) {
           }
         }
         var uid = sessionToken.uid.toString('hex')
-        signer.sign(
-          {
-            email: uid + '@' + domain,
-            publicKey: publicKey,
-            domain: domain,
-            duration: duration,
-            generation: sessionToken.verifierSetAt,
-            lastAuthAt: sessionToken.lastAuthAt(),
-            verifiedEmail: sessionToken.email
-          }
-        ).then(function(certResult) {
-          log.activityEvent('account.signed', request, {
-            uid: uid,
-            account_created_at: sessionToken.accountCreatedAt
-          })
-          reply(certResult)
-        }, reply)
+
+        db.sessionDevice(sessionToken.tokenId)
+          .then(
+            function (device) {
+              return signer.sign(
+                {
+                  email: uid + '@' + domain,
+                  publicKey: publicKey,
+                  domain: domain,
+                  duration: duration,
+                  generation: sessionToken.verifierSetAt,
+                  lastAuthAt: sessionToken.lastAuthAt(),
+                  verifiedEmail: sessionToken.email,
+                  deviceId: device ? device.id.toString('hex') : null
+                }
+              )
+            }
+          )
+          .then(
+            function(certResult) {
+              log.activityEvent(
+                'account.signed',
+                request,
+                {
+                  uid: uid,
+                  account_created_at: sessionToken.accountCreatedAt
+                }
+              )
+              reply(certResult)
+            },
+            reply
+          )
       }
     }
   ]

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -21,7 +21,8 @@ module.exports = function (secretKeyFile, domain) {
           exp: now + data.duration,
           'fxa-generation': data.generation,
           'fxa-lastAuthAt': data.lastAuthAt,
-          'fxa-verifiedEmail': data.verifiedEmail
+          'fxa-verifiedEmail': data.verifiedEmail,
+          'fxa-deviceId': data.deviceId
         }
       )
       .then(


### PR DESCRIPTION
This will support piping the `deviceId` through the auth-server to the sync token-server via the signed certificate to allow new sync metrics.