### PR TITLE
fix(logging): Remove PII from logged error object details.

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -41,6 +41,15 @@ Lug.prototype.trace = function (data) {
 }
 
 Lug.prototype.error = function (data) {
+  // If the error object contains an email address,
+  // lift it into top-level fields so that our
+  // PII-scrubbing tool is able to find it.
+  if (data.err && data.err.email) {
+    if (!data.email) {
+      data.email = data.err.email
+    }
+    data.err.email = null
+  }
   this.logger.error(data.op, data)
 }
 

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -286,3 +286,22 @@ test(
   }
 )
 
+test(
+  'log.error removes PII from error objects',
+  function (t) {
+    var err = new Error()
+    err.email = 'test@example.com'
+    log.error({ op: 'unexpectedError', err: err })
+
+    t.equal(logger.error.callCount, 1, 'logger.error was called once')
+    var args = logger.error.args[0]
+    t.equal(args[0], 'unexpectedError', 'logger.error received "op" value')
+    t.equal(Object.keys(args[1]).length, 3, 'log info has three fields')
+    t.equal(args[1].email, 'test@example.com', 'email is reported in top-level fields')
+    t.notOk(args[1].err.email, 'email should not be reported in error object')
+
+    t.end()
+
+    logger.error.reset()
+  }
+)


### PR DESCRIPTION
Our log-scrubber will automatically remove PII from a top-level field named "email", but not from within nested JSON in other fields.  This lifts the "email" property off error objects into the top-level fields for logging purposes.  @dannycoates r?

Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/124 (https://bugzilla.mozilla.org/show_bug.cgi?id=1232570)