### PR TITLE
OAuth config fixes

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -303,6 +303,12 @@ var conf = convict({
       default: 'http://localhost:9010',
       env: 'OAUTH_URL'
     },
+    keepAlive: {
+      format: Boolean,
+      doc: 'Use HTTP keep-alive connections when talking to oauth server',
+      env: 'OAUTH_KEEPALIVE',
+      default: false
+    },
     extra: {
       email: {
         doc: 'Temporary extra parameter to prevent request recursion',

--- a/config/index.js
+++ b/config/index.js
@@ -303,9 +303,11 @@ var conf = convict({
       default: 'http://localhost:9010',
       env: 'OAUTH_URL'
     },
-    email: {
-      doc: 'Temporary extra parameter to prevent request recursion',
-      default: false
+    extra: {
+      email: {
+        doc: 'Temporary extra parameter to prevent request recursion',
+        default: false
+      }
     }
   },
   openIdProviders: {


### PR DESCRIPTION
Fixes #1155 by adding a config option to disable HTTP keepalive in hapi-fxa-oauth, and defaulting it to False.

Also fixes the bug noted in https://github.com/mozilla/fxa-auth-server/pull/1111#issuecomment-175474037 which we missed during initial review of that PR.

@seanmonstar r?