### PR TITLE
fix(tests): sanely handle unicode email addresses in account tests

### DIFF
--- a/test/mailbox.js
+++ b/test/mailbox.js
@@ -25,7 +25,7 @@ module.exports = function (host, port) {
   }
 
   function loop(name, tries, cb) {
-    var url = 'http://' + host + ':' + port + '/mail/' + name
+    var url = 'http://' + host + ':' + port + '/mail/' + encodeURIComponent(name)
     console.log('checking mail', url)
     request({ url: url, method: 'GET' },
       function (err, res, body) {

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -378,6 +378,21 @@ TestServer.start(config)
   )
 
   test(
+    'account creation works with unicode email address',
+    function (t) {
+      var email = server.uniqueUnicodeEmail()
+      return Client.create(config.publicUrl, email, 'foo')
+        .then(function (client) {
+          t.ok(client, 'created account')
+          return server.mailbox.waitForEmail(email)
+        })
+        .then(function (emailData) {
+          t.ok(emailData, 'received email')
+        })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/account_login_tests.js
+++ b/test/remote/account_login_tests.js
@@ -126,6 +126,25 @@ TestServer.start(config)
   )
 
   test(
+    'login works with unicode email address',
+    function (t) {
+      var email = server.uniqueUnicodeEmail()
+      var password = 'wibble'
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+        .then(
+          function () {
+            return Client.login(config.publicUrl, email, password)
+          }
+        )
+        .then(
+          function (client) {
+            t.ok(client, 'logged in to account')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -234,6 +234,24 @@ TestServer.start(config)
   )
 
   test(
+    'account profile works with unicode email address',
+    function (t) {
+      var email = server.uniqueUnicodeEmail()
+      return Client.create(config.publicUrl, email, 'password')
+        .then(
+          function (c) {
+            return c.api.accountProfile(c.sessionToken)
+          }
+        )
+        .then(
+          function (response) {
+            t.equal(response.email, email, 'email address is returned')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/account_status_tests.js
+++ b/test/remote/account_status_tests.js
@@ -158,6 +158,24 @@ TestServer.start(config)
   )
 
   test(
+    'account status by email works with unicode email address',
+    function (t) {
+      var email = server.uniqueUnicodeEmail()
+      return Client.create(config.publicUrl, email, 'password')
+        .then(
+          function (c) {
+            return c.api.accountStatusByEmail(email)
+          }
+        )
+        .then(
+          function (response) {
+            t.ok(response.exists, 'account exists')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -115,4 +115,12 @@ TestServer.prototype.uniqueEmail = function () {
   return crypto.randomBytes(10).toString('hex') + '@restmail.net'
 }
 
+TestServer.prototype.uniqueUnicodeEmail = function () {
+  return crypto.randomBytes(10).toString('hex') +
+    String.fromCharCode(1234) +
+    '@' +
+    String.fromCharCode(5678) +
+    'restmail.net'
+}
+
 module.exports = TestServer


### PR DESCRIPTION
Fixes #1206.

The problem was fixed by URI-encoding the `name` portion of the path when the `server.mailbox` test helper makes requests to the auth mailer.

Even though the tests were just written as a sanity check ahead of https://github.com/mozilla/fxa-content-server/pull/3546 and the fix is not to production code, I figured it's still worth landing?