### PR TITLE
feat(logging): Log hawk timestamp skew to statsd for easier analysis.

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -150,6 +150,10 @@ Lug.prototype.timing = function(name, timing, tags) {
   this.statsd.timing(name, timing, tags)
 }
 
+Lug.prototype.histogram = function(name, value, tags) {
+  this.statsd.histogram(name, value, tags)
+}
+
 module.exports = function (level, name) {
   var log = new Lug(
     {

--- a/lib/metrics/statsd.js
+++ b/lib/metrics/statsd.js
@@ -7,6 +7,7 @@ var uaParser = require('node-uap')
 
 var STATSD_PREFIX = 'fxa.auth.'
 var TIMING_SUFFIX = '.time'
+var HISTOGRAM_SUFFIX = '.hist'
 
 function getGenericTags(info) {
   var tags = []
@@ -104,6 +105,18 @@ StatsDCollector.prototype = {
         this.sampleRate,
         tags,
         handleErrors(this, 'timing')
+      )
+    }
+  },
+
+  histogram: function (name, value, tags) {
+    if (this.client) {
+      this.client.histogram(
+        STATSD_PREFIX + name + HISTOGRAM_SUFFIX,
+        value,
+        this.sampleRate,
+        tags,
+        handleErrors(this, 'histogram')
       )
     }
   },

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,8 +32,8 @@ function create(log, error, config, routes, db) {
       // Since we've disabled timestamp checks, there's not much point
       // keeping a nonce cache.  Instead we use this as an opportunity
       // to report on the clock skew values seen in the wild.
-      var skew = (Date.now() / 1000) - (+ts)
-      log.trace({ op: 'server.nonceFunc', skew: skew })
+      var skew = Math.abs((Date.now() / 1000) - (+ts))
+      log.histogram('server.hawkTimestampSkew', skew)
       return cb()
     }
   }


### PR DESCRIPTION
We meant to do some analysis of this skew measurement, but haven't prioritized it.  Let's sent it to statsd/datadog for easier aggregation and analysis.  @jrgm r?