### PR TITLE
Some shrinkwrap bumps for train-59 (narrowly targetted)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -863,8 +863,8 @@
     },
     "fxa-auth-mailer": {
       "version": "1.0.8",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#058557d4bcc4a90845f7c4bcb6788abf9f325e6e",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#058557d4bcc4a90845f7c4bcb6788abf9f325e6e",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#f4098f9f58c98e47058157f84de63a1394275bc4",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#f4098f9f58c98e47058157f84de63a1394275bc4",
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",
@@ -950,8 +950,8 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#4bf305a1fdeec9fa4f7bec84f2797f4aeb5fbcd3",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#4bf305a1fdeec9fa4f7bec84f2797f4aeb5fbcd3"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#b61acfa33bc05ceef647abd39b3fdb1a8274f2e4",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#b61acfa33bc05ceef647abd39b3fdb1a8274f2e4"
         },
         "grunt-nunjucks-2-html": {
           "version": "0.3.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -368,9 +368,9 @@
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
     },
     "fxa-auth-db-mysql": {
-      "version": "0.58.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#5b73dbbdbde947c7bc2dcb2b926bae475f6b3cd9",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#5b73dbbdbde947c7bc2dcb2b926bae475f6b3cd9",
+      "version": "0.59.0",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#a0522c1eda66f9fa92073f4f99959af78dec3490",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#a0522c1eda66f9fa92073f4f99959af78dec3490",
       "dependencies": {
         "bluebird": {
           "version": "2.1.3",


### PR DESCRIPTION
Only changing top-level deps fxa-auth-db-mysql, fxa-auth-mailer, and fxa-content-server-l10n.