### PR TITLE
fix(api): reject emails without a dot in the domain

### DIFF
--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -71,9 +71,11 @@ module.exports.isValidEmailAddress = function(value) {
   if (domain[0] === '.' || domain[0] === '-') {
     return false
   }
+  var hasDot = false
   // The domain portion must be a valid punycode domain.
   for (i = 0; i < domain.length; i++) {
     if (domain[i] === '.') {
+      hasDot = true
       // A dot can't follow a dot or a dash.
       if (domain[i - 1] === '.' || domain[i - 1] === '-') {
         return false
@@ -89,7 +91,9 @@ module.exports.isValidEmailAddress = function(value) {
       return false
     }
   }
-  return true
+  // Even though the RFC doesn't require it, we need a dot. See:
+  // https://github.com/mozilla/fxa-auth-server/issues/1193
+  return hasDot
 }
 
 module.exports.redirectTo = function (base) {

--- a/test/local/email_validity_tests.js
+++ b/test/local/email_validity_tests.js
@@ -23,6 +23,7 @@ TestServer.start(config)
         'me@hello world.com',
         'me@hello+world.com',
         'me@.example',
+        'me@example',
         'me@example.com-',
         'me@example..com',
         'me@example-.com',


### PR DESCRIPTION
Fixes #1193.

I'm not sure whether this is still worth resolving in light of [the decision](https://github.com/mozilla/fxa-content-server/pull/3546#issuecomment-191324647) over on the content server not to support unicode email addresses. This change does not bring us full harmony between the two implementations, although they are closer with this change than without it. But at some point in the future, we'll still need to address the divergence between the two.

Anyway, here it is just in case.