### PR TITLE
Cope with quoted email addresses in bounce notifications

### DIFF
--- a/lib/bounces.js
+++ b/lib/bounces.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (log) {
+var P = require('./promise')
 
-  var SQSReceiver = require('./sqs')(log)
+module.exports = function (log, error) {
 
-  return function start(config, db) {
+  return function start(bounceQueue, db) {
 
     function accountDeleted(uid, email) {
       log.info({ op: 'accountDeleted', uid: uid.toString('hex'), email: email })
@@ -18,8 +18,8 @@ module.exports = function (log) {
 
     function deleteAccountIfUnverified(record) {
       if (!record.emailVerified) {
-        db.deleteAccount(record)
-          .done(
+        return db.deleteAccount(record)
+          .then(
             accountDeleted.bind(null, record.uid, record.email),
             gotError.bind(null, record.email)
           )
@@ -39,22 +39,34 @@ module.exports = function (log) {
       else if (message.complaint && message.complaint.complaintFeedbackType === 'abuse') {
         recipients = message.complaint.complainedRecipients
       }
-      for (var i = 0; i < recipients.length; i++) {
-        var email = recipients[i].emailAddress
-        log.info({ op: 'handleBounce', email: email, bounce: !!message.bounce })
-        log.increment('account.email_bounced')
-        db.emailRecord(email)
-          .done(
-            deleteAccountIfUnverified,
-            gotError.bind(null, email)
-          )
-      }
-      message.del()
+      var p = P.resolve()
+      recipients.forEach(function(recipient) {
+        var email = recipient.emailAddress
+        p = p.then(
+          function () {
+            log.info({ op: 'handleBounce', email: email, bounce: !!message.bounce })
+            log.increment('account.email_bounced')
+            return db.emailRecord(email)
+              .then(
+                deleteAccountIfUnverified,
+                gotError.bind(null, email)
+              )
+          }
+        )
+      })
+      return p.then(
+        function () {
+          message.del()
+        }
+      )
     }
 
-    var bounceQueue = new SQSReceiver(config.region, [config.bounceQueueUrl, config.complaintQueueUrl])
     bounceQueue.on('data', handleBounce)
     bounceQueue.start()
-    return bounceQueue
+
+    return {
+      bounceQueue: bounceQueue,
+      handleBounce: handleBounce
+    }
   }
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -733,6 +733,9 @@ module.exports = function (
   return DB
 }
 
+// Note that these errno's are defined in the fxa-auth-db-mysql repo
+// and don't necessarily match the errnos in this repo...
+
 function isRecordAlreadyExistsError (err) {
   return err.statusCode === 409 && err.errno === 101
 }

--- a/lib/error.js
+++ b/lib/error.js
@@ -5,10 +5,37 @@
 var inherits = require('util').inherits
 var messages = require('joi/lib/language').errors
 
+var ERRNO = {
+  ACCOUNT_EXISTS: 101,
+  ACCOUNT_LOCKED: 121,
+  ACCOUNT_NOT_LOCKED: 122,
+  ACCOUNT_UNKNOWN: 102,
+  ACCOUNT_UNVERIFIED: 104,
+  DEVICE_UNKNOWN: 123,
+  DEVICE_CONFLICT: 124,
+  ENDPOINT_NOT_SUPPORTED: 116,
+  INCORRECT_EMAIL_CASE: 120,
+  INCORRECT_PASSWORD: 103,
+  INVALID_JSON: 106,
+  INVALID_NONCE: 115,
+  INVALID_PARAMETER: 107,
+  INVALID_REQUEST_SIGNATURE: 109,
+  INVALID_TIMESTAMP: 111,
+  INVALID_TOKEN: 110,
+  INVALID_VERIFICATION_CODE: 105,
+  MISSING_CONTENT_LENGTH_HEADER: 112,
+  MISSING_PARAMETER: 108,
+  REQUEST_TOO_LARGE: 113,
+  SERVER_BUSY: 201,
+  SERVER_CONFIG_ERROR: 100,
+  THROTTLED: 114,
+  UNEXPECTED_ERROR: 999
+}
+
 var DEFAULTS = {
   code: 500,
   error: 'Internal Server Error',
-  errno: 999,
+  errno: ERRNO.UNEXPECTED_ERROR,
   message: 'Unspecified error',
   info: 'https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md#response-format'
 }
@@ -115,7 +142,7 @@ AppError.dbIncorrectPatchLevel = function (level, levelRequired) {
     {
       code: 400,
       error: 'Server Startup',
-      errno: 100,
+      errno: ERRNO.SERVER_CONFIG_ERROR,
       message: 'Incorrect Database Patch Level'
     },
     {
@@ -130,7 +157,7 @@ AppError.accountExists = function (email) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 101,
+      errno: ERRNO.ACCOUNT_EXISTS,
       message: 'Account already exists'
     },
     {
@@ -144,7 +171,7 @@ AppError.unknownAccount = function (email) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 102,
+      errno: ERRNO.ACCOUNT_UNKNOWN,
       message: 'Unknown account'
     },
     {
@@ -159,7 +186,7 @@ AppError.incorrectPassword = function (dbEmail, requestEmail) {
       {
         code: 400,
         error: 'Bad Request',
-        errno: 120,
+        errno: ERRNO.INCORRECT_EMAIL_CASE,
         message: 'Incorrect email case'
       },
       {
@@ -171,7 +198,7 @@ AppError.incorrectPassword = function (dbEmail, requestEmail) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 103,
+      errno: ERRNO.INCORRECT_PASSWORD,
       message: 'Incorrect password'
     },
     {
@@ -184,7 +211,7 @@ AppError.unverifiedAccount = function () {
   return new AppError({
     code: 400,
     error: 'Bad Request',
-    errno: 104,
+    errno: ERRNO.ACCOUNT_UNVERIFIED,
     message: 'Unverified account'
   })
 }
@@ -194,7 +221,7 @@ AppError.invalidVerificationCode = function (details) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 105,
+      errno: ERRNO.INVALID_VERIFICATION_CODE,
       message: 'Invalid verification code'
     },
     details
@@ -205,7 +232,7 @@ AppError.invalidRequestBody = function () {
   return new AppError({
     code: 400,
     error: 'Bad Request',
-    errno: 106,
+    errno: ERRNO.INVALID_JSON,
     message: 'Invalid JSON in request body'
   })
 }
@@ -215,7 +242,7 @@ AppError.invalidRequestParameter = function (validation) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 107,
+      errno: ERRNO.INVALID_PARAMETER,
       message: 'Invalid parameter in request body'
     },
     {
@@ -229,7 +256,7 @@ AppError.missingRequestParameter = function (param) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 108,
+      errno: ERRNO.MISSING_PARAMETER,
       message: 'Missing parameter in request body' + (param ? ': ' + param : '')
     },
     {
@@ -242,7 +269,7 @@ AppError.invalidSignature = function (message) {
   return new AppError({
     code: 401,
     error: 'Unauthorized',
-    errno: 109,
+    errno: ERRNO.INVALID_REQUEST_SIGNATURE,
     message: message || 'Invalid request signature'
   })
 }
@@ -251,7 +278,7 @@ AppError.invalidToken = function (message) {
   return new AppError({
     code: 401,
     error: 'Unauthorized',
-    errno: 110,
+    errno: ERRNO.INVALID_TOKEN,
     message: message || 'Invalid authentication token in request signature'
   })
 }
@@ -261,7 +288,7 @@ AppError.invalidTimestamp = function () {
     {
       code: 401,
       error: 'Unauthorized',
-      errno: 111,
+      errno: ERRNO.INVALID_TIMESTAMP,
       message: 'Invalid timestamp in request signature'
     },
     {
@@ -274,7 +301,7 @@ AppError.invalidNonce = function () {
   return new AppError({
     code: 401,
     error: 'Unauthorized',
-    errno: 115,
+    errno: ERRNO.INVALID_NONCE,
     message: 'Invalid nonce in request signature'
   })
 }
@@ -283,7 +310,7 @@ AppError.missingContentLength = function () {
   return new AppError({
     code: 411,
     error: 'Length Required',
-    errno: 112,
+    errno: ERRNO.MISSING_CONTENT_LENGTH_HEADER,
     message: 'Missing content-length header'
   })
 }
@@ -292,7 +319,7 @@ AppError.requestBodyTooLarge = function () {
   return new AppError({
     code: 413,
     error: 'Request Entity Too Large',
-    errno: 113,
+    errno: ERRNO.REQUEST_TOO_LARGE,
     message: 'Request body too large'
   })
 }
@@ -305,7 +332,7 @@ AppError.tooManyRequests = function (retryAfter) {
     {
       code: 429,
       error: 'Too Many Requests',
-      errno: 114,
+      errno: ERRNO.THROTTLED,
       message: 'Client has sent too many requests'
     },
     {
@@ -325,7 +352,7 @@ AppError.serviceUnavailable = function (retryAfter) {
     {
       code: 503,
       error: 'Service Unavailable',
-      errno: 201,
+      errno: ERRNO.SERVER_BUSY,
       message: 'Service unavailable'
     },
     {
@@ -341,7 +368,7 @@ AppError.gone = function () {
   return new AppError({
     code: 410,
     error: 'Gone',
-    errno: 116,
+    errno: ERRNO.ENDPOINT_NOT_SUPPORTED,
     message: 'This endpoint is no longer supported'
   })
 }
@@ -350,7 +377,7 @@ AppError.lockedAccount = function () {
   return new AppError({
     code: 400,
     error: 'Bad Request',
-    errno: 121,
+    errno: ERRNO.ACCOUNT_LOCKED,
     message: 'Account is locked'
   })
 }
@@ -360,7 +387,7 @@ AppError.accountNotLocked = function (email) {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 122,
+      errno: ERRNO.ACCOUNT_NOT_LOCKED,
       message: 'Account is not locked'
     },
     {
@@ -374,7 +401,7 @@ AppError.unknownDevice = function () {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 123,
+      errno: ERRNO.DEVICE_UNKNOWN,
       message: 'Unknown device'
     }
   )
@@ -385,10 +412,11 @@ AppError.deviceSessionConflict = function () {
     {
       code: 400,
       error: 'Bad Request',
-      errno: 124,
+      errno: ERRNO.DEVICE_CONFLICT,
       message: 'Session already registered by another device'
     }
   )
 }
 
 module.exports = AppError
+module.exports.ERRNO = ERRNO

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -121,7 +121,7 @@ module.exports = function (
         }
 
         function ignoreUnknownAccountError (err) {
-          if (err.errno !== 102) {
+          if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
             throw err
           }
         }
@@ -481,7 +481,7 @@ module.exports = function (
                   return record
                 },
                 function (err) {
-                  if (err.errno !== 102) {
+                  if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
                     throw err
                   }
                   var uid = uuid.v4('binary')
@@ -617,7 +617,7 @@ module.exports = function (
                 reply({ exists: true })
               },
               function (err) {
-                if (err.errno === 102) {
+                if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
                   return reply({ exists: false })
                 }
                 reply(err)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -244,7 +244,7 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@1.8.1",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
@@ -338,6 +338,11 @@
         }
       }
     },
+    "email-addresses": {
+      "version": "2.0.2",
+      "from": "email-addresses@2.0.2",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-2.0.2.tgz"
+    },
     "envc": {
       "version": "2.4.0",
       "from": "envc@2.4.0",
@@ -364,7 +369,7 @@
     },
     "fxa-auth-db-mysql": {
       "version": "0.55.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#7c283188a18dd04319a11b932398d07b5f22190d",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#7c283188a18dd04319a11b932398d07b5f22190d",
       "dependencies": {
         "bluebird": {
@@ -394,7 +399,7 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
@@ -479,7 +484,7 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
@@ -496,7 +501,7 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.3 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
@@ -506,12 +511,12 @@
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+              "from": "tough-cookie@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "http-signature": {
@@ -521,7 +526,7 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -548,7 +553,7 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "combined-stream": {
@@ -565,14 +570,14 @@
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             }
           }
         },
         "restify": {
           "version": "4.0.3",
-          "from": "https://registry.npmjs.org/restify/-/restify-4.0.3.tgz",
+          "from": "restify@4.0.3",
           "resolved": "https://registry.npmjs.org/restify/-/restify-4.0.3.tgz",
           "dependencies": {
             "assert-plus": {
@@ -727,7 +732,7 @@
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "asn1": {
@@ -744,7 +749,7 @@
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
@@ -754,7 +759,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@>=1.3.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
@@ -764,7 +769,7 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.3 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "once": {
@@ -786,7 +791,7 @@
             },
             "semver": {
               "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "from": "semver@>=4.3.3 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "spdy": {
@@ -796,7 +801,7 @@
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "vasync": {
@@ -834,7 +839,7 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.8",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#01f8ee75fdd381ee26820545aba99ad95ce87c0f",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
       "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#01f8ee75fdd381ee26820545aba99ad95ce87c0f",
       "dependencies": {
         "bluebird": {
@@ -921,12 +926,12 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#a45024ef0033fac8807c0183e2b9bd6315e388bd",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#a45024ef0033fac8807c0183e2b9bd6315e388bd"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#8db916469ec50ff2ab3a6c0148b21f5b146ca4f7"
         },
         "grunt-nunjucks-2-html": {
           "version": "0.3.4",
-          "from": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
+          "from": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",
           "resolved": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
           "dependencies": {
             "async": {
@@ -1198,9 +1203,9 @@
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.2",
+                              "version": "1.1.3",
                               "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
@@ -1284,15 +1289,15 @@
                           "from": "ansi@~0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                         },
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        },
                         "ansi-styles": {
                           "version": "2.1.0",
                           "from": "ansi-styles@^2.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         },
                         "are-we-there-yet": {
                           "version": "1.0.5",
@@ -1309,15 +1314,15 @@
                           "from": "assert-plus@^0.1.5",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
-                        "async": {
-                          "version": "1.5.1",
-                          "from": "async@^1.4.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
-                        },
                         "aws-sign2": {
                           "version": "0.6.0",
                           "from": "aws-sign2@~0.6.0",
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                        },
+                        "async": {
+                          "version": "1.5.1",
+                          "from": "async@^1.4.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
                         },
                         "bl": {
                           "version": "1.0.0",
@@ -1334,15 +1339,15 @@
                           "from": "boom@2.x.x",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                         },
-                        "caseless": {
-                          "version": "0.11.0",
-                          "from": "caseless@~0.11.0",
-                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                        },
                         "chalk": {
                           "version": "1.1.1",
                           "from": "chalk@^1.1.1",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "from": "caseless@~0.11.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                         },
                         "combined-stream": {
                           "version": "1.0.5",
@@ -1359,30 +1364,30 @@
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
-                        "cryptiles": {
-                          "version": "2.0.5",
-                          "from": "cryptiles@2.x.x",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                        },
                         "dashdash": {
                           "version": "1.11.0",
                           "from": "dashdash@>=1.10.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "from": "cryptiles@2.x.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                         },
                         "debug": {
                           "version": "0.7.4",
                           "from": "debug@~0.7.2",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                         },
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "from": "delayed-stream@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                        },
                         "deep-extend": {
                           "version": "0.4.0",
                           "from": "deep-extend@~0.4.0",
                           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                        },
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "from": "delayed-stream@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                         },
                         "delegates": {
                           "version": "0.1.0",
@@ -1393,6 +1398,11 @@
                           "version": "0.1.1",
                           "from": "ecc-jsbn@>=0.0.1 <1.0.0",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "from": "extend@~3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.4",
@@ -1409,11 +1419,6 @@
                           "from": "forever-agent@~0.6.1",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                         },
-                        "extend": {
-                          "version": "3.0.0",
-                          "from": "extend@~3.0.0",
-                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                        },
                         "form-data": {
                           "version": "1.0.0-rc3",
                           "from": "form-data@~1.0.0-rc3",
@@ -1424,15 +1429,15 @@
                           "from": "fstream@^1.0.2",
                           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                         },
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "from": "generate-function@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                        },
                         "gauge": {
                           "version": "1.2.2",
                           "from": "gauge@~1.2.0",
                           "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                        },
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
@@ -1469,15 +1474,15 @@
                           "from": "hawk@~3.1.0",
                           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
                         },
-                        "http-signature": {
-                          "version": "1.1.0",
-                          "from": "http-signature@~1.1.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
-                        },
                         "hoek": {
                           "version": "2.16.3",
                           "from": "hoek@2.x.x",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "http-signature": {
+                          "version": "1.1.0",
+                          "from": "http-signature@~1.1.0",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
@@ -1514,15 +1519,15 @@
                           "from": "isstream@~0.1.2",
                           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                         },
-                        "jsbn": {
-                          "version": "0.1.0",
-                          "from": "jsbn@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                        },
                         "jodid25519": {
                           "version": "1.0.2",
                           "from": "jodid25519@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "from": "jsbn@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "json-schema": {
                           "version": "0.2.2",
@@ -1549,30 +1554,30 @@
                           "from": "lodash._basetostring@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                         },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-                        },
                         "lodash._createpadding": {
                           "version": "3.6.1",
                           "from": "lodash._createpadding@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
                         },
                         "lodash.padright": {
                           "version": "3.1.1",
                           "from": "lodash.padright@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                         },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "from": "lodash.padleft@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-                        },
                         "lodash.repeat": {
                           "version": "3.0.1",
                           "from": "lodash.repeat@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "lodash.padleft@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                         },
                         "mime-db": {
                           "version": "1.21.0",
@@ -1584,20 +1589,15 @@
                           "from": "mime-types@~2.1.7",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
                         },
-                        "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                        },
                         "minimist": {
                           "version": "0.0.8",
                           "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         },
-                        "node-uuid": {
-                          "version": "1.4.7",
-                          "from": "node-uuid@~1.4.7",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                         },
                         "npmlog": {
                           "version": "2.0.0",
@@ -1609,30 +1609,35 @@
                           "from": "oauth-sign@~0.8.0",
                           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                         },
-                        "once": {
-                          "version": "1.1.1",
-                          "from": "once@~1.1.1",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                        "node-uuid": {
+                          "version": "1.4.7",
+                          "from": "node-uuid@~1.4.7",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                         },
                         "pinkie": {
                           "version": "2.0.1",
                           "from": "pinkie@^2.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                         },
+                        "once": {
+                          "version": "1.1.1",
+                          "from": "once@~1.1.1",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                        },
                         "pinkie-promise": {
                           "version": "2.0.0",
                           "from": "pinkie-promise@^2.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                         },
-                        "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@~1.0.6",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
                         "qs": {
                           "version": "5.2.0",
                           "from": "qs@~5.2.0",
                           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@~1.0.6",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.5",
@@ -1659,15 +1664,15 @@
                           "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
-                        "stringstream": {
-                          "version": "0.0.5",
-                          "from": "stringstream@~0.0.4",
-                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                        },
                         "strip-ansi": {
                           "version": "3.0.0",
                           "from": "strip-ansi@^3.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                        },
+                        "stringstream": {
+                          "version": "0.0.5",
+                          "from": "stringstream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                         },
                         "strip-json-comments": {
                           "version": "1.0.4",
@@ -1709,15 +1714,15 @@
                           "from": "verror@1.3.6",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                         },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@~1.0.1",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        },
                         "xtend": {
                           "version": "4.0.1",
                           "from": "xtend@^4.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@~1.0.1",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         },
                         "rc": {
                           "version": "1.1.6",
@@ -2245,7 +2250,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -2286,7 +2291,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -2485,7 +2490,7 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.8.3",
-                      "from": "underscore@latest",
+                      "from": "underscore@*",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
                     }
                   }
@@ -2570,7 +2575,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2584,7 +2589,7 @@
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "nomnom@1.8.1",
+              "from": "nomnom@>=1.5.0",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
@@ -2660,9 +2665,9 @@
               }
             },
             "bl": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "from": "bl@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
@@ -2705,17 +2710,17 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
@@ -2732,7 +2737,7 @@
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@1.0.0-rc3",
+              "from": "form-data@>=1.0.0-rc3 <1.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
@@ -2749,7 +2754,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@1.1.1",
+                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
@@ -2795,7 +2800,7 @@
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@2.9.0",
+                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
@@ -2865,12 +2870,12 @@
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
@@ -3005,7 +3010,7 @@
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
@@ -3033,9 +3038,9 @@
               }
             },
             "bunyan": {
-              "version": "1.5.1",
+              "version": "1.6.0",
               "from": "bunyan@>=1.4.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.6.0.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.1.1",
@@ -3092,9 +3097,9 @@
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
@@ -3125,6 +3130,11 @@
                   "version": "1.0.3",
                   "from": "safe-json-stringify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
+                },
+                "moment": {
+                  "version": "2.11.2",
+                  "from": "moment@>=2.10.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
                 }
               }
             },
@@ -3167,7 +3177,7 @@
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@0.11.0",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "asn1": {
@@ -3189,7 +3199,7 @@
             },
             "lru-cache": {
               "version": "2.7.3",
-              "from": "lru-cache@>=2.6.5 <3.0.0",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "mime": {
@@ -3204,7 +3214,7 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "once": {
@@ -3265,7 +3275,7 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "extsprintf": {
@@ -3364,7 +3374,7 @@
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
@@ -3405,7 +3415,7 @@
           "dependencies": {
             "encoding": {
               "version": "0.1.12",
-              "from": "encoding@>=0.1.11 <0.2.0",
+              "from": "encoding@*",
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
@@ -3429,7 +3439,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
@@ -3460,7 +3470,7 @@
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
@@ -3475,17 +3485,17 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
@@ -3500,7 +3510,7 @@
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@>=2.6.5 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
@@ -3538,12 +3548,12 @@
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
@@ -3592,7 +3602,7 @@
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
@@ -3626,12 +3636,12 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
@@ -3656,7 +3666,7 @@
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "from": "underscore.string@2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -3694,12 +3704,12 @@
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
@@ -3714,7 +3724,7 @@
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@>=2.6.5 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
@@ -3747,12 +3757,12 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
@@ -3762,7 +3772,7 @@
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
@@ -3798,7 +3808,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
@@ -3896,12 +3906,12 @@
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
-                      "from": "async@>=1.4.2 <2.0.0",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "optimist@0.6.1",
+                      "from": "optimist@>=0.6.1 <0.7.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
@@ -4174,7 +4184,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -4231,7 +4241,7 @@
                     },
                     "lodash._basetostring": {
                       "version": "3.0.1",
-                      "from": "lodash._basetostring@3.0.1",
+                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
                     "lodash._basevalues": {
@@ -4336,7 +4346,7 @@
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     }
                   }
@@ -4365,12 +4375,12 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.0 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -4402,7 +4412,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -4552,7 +4562,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.0 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -4584,7 +4594,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -4776,12 +4786,12 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
@@ -4791,7 +4801,7 @@
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
@@ -4888,7 +4898,7 @@
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "doctrine@>=0.6.2 <0.7.0",
+              "from": "doctrine@0.6.4",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
@@ -4972,7 +4982,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     }
                   }
@@ -4998,7 +5008,7 @@
             },
             "espree": {
               "version": "2.2.5",
-              "from": "espree@2.2.5",
+              "from": "espree@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
@@ -5008,7 +5018,7 @@
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "estraverse-fb@1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
@@ -5018,7 +5028,7 @@
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "inquirer@>=0.8.2 <0.9.0",
+              "from": "inquirer@0.8.5",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
@@ -5067,7 +5077,7 @@
             },
             "is-my-json-valid": {
               "version": "2.12.4",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
               "dependencies": {
                 "generate-function": {
@@ -5100,9 +5110,9 @@
               }
             },
             "js-yaml": {
-              "version": "3.5.2",
+              "version": "3.5.3",
               "from": "js-yaml@>=3.2.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.6",
@@ -5129,9 +5139,9 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
@@ -5161,7 +5171,7 @@
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
@@ -5213,7 +5223,7 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
@@ -5304,6 +5314,11 @@
               "from": "ansi@0.3.0",
               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
             },
+            "boom": {
+              "version": "2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
             "builtin-modules": {
               "version": "1.1.0",
               "from": "builtin-modules@1.1.0",
@@ -5313,11 +5328,6 @@
               "version": "0.0.2",
               "from": "chownr@0.0.2",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "boom@2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cliclopts": {
               "version": "1.1.1",
@@ -5339,15 +5349,15 @@
               "from": "delegates@0.1.0",
               "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
             },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
             "gauge": {
               "version": "1.2.2",
               "from": "gauge@1.2.2",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "graceful-fs": {
               "version": "3.0.8",
@@ -5374,15 +5384,15 @@
               "from": "ini@1.3.4",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "from": "is-builtin-module@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-            },
             "isemail": {
               "version": "1.2.0",
               "from": "isemail@1.2.0",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "from": "is-builtin-module@1.0.0",
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
@@ -5451,7 +5461,7 @@
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "from": "spdx-correct@>=1.0.0 <1.1.0",
+              "from": "spdx-correct@1.0.2",
               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
             },
             "spdx-exceptions": {
@@ -5481,7 +5491,7 @@
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+              "from": "validate-npm-package-license@3.0.1",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
             },
             "are-we-there-yet": {
@@ -5491,7 +5501,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                 }
               }
@@ -5517,7 +5527,7 @@
         },
         "ansi-styles": {
           "version": "2.1.0",
-          "from": "ansi-styles@2.1.0",
+          "from": "ansi-styles@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "balanced-match": {
@@ -5532,7 +5542,7 @@
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "concat-map": {
@@ -5550,10 +5560,20 @@
           "from": "core-util-is@1.0.1",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "escape-string-regexp": {
           "version": "1.0.3",
           "from": "escape-string-regexp@1.0.3",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
@@ -5567,7 +5587,7 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@2.0.1",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "isarray": {
@@ -5577,8 +5597,13 @@
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "minimatch@2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -5590,9 +5615,14 @@
           "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
+        "once": {
+          "version": "1.3.2",
+          "from": "once@1.3.2",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+        },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "path-is-absolute@1.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "process-nextick-args": {
@@ -5605,65 +5635,45 @@
           "from": "readable-stream@2.0.4",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
         },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        "rimraf": {
+          "version": "2.4.3",
+          "from": "rimraf@2.4.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
           "from": "string_decoder@0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
+        "strip-ansi": {
+          "version": "3.0.0",
+          "from": "strip-ansi@3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
         "typedarray": {
           "version": "0.0.6",
-          "from": "typedarray@>=0.0.5 <0.1.0",
+          "from": "typedarray@0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "from": "util-deprecate@>=1.0.1 <1.1.0",
+          "from": "util-deprecate@1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
         },
         "wrappy": {
           "version": "1.0.1",
-          "from": "wrappy@>=1.0.0 <2.0.0",
+          "from": "wrappy@1.0.1",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "once": {
-          "version": "1.3.2",
-          "from": "once@1.3.2",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-        },
-        "rimraf": {
-          "version": "2.4.3",
-          "from": "rimraf@2.4.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
         }
       }
     },
@@ -5731,7 +5741,7 @@
               "dependencies": {
                 "isemail": {
                   "version": "1.2.0",
-                  "from": "isemail@1.2.0",
+                  "from": "isemail@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                 },
                 "moment": {
@@ -5894,17 +5904,17 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.0.0 <4.0.0",
+          "from": "hawk@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "cryptiles@2.0.5",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "sntp@1.0.9",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
@@ -6047,7 +6057,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
@@ -6096,7 +6106,7 @@
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.1 <2.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
@@ -6134,7 +6144,7 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "object-assign": {
@@ -6165,12 +6175,12 @@
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1.0.1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -6186,9 +6196,9 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.2",
+                      "version": "1.1.3",
                       "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
@@ -6211,7 +6221,7 @@
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1.0.1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -6232,7 +6242,7 @@
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
@@ -6253,9 +6263,9 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
@@ -6340,7 +6350,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.0 <1.2.0",
+              "from": "chalk@1.1.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -6540,13 +6550,13 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
       "dependencies": {
         "bl": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "from": "bl@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -6605,7 +6615,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.4.0 <2.0.0",
+              "from": "async@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             }
           }
@@ -6691,12 +6701,12 @@
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "cryptiles@2.0.5",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "sntp@1.0.9",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
@@ -6735,7 +6745,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "chalk@1.1.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -6781,7 +6791,7 @@
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
+              "from": "commander@2.9.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
@@ -6798,7 +6808,7 @@
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
@@ -6820,7 +6830,7 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -6892,7 +6902,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -6958,12 +6968,12 @@
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "inflight@1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -6974,9 +6984,9 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
@@ -6999,7 +7009,7 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -7008,7 +7018,7 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@2.0.1",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "binary-split": "0.1.2",
     "bluebird": "2.10.2",
     "convict": "1.0.1",
+    "email-addresses": "2.0.2",
     "envc": "2.4.0",
     "fxa-auth-mailer": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
     "fxa-jwtool": "0.7.1",

--- a/test/local/bounce_tests.js
+++ b/test/local/bounce_tests.js
@@ -51,7 +51,7 @@ test(
         return P.resolve({ })
       })
     }
-    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+    var mockMsg = mockMessage({
       bounce: {
         bounceType: 'Permanent',
         bouncedRecipients: [
@@ -59,7 +59,8 @@ test(
           { emailAddress: 'foobar@example.com'}
         ]
       }
-    })).then(function () {
+    })
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMsg).then(function () {
       t.equal(mockDB.emailRecord.callCount, 2)
       t.equal(mockDB.deleteAccount.callCount, 2)
       t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
@@ -70,6 +71,7 @@ test(
       t.equal(mockLog.messages[5].level, 'info')
       t.equal(mockLog.messages[5].args[0].op, 'accountDeleted')
       t.equal(mockLog.messages[5].args[0].email, 'foobar@example.com')
+      t.equal(mockMsg.del.callCount, 1)
     })
   }
 )
@@ -162,14 +164,15 @@ test(
         return P.reject(new error({}))
       })
     }
-    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+    var mockMsg = mockMessage({
       bounce: {
         bounceType: 'Permanent',
         bouncedRecipients: [
           { emailAddress: 'test@example.com' },
         ]
       }
-    })).then(function () {
+    })
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMsg).then(function () {
       t.equal(mockDB.emailRecord.callCount, 1)
       t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
       t.equal(mockLog.messages.length, 3)
@@ -178,6 +181,7 @@ test(
       t.equal(mockLog.messages[1].args[0], 'account.email_bounced')
       t.equal(mockLog.messages[2].args[0].op, 'databaseError')
       t.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+      t.equal(mockMsg.del.callCount, 1)
     })
   }
 )
@@ -194,18 +198,19 @@ test(
           emailVerified: false
         })
       }),
-      deleteAccount: sinon.spy(function (email) {
+      deleteAccount: sinon.spy(function (record) {
         return P.reject(new error.unknownAccount('test@example.com'))
       })
     }
-    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+    var mockMsg = mockMessage({
       bounce: {
         bounceType: 'Permanent',
         bouncedRecipients: [
           { emailAddress: 'test@example.com' },
         ]
       }
-    })).then(function () {
+    })
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMsg).then(function () {
       t.equal(mockDB.emailRecord.callCount, 1)
       t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
       t.equal(mockDB.deleteAccount.callCount, 1)
@@ -217,6 +222,46 @@ test(
       t.equal(mockLog.messages[2].args[0].op, 'databaseError')
       t.equal(mockLog.messages[2].args[0].email, 'test@example.com')
       t.equal(mockLog.messages[2].args[0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
+      t.equal(mockMsg.del.callCount, 1)
+    })
+  }
+)
+
+test(
+  'quoted email addresses are normalized for lookup',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        // Lookup only succeeds when using original, unquoted email addr.
+        if (email !== 'test.@example.com') {
+          return P.reject(new error.unknownAccount(email))
+        }
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: false
+        })
+      }),
+      deleteAccount: sinon.spy(function (record) {
+        return P.resolve({ })
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          // Bounce message has email addr in quoted form, since some
+          // mail agents normalize it in this way.
+          { emailAddress: '"test."@example.com' },
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 2)
+      t.equal(mockDB.emailRecord.args[0][0], '"test."@example.com')
+      t.equal(mockDB.emailRecord.args[1][0], 'test.@example.com')
+      t.equal(mockDB.deleteAccount.callCount, 1)
+      t.equal(mockDB.deleteAccount.args[0][0].email, 'test.@example.com')
     })
   }
 )

--- a/test/local/bounce_tests.js
+++ b/test/local/bounce_tests.js
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var EventEmitter = require('events').EventEmitter
+var sinon = require('sinon')
+var test = require('../ptaptest')
+var spyLog = require('../mocks').spyLog
+var error = require('../../lib/error')
+var P = require('../../lib/promise')
+var bounces = require('../../lib/bounces')
+
+var mockBounceQueue = new EventEmitter()
+mockBounceQueue.start = function start() {}
+
+function mockMessage(msg) {
+  msg.del = sinon.spy()
+  return msg
+}
+
+function mockedBounces(log, db) {
+  return bounces(log, error)(mockBounceQueue, db)
+}
+
+test(
+  'unknown message types are silently ignored',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {}
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      junk: 'message'
+    })).then(function () {
+      t.equal(mockLog.messages.length, 0)
+    })
+  }
+)
+
+test(
+  'multiple recipients are all handled in turn',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: false
+        })
+      }),
+      deleteAccount: sinon.spy(function (record) {
+        return P.resolve({ })
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          { emailAddress: 'test@example.com' },
+          { emailAddress: 'foobar@example.com'}
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 2)
+      t.equal(mockDB.deleteAccount.callCount, 2)
+      t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+      t.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
+      t.equal(mockLog.messages.length, 6)
+      t.equal(mockLog.messages[1].level, 'increment')
+      t.equal(mockLog.messages[1].args[0], 'account.email_bounced')
+      t.equal(mockLog.messages[5].level, 'info')
+      t.equal(mockLog.messages[5].args[0].op, 'accountDeleted')
+      t.equal(mockLog.messages[5].args[0].email, 'foobar@example.com')
+    })
+  }
+)
+
+test(
+  'abuse complaints are treated like bounces',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: false
+        })
+      }),
+      deleteAccount: sinon.spy(function (record) {
+        return P.resolve({ })
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      complaint: {
+        complaintFeedbackType: 'abuse',
+        complainedRecipients: [
+          { emailAddress: 'test@example.com' },
+          { emailAddress: 'foobar@example.com'}
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 2)
+      t.equal(mockDB.deleteAccount.callCount, 2)
+      t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+      t.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
+      t.equal(mockLog.messages.length, 6)
+    })
+  }
+)
+
+test(
+  'verified accounts are not deleted on bounce',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: (email === 'verified@example.com')
+        })
+      }),
+      deleteAccount: sinon.spy(function (record) {
+        return P.resolve({ })
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          { emailAddress: 'test@example.com' },
+          { emailAddress: 'verified@example.com'}
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 2)
+      t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+      t.equal(mockDB.emailRecord.args[1][0], 'verified@example.com')
+      t.equal(mockDB.deleteAccount.callCount, 1)
+      t.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      t.equal(mockLog.messages.length, 6)
+      t.equal(mockLog.messages[0].args[0].op, 'handleBounce')
+      t.equal(mockLog.messages[0].args[0].email, 'test@example.com')
+      t.equal(mockLog.messages[1].args[0], 'account.email_bounced')
+      t.equal(mockLog.messages[2].args[0].op, 'accountDeleted')
+      t.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+      t.equal(mockLog.messages[3].args[0].op, 'handleBounce')
+      t.equal(mockLog.messages[3].args[0].email, 'verified@example.com')
+      t.equal(mockLog.messages[4].args[0], 'account.email_bounced')
+      t.equal(mockLog.messages[5].level, 'increment')
+      t.equal(mockLog.messages[5].args[0], 'account.email_bounced.already_verified')
+    })
+  }
+)
+
+test(
+  'errors when looking up the email record are logged',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        return P.reject(new error({}))
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          { emailAddress: 'test@example.com' },
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 1)
+      t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+      t.equal(mockLog.messages.length, 3)
+      t.equal(mockLog.messages[0].args[0].op, 'handleBounce')
+      t.equal(mockLog.messages[0].args[0].email, 'test@example.com')
+      t.equal(mockLog.messages[1].args[0], 'account.email_bounced')
+      t.equal(mockLog.messages[2].args[0].op, 'databaseError')
+      t.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+    })
+  }
+)
+
+test(
+  'errors when deleting the email record are logged',
+  function (t) {
+    var mockLog = spyLog()
+    var mockDB = {
+      emailRecord: sinon.spy(function (email) {
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: false
+        })
+      }),
+      deleteAccount: sinon.spy(function (email) {
+        return P.reject(new error.unknownAccount('test@example.com'))
+      })
+    }
+    return mockedBounces(mockLog, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          { emailAddress: 'test@example.com' },
+        ]
+      }
+    })).then(function () {
+      t.equal(mockDB.emailRecord.callCount, 1)
+      t.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+      t.equal(mockDB.deleteAccount.callCount, 1)
+      t.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      t.equal(mockLog.messages.length, 3)
+      t.equal(mockLog.messages[0].args[0].op, 'handleBounce')
+      t.equal(mockLog.messages[0].args[0].email, 'test@example.com')
+      t.equal(mockLog.messages[1].args[0], 'account.email_bounced')
+      t.equal(mockLog.messages[2].args[0].op, 'databaseError')
+      t.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+      t.equal(mockLog.messages[2].args[0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
+    })
+  }
+)

--- a/test/local/password_check_test.js
+++ b/test/local/password_check_test.js
@@ -4,9 +4,9 @@
 
 var P = require('../../lib/promise')
 var test = require('../ptaptest')
-var MockLog = { info: function () { } }
+var mockLog = require('../mocks').mockLog()
 var config = { lockoutEnabled: true }
-var Password = require('../../lib/crypto/password')(MockLog, config)
+var Password = require('../../lib/crypto/password')(mockLog, config)
 
 var triggersLockout = false
 var MockCustoms = {
@@ -28,7 +28,7 @@ var MockDB = {
   }
 }
 
-var checkPassword = require('../../lib/routes/utils/password_check')(MockLog, config, Password, MockCustoms, MockDB)
+var checkPassword = require('../../lib/routes/utils/password_check')(mockLog, config, Password, MockCustoms, MockDB)
 
 test(
   'password check with correct password',

--- a/test/local/push_tests.js
+++ b/test/local/push_tests.js
@@ -4,7 +4,6 @@
 
 var tap = require('tap')
 var proxyquire = require('proxyquire')
-var extend = require('util')._extend
 
 var test = tap.test
 var P = require('../../lib/promise')

--- a/test/local/push_tests.js
+++ b/test/local/push_tests.js
@@ -8,15 +8,8 @@ var extend = require('util')._extend
 
 var test = tap.test
 var P = require('../../lib/promise')
+var mockLog = require('../mocks').mockLog
 var mockUid = new Buffer('foo')
-var mockLog = {
-  error: function () {
-  },
-  increment: function () {
-  },
-  trace: function () {
-  }
-}
 
 var mockDbEmpty = {
   devices: function () {
@@ -52,12 +45,13 @@ var mockDbResult = {
 test(
   'notifyUpdate does not throw on empty device result',
   function (t) {
-    var thisMockLog = extend({}, mockLog)
-    thisMockLog.increment = function (log) {
-      if (log === 'push.success') {
-        t.fail('must not call push.success')
+    var thisMockLog = mockLog({
+      increment: function (name) {
+        if (name === 'push.success') {
+          t.fail('must not call push.success')
+        }
       }
-    }
+    })
 
     try {
       var push = require('../../lib/push')(thisMockLog, mockDbEmpty)
@@ -76,18 +70,19 @@ test(
   'notifyUpdate sends notifications',
   function (t) {
     var successCalled = 0
-    var thisMockLog = extend({}, mockLog)
-    thisMockLog.increment = function (log) {
-      if (log === 'push.success') {
-        // notification sent
-        successCalled++
-      }
+    var thisMockLog = mockLog({
+      increment: function (log) {
+        if (log === 'push.success') {
+          // notification sent
+          successCalled++
+        }
 
-      if (successCalled === 2) {
-        // we should send 2 notifications for 2 devices
-        t.end()
+        if (successCalled === 2) {
+          // we should send 2 notifications for 2 devices
+          t.end()
+        }
       }
-    }
+    })
 
     var mocks = {
       request: {
@@ -114,13 +109,14 @@ test(
       }
     }
 
-    var thisMockLog = extend({}, mockLog)
-    thisMockLog.increment = function (log) {
-      if (log === 'push.no_push_callback') {
-        // device had no push callback
-        t.end()
+    var thisMockLog = mockLog({
+      increment: function (log) {
+        if (log === 'push.no_push_callback') {
+          // device had no push callback
+          t.end()
+        }
       }
-    }
+    })
 
     var push = require('../../lib/push')(thisMockLog, mockDbNoCallback)
     push.notifyUpdate(mockUid)
@@ -141,13 +137,14 @@ test(
       }
     }
 
-    var thisMockLog = extend({}, mockLog)
-    thisMockLog.increment = function (log) {
-      if (log === 'push.failed') {
-        // request failed
-        t.end()
+    var thisMockLog = mockLog({
+      increment: function (log) {
+        if (log === 'push.failed') {
+          // request failed
+          t.end()
+        }
       }
-    }
+    })
 
     var mocks = {
       request: {
@@ -179,13 +176,14 @@ test(
       }
     }
 
-    var thisMockLog = extend({}, mockLog)
-    thisMockLog.increment = function (log) {
-      if (log === 'push.reset_settings') {
-        // request failed
-        t.end()
+    var thisMockLog = mockLog({
+      increment: function (log) {
+        if (log === 'push.reset_settings') {
+          // request failed
+          t.end()
+        }
       }
-    }
+    })
 
     var mocks = {
       request: {

--- a/test/local/statsd_tests.js
+++ b/test/local/statsd_tests.js
@@ -6,9 +6,7 @@ var tap = require('tap')
 var test = tap.test
 
 var StatsDCollector = require('../../lib/metrics/statsd')
-var mockLog = {
-  error: function () {}
-}
+var mockLog = require('../mocks').mockLog()
 
 test(
   'statsd init failure cases',

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -6,22 +6,47 @@
  * Shared helpers for mocking things out in the tests.
  */
 
+var sinon = require('sinon')
+var extend = require('util')._extend
 
 // A logging mock that doesn't capture anything.
 // You can pass in an object of custom logging methods
-// if you need to e.g. capture messages.
+// if you need to e.g. make assertions about logged values.
 
+var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error']
 
 var mockLog = function(methods) {
-  var log = {}
-  var noop = function () {}
-  methods = methods || {}
-  ;['trace', 'increment', 'info', 'error'].forEach(function(name) {
-    log[name] = (methods[name] || noop).bind(log)
+  var log = extend({}, methods)
+  LOG_METHOD_NAMES.forEach(function(name) {
+    if (!log[name]) {
+      log[name] = function() {}
+    }
   })
   return log
 }
 
+// A logging mock where all logging methods are sinon spys,
+// and we capture a log of all their calls in order.
+
+var spyLog = function(methods) {
+  methods = extend({}, methods)
+  methods.messages = methods.messages || []
+  LOG_METHOD_NAMES.forEach(function(name) {
+    if (!methods[name]) {
+      methods[name] = function() {
+        this.messages.push({
+          level: name,
+          args: Array.prototype.slice.call(arguments)
+        })
+      }
+    }
+    methods[name] = sinon.spy(methods[name])
+  })
+  return mockLog(methods)
+}
+
+
 module.exports = {
-  mockLog: mockLog
+  mockLog: mockLog,
+  spyLog: spyLog
 }

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Shared helpers for mocking things out in the tests.
+ */
+
+
+// A logging mock that doesn't capture anything.
+// You can pass in an object of custom logging methods
+// if you need to e.g. capture messages.
+
+
+var mockLog = function(methods) {
+  var log = {}
+  var noop = function () {}
+  methods = methods || {}
+  ;['trace', 'increment', 'info', 'error'].forEach(function(name) {
+    log[name] = (methods[name] || noop).bind(log)
+  })
+  return log
+}
+
+module.exports = {
+  mockLog: mockLog
+}


### PR DESCRIPTION
This PR adds some de-mangling logic to our bounce handling as proposed in [1].  It's complicated by the fact that we didn't have existing tests for the bounce-handling code, and by the fact that I wanted to use a named constant rather than check for the magic value `errno === 102` in the new test.  So it may be easier to review as three separate commits:

* Add named constants for our errno values
* Refactor the bounce handler to be mockable/testable, and add some tests
* Add the de-mangling logic along with an additional test for it

Fixes #1136.

@dannycoates f?, could you please sanity-check my refactor of `./bin/email_bouncer.js`?
@vbudhram r?

[1] https://github.com/mozilla/fxa-auth-server/issues/1136#issuecomment-174443640