### PR TITLE
feat(polling): Send 429/retry-after when polling email status on old accounts

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -10,6 +10,10 @@ var butil = require('../crypto/butil')
 var openid = require('openid')
 var url = require('url')
 
+var ONE_MINUTE = 60 * 1000
+var ONE_DAY = 24 * 60 * ONE_MINUTE
+var ONE_WEEK = 7 * ONE_DAY
+
 module.exports = function (
   log,
   crypto,
@@ -888,6 +892,21 @@ module.exports = function (
       handler: function (request, reply) {
         log.begin('Account.RecoveryEmailStatus', request)
         var sessionToken = request.auth.credentials
+        // Desktop browsers poll this endpoint to check whether
+        // the account is verified, generating a *lot* of traffic.
+        // If the account remains unverified after too long,
+        // try to slow-walk their polling requests with 429s
+        // to reduce traffic.
+        var age = Date.now() - sessionToken.createdAt
+        log.histogram('recoveryEmailStatus.sessionAge', age / 1000)
+        if (!sessionToken.emailVerified && age > ONE_DAY) {
+          // Too old and still unverified, try again later.
+          var retryAfter = ONE_MINUTE;
+          if (age > ONE_WEEK) {
+            retryAfter = 5 * ONE_MINUTE;
+          }
+          throw error.tooManyRequests(retryAfter);
+        }
         reply(
           {
             email: sessionToken.email,


### PR DESCRIPTION
@jrgm what do you think about something like to help reduce verification polling load?  The desktop client code does seem to respect retry-after headers sent on error responses during the polling.

Of course, it would only help is some meaningful fraction of the polling traffic comes from browsers that remain in the unverified state for a long time.  Adding a histogram here could help tell us the distribution of these requests.