### PR TITLE
chore(api): Add signin config value

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -184,6 +184,11 @@ var conf = convict({
       format: String,
       default: 'https://www.mozilla.org/firefox/ios/'
     },
+    signInUrl: {
+      doc: 'Deprecated. uses contentServer.url',
+      format: String,
+      default: 'undefined'
+    },
     supportUrl: {
       doc: 'url to Mozilla Support product page',
       format: String,
@@ -364,6 +369,7 @@ conf.validate({ strict: true })
 conf.set('domain', url.parse(conf.get('publicUrl')).host)
 
 // derive fxa-auth-mailer configuration from our content-server url
+conf.set('smtp.signInUrl', conf.get('contentServer.url') + '/signin')
 conf.set('smtp.verificationUrl', conf.get('contentServer.url') + '/v1/verify_email')
 conf.set('smtp.passwordResetUrl', conf.get('contentServer.url') + '/v1/complete_reset_password')
 conf.set('smtp.accountUnlockUrl', conf.get('contentServer.url') + '/v1/complete_unlock_account')


### PR DESCRIPTION
This adds signIn configuration value needed by new password flow templates. This is needed by new password email templates.

Ref: https://github.com/mozilla/fxa-auth-mailer/pull/124
Ref: https://github.com/mozilla/fxa-content-server/issues/3467

@vladikoff r?