### PR TITLE
fix(api): permit lastAccessTime 0 in devices response

### DIFF
--- a/lib/tokens/token.js
+++ b/lib/tokens/token.js
@@ -38,7 +38,7 @@ module.exports = function (log, crypto, P, hkdf, Bundle, error) {
     this.algorithm = 'sha256'
     this.uid = details.uid || null
     this.lifetime = details.lifetime || Infinity
-    this.createdAt = details.createdAt || Date.now()
+    this.createdAt = details.createdAt >= 0 ? details.createdAt : Date.now()
   }
 
   // Create a new token of the given type.
@@ -60,7 +60,6 @@ module.exports = function (log, crypto, P, hkdf, Bundle, error) {
           Token.deriveTokenKeys(TokenType, bytes)
             .then(
               function (keys) {
-                details.createdAt = Date.now()
                 d.resolve(new TokenType(keys, details || {}))
               }
             )

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -547,7 +547,11 @@ function getQueryString (options) {
   }
 
   if (options.serviceQuery) {
-    qs += 'service=' + options.serviceQuery
+    qs += 'service=' + options.serviceQuery + '&'
+  }
+
+  if (options.createdAt) {
+    qs += '_createdAt=' + options.createdAt
   }
 
   return qs


### PR DESCRIPTION
Fixes #1197.

The fix itself just updates the Joi data but I'm feeling pretty sketchy about the changes made to test it. As per https://github.com/mozilla/fxa-auth-server/issues/1197#issuecomment-188755474, it's difficult to force a certain value for `lastAccessTime` from the remote tests because it gets set automatically. I took the approach of passing in a query param to force it but there's one place in particular where that feels a little bit hairy, see my comment inline.

@rfk, @jrgm r?