### PR TITLE
fix(sessiontokens): effectively disable sessionToken updates

### DIFF
--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -5,9 +5,10 @@
 var userAgent = require('../userAgent')
 var ONE_HOUR = 60 * 60 * 1000
 
-// Browsers ask for 6 hour duration on certificate sign,
-// so don't bother updating device info any more frequently than that.
-var TOKEN_FRESHNESS_THRESHOLD = 6 * ONE_HOUR
+// setting to "forever" to eliminate ~99% of the updates to sessionToken
+// (A small percentage do qualify as "fresh" due to changes in UA).
+// See https://github.com/mozilla/fxa-auth-server/pull/1169
+var TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * ONE_HOUR // 50 years or post Y2038 ;-)
 
 module.exports = function (log, inherits, Token) {
 


### PR DESCRIPTION
This follows on from https://github.com/mozilla/fxa-auth-server/pull/1169 which changed the current production branch to effectively disable sessionToken updates, to reduce database load affecting users.
Simpler change on master, where tests were refactored to import the value from `./lib/tokens/session_tokens.js`.

r? - @rfk or @dannycoates 

We can figure out how to address this load issue, post db upgrade, in a future release.