### PR TITLE
feat(logging): add metrics context metadata to activity events

### DIFF
--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var isA = require('joi')
+var HEX = require('../routes/validators').HEX_STRING
+
+module.exports = {
+  schema: isA.object({
+    flowId: isA.string().length(64).regex(HEX).optional(),
+    flowBeginTime: isA.number().integer().positive().optional(),
+    context: isA.string().optional(),
+    entrypoint: isA.string().optional(),
+    migration: isA.string().optional(),
+    service: isA.string().optional(),
+    utmCampaign: isA.string().optional(),
+    utmContent: isA.string().optional(),
+    utmMedium: isA.string().optional(),
+    utmSource: isA.string().optional(),
+    utmTerm: isA.string().optional()
+  }).and('flowId', 'flowBeginTime').optional(),
+
+  add: function (data, metadata, doNotTrack) {
+    if (metadata) {
+      data.time = Date.now()
+      data.flow_id = metadata.flowId
+      data.flow_time = calculateFlowTime(data.time, metadata.flowBeginTime)
+      data.context = metadata.context
+      data.entrypoint = metadata.entrypoint
+      data.migration = metadata.migration
+      data.service = metadata.service
+
+      if (! doNotTrack) {
+        data.utm_campaign = metadata.utmCampaign
+        data.utm_content = metadata.utmContent
+        data.utm_medium = metadata.utmMedium
+        data.utm_source = metadata.utmSource
+        data.utm_term = metadata.utmTerm
+      }
+    }
+
+    return data
+  }
+}
+
+function calculateFlowTime (time, flowBeginTime) {
+  if (time <= flowBeginTime) {
+    return 0
+  }
+
+  return time - flowBeginTime
+}
+

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -9,6 +9,7 @@ var BASE64_JWT = validators.BASE64_JWT
 var butil = require('../crypto/butil')
 var openid = require('openid')
 var url = require('url')
+var metricsContext = require('../metrics/context')
 
 module.exports = function (
   log,
@@ -66,7 +67,8 @@ module.exports = function (
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
             })
-            .optional()
+            .optional(),
+            metricsContext: metricsContext.schema
           }
         },
         response: {
@@ -303,7 +305,8 @@ module.exports = function (
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
             })
-            .optional()
+            .optional(),
+            metricsContext: metricsContext.schema
           }
         },
         response: {
@@ -1112,7 +1115,8 @@ module.exports = function (
         },
         validate: {
           payload: {
-            authPW: isA.string().min(64).max(64).regex(HEX_STRING).required()
+            authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
+            metricsContext: metricsContext.schema
           }
         }
       },
@@ -1271,3 +1275,4 @@ module.exports = function (
 
   return routes
 }
+

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var metricsContext = require('../metrics/context')
+
 module.exports = function (log, isA, error, signer, db, domain) {
 
   const HOUR = 1000 * 60 * 60
@@ -27,7 +29,8 @@ module.exports = function (log, isA, error, signer, db, domain) {
               g: isA.string(),
               version: isA.string()
             }).required(),
-            duration: isA.number().integer().min(0).max(24 * HOUR).required()
+            duration: isA.number().integer().min(0).max(24 * HOUR).required(),
+            metricsContext: metricsContext.schema
           }
         }
       },

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -113,7 +113,8 @@ ClientApi.prototype.accountCreate = function (email, authPW, options) {
       redirectTo: options.redirectTo || undefined,
       resume: options.resume || undefined,
       preVerifyToken: options.preVerifyToken || undefined,
-      device: options.device || undefined
+      device: options.device || undefined,
+      metricsContext: options.metricsContext || undefined
     },
     {
       'accept-language': options.lang
@@ -134,7 +135,8 @@ ClientApi.prototype.accountLogin = function (email, authPW, opts) {
       authPW: authPW.toString('hex'),
       service: opts.service || undefined,
       reason: opts.reason || undefined,
-      device: opts.device || undefined
+      device: opts.device || undefined,
+      metricsContext: opts.metricsContext || undefined
     },
     {
       'accept-language': opts.lang
@@ -240,7 +242,8 @@ ClientApi.prototype.accountStatus = function (uid, sessionTokenHex) {
   }
 }
 
-ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, headers) {
+ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, headers, options) {
+  options = options || {}
   return tokens.AccountResetToken.fromHex(accountResetTokenHex)
     .then(
       function (token) {
@@ -249,7 +252,8 @@ ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, heade
           this.baseURL + '/account/reset',
           token,
           {
-            authPW: authPW.toString('hex')
+            authPW: authPW.toString('hex'),
+            metricsContext: options.metricsContext || undefined
           },
           headers
         )
@@ -317,7 +321,8 @@ ClientApi.prototype.recoveryEmailVerifyCode = function (uid, code, options) {
   )
 }
 
-ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration, locale) {
+ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration, locale, options) {
+  options = options || {}
   return tokens.SessionToken.fromHex(sessionTokenHex)
     .then(
       function (token) {
@@ -327,7 +332,8 @@ ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, dura
           token,
           {
             publicKey: publicKey,
-            duration: duration
+            duration: duration,
+            metricsContext: options.metricsContext || undefined
           },
           {
             'accept-language': locale

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -201,11 +201,11 @@ Client.prototype.requestVerifyEmail = function () {
   )
 }
 
-Client.prototype.sign = function (publicKey, duration) {
+Client.prototype.sign = function (publicKey, duration, locale, options) {
   var o = this.sessionToken ? P.resolve(null) : this.login()
   return o.then(
       function () {
-        return this.api.certificateSign(this.sessionToken, publicKey, duration)
+        return this.api.certificateSign(this.sessionToken, publicKey, duration, locale, options)
       }.bind(this)
     )
     .then(
@@ -376,7 +376,7 @@ Client.prototype.verifyAccountUnlockCode = function (uid, code) {
   return this.api.accountUnlockVerifyCode(uid, code)
 }
 
-Client.prototype.resetPassword = function (newPassword, headers) {
+Client.prototype.resetPassword = function (newPassword, headers, options) {
   if (!this.accountResetToken) {
     throw new Error('call verifyPasswordResetCode before calling resetPassword')
   }
@@ -387,7 +387,8 @@ Client.prototype.resetPassword = function (newPassword, headers) {
         return this.api.accountReset(
           this.accountResetToken,
           this.authPW,
-          headers
+          headers,
+          options
         )
       }.bind(this)
     )

--- a/test/local/metrics_context_tests.js
+++ b/test/local/metrics_context_tests.js
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var test = require('../ptaptest')
+
+var metricsContext = require('../../lib/metrics/context')
+
+test(
+  'metricsContext interface is correct',
+  function (t) {
+    t.equal(typeof metricsContext, 'object', 'metricsContext is object')
+    t.notEqual(metricsContext, null, 'metricsContext is not null')
+    t.equal(Object.keys(metricsContext).length, 2, 'metricsContext has 2 properties')
+
+    t.equal(typeof metricsContext.schema, 'object', 'metricsContext.schema is object')
+    t.notEqual(metricsContext.schema, null, 'metricsContext.schema is not null')
+
+    t.equal(typeof metricsContext.add, 'function', 'metricsContext.add is function')
+    t.equal(metricsContext.add.length, 3, 'metricsContext.add expects 3 arguments')
+
+    t.end()
+  }
+)
+
+test(
+  'metricsContext.add without metadata',
+  function (t) {
+    var result = metricsContext.add({})
+
+    t.equal(typeof result, 'object', 'result is object')
+    t.notEqual(result, null, 'result is not null')
+    t.equal(Object.keys(result).length, 0, 'result is empty')
+
+    t.end()
+  }
+)
+
+test(
+  'metricsContext.add with metadata',
+  function (t) {
+    var time = Date.now() - 1
+    var result = metricsContext.add({}, {
+      flowId: 'mock flow id',
+      flowBeginTime: time,
+      context: 'mock context',
+      entrypoint: 'mock entry point',
+      migration: 'mock migration',
+      service: 'mock service',
+      utmCampaign: 'mock utm_campaign',
+      utmContent: 'mock utm_content',
+      utmMedium: 'mock utm_medium',
+      utmSource: 'mock utm_source',
+      utmTerm: 'mock utm_term',
+      ignore: 'mock ignorable property'
+    })
+
+    t.equal(typeof result, 'object', 'result is object')
+    t.notEqual(result, null, 'result is not null')
+    t.equal(Object.keys(result).length, 12, 'result has 12 properties')
+    t.ok(result.time > time, 'result.time seems correct')
+    t.equal(result.flow_id, 'mock flow id', 'result.flow_id is correct')
+    t.ok(result.flow_time > 0, 'result.flow_time is greater than zero')
+    t.ok(result.flow_time < time, 'result.flow_time is less than the current time')
+    t.equal(result.context, 'mock context', 'result.context is correct')
+    t.equal(result.entrypoint, 'mock entry point', 'result.entry point is correct')
+    t.equal(result.migration, 'mock migration', 'result.migration is correct')
+    t.equal(result.service, 'mock service', 'result.service is correct')
+    t.equal(result.utm_campaign, 'mock utm_campaign', 'result.utm_campaign is correct')
+    t.equal(result.utm_content, 'mock utm_content', 'result.utm_content is correct')
+    t.equal(result.utm_medium, 'mock utm_medium', 'result.utm_medium is correct')
+    t.equal(result.utm_source, 'mock utm_source', 'result.utm_source is correct')
+    t.equal(result.utm_term, 'mock utm_term', 'result.utm_term is correct')
+
+    t.end()
+  }
+)
+
+test(
+  'metricsContext.add with bad flowBeginTime',
+  function (t) {
+    var result = metricsContext.add({}, {
+      flowBeginTime: Date.now() + 10000
+    })
+
+    t.equal(typeof result, 'object', 'result is object')
+    t.notEqual(result, null, 'result is not null')
+    t.strictEqual(result.flow_time, 0, 'result.time is zero')
+
+    t.end()
+  }
+)
+
+test(
+  'metricsContext.add with DNT header',
+  function (t) {
+    var time = Date.now() - 1
+    var result = metricsContext.add({}, {
+      flowId: 'mock flow id',
+      flowBeginTime: time,
+      context: 'mock context',
+      entrypoint: 'mock entry point',
+      migration: 'mock migration',
+      service: 'mock service',
+      utmCampaign: 'mock utm_campaign',
+      utmContent: 'mock utm_content',
+      utmMedium: 'mock utm_medium',
+      utmSource: 'mock utm_source',
+      utmTerm: 'mock utm_term',
+      ignore: 'mock ignorable property'
+    }, true)
+
+    t.equal(Object.keys(result).length, 7, 'result has 7 properties')
+    t.equal(result.utm_campaign, undefined, 'result.utm_campaign is undefined')
+    t.equal(result.utm_content, undefined, 'result.utm_content is undefined')
+    t.equal(result.utm_medium, undefined, 'result.utm_medium is undefined')
+    t.equal(result.utm_source, undefined, 'result.utm_source is undefined')
+    t.equal(result.utm_term, undefined, 'result.utm_term is undefined')
+
+    t.end()
+  }
+)
+

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -393,6 +393,123 @@ TestServer.start(config)
   )
 
   test(
+    'account creation works with minimal metricsContext metadata',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 1
+        }
+      }).then(function (client) {
+        t.ok(client, 'created account')
+      })
+    }
+  )
+
+  test(
+    'account creation fails with invalid metricsContext flowId',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 1
+        }
+      }).then(function () {
+        t.fail('account creation should have failed')
+      }, function (err) {
+        t.ok(err, 'account creation failed')
+      })
+    }
+  )
+
+  test(
+    'account creation fails with invalid metricsContext flowBeginTime',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 0
+        }
+      }).then(function () {
+        t.fail('account creation should have failed')
+      }, function (err) {
+        t.ok(err, 'account creation failed')
+      })
+    }
+  )
+
+  test(
+    'account creation works with maximal metricsContext metadata',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 1,
+          context: 'foo',
+          entrypoint: 'bar',
+          migration: 'baz',
+          service: 'qux',
+          utmCampaign: 'wibble',
+          utmContent: 'blurgh',
+          utmMedium: 'blee',
+          utmSource: 'fnarr',
+          utmTerm: 'frang'
+        }
+      }).then(function (client) {
+        t.ok(client, 'created account')
+      })
+    }
+  )
+
+  test(
+    'account creation works with empty metricsContext metadata',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {}
+      }).then(function (client) {
+        t.ok(client, 'created account')
+      })
+    }
+  )
+
+  test(
+    'account creation fails with missing flowBeginTime',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d'
+        }
+      }).then(function () {
+        t.fail('account creation should have failed')
+      }, function (err) {
+        t.ok(err, 'account creation failed')
+      })
+    }
+  )
+
+  test(
+    'account creation fails with missing flowId',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.create(config.publicUrl, email, 'foo', {
+        metricsContext: {
+          flowBeginTime: Date.now()
+        }
+      }).then(function () {
+        t.fail('account creation should have failed')
+      }, function (err) {
+        t.ok(err, 'account creation failed')
+      })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/account_login_tests.js
+++ b/test/remote/account_login_tests.js
@@ -145,6 +145,67 @@ TestServer.start(config)
   )
 
   test(
+    'account login works with minimal metricsContext metadata',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.createAndVerify(config.publicUrl, email, 'foo', server.mailbox)
+        .then(function () {
+          return Client.login(config.publicUrl, email, 'foo', {
+            metricsContext: {
+              flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              flowBeginTime: Date.now()
+            }
+          })
+        })
+        .then(function (client) {
+          t.ok(client, 'logged in to account')
+        })
+    }
+  )
+
+  test(
+    'account login fails with invalid metricsContext flowId',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.createAndVerify(config.publicUrl, email, 'foo', server.mailbox)
+        .then(function () {
+          return Client.login(config.publicUrl, email, 'foo', {
+            metricsContext: {
+              flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0',
+              flowBeginTime: Date.now()
+            }
+          })
+        })
+        .then(function () {
+          t.fail('account login should have failed')
+        }, function (err) {
+          t.ok(err, 'account login failed')
+        })
+    }
+  )
+
+  test(
+    'account login fails with invalid metricsContext flowBeginTime',
+    function (t) {
+      var email = server.uniqueEmail()
+      return Client.createAndVerify(config.publicUrl, email, 'foo', server.mailbox)
+        .then(function () {
+          return Client.login(config.publicUrl, email, 'foo', {
+            metricsContext: {
+              flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              flowBeginTime: 'wibble'
+            }
+          })
+        })
+        .then(function () {
+          t.fail('account login should have failed')
+        }, function (err) {
+          t.ok(err, 'account login failed')
+        })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -218,6 +218,54 @@ TestServer.start(config)
   )
 
   test(
+    'certificate sign works with minimal metricsContext metadata',
+    function (t) {
+      var duration = 1000 * 60 * 60 * 24 // 24 hours
+      return Client.createAndVerify(config.publicUrl, server.uniqueEmail(), 'foo', server.mailbox)
+        .then(
+          function (client) {
+            return client.sign(publicKey, duration, null, {
+              metricsContext: {
+                flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+                flowBeginTime: 1
+              }
+            })
+          }
+        )
+        .then(
+          function (cert) {
+            t.ok(cert, 'signed certificate')
+          }
+        )
+    }
+  )
+
+  test(
+    'certificate sign fails with invalid metricsContext flowId',
+    function (t) {
+      var duration = 1000 * 60 * 60 * 24 // 24 hours
+      return Client.createAndVerify(config.publicUrl, server.uniqueEmail(), 'foo', server.mailbox)
+        .then(
+          function (client) {
+            return client.sign(publicKey, duration, null, {
+              metricsContext: {
+                flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
+                flowBeginTime: 1
+              }
+            })
+          }
+        )
+        .then(
+          function () {
+            t.fail('certificate sign should have failed')
+          }, function (err) {
+            t.ok(err, 'certificate sign failed')
+          }
+        )
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
Fixes #1200.

To reduce repetition of the validation boilerplate, I extracted the schema into the `metricsContext` module. I opted for there rather than the `validators` module so that the schema could live close to the `add` method; if any changes need to be made to this stuff down the line, they will only affect this one module. But I also realise I'm breaking with convention a bit so if you don't like it I'm happy to stick it in `validators`.

@rfk, r?