### PR TITLE
feat(api): Add get account status by email endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,7 @@ Since this is a HTTP-based protocol, clients should be prepared to gracefully ha
 * Account
     * [POST /v1/account/create](#post-v1accountcreate)
     * [GET  /v1/account/status](#get-v1accountstatus)
+    * [POST /v1/account/status](#post-v1accountstatus)
     * [GET  /v1/account/keys (:lock: keyFetchToken) (verf-required)](#get-v1accountkeys)
     * [GET  /v1/account/profile (:lock: oauthBearerToken)](#get-v1accountprofile)
     * [POST /v1/account/reset (:lock: accountResetToken)](#post-v1accountreset)
@@ -272,6 +273,41 @@ Failing requests may be due to the following errors:
 * status code 400, errno 107:  request query contains invalid parameters
 * status code 400, errno 108:  request query missing required parameters
 
+## POST /v1/account/status
+
+Gets the status of an account without exposing user data through query params. This
+endpoint is rate limited by the [fxa-customs-server]()
+
+___Parameters___
+
+* email - the primary email for this account
+
+### Request
+
+```sh
+curl -v \
+-X POST \
+-H "Content-Type: application/json" \
+"https://api-accounts.dev.lcip.org/v1/account/status" \
+-d '{
+  "email": "me@example.com"
+}'
+```
+
+### Response
+
+Successful requests will produce a "200 OK" response with the account status provided in the JSON body:
+
+```json
+{
+  "exists": true
+}
+```
+
+Failing requests may be due to the following errors:
+
+* status code 400, errno 107:  request query contains invalid parameters
+* status code 429, errno 114:  client has sent too many requests
 
 ## POST /v1/account/login
 

--- a/lib/customs.js
+++ b/lib/customs.js
@@ -26,7 +26,7 @@ module.exports = function (log, error) {
       {
         ip: ip,
         email: email,
-        action: action,
+        action: action
       }
     )
     .then(

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -630,6 +630,46 @@ module.exports = function (
       }
     },
     {
+      method: 'POST',
+      path: '/account/status',
+      config: {
+        validate: {
+          payload: {
+            email: validators.email().required()
+          }
+        },
+        response: {
+          schema: {
+            exists: isA.boolean().required()
+          }
+        }
+      },
+      handler: function (request, reply) {
+        var email = request.payload.email
+
+        customs.check(
+          request.app.clientAddress,
+          email,
+          'accountStatusCheck')
+          .then(
+            db.accountExists.bind(db, email)
+          )
+          .done(
+            function (exist) {
+              reply({
+                exists: exist
+              })
+            },
+            function (err) {
+              if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
+                return reply({ exists: false })
+              }
+              reply(err)
+            }
+          )
+      }
+    },
+    {
       method: 'GET',
       path: '/account/profile',
       config: {

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -198,6 +198,23 @@ ClientApi.prototype.deviceDestroy = function (sessionTokenHex, id) {
     )
 }
 
+
+ClientApi.prototype.accountStatusByEmail = function (email) {
+  if (email) {
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/account/status',
+      null,
+      {
+        email: email
+      }
+    )
+  }
+  else {
+    return this.doRequest('POST', this.baseURL + '/account/status')
+  }
+}
+
 ClientApi.prototype.accountStatus = function (uid, sessionTokenHex) {
   if (sessionTokenHex) {
     return tokens.SessionToken.fromHex(sessionTokenHex)

--- a/test/remote/account_status_tests.js
+++ b/test/remote/account_status_tests.js
@@ -97,6 +97,67 @@ TestServer.start(config)
   )
 
   test(
+    'account status by email with existing account',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'password')
+        .then(
+          function (c) {
+            return c.api.accountStatusByEmail(email)
+          }
+        )
+        .then(
+          function (response) {
+            t.ok(response.exists, 'account exists')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status by email with non-existing account',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'password')
+        .then(
+          function (c) {
+            var nonExistEmail = server.uniqueEmail()
+            return c.api.accountStatusByEmail(nonExistEmail)
+          }
+        )
+        .then(
+          function (response) {
+            t.ok(!response.exists, 'account does not exist')
+          }
+        )
+    }
+  )
+
+  test(
+    'account status by email with invald email',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'password')
+        .then(
+          function (c) {
+            var invalidEmail = 'notAnEmail'
+            return c.api.accountStatusByEmail(invalidEmail)
+          }
+        )
+        .then(
+          function () {
+            t.fail('should not have successful request')
+          },
+          function (err) {
+            t.equal(err.code, 400)
+            t.equal(err.errno, 107)
+            t.equal(err.message, 'Invalid parameter in request body')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
This PR adds the route `POST /v1/account/status` to check that status of an account by its email address.

Fixes #1176 