### PR TITLE
fix(sessiontokens): effectively disable sessionToken updates

### DIFF
--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -4,8 +4,11 @@
 
 var userAgent = require('../userAgent')
 var ONE_HOUR = 60 * 60 * 1000
-// browsers ask for 6 hour duration on certificate sign
-var TOKEN_FRESHNESS_THRESHOLD = 6 * ONE_HOUR
+
+// setting to "forever" to eliminate ~99% of the updates to sessionToken
+// (A small percentage do qualify as "fresh" due to changes in UA).
+// See https://github.com/mozilla/fxa-auth-server/pull/1169
+var TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * ONE_HOUR // 50 years or post Y2038 ;-)
 
 module.exports = function (log, inherits, Token) {
 

--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -25,8 +25,9 @@ var DB = require('../../lib/db')(
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 
-// browsers ask for 6 hour duration on certificate sign
-var TOKEN_FRESHNESS_THRESHOLD = 6 * 60 * 60 * 1000
+// setting to "forever" to eliminate ~99% of the updates to sessionToken
+// (A small percentage do qualify as "fresh" due to changes in UA).
+var TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * 60 * 60 * 1000 // 50 years
 
 var ACCOUNT = {
   uid: uuid.v4('binary'),

--- a/test/local/session_token_tests.js
+++ b/test/local/session_token_tests.js
@@ -9,8 +9,9 @@ var log = { trace: function() {}, info: function () {} }
 var tokens = require('../../lib/tokens')(log)
 var SessionToken = tokens.SessionToken
 
-// browsers ask for 6 hour duration on certificate sign
-var TOKEN_FRESHNESS_THRESHOLD = 6 * 60 * 60 * 1000
+// setting to "forever" to eliminate ~99% of the updates to sessionToken
+// (A small percentage do qualify as "fresh" due to changes in UA).
+var TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * 60 * 60 * 1000
 
 var ACCOUNT = {
   uid: 'xxx',


### PR DESCRIPTION
We've been having bursts of 5xx errors in production today. Snap shotting `show processlist` on the database shows these bursts are correlated with "logjams" of updates to sessionTokens taking dozens of seconds. To alleviate this problem, effectively stop these updates from happening (a few will still occur due to other reasons `isFresh()` would return true, but from data this is on the order of 1%).

Already discussed with @dannycoates. r? to make sure I have no typo in there ;-)

Note: this is targeted to the branch that is running in production. I'll prepare a similar patch for `master`, where the code is just a tiny bit different.

/cc @ckolos