### PR TITLE
fix(api): permit null lastAccessTime in devices response

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -823,7 +823,7 @@ module.exports = function (
           schema: isA.array().items(isA.object({
             id: isA.string().length(32).regex(HEX_STRING).required(),
             isCurrentDevice: isA.boolean().required(),
-            lastAccessTime: isA.number().min(0).required(),
+            lastAccessTime: isA.number().min(0).required().allow(null),
             name: isA.string().max(255).required(),
             type: isA.string().max(16).required(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow('').allow(null),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -369,8 +369,8 @@
     },
     "fxa-auth-db-mysql": {
       "version": "0.55.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#3f5521976498fe1e7b260aeffc03dd828cf2b04f",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#3f5521976498fe1e7b260aeffc03dd828cf2b04f",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#87903a7d15401277b12e4b30fbecc56e70bf7b1f",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#87903a7d15401277b12e4b30fbecc56e70bf7b1f",
       "dependencies": {
         "bluebird": {
           "version": "2.1.3",


### PR DESCRIPTION
Fixes the recent 500 errors that have been occurring on the `/devices` endpoint by permitting a null `lastAccessTime` in the response.

Note that these nulls are a result of the `LEFT JOIN` in the stored procedure rather than being in the database directly, so the `NOT NULL` in the schema still stands.

@jrgm, @rfk r?