### PR TITLE
fix(email): Clean up accounts with invalid emails on status poll.

### DIFF
--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require('ass')
+
+var sinon = require('sinon')
+
+var test = require('../ptaptest')
+var mocks = require('../mocks')
+
+var P = require('../../lib/promise')
+var uuid = require('uuid')
+var crypto = require('crypto')
+var isA = require('joi')
+var error = require('../../lib/error')
+
+var TEST_EMAIL_INVALID = 'example@dotless-domain'
+
+var makeRoutes = function (options) {
+  options = options || {}
+
+  var config = options.config || {
+    smtp: {}
+  }
+  var log = options.log || mocks.mockLog()
+  var Password = require('../../lib/crypto/password')(log, config)
+  return require('../../lib/routes/account')(
+    log,
+    crypto,
+    P,
+    uuid,
+    isA,
+    error,
+    options.db || {},
+    options.mailer || {},
+    Password,
+    config
+  )
+}
+
+var getRoute = function (routes, path) {
+  var route = null
+
+  routes.some(function (r) {
+    if (r.path === path) {
+      route = r
+      return true
+    }
+  })
+
+  return route
+}
+
+test(
+  'account with unverified invalid email gets deleted on status poll',
+  function (t) {
+    var mockDB = {
+      deleteAccount: sinon.spy(function() {
+        return P.resolve()
+      })
+    }
+    var mockRequest = {
+      auth: {
+        credentials: {
+          email: TEST_EMAIL_INVALID,
+          emailVerified: false
+        }
+      }
+    }
+
+    var accountRoutes = makeRoutes({
+      db: mockDB
+    })
+    var route = getRoute(accountRoutes, '/recovery_email/status')
+
+    return new P(function(resolve) {
+      route.handler(mockRequest, function(response) {
+        resolve(response)
+      })
+    })
+    .then(function(response) {
+      t.equal(mockDB.deleteAccount.callCount, 1)
+      t.equal(mockDB.deleteAccount.firstCall.args[0].email, TEST_EMAIL_INVALID)
+      t.equal(response.errno, error.ERRNO.INVALID_TOKEN)
+    })
+  }
+)
+
+test(
+  'account with verified invalid email does not get deleted on status poll',
+  function (t) {
+    var mockDB = {
+      deleteAccount: sinon.spy()
+    }
+    var mockRequest = {
+      auth: {
+        credentials: {
+          email: TEST_EMAIL_INVALID,
+          emailVerified: true
+        }
+      }
+    }
+
+    var accountRoutes = makeRoutes({
+      db: mockDB
+    })
+    var route = getRoute(accountRoutes, '/recovery_email/status')
+
+    return new P(function(resolve) {
+      route.handler(mockRequest, function(response) {
+        resolve(response)
+      })
+    })
+    .then(function(response) {
+      t.equal(mockDB.deleteAccount.callCount, 0)
+      t.deepEqual(response, {
+        email: TEST_EMAIL_INVALID,
+        verified: true
+      })
+    })
+  }
+)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -13,7 +13,7 @@ var extend = require('util')._extend
 // You can pass in an object of custom logging methods
 // if you need to e.g. make assertions about logged values.
 
-var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error']
+var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error', 'begin']
 
 var mockLog = function(methods) {
   var log = extend({}, methods)


### PR DESCRIPTION
Potentially fixes #1219, /cc @jrgm; @philbooth mind an r?

This proved tricky to test using the current test infrastructure, because the desired logic requires the creation of a strange database state.  I took a new approach based on mocking out everything but the route-handling code itself, which made the specific change in this PR easier to test, but may have other downsides overall.  What do you think @philbooth?  If we like it, we could work on slowly refactoring other routes to have more unit-test-style tests like this as well.