### PR TITLE
feat(devices): notify other devices of a new device

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -10,6 +10,10 @@ var ERR_DATA_BUT_NO_KEYS = 'Data payload present but missing key(s)'
 
 var LOG_OP_PUSH_TO_DEVICES = 'push.pushToDevices'
 
+var pushActions = {
+  newDevice: 'fxaccounts:new_device'
+}
+
 var reasonToEvents = {
   accountVerify: {
     send: 'push.account_verify.send',
@@ -34,6 +38,14 @@ var reasonToEvents = {
     failed: 'push.password_change.failed',
     noCallback: 'push.password_change.no_push_callback',
     noKeys: 'push.password_change.data_but_no_keys'
+  },
+  newDevice: {
+    send: 'push.new_device.send',
+    success: 'push.new_device.success',
+    resetSettings: 'push.new_device.reset_settings',
+    failed: 'push.new_device.failed',
+    noCallback: 'push.new_device.no_push_callback',
+    noKeys: 'push.new_device.data_but_no_keys'
   }
 }
 
@@ -56,6 +68,24 @@ module.exports = function (log, db) {
     notifyUpdate: function notifyUpdate(uid, reason) {
       reason = reason || 'accountVerify'
       return this.pushToDevices(uid, reason)
+    },
+
+    /**
+     *  Notifies all devices (except the one who joined) that a new device joined the account
+     *
+     * @param uid
+     * @param deviceName
+     * @param currentDeviceId
+     * @promise
+     */
+    notifyNewDevice: function notifyNewDevice(uid, deviceName, currentDeviceId) {
+      var data = new Buffer(JSON.stringify({
+        action: pushActions.newDevice,
+        data: {
+          deviceName: deviceName
+        }
+      }))
+      return this.pushToDevices(uid, 'newDevice', data, [currentDeviceId])
     },
 
     /**

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -421,6 +421,9 @@ module.exports = function (
             .then(
               function (result) {
                 device = result
+                process.nextTick(function() {
+                  push.notifyNewDevice(emailRecord.uid, device.name, device.id.toString('hex'))
+                })
               },
               function (err) {
                 log.error({ op: 'account.login.device', err: err })
@@ -867,6 +870,7 @@ module.exports = function (
         db[operation](sessionToken.uid, sessionToken.tokenId, payload).then(
           function (device) {
             reply(butil.unbuffer(device))
+            push.notifyNewDevice(sessionToken.uid, device.name, device.id.toString('hex'))
           },
           reply
         )

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -297,6 +297,7 @@ test(
       db: mockDB,
       log: mockLog
     })
+
     return new P(function(resolve) {
       getRoute(accountRoutes, '/account/device')
         .handler(mockRequest, function(response) {
@@ -312,6 +313,54 @@ test(
       t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
       t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
       t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
+    })
+  }
+)
+
+test(
+  'device should be notified when another device is registered',
+  function (t) {
+    var device = {
+      name: 'My Phone',
+      type: 'mobile',
+      pushCallback: 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef'
+    }
+    var uid = uuid.v4('binary')
+    var mockRequest = {
+      auth: {
+        credentials: {
+          uid: uid.toString('hex')
+        }
+      },
+      payload: device
+    }
+    var mockDB = {
+      createDevice: sinon.spy(function () {
+        device.id = crypto.randomBytes(16)
+        return P.resolve(device)
+      })
+    }
+    var mockPush = {
+      notifyNewDevice: sinon.spy(function () {})
+    }
+    var accountRoutes = makeRoutes({
+      db: mockDB,
+      push: mockPush
+    })
+
+    return new P(function(resolve) {
+      getRoute(accountRoutes, '/account/device')
+        .handler(mockRequest, function(response) {
+          resolve(response)
+        })
+    })
+    .then(function(response) {
+      t.equal(mockDB.createDevice.callCount, 1)
+
+      t.equal(mockPush.notifyNewDevice.callCount, 1)
+      t.equal(mockPush.notifyNewDevice.firstCall.args[0], mockRequest.auth.credentials.uid)
+      t.equal(mockPush.notifyNewDevice.firstCall.args[1], device.name)
+      t.equal(mockPush.notifyNewDevice.firstCall.args[2], device.id.toString('hex'))
     })
   }
 )

--- a/test/local/push_tests.js
+++ b/test/local/push_tests.js
@@ -320,3 +320,36 @@ test(
   }
 )
 
+test(
+  'notifyNewDevice calls pushToDevices',
+  function (t) {
+    try {
+      var push = require('../../lib/push')(mockLog(), mockDbEmpty)
+      sinon.spy(push, 'pushToDevices')
+      var deviceId = 'gjfkd5434jk5h5fd'
+      var deviceName = 'My phone'
+      var expectedData = new Buffer(JSON.stringify({
+        action: 'fxaccounts:new_device',
+        data: {
+          deviceName: deviceName
+        }
+      }))
+      push.notifyNewDevice(mockUid, deviceName, deviceId).catch(function (err) {
+        t.fail('must not throw')
+        throw err
+      })
+      .then(function() {
+        t.ok(push.pushToDevices.calledOnce, 'pushToDevices was called')
+        t.equal(push.pushToDevices.getCall(0).args[0], mockUid)
+        t.equal(push.pushToDevices.getCall(0).args[1], 'newDevice')
+        t.deepEqual(push.pushToDevices.getCall(0).args[2], expectedData)
+        t.deepEqual(push.pushToDevices.getCall(0).args[3], [deviceId])
+        push.pushToDevices.restore()
+        t.end()
+      })
+    } catch (e) {
+      t.fail('must not throw')
+    }
+  }
+)
+


### PR DESCRIPTION
I split this PR in 4 self-explanatory commits.
The web-push npm module is probably the best way for us to send data payloads without doing the encryption stuff ourselves.

I would love to have some feedback on this.

See also https://github.com/mozilla/fxa-auth-db-mysql/pull/133