### PR TITLE
fix(push): Disallow storing of public-key values until we're ready to use them

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -66,7 +66,8 @@ module.exports = function (
               name: isA.string().max(255).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+              // We're not yet ready to store pubkey values, don't let clients submit them.
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).allow('').forbidden()
             })
             .optional(),
             metricsContext: metricsContext.schema
@@ -304,7 +305,8 @@ module.exports = function (
               name: isA.string().max(255).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+              // We're not yet ready to store pubkey values, don't let clients submit them.
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).allow('').forbidden()
             })
             .optional(),
             metricsContext: metricsContext.schema
@@ -812,13 +814,15 @@ module.exports = function (
               name: isA.string().max(255).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+              // We're not yet ready to store pubkey values, don't let clients submit them.
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).allow('').forbidden()
             }).or('name', 'type', 'pushCallback', 'pushPublicKey'),
             isA.object({
               name: isA.string().max(255).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
-              pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
+              // We're not yet ready to store pubkey values, don't let clients submit them.
+              pushPublicKey: isA.string().length(64).regex(HEX_STRING).allow('').forbidden()
             })
           )
         },

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -6,7 +6,6 @@ var test = require('../ptaptest')
 var url = require('url')
 var Client = require('../client')
 var TestServer = require('../test_server')
-var crypto = require('crypto')
 
 var config = require('../../config').getProperties()
 
@@ -369,8 +368,7 @@ TestServer.start(config)
         device: {
           name: 'baz',
           type: 'mobile',
-          pushCallback: 'https://example.com/qux',
-          pushPublicKey: crypto.randomBytes(32).toString('hex')
+          pushCallback: 'https://example.com/qux'
         }
       })
         .then(


### PR DESCRIPTION
Per https://github.com/mozilla/fxa-auth-server/pull/1229, we're going to need to refactor the way we accept and store keys for push connections.  To avoid any weirdness with data in old formats, I think we should lead with a deployment that specifically disables the storage of keys until we're ready for them.

In theory this will have no observable effect, since none of our clients are sending the keys bundle.  But that's only in theory, I'd quite like to be able to know it in practice.