### PR TITLE
chore(nsp): Update convict, add .nsprc file to silence some NSP warnings

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,7 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/45",
+    "https://nodesecurity.io/advisories/63",
+    "https://nodesecurity.io/advisories/65"
+  ]
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,32 +9,32 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "from": "async@0.9.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "blanket": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "from": "blanket@1.1.6",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+              "from": "falafel@>=0.1.6 <0.2.0",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "from": "xtend@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -43,37 +43,37 @@
         },
         "cheerio": {
           "version": "0.14.0",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+          "from": "cheerio@0.14.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.7.3",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "from": "domutils@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                          "from": "entities@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -82,32 +82,32 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "1.1.14",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -116,27 +116,27 @@
             },
             "entities": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "from": "domutils@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                     }
                   }
@@ -145,19 +145,19 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "temp": {
           "version": "0.8.1",
-          "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "from": "temp@0.8.1",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.6 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -166,44 +166,44 @@
     },
     "aws-sdk": {
       "version": "2.2.10",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.10.tgz",
+      "from": "aws-sdk@2.2.10",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.10.tgz",
       "dependencies": {
         "sax": {
           "version": "0.5.3",
-          "from": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
+          "from": "sax@0.5.3",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
         },
         "xml2js": {
           "version": "0.2.8",
-          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+          "from": "xml2js@0.2.8",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
         },
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+          "from": "xmlbuilder@0.4.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "binary-split": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
+      "from": "binary-split@0.1.2",
       "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-0.1.2.tgz",
       "dependencies": {
         "bops": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+          "from": "bops@0.0.6",
           "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+              "from": "base64-js@0.0.2",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
             },
             "to-utf8": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+              "from": "to-utf8@0.0.1",
               "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz"
             }
           }
@@ -212,92 +212,44 @@
     },
     "bluebird": {
       "version": "2.10.2",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+      "from": "bluebird@2.10.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "commander": {
       "version": "2.8.1",
-      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "from": "commander@2.8.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "dependencies": {
         "graceful-readlink": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "from": "graceful-readlink@>=1.0.0",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
         }
       }
     },
     "convict": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/convict/-/convict-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-1.0.1.tgz",
+      "version": "1.3.0",
+      "from": "convict@1.3.0",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-1.3.0.tgz",
       "dependencies": {
-        "cjson": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
-          "dependencies": {
-            "jsonlint": {
-              "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-              "dependencies": {
-                "nomnom": {
-                  "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-                  "dependencies": {
-                    "underscore": {
-                      "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                    },
-                    "chalk": {
-                      "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                      "dependencies": {
-                        "has-color": {
-                          "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                        },
-                        "ansi-styles": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                        },
-                        "strip-ansi": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "JSV": {
-                  "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
         "depd": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "json5": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
         },
         "moment": {
-          "version": "2.10.6",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+          "version": "2.12.0",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
@@ -313,9 +265,9 @@
           }
         },
         "validator": {
-          "version": "3.43.0",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz"
+          "version": "4.6.1",
+          "from": "https://registry.npmjs.org/validator/-/validator-4.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-4.6.1.tgz"
         },
         "varify": {
           "version": "0.1.1",
@@ -340,22 +292,22 @@
     },
     "email-addresses": {
       "version": "2.0.2",
-      "from": "https://registry.npmjs.org/email-addresses/-/email-addresses-2.0.2.tgz",
+      "from": "email-addresses@2.0.2",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-2.0.2.tgz"
     },
     "envc": {
       "version": "2.4.0",
-      "from": "https://registry.npmjs.org/envc/-/envc-2.4.0.tgz",
+      "from": "envc@2.4.0",
       "resolved": "https://registry.npmjs.org/envc/-/envc-2.4.0.tgz",
       "dependencies": {
         "params": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/params/-/params-0.1.1.tgz",
+          "from": "params@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/params/-/params-0.1.1.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.2.tgz",
+              "from": "type-detect@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.2.tgz"
             }
           }
@@ -364,13 +316,13 @@
     },
     "eslint-config-fxa": {
       "version": "1.6.0",
-      "from": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz",
+      "from": "eslint-config-fxa@1.6.0",
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.6.0.tgz"
     },
     "fxa-auth-db-mysql": {
       "version": "0.59.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#a0522c1eda66f9fa92073f4f99959af78dec3490",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#a0522c1eda66f9fa92073f4f99959af78dec3490",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#70e3ce0ddded7d34876f569eeb97d1a93363c66f",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#70e3ce0ddded7d34876f569eeb97d1a93363c66f",
       "dependencies": {
         "bluebird": {
           "version": "2.1.3",
@@ -381,6 +333,117 @@
           "version": "0.2.0",
           "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "convict": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/convict/-/convict-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/convict/-/convict-1.0.1.tgz",
+          "dependencies": {
+            "cjson": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
+              "dependencies": {
+                "jsonlint": {
+                  "version": "1.6.0",
+                  "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                  "dependencies": {
+                    "nomnom": {
+                      "version": "1.8.1",
+                      "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.6.0",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                        },
+                        "chalk": {
+                          "version": "0.4.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                          "dependencies": {
+                            "has-color": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                            },
+                            "ansi-styles": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                            },
+                            "strip-ansi": {
+                              "version": "0.1.1",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "JSV": {
+                      "version": "4.0.2",
+                      "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "depd": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+            },
+            "moment": {
+              "version": "2.10.6",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "validator": {
+              "version": "3.43.0",
+              "from": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
+              "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz"
+            },
+            "varify": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
+              "dependencies": {
+                "redeyed": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "mysql": {
           "version": "2.10.0",
@@ -868,28 +931,28 @@
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+          "from": "bluebird@2.9.34",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
         },
         "convict": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/convict/-/convict-1.0.2.tgz",
+          "from": "convict@1.0.2",
           "resolved": "https://registry.npmjs.org/convict/-/convict-1.0.2.tgz",
           "dependencies": {
             "cjson": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.2.tgz",
+              "from": "cjson@0.3.2",
               "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.2.tgz",
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "from": "json-parse-helpfulerror@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
                   "dependencies": {
                     "jju": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz"
+                      "version": "1.3.0",
+                      "from": "jju@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
                     }
                   }
                 }
@@ -897,49 +960,49 @@
             },
             "depd": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "from": "depd@1.1.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "moment": {
               "version": "2.10.6",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+              "from": "moment@2.10.6",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "from": "optimist@0.6.1",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "validator": {
               "version": "4.0.5",
-              "from": "https://registry.npmjs.org/validator/-/validator-4.0.5.tgz",
+              "from": "validator@4.0.5",
               "resolved": "https://registry.npmjs.org/validator/-/validator-4.0.5.tgz"
             },
             "varify": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
+              "from": "varify@0.1.1",
               "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
               "dependencies": {
                 "redeyed": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "from": "redeyed@>=0.4.2 <0.5.0",
                   "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                      "from": "esprima@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
@@ -950,8 +1013,8 @@
         },
         "fxa-content-server-l10n": {
           "version": "0.0.0",
-          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#b61acfa33bc05ceef647abd39b3fdb1a8274f2e4",
-          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#b61acfa33bc05ceef647abd39b3fdb1a8274f2e4"
+          "from": "git://github.com/mozilla/fxa-content-server-l10n.git#3dc1d0ca4b0e841dabae3eb6c17a9954dcb04ee6",
+          "resolved": "git://github.com/mozilla/fxa-content-server-l10n.git#3dc1d0ca4b0e841dabae3eb6c17a9954dcb04ee6"
         },
         "grunt-nunjucks-2-html": {
           "version": "0.3.4",
@@ -960,97 +1023,97 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "from": "async@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "nunjucks": {
-              "version": "2.3.0",
-              "from": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.3.0.tgz",
+              "version": "2.4.2",
+              "from": "nunjucks@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.4.2.tgz",
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
+                  "from": "asap@>=2.0.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
                 },
                 "chokidar": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+                  "version": "1.4.3",
+                  "from": "chokidar@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
                   "dependencies": {
                     "anymatch": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                      "from": "anymatch@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                       "dependencies": {
                         "arrify": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                          "from": "arrify@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                         },
                         "micromatch": {
-                          "version": "2.3.7",
-                          "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
-                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                          "version": "2.3.8",
+                          "from": "micromatch@>=2.1.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                           "dependencies": {
                             "arr-diff": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                              "from": "arr-diff@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                               "dependencies": {
                                 "arr-flatten": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                                  "from": "arr-flatten@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                                 }
                               }
                             },
                             "array-unique": {
                               "version": "0.2.1",
-                              "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                              "from": "array-unique@>=0.2.1 <0.3.0",
                               "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                             },
                             "braces": {
-                              "version": "1.8.3",
-                              "from": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
-                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                              "version": "1.8.4",
+                              "from": "braces@>=1.8.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                               "dependencies": {
                                 "expand-range": {
                                   "version": "1.8.1",
-                                  "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                                  "from": "expand-range@>=1.8.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                                   "dependencies": {
                                     "fill-range": {
                                       "version": "2.2.3",
-                                      "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                      "from": "fill-range@>=2.1.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                       "dependencies": {
                                         "is-number": {
                                           "version": "2.1.0",
-                                          "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                          "from": "is-number@>=2.1.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                         },
                                         "isobject": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                          "version": "2.1.0",
+                                          "from": "isobject@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                           "dependencies": {
                                             "isarray": {
-                                              "version": "0.0.1",
-                                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                              "version": "1.0.0",
+                                              "from": "isarray@1.0.0",
+                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                             }
                                           }
                                         },
                                         "randomatic": {
                                           "version": "1.1.5",
-                                          "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+                                          "from": "randomatic@>=1.1.3 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                         }
                                       }
                                     }
@@ -1058,107 +1121,114 @@
                                 },
                                 "preserve": {
                                   "version": "0.2.0",
-                                  "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                                  "from": "preserve@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                                 },
                                 "repeat-element": {
                                   "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                                  "from": "repeat-element@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                                 }
                               }
                             },
                             "expand-brackets": {
-                              "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                              "version": "0.1.5",
+                              "from": "expand-brackets@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                              "dependencies": {
+                                "is-posix-bracket": {
+                                  "version": "0.1.1",
+                                  "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                                }
+                              }
                             },
                             "extglob": {
                               "version": "0.3.2",
-                              "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                              "from": "extglob@>=0.3.1 <0.4.0",
                               "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                             },
                             "filename-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                              "from": "filename-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                             },
                             "is-extglob": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                              "from": "is-extglob@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                             },
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                  "version": "1.1.3",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "normalize-path": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                              "from": "normalize-path@>=2.0.1 <3.0.0",
                               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                             },
                             "object.omit": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                              "from": "object.omit@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                               "dependencies": {
                                 "for-own": {
-                                  "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                                  "version": "0.1.4",
+                                  "from": "for-own@>=0.1.3 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                                   "dependencies": {
                                     "for-in": {
-                                      "version": "0.1.4",
-                                      "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
-                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                      "version": "0.1.5",
+                                      "from": "for-in@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                                     }
                                   }
                                 },
                                 "is-extendable": {
                                   "version": "0.1.1",
-                                  "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                                  "from": "is-extendable@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                                 }
                               }
                             },
                             "parse-glob": {
                               "version": "3.0.4",
-                              "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                              "from": "parse-glob@>=3.0.4 <4.0.0",
                               "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                               "dependencies": {
                                 "glob-base": {
                                   "version": "0.3.0",
-                                  "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                                  "from": "glob-base@>=0.3.0 <0.4.0",
                                   "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                                 },
                                 "is-dotfile": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                                 }
                               }
                             },
                             "regex-cache": {
-                              "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                              "version": "0.4.3",
+                              "from": "regex-cache@>=0.4.2 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                               "dependencies": {
                                 "is-equal-shallow": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                                  "from": "is-equal-shallow@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                                 },
                                 "is-primitive": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                                  "from": "is-primitive@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                                 }
                               }
@@ -1168,77 +1238,77 @@
                       }
                     },
                     "async-each": {
-                      "version": "0.1.6",
-                      "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                      "version": "1.0.0",
+                      "from": "async-each@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
                     },
                     "glob-parent": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                      "from": "glob-parent@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "is-binary-path": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                      "from": "is-binary-path@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                       "dependencies": {
                         "binary-extensions": {
                           "version": "1.4.0",
-                          "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
+                          "from": "binary-extensions@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                         }
                       }
                     },
                     "is-glob": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                      "from": "is-glob@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                       "dependencies": {
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     },
                     "readdirp": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                      "from": "readdirp@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.3",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                         },
                         "minimatch": {
                           "version": "2.0.10",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "from": "minimatch@>=2.0.10 <3.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "from": "balanced-match@>=0.3.0 <0.4.0",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -1246,33 +1316,130 @@
                           }
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "version": "2.1.0",
+                          "from": "readable-stream@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
+                            "inline-process-browser": {
+                              "version": "2.0.1",
+                              "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                              "dependencies": {
+                                "falafel": {
+                                  "version": "1.2.0",
+                                  "from": "falafel@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                                  "dependencies": {
+                                    "acorn": {
+                                      "version": "1.2.2",
+                                      "from": "acorn@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                                    },
+                                    "foreach": {
+                                      "version": "2.0.5",
+                                      "from": "foreach@>=2.0.5 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "object-keys": {
+                                      "version": "1.0.9",
+                                      "from": "object-keys@>=1.0.6 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "0.6.5",
+                                  "from": "through2@>=0.6.5 <0.7.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "1.0.34",
+                                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.1",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
                               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "unreachable-branch-transform": {
+                              "version": "0.5.1",
+                              "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                              "dependencies": {
+                                "esmangle-evaluator": {
+                                  "version": "1.0.0",
+                                  "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+                                },
+                                "recast": {
+                                  "version": "0.11.5",
+                                  "from": "recast@>=0.11.4 <0.12.0",
+                                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+                                  "dependencies": {
+                                    "ast-types": {
+                                      "version": "0.8.16",
+                                      "from": "ast-types@0.8.16",
+                                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
+                                    },
+                                    "esprima": {
+                                      "version": "2.7.2",
+                                      "from": "esprima@>=2.7.1 <2.8.0",
+                                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                                    },
+                                    "private": {
+                                      "version": "0.1.6",
+                                      "from": "private@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                                    },
+                                    "source-map": {
+                                      "version": "0.5.5",
+                                      "from": "source-map@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
+                                    }
+                                  }
+                                }
+                              }
                             },
                             "util-deprecate": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
@@ -1280,19 +1447,19 @@
                       }
                     },
                     "fsevents": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+                      "version": "1.0.11",
+                      "from": "fsevents@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
                       "dependencies": {
                         "nan": {
-                          "version": "2.2.0",
-                          "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                          "version": "2.2.1",
+                          "from": "nan@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
                         },
                         "node-pre-gyp": {
-                          "version": "0.6.19",
-                          "from": "node-pre-gyp@>=0.6.17 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                          "version": "0.6.25",
+                          "from": "node-pre-gyp@0.6.25",
+                          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz",
                           "dependencies": {
                             "nopt": {
                               "version": "3.0.6",
@@ -1309,9 +1476,9 @@
                           }
                         },
                         "ansi": {
-                          "version": "0.3.0",
-                          "from": "ansi@~0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                          "version": "0.3.1",
+                          "from": "ansi@~0.3.1",
+                          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                         },
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -1319,14 +1486,14 @@
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         },
                         "ansi-styles": {
-                          "version": "2.1.0",
-                          "from": "ansi-styles@^2.1.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "are-we-there-yet": {
-                          "version": "1.0.5",
-                          "from": "are-we-there-yet@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                          "version": "1.1.2",
+                          "from": "are-we-there-yet@~1.1.2",
+                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
                         },
                         "asn1": {
                           "version": "0.2.3",
@@ -1334,14 +1501,14 @@
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                         },
                         "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                          "version": "0.2.0",
+                          "from": "assert-plus@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                         },
                         "async": {
-                          "version": "1.5.1",
-                          "from": "async@^1.4.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                          "version": "1.5.2",
+                          "from": "async@^1.5.2",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                         },
                         "aws-sign2": {
                           "version": "0.6.0",
@@ -1349,9 +1516,9 @@
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                         },
                         "bl": {
-                          "version": "1.0.0",
+                          "version": "1.0.3",
                           "from": "bl@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                         },
                         "block-stream": {
                           "version": "0.0.8",
@@ -1369,9 +1536,9 @@
                           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                         },
                         "chalk": {
-                          "version": "1.1.1",
+                          "version": "1.1.3",
                           "from": "chalk@^1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
                         },
                         "combined-stream": {
                           "version": "1.0.5",
@@ -1393,20 +1560,15 @@
                           "from": "cryptiles@2.x.x",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                         },
-                        "dashdash": {
-                          "version": "1.11.0",
-                          "from": "dashdash@>=1.10.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
-                        },
                         "debug": {
-                          "version": "0.7.4",
-                          "from": "debug@~0.7.2",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                          "version": "2.2.0",
+                          "from": "debug@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                         },
                         "deep-extend": {
-                          "version": "0.4.0",
+                          "version": "0.4.1",
                           "from": "deep-extend@~0.4.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                         },
                         "delayed-stream": {
                           "version": "1.0.0",
@@ -1414,9 +1576,9 @@
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                         },
                         "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@^0.1.0",
-                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                          "version": "1.0.0",
+                          "from": "delegates@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
@@ -1424,9 +1586,9 @@
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         },
                         "escape-string-regexp": {
-                          "version": "1.0.4",
+                          "version": "1.0.5",
                           "from": "escape-string-regexp@^1.0.2",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "extend": {
                           "version": "3.0.0",
@@ -1444,9 +1606,9 @@
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                         },
                         "form-data": {
-                          "version": "1.0.0-rc3",
+                          "version": "1.0.0-rc4",
                           "from": "form-data@~1.0.0-rc3",
-                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                         },
                         "fstream": {
                           "version": "1.0.8",
@@ -1454,34 +1616,39 @@
                           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                         },
                         "gauge": {
-                          "version": "1.2.2",
-                          "from": "gauge@~1.2.0",
-                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "from": "generate-object-property@^1.1.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                          "version": "1.2.7",
+                          "from": "gauge@~1.2.5",
+                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                         },
                         "generate-function": {
                           "version": "2.0.0",
                           "from": "generate-function@^2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@^1.1.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                        },
                         "graceful-fs": {
-                          "version": "4.1.2",
+                          "version": "4.1.3",
                           "from": "graceful-fs@^4.1.2",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                         },
                         "graceful-readlink": {
                           "version": "1.0.1",
                           "from": "graceful-readlink@>= 1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         },
+                        "has-unicode": {
+                          "version": "2.0.0",
+                          "from": "has-unicode@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                        },
                         "har-validator": {
-                          "version": "2.0.3",
-                          "from": "har-validator@~2.0.2",
-                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                          "version": "2.0.6",
+                          "from": "har-validator@~2.0.6",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
@@ -1489,9 +1656,9 @@
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                         },
                         "hawk": {
-                          "version": "3.1.2",
+                          "version": "3.1.3",
                           "from": "hawk@~3.1.0",
-                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                         },
                         "hoek": {
                           "version": "2.16.3",
@@ -1499,39 +1666,39 @@
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                         },
                         "http-signature": {
-                          "version": "1.1.0",
+                          "version": "1.1.1",
                           "from": "http-signature@~1.1.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
                           "from": "inherits@*",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
-                        "is-my-json-valid": {
-                          "version": "2.12.3",
-                          "from": "is-my-json-valid@^2.12.3",
-                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
-                        },
                         "ini": {
                           "version": "1.3.4",
                           "from": "ini@~1.3.0",
                           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                         },
-                        "is-typedarray": {
-                          "version": "1.0.0",
-                          "from": "is-typedarray@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                        "is-my-json-valid": {
+                          "version": "2.13.1",
+                          "from": "is-my-json-valid@^2.12.4",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                         },
                         "is-property": {
                           "version": "1.0.2",
                           "from": "is-property@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         },
+                        "is-typedarray": {
+                          "version": "1.0.0",
+                          "from": "is-typedarray@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                        },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "isstream": {
                           "version": "0.1.2",
@@ -1568,45 +1735,40 @@
                           "from": "jsprim@^1.2.2",
                           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                         },
-                        "lodash._basetostring": {
-                          "version": "3.0.1",
-                          "from": "lodash._basetostring@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        "lodash.padend": {
+                          "version": "4.2.0",
+                          "from": "lodash.padend@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
                         },
                         "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                          "version": "4.1.0",
+                          "from": "lodash.pad@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
                         },
-                        "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "from": "lodash._createpadding@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "from": "lodash.padleft@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "from": "lodash.padright@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                        "lodash.padstart": {
+                          "version": "4.2.0",
+                          "from": "lodash.padstart@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
                         },
                         "lodash.repeat": {
-                          "version": "3.0.1",
-                          "from": "lodash.repeat@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                          "version": "4.0.0",
+                          "from": "lodash.repeat@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "from": "lodash.tostring@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                         },
                         "mime-db": {
-                          "version": "1.21.0",
-                          "from": "mime-db@~1.21.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                          "version": "1.22.0",
+                          "from": "mime-db@~1.22.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                         },
                         "mime-types": {
-                          "version": "2.1.9",
+                          "version": "2.1.10",
                           "from": "mime-types@~2.1.7",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
                         },
                         "minimist": {
                           "version": "0.0.8",
@@ -1618,30 +1780,35 @@
                           "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                         },
-                        "npmlog": {
-                          "version": "2.0.0",
-                          "from": "npmlog@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         },
                         "node-uuid": {
                           "version": "1.4.7",
                           "from": "node-uuid@~1.4.7",
                           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                         },
-                        "oauth-sign": {
-                          "version": "0.8.0",
-                          "from": "oauth-sign@~0.8.0",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                        "npmlog": {
+                          "version": "2.0.3",
+                          "from": "npmlog@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                         },
-                        "once": {
-                          "version": "1.1.1",
-                          "from": "once@~1.1.1",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                        "oauth-sign": {
+                          "version": "0.8.1",
+                          "from": "oauth-sign@~0.8.0",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                         },
                         "pinkie": {
-                          "version": "2.0.1",
+                          "version": "2.0.4",
                           "from": "pinkie@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@~1.3.3",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
@@ -1654,19 +1821,19 @@
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "qs": {
-                          "version": "5.2.0",
-                          "from": "qs@~5.2.0",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                          "version": "6.0.2",
+                          "from": "qs@~6.0.2",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "from": "readable-stream@^2.0.0 || ^1.1.13",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
                         },
                         "request": {
-                          "version": "2.67.0",
+                          "version": "2.69.0",
                           "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
                         },
                         "semver": {
                           "version": "5.1.0",
@@ -1677,6 +1844,11 @@
                           "version": "1.0.9",
                           "from": "sntp@1.x.x",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        },
+                        "sshpk": {
+                          "version": "1.7.4",
+                          "from": "sshpk@^1.7.0",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -1689,14 +1861,9 @@
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                         },
                         "strip-ansi": {
-                          "version": "3.0.0",
+                          "version": "3.0.1",
                           "from": "strip-ansi@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                        },
-                        "has-unicode": {
-                          "version": "1.0.1",
-                          "from": "has-unicode@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                         },
                         "strip-json-comments": {
                           "version": "1.0.4",
@@ -1713,10 +1880,15 @@
                           "from": "tar@~2.2.0",
                           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                         },
+                        "tar-pack": {
+                          "version": "3.1.3",
+                          "from": "tar-pack@~3.1.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+                        },
                         "tough-cookie": {
-                          "version": "2.2.1",
+                          "version": "2.2.2",
                           "from": "tough-cookie@~2.2.0",
-                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                         },
                         "tunnel-agent": {
                           "version": "0.4.2",
@@ -1724,14 +1896,14 @@
                           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                         },
                         "tweetnacl": {
-                          "version": "0.13.2",
+                          "version": "0.14.3",
                           "from": "tweetnacl@>=0.13.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                         },
                         "uid-number": {
-                          "version": "0.0.3",
-                          "from": "uid-number@0.0.3",
-                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                          "version": "0.0.6",
+                          "from": "uid-number@~0.0.6",
+                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -1748,6 +1920,23 @@
                           "from": "xtend@^4.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         },
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        },
+                        "dashdash": {
+                          "version": "1.13.0",
+                          "from": "dashdash@>=1.10.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "from": "assert-plus@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                            }
+                          }
+                        },
                         "rc": {
                           "version": "1.1.6",
                           "from": "rc@~1.1.0",
@@ -1760,15 +1949,27 @@
                             }
                           }
                         },
-                        "sshpk": {
-                          "version": "1.7.2",
-                          "from": "sshpk@^1.7.0",
-                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                        "aws4": {
+                          "version": "1.3.2",
+                          "from": "aws4@^1.2.1",
+                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
                           "dependencies": {
-                            "assert-plus": {
-                              "version": "0.2.0",
-                              "from": "assert-plus@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                            "lru-cache": {
+                              "version": "4.0.1",
+                              "from": "lru-cache@^4.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                              "dependencies": {
+                                "pseudomap": {
+                                  "version": "1.0.2",
+                                  "from": "pseudomap@^1.0.1",
+                                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                                },
+                                "yallist": {
+                                  "version": "2.0.0",
+                                  "from": "yallist@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                                }
+                              }
                             }
                           }
                         },
@@ -1783,9 +1984,9 @@
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "from": "brace-expansion@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
@@ -1804,14 +2005,14 @@
                           }
                         },
                         "rimraf": {
-                          "version": "2.5.0",
+                          "version": "2.5.2",
                           "from": "rimraf@~2.5.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                           "dependencies": {
                             "glob": {
-                              "version": "6.0.3",
-                              "from": "glob@^6.0.1",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                              "version": "7.0.3",
+                              "from": "glob@^7.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.4",
@@ -1827,7 +2028,7 @@
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
+                                  "from": "inherits@2",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "minimatch": {
@@ -1836,9 +2037,9 @@
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
-                                      "version": "1.1.2",
+                                      "version": "1.1.3",
                                       "from": "brace-expansion@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.3.0",
@@ -1874,104 +2075,121 @@
                               }
                             }
                           }
-                        },
-                        "tar-pack": {
-                          "version": "3.1.2",
-                          "from": "tar-pack@~3.1.0",
-                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
-                          "dependencies": {
-                            "rimraf": {
-                              "version": "2.4.5",
-                              "from": "rimraf@~2.4.4",
-                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                              "dependencies": {
-                                "glob": {
-                                  "version": "6.0.3",
-                                  "from": "glob@^6.0.1",
-                                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-                                  "dependencies": {
-                                    "inflight": {
-                                      "version": "1.0.4",
-                                      "from": "inflight@^1.0.4",
-                                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                                      "dependencies": {
-                                        "wrappy": {
-                                          "version": "1.0.1",
-                                          "from": "wrappy@1",
-                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@2",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                    },
-                                    "minimatch": {
-                                      "version": "3.0.0",
-                                      "from": "minimatch@2 || 3",
-                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                                      "dependencies": {
-                                        "brace-expansion": {
-                                          "version": "1.1.2",
-                                          "from": "brace-expansion@^1.0.0",
-                                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                                          "dependencies": {
-                                            "balanced-match": {
-                                              "version": "0.3.0",
-                                              "from": "balanced-match@^0.3.0",
-                                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                                            },
-                                            "concat-map": {
-                                              "version": "0.0.1",
-                                              "from": "concat-map@0.0.1",
-                                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "once": {
-                                      "version": "1.3.3",
-                                      "from": "once@^1.3.0",
-                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                      "dependencies": {
-                                        "wrappy": {
-                                          "version": "1.0.1",
-                                          "from": "wrappy@1",
-                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "path-is-absolute": {
-                                      "version": "1.0.0",
-                                      "from": "path-is-absolute@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
                         }
                       }
                     }
                   }
                 },
-                "optimist": {
-                  "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                "yargs": {
+                  "version": "3.32.0",
+                  "from": "yargs@>=3.32.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
                   "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    "camelcase": {
+                      "version": "2.1.1",
+                      "from": "camelcase@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     },
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    "cliui": {
+                      "version": "3.2.0",
+                      "from": "cliui@>=3.0.3 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                      "dependencies": {
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "wrap-ansi": {
+                          "version": "2.0.0",
+                          "from": "wrap-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "decamelize@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "os-locale": {
+                      "version": "1.4.0",
+                      "from": "os-locale@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "dependencies": {
+                        "lcid": {
+                          "version": "1.0.0",
+                          "from": "lcid@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0",
+                              "from": "invert-kv@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "string-width": {
+                      "version": "1.0.1",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.4",
+                      "from": "window-size@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                    },
+                    "y18n": {
+                      "version": "3.2.1",
+                      "from": "y18n@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                     }
                   }
                 }
@@ -1981,39 +2199,39 @@
         },
         "handlebars": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+          "from": "handlebars@1.3.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -2024,12 +2242,12 @@
         },
         "i18n-abide": {
           "version": "0.0.23",
-          "from": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.23.tgz",
+          "from": "i18n-abide@0.0.23",
           "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.23.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "gobbledygook": {
@@ -2039,27 +2257,27 @@
             },
             "jsxgettext": {
               "version": "0.7.0",
-              "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.7.0.tgz",
+              "from": "jsxgettext@0.7.0",
               "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.7.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
+                  "from": "acorn@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
                 },
                 "gettext-parser": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
+                  "from": "gettext-parser@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "from": "encoding@>=0.1.11 <0.2.0",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.13",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                         }
                       }
@@ -2068,44 +2286,44 @@
                 },
                 "commander": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz",
+                  "from": "commander@2.5.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz"
                 },
                 "jade": {
                   "version": "1.11.0",
-                  "from": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
+                  "from": "jade@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
                   "dependencies": {
                     "character-parser": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
+                      "from": "character-parser@1.2.1",
                       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
                     },
                     "clean-css": {
-                      "version": "3.4.9",
-                      "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
-                      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+                      "version": "3.4.12",
+                      "from": "clean-css@>=3.1.9 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
                       "dependencies": {
                         "commander": {
                           "version": "2.8.1",
-                          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                          "from": "commander@>=2.8.0 <2.9.0",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                           "dependencies": {
                             "graceful-readlink": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "from": "graceful-readlink@>=1.0.0",
                               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.4.4",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                          "from": "source-map@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -2114,39 +2332,39 @@
                     },
                     "commander": {
                       "version": "2.6.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+                      "from": "commander@>=2.6.0 <2.7.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
                     },
                     "constantinople": {
                       "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
+                      "from": "constantinople@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "2.7.0",
-                          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                          "from": "acorn@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                         }
                       }
                     },
                     "jstransformer": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+                      "from": "jstransformer@0.0.2",
                       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+                          "from": "is-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
                         },
                         "promise": {
                           "version": "6.1.0",
-                          "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+                          "from": "promise@>=6.0.1 <7.0.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
                           "dependencies": {
                             "asap": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+                              "from": "asap@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
                             }
                           }
@@ -2155,75 +2373,75 @@
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "transformers": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+                      "from": "transformers@2.1.0",
                       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
                       "dependencies": {
                         "promise": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                          "from": "promise@>=2.0.0 <2.1.0",
                           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                           "dependencies": {
                             "is-promise": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                              "from": "is-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                             }
                           }
                         },
                         "css": {
                           "version": "1.0.8",
-                          "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                          "from": "css@>=1.0.8 <1.1.0",
                           "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                           "dependencies": {
                             "css-parse": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                              "from": "css-parse@1.0.4",
                               "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                             },
                             "css-stringify": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                              "from": "css-stringify@1.0.5",
                               "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                             }
                           }
                         },
                         "uglify-js": {
                           "version": "2.2.5",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                          "from": "uglify-js@>=2.2.5 <2.3.0",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                           "dependencies": {
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "from": "source-map@>=0.1.7 <0.2.0",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                                  "from": "amdefine@>=0.0.4",
                                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                                 }
                               }
                             },
                             "optimist": {
                               "version": "0.3.7",
-                              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                              "from": "optimist@>=0.3.5 <0.4.0",
                               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                               "dependencies": {
                                 "wordwrap": {
                                   "version": "0.0.3",
-                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                                  "from": "wordwrap@>=0.0.2 <0.1.0",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                                 }
                               }
@@ -2233,112 +2451,112 @@
                       }
                     },
                     "uglify-js": {
-                      "version": "2.6.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                      "version": "2.6.2",
+                      "from": "uglify-js@>=2.4.19 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                          "from": "async@>=0.2.6 <0.3.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "source-map": {
-                          "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                          "version": "0.5.5",
+                          "from": "source-map@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                         },
                         "uglify-to-browserify": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                         },
                         "yargs": {
                           "version": "3.10.0",
-                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                          "from": "yargs@>=3.10.0 <3.11.0",
                           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "from": "camelcase@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                             },
                             "cliui": {
                               "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "from": "cliui@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                               "dependencies": {
                                 "center-align": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "from": "center-align@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
                                           "version": "3.0.2",
-                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.2",
-                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                              "version": "1.1.3",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                             }
                                           }
                                         },
                                         "longest": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "from": "longest@>=1.0.1 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                         }
                                       }
                                     },
                                     "lazy-cache": {
-                                      "version": "1.0.3",
-                                      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                      "version": "1.0.4",
+                                      "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                                     }
                                   }
                                 },
                                 "right-align": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "from": "right-align@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
                                           "version": "3.0.2",
-                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.2",
-                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                              "version": "1.1.3",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                             }
                                           }
                                         },
                                         "longest": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "from": "longest@>=1.0.1 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                         }
                                       }
                                     }
@@ -2346,26 +2564,19 @@
                                 },
                                 "wordwrap": {
                                   "version": "0.0.2",
-                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "from": "wordwrap@0.0.2",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                                 }
                               }
                             },
                             "decamelize": {
-                              "version": "1.1.2",
-                              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                              "dependencies": {
-                                "escape-string-regexp": {
-                                  "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                                }
-                              }
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                             },
                             "window-size": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                              "from": "window-size@0.1.0",
                               "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                             }
                           }
@@ -2374,27 +2585,27 @@
                     },
                     "void-elements": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+                      "from": "void-elements@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
                     },
                     "with": {
                       "version": "4.0.3",
-                      "from": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
+                      "from": "with@>=4.0.0 <4.1.0",
                       "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                          "from": "acorn@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "acorn-globals": {
                           "version": "1.0.9",
-                          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+                          "from": "acorn-globals@>=1.0.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
                           "dependencies": {
                             "acorn": {
                               "version": "2.7.0",
-                              "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                              "from": "acorn@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                             }
                           }
@@ -2405,58 +2616,58 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz",
+                  "from": "escape-string-regexp@1.0.1",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "from": "optimist@0.6.1",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "plist": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
+              "from": "plist@1.1.0",
               "resolved": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz",
+                  "from": "base64-js@0.0.6",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
                 },
                 "xmlbuilder": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
+                  "from": "xmlbuilder@2.2.1",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
                   "dependencies": {
                     "lodash-node": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+                      "from": "lodash-node@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
                     }
                   }
                 },
                 "xmldom": {
                   "version": "0.1.22",
-                  "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
+                  "from": "xmldom@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz",
+                  "from": "util-deprecate@1.0.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz"
                 }
               }
@@ -2465,68 +2676,68 @@
         },
         "jed": {
           "version": "0.5.4",
-          "from": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz",
+          "from": "jed@0.5.4",
           "resolved": "https://registry.npmjs.org/jed/-/jed-0.5.4.tgz"
         },
         "nodemailer": {
           "version": "0.7.1",
-          "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
+          "from": "nodemailer@0.7.1",
           "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
           "dependencies": {
             "mailcomposer": {
               "version": "0.2.12",
-              "from": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
+              "from": "mailcomposer@>=0.2.10 <0.3.0",
               "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
               "dependencies": {
                 "mimelib": {
                   "version": "0.2.19",
-                  "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+                  "from": "mimelib@>=0.2.15 <0.3.0",
                   "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "from": "encoding@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.13",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                         }
                       }
                     },
                     "addressparser": {
                       "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+                      "from": "addressparser@>=0.3.2 <0.4.0",
                       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@>=1.2.11 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "follow-redirects": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
+                  "from": "follow-redirects@0.0.3",
                   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.8.3",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                      "from": "underscore@latest",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
                     }
                   }
                 },
                 "dkim-signer": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
+                  "from": "dkim-signer@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+                      "from": "punycode@>=1.2.4 <1.3.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                     }
                   }
@@ -2535,71 +2746,71 @@
             },
             "directmail": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz",
+              "from": "directmail@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
             },
             "he": {
               "version": "0.3.6",
-              "from": "https://registry.npmjs.org/he/-/he-0.3.6.tgz",
+              "from": "he@>=0.3.6 <0.4.0",
               "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
             },
             "public-address": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz",
+              "from": "public-address@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
             },
             "aws-sdk": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
+              "from": "aws-sdk@2.0.5",
               "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
               "dependencies": {
                 "aws-sdk-apis": {
                   "version": "3.1.10",
-                  "from": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz",
+                  "from": "aws-sdk-apis@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
                 },
                 "xml2js": {
                   "version": "0.2.6",
-                  "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+                  "from": "xml2js@0.2.6",
                   "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+                      "from": "sax@0.4.2",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                     }
                   }
                 },
                 "xmlbuilder": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+                  "from": "xmlbuilder@0.4.2",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
                 }
               }
             },
             "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "version": "1.1.14",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2608,37 +2819,37 @@
         },
         "po2json": {
           "version": "0.4.1",
-          "from": "https://registry.npmjs.org/po2json/-/po2json-0.4.1.tgz",
+          "from": "po2json@0.4.1",
           "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.4.1.tgz",
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+              "from": "nomnom@1.8.1",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "from": "underscore@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "from": "chalk@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "from": "has-color@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                      "from": "ansi-styles@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                      "from": "strip-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -2647,17 +2858,17 @@
             },
             "gettext-parser": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
+              "from": "gettext-parser@1.1.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                  "from": "encoding@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.13",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                      "from": "iconv-lite@>=0.4.13 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
@@ -2668,64 +2879,76 @@
         },
         "request": {
           "version": "2.69.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+          "from": "request@2.69.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+              "version": "1.3.2",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "version": "4.0.1",
+                  "from": "lru-cache@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "from": "pseudomap@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                    },
+                    "yallist": {
+                      "version": "2.0.0",
+                      "from": "yallist@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                    }
+                  }
                 }
               }
             },
             "bl": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+              "from": "bl@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -2734,148 +2957,148 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "from": "caseless@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "version": "1.0.0-rc4",
+              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "from": "async@>=1.5.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "chalk": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.4",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+                  "version": "2.13.1",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                  "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -2884,103 +3107,106 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "from": "hawk@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "from": "boom@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "from": "json-schema@0.2.2",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "from": "verror@1.3.6",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "1.7.4",
-                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+                  "version": "1.8.2",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.2.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "from": "asn1@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
                     "dashdash": {
-                      "version": "1.13.0",
-                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
+                      "version": "1.13.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.5",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
@@ -2989,157 +3215,157 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
               "version": "6.0.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
+              "from": "qs@>=6.0.2 <6.1.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+              "version": "2.2.2",
+              "from": "tough-cookie@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
         "restify": {
           "version": "4.0.3",
-          "from": "https://registry.npmjs.org/restify/-/restify-4.0.3.tgz",
+          "from": "restify@4.0.3",
           "resolved": "https://registry.npmjs.org/restify/-/restify-4.0.3.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "version": "2.5.0",
+              "from": "backoff@>=2.4.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "from": "precond@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
-              "version": "1.6.0",
-              "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.6.0.tgz",
+              "version": "1.8.1",
+              "from": "bunyan@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.1.1",
-                  "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "from": "mv@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "from": "ncp@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.4.5",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "from": "rimraf@>=2.4.0 <2.5.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "6.0.4",
-                          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "from": "glob@>=6.0.1 <7.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "from": "inflight@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "from": "balanced-match@>=0.3.0 <0.4.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -3148,7 +3374,7 @@
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                             }
                           }
@@ -3159,140 +3385,140 @@
                 },
                 "safe-json-stringify": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                  "from": "safe-json-stringify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
                 },
                 "moment": {
-                  "version": "2.11.2",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                  "version": "2.13.0",
+                  "from": "moment@>=2.10.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                 }
               }
             },
             "csv": {
               "version": "0.4.6",
-              "from": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
+              "from": "csv@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
               "dependencies": {
                 "csv-generate": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz",
+                  "from": "csv-generate@>=0.0.6 <0.0.7",
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
                 },
                 "csv-parse": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.1.tgz"
+                  "version": "1.1.0",
+                  "from": "csv-parse@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.1.0.tgz"
                 },
                 "stream-transform": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.1.tgz",
+                  "from": "stream-transform@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.1.tgz"
                 },
                 "csv-stringify": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz",
+                  "from": "csv-stringify@>=0.0.8 <0.0.9",
                   "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
                 }
               }
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "from": "formidable@>=1.0.14 <2.0.0",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.7.3",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@>=1.2.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+              "from": "negotiator@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "once": {
               "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+              "from": "qs@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "from": "semver@>=4.3.3 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "spdy": {
               "version": "1.32.5",
-              "from": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz",
+              "from": "spdy@>=1.26.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "vasync": {
               "version": "1.6.3",
-              "from": "https://registry.npmjs.org/vasync/-/vasync-1.6.3.tgz",
+              "from": "vasync@1.6.3",
               "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.3.tgz",
               "dependencies": {
                 "verror": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+                  "from": "verror@1.6.0",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                      "from": "extsprintf@1.2.0",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                     }
                   }
@@ -3301,30 +3527,30 @@
             },
             "verror": {
               "version": "1.6.1",
-              "from": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
+              "from": "verror@>=1.4.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "extsprintf": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "from": "extsprintf@1.2.0",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+              "from": "dtrace-provider@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                  "version": "2.2.1",
+                  "from": "nan@>=2.0.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
                 }
               }
             }
@@ -3334,89 +3560,96 @@
     },
     "fxa-conventional-changelog": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/fxa-conventional-changelog/-/fxa-conventional-changelog-1.1.0.tgz",
+      "from": "fxa-conventional-changelog@1.1.0",
       "resolved": "https://registry.npmjs.org/fxa-conventional-changelog/-/fxa-conventional-changelog-1.1.0.tgz",
       "dependencies": {
         "compare-func": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.1.tgz",
+          "from": "compare-func@1.3.1",
           "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.1.tgz",
           "dependencies": {
             "array-ify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+              "from": "array-ify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz"
             },
             "dot-prop": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.2.0.tgz"
+              "version": "2.4.0",
+              "from": "dot-prop@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
+              "dependencies": {
+                "is-obj": {
+                  "version": "1.0.1",
+                  "from": "is-obj@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+                }
+              }
             }
           }
         },
         "lodash.map": {
           "version": "3.1.4",
-          "from": "https://registry.npmjs.org/lodash.map/-/lodash.map-3.1.4.tgz",
+          "from": "lodash.map@3.1.4",
           "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-3.1.4.tgz",
           "dependencies": {
             "lodash._arraymap": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+              "from": "lodash._arraymap@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
             },
             "lodash._basecallback": {
               "version": "3.3.1",
-              "from": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+              "from": "lodash._basecallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
               "dependencies": {
                 "lodash._baseisequal": {
                   "version": "3.0.7",
-                  "from": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+                  "from": "lodash._baseisequal@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
                   "dependencies": {
                     "lodash.istypedarray": {
-                      "version": "3.0.5",
-                      "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
+                      "version": "3.0.6",
+                      "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz"
                     }
                   }
                 },
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash.pairs": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+                  "from": "lodash.pairs@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz"
                 }
               }
             },
             "lodash._baseeach": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+              "from": "lodash._baseeach@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.7",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                  "version": "3.0.8",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                 }
               }
             }
@@ -3424,34 +3657,34 @@
         },
         "semver": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/semver/-/semver-5.0.1.tgz",
+          "from": "semver@5.0.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.1.tgz"
         }
       }
     },
     "fxa-jwtool": {
       "version": "0.7.1",
-      "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
+      "from": "fxa-jwtool@0.7.1",
       "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.9.15",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
+          "from": "bluebird@2.9.15",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
         },
         "fetch": {
           "version": "0.3.6",
-          "from": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
+          "from": "fetch@0.3.6",
           "resolved": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
           "dependencies": {
             "encoding": {
               "version": "0.1.12",
-              "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "from": "encoding@*",
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                  "from": "iconv-lite@>=0.4.13 <0.5.0",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 }
               }
@@ -3460,27 +3693,27 @@
         },
         "pem-jwk": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
+          "from": "pem-jwk@1.5.1",
           "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
           "dependencies": {
             "asn1.js": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+              "from": "asn1.js@1.0.3",
               "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                 },
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 }
               }
@@ -3491,62 +3724,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3555,149 +3788,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.7.3",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -3706,61 +3939,61 @@
     },
     "grunt-bump": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
+      "from": "grunt-bump@0.3.1",
       "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "from": "semver@>=4.3.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "from": "grunt-cli@0.1.13",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3769,112 +4002,112 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "from": "resolve@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-conventional-changelog": {
       "version": "5.0.0",
-      "from": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-5.0.0.tgz",
+      "from": "grunt-conventional-changelog@5.0.0",
       "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-5.0.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "version": "1.1.3",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "from": "concat-stream@>=1.5.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -3883,199 +4116,206 @@
         },
         "conventional-changelog": {
           "version": "0.5.3",
-          "from": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.5.3.tgz",
+          "from": "conventional-changelog@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.5.3.tgz",
           "dependencies": {
             "add-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+              "from": "add-stream@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz"
             },
             "compare-func": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.1.tgz",
+              "from": "compare-func@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.1.tgz",
               "dependencies": {
                 "array-ify": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+                  "from": "array-ify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz"
                 },
                 "dot-prop": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.2.0.tgz"
+                  "version": "2.4.0",
+                  "from": "dot-prop@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "from": "is-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "conventional-changelog-writer": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-0.4.2.tgz",
+              "from": "conventional-changelog-writer@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-0.4.2.tgz",
               "dependencies": {
                 "conventional-commits-filter": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-0.1.1.tgz",
+                  "from": "conventional-commits-filter@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-0.1.1.tgz",
                   "dependencies": {
                     "is-subset": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+                      "from": "is-subset@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
                     },
                     "modify-values": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+                      "from": "modify-values@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
                     }
                   }
                 },
                 "handlebars": {
                   "version": "4.0.5",
-                  "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+                  "from": "handlebars@>=4.0.2 <5.0.0",
                   "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
-                      "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "from": "optimist@>=0.6.1 <0.7.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "minimist": {
                           "version": "0.0.10",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                          "from": "minimist@>=0.0.1 <0.1.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.4.4",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "from": "source-map@>=0.4.4 <0.5.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
                     },
                     "uglify-js": {
-                      "version": "2.6.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                      "version": "2.6.2",
+                      "from": "uglify-js@>=2.6.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                          "from": "async@>=0.2.6 <0.3.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "source-map": {
-                          "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                          "version": "0.5.5",
+                          "from": "source-map@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                         },
                         "uglify-to-browserify": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                         },
                         "yargs": {
                           "version": "3.10.0",
-                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                          "from": "yargs@>=3.10.0 <3.11.0",
                           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "from": "camelcase@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                             },
                             "cliui": {
                               "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "from": "cliui@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                               "dependencies": {
                                 "center-align": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "from": "center-align@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
                                           "version": "3.0.2",
-                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.2",
-                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                              "version": "1.1.3",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                             }
                                           }
                                         },
                                         "longest": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "from": "longest@>=1.0.1 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                         }
                                       }
                                     },
                                     "lazy-cache": {
-                                      "version": "1.0.3",
-                                      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                      "version": "1.0.4",
+                                      "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                                     }
                                   }
                                 },
                                 "right-align": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "from": "right-align@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
                                           "version": "3.0.2",
-                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.2",
-                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                              "version": "1.1.3",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                             }
                                           }
                                         },
                                         "longest": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "from": "longest@>=1.0.1 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                         }
                                       }
                                     }
@@ -4083,26 +4323,19 @@
                                 },
                                 "wordwrap": {
                                   "version": "0.0.2",
-                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "from": "wordwrap@0.0.2",
                                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                                 }
                               }
                             },
                             "decamelize": {
-                              "version": "1.1.2",
-                              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                              "dependencies": {
-                                "escape-string-regexp": {
-                                  "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                                }
-                              }
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                             },
                             "window-size": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                              "from": "window-size@0.1.0",
                               "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                             }
                           }
@@ -4112,128 +4345,128 @@
                   }
                 },
                 "lodash": {
-                  "version": "4.5.0",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
+                  "version": "4.11.1",
+                  "from": "lodash@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz"
                 },
                 "split": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+                  "from": "split@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
                 }
               }
             },
             "conventional-commits-parser": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-0.1.2.tgz",
+              "from": "conventional-commits-parser@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-0.1.2.tgz",
               "dependencies": {
                 "JSONStream": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "version": "1.1.1",
+                  "from": "JSONStream@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                     }
                   }
                 },
                 "is-text-path": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+                  "from": "is-text-path@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
                   "dependencies": {
                     "text-extensions": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz",
+                      "from": "text-extensions@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz"
                     }
                   }
                 },
                 "split": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+                  "from": "split@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
                 },
                 "trim-off-newlines": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.0.tgz",
+                  "from": "trim-off-newlines@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.12",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "from": "dateformat@>=1.0.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "get-pkg-repo": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-0.1.0.tgz",
+              "from": "get-pkg-repo@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-0.1.0.tgz",
               "dependencies": {
                 "hosted-git-info": {
                   "version": "2.1.4",
-                  "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -4245,223 +4478,216 @@
             },
             "git-raw-commits": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-0.1.2.tgz",
+              "from": "git-raw-commits@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-0.1.2.tgz",
               "dependencies": {
                 "dargs": {
                   "version": "4.1.0",
-                  "from": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+                  "from": "dargs@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "lodash.template": {
                   "version": "3.6.2",
-                  "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                  "from": "lodash.template@>=3.6.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash._basetostring": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
                     "lodash._basevalues": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash._reinterpolate": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
                     },
                     "lodash.escape": {
                       "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                      "from": "lodash.escape@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                       "dependencies": {
                         "lodash._root": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                          "from": "lodash._root@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                         }
                       }
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
-                          "version": "3.0.7",
-                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                          "version": "3.0.8",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     },
                     "lodash.templatesettings": {
                       "version": "3.1.1",
-                      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
                     }
                   }
                 },
                 "split2": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/split2/-/split2-1.1.1.tgz",
+                  "from": "split2@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/split2/-/split2-1.1.1.tgz"
                 }
               }
             },
             "git-semver-tags": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz",
+              "from": "git-semver-tags@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.9.3 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "meow": {
               "version": "3.7.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                  "version": "2.1.0",
+                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "version": "2.1.1",
+                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                    }
-                  }
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                  "version": "1.3.0",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                   "dependencies": {
                     "array-find-index": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
+                      "from": "array-find-index@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                     },
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                      "from": "signal-exit@>=2.1.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "from": "map-obj@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -4471,32 +4697,32 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                          "version": "2.0.1",
+                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -4507,12 +4733,12 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         }
                       }
@@ -4521,39 +4747,39 @@
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
             "read-pkg": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+              "from": "read-pkg@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                  "from": "load-json-file@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "parse-json": {
                       "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                      "from": "parse-json@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                          "from": "error-ex@>=1.2.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
-                              "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                              "from": "is-arrayish@>=0.2.1 <0.3.0",
                               "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                             }
                           }
@@ -4562,29 +4788,29 @@
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "from": "pify@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     },
                     "strip-bom": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                      "from": "strip-bom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                          "from": "is-utf8@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                         }
                       }
@@ -4593,57 +4819,57 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -4653,27 +4879,27 @@
                 },
                 "path-type": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                  "from": "path-type@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "from": "pify@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -4684,27 +4910,27 @@
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "from": "read-pkg-up@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "dependencies": {
                 "find-up": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                  "version": "1.1.2",
+                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                      "from": "path-exists@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -4715,71 +4941,71 @@
             },
             "semver": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+              "from": "semver@>=5.0.1 <6.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
             },
             "tempfile": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+              "from": "tempfile@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "uuid": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                  "version": "2.0.2",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
                 }
               }
             },
             "through2": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+              "from": "through2@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -4788,127 +5014,127 @@
         },
         "plur": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "from": "plur@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
           "dependencies": {
             "irregular-plurals": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.1.0.tgz",
+              "from": "irregular-plurals@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.1.0.tgz"
             }
           }
         },
         "q": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "from": "q@>=1.4.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz",
+      "from": "grunt-copyright@0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
     "grunt-eslint": {
       "version": "15.0.0",
-      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
+      "from": "grunt-eslint@15.0.0",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "version": "1.1.3",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "eslint": {
           "version": "0.23.0",
-          "from": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
+          "from": "eslint@>=0.23.0 <0.24.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -4917,271 +5143,276 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+              "from": "doctrine@>=0.6.2 <0.7.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                  "from": "esutils@>=1.1.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "escape-string-regexp": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "escope": {
-              "version": "3.4.0",
-              "from": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
+              "version": "3.6.0",
+              "from": "escope@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+                  "from": "es6-map@>=0.1.3 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.11",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-set": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
+                      "from": "es6-set@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.4",
-                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+                      "from": "event-emitter@>=0.3.4 <0.4.0",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.11",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     }
                   }
                 },
                 "esrecurse": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+                  "version": "4.1.0",
+                  "from": "esrecurse@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
                   "dependencies": {
                     "estraverse": {
-                      "version": "3.1.0",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                      "version": "4.1.1",
+                      "from": "estraverse@>=4.1.0 <4.2.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     }
                   }
                 },
                 "estraverse": {
-                  "version": "4.1.1",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                  "version": "4.2.0",
+                  "from": "estraverse@>=4.1.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
                 }
               }
             },
             "espree": {
               "version": "2.2.5",
-              "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+              "from": "espree@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+              "from": "estraverse@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
               "version": "8.18.0",
-              "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+              "from": "globals@>=8.0.0 <9.0.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+              "from": "inquirer@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "cli-width": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
                 },
                 "figures": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                  "version": "1.5.0",
+                  "from": "figures@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "from": "readline2@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                      "from": "mute-stream@0.0.4",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+                  "from": "rx@>=2.4.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.4",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+              "version": "2.13.1",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                  "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "js-yaml": {
-              "version": "3.5.3",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
+              "version": "3.6.0",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
+                  "version": "1.0.7",
+                  "from": "argparse@>=1.0.7 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.7.2",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                  "from": "esprima@>=2.6.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -5190,81 +5421,81 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+              "from": "object-assign@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "from": "optionator@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "from": "type-check@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "from": "levn@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "from": "text-table@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "from": "user-home@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "xml-escape": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
@@ -5273,278 +5504,278 @@
     },
     "grunt-nsp": {
       "version": "2.1.2",
-      "from": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
+      "from": "grunt-nsp@2.1.2",
       "resolved": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
       "dependencies": {
         "nsp": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
+          "from": "nsp@2.0.1",
           "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
           "dependencies": {
             "nodesecurity-npm-utils": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz",
+              "from": "nodesecurity-npm-utils@3.0.0",
               "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz"
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "from": "cli-table@0.3.1",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
             },
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "from": "https-proxy-agent@1.0.0",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
             },
             "joi": {
               "version": "6.10.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz",
+              "from": "joi@6.10.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz"
             },
             "rc": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+              "from": "rc@1.1.2",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "semver": {
               "version": "5.0.3",
-              "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "from": "semver@5.0.3",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
             },
             "subcommand": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
+              "from": "subcommand@2.0.3",
               "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "wreck": {
               "version": "6.3.0",
-              "from": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
+              "from": "wreck@6.3.0",
               "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz"
             },
             "agent-base": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+              "from": "agent-base@2.0.1",
               "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz"
             },
             "ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+              "from": "ansi@0.3.0",
               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "from": "boom@2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "builtin-modules": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+              "from": "builtin-modules@1.1.0",
               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
             },
             "chownr": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz",
+              "from": "chownr@0.0.2",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
             },
             "cliclopts": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+              "from": "cliclopts@1.1.1",
               "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "from": "colors@1.0.3",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "from": "deep-extend@0.2.11",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "delegates": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+              "from": "delegates@0.1.0",
               "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@3.0.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "gauge": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+              "from": "gauge@1.2.2",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+            },
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "graceful-fs@3.0.8",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "has-unicode": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+              "from": "has-unicode@1.0.1",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
             },
             "hoek": {
               "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "from": "hoek@2.16.3",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "hosted-git-info": {
               "version": "2.1.4",
-              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+              "from": "hosted-git-info@2.1.4",
               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "from": "ini@1.3.4",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "from": "is-builtin-module@1.0.0",
               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
             },
             "isemail": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+              "from": "isemail@1.2.0",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "from": "lodash._basetostring@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._createpadding": {
               "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+              "from": "lodash._createpadding@3.6.1",
               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
             },
             "lodash.pad": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+              "from": "lodash.pad@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
             },
             "lodash.padleft": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+              "from": "lodash.padleft@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
             },
             "lodash.padright": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+              "from": "lodash.padright@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
             },
             "lodash.repeat": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+              "from": "lodash.repeat@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
             },
             "moment": {
               "version": "2.10.6",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+              "from": "moment@2.10.6",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "from": "normalize-package-data@2.3.5",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
             },
             "npm-package-arg": {
               "version": "4.0.2",
-              "from": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz",
+              "from": "npm-package-arg@4.0.2",
               "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz"
             },
             "npmlog": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+              "from": "npmlog@1.2.1",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
             },
             "retry": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+              "from": "retry@0.6.1",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-            },
-            "slide": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "silent-npm-registry-client": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz",
+              "from": "silent-npm-registry-client@1.0.0",
               "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz"
+            },
+            "slide": {
+              "version": "1.1.6",
+              "from": "slide@1.1.6",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "from": "spdx-correct@1.0.2",
               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
             },
             "spdx-exceptions": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
+              "from": "spdx-exceptions@1.0.3",
               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
-            },
-            "spdx-license-ids": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
             },
             "spdx-expression-parse": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+              "from": "spdx-expression-parse@1.0.0",
               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz"
+            },
+            "spdx-license-ids": {
+              "version": "1.1.0",
+              "from": "spdx-license-ids@1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+              "from": "strip-json-comments@0.1.3",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "topo": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+              "from": "topo@1.1.0",
               "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "from": "validate-npm-package-license@3.0.1",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
             },
             "are-we-there-yet": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+              "from": "are-we-there-yet@1.0.4",
               "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@1.1.13",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                 }
               }
             },
             "npm-registry-client": {
               "version": "6.3.3",
-              "from": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
+              "from": "npm-registry-client@6.3.3",
               "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
               "dependencies": {
                 "semver": {
                   "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "from": "semver@4.3.6",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 }
               }
@@ -5553,232 +5784,232 @@
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+          "from": "ansi-regex@2.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+          "from": "ansi-styles@2.1.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "balanced-match": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+          "from": "balanced-match@0.2.1",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
         },
         "brace-expansion": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+          "from": "brace-expansion@1.1.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "from": "chalk@1.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "concat-map": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "from": "concat-stream@1.5.1",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
         },
         "core-util-is": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+          "from": "core-util-is@1.0.1",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "from": "escape-string-regexp@1.0.3",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "from": "glob@5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "from": "has-ansi@2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "inflight": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+          "from": "inflight@1.0.4",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "from": "isarray@0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "from": "minimatch@2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "minimist": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
         },
         "ms": {
           "version": "0.7.1",
-          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "once": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "from": "once@1.3.2",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "from": "path-is-absolute@1.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "process-nextick-args": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+          "from": "process-nextick-args@1.0.3",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
         },
         "readable-stream": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+          "from": "readable-stream@2.0.4",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
         },
         "rimraf": {
           "version": "2.4.3",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+          "from": "rimraf@2.4.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "from": "string_decoder@0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+          "from": "strip-ansi@3.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "from": "supports-color@2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "typedarray": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "from": "typedarray@0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "from": "util-deprecate@1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
         },
         "wrappy": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+          "from": "wrappy@1.0.1",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "from": "xtend@4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "hapi": {
       "version": "8.8.1",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-8.8.1.tgz",
+      "from": "hapi@8.8.1",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.8.1.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "ammo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+          "from": "ammo@1.0.0",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
         },
         "boom": {
           "version": "2.7.2",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
+          "from": "boom@2.7.2",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
         },
         "call": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+          "from": "call@2.0.1",
           "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
         },
         "catbox": {
           "version": "4.3.0",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz",
+          "from": "catbox@4.3.0",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz"
         },
         "catbox-memory": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+          "from": "catbox-memory@1.1.1",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "4.0.1",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
+          "from": "h2o2@4.0.1",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
           "dependencies": {
             "wreck": {
               "version": "5.6.1",
-              "from": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+              "from": "wreck@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz"
             }
           }
         },
         "heavy": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+          "from": "heavy@3.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
           "dependencies": {
             "joi": {
               "version": "5.1.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "from": "joi@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                  "from": "isemail@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                 },
                 "moment": {
-                  "version": "2.11.2",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                  "version": "2.13.0",
+                  "from": "moment@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                 }
               }
             }
@@ -5786,113 +6017,113 @@
         },
         "hoek": {
           "version": "2.14.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+          "from": "hoek@2.14.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
         },
         "inert": {
           "version": "2.1.6",
-          "from": "https://registry.npmjs.org/inert/-/inert-2.1.6.tgz",
+          "from": "inert@2.1.6",
           "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.6.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+              "from": "lru-cache@2.6.5",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "6.4.1",
-          "from": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+          "from": "joi@6.4.1",
           "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.1.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             },
             "moment": {
               "version": "2.10.3",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+              "from": "moment@2.10.3",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+          "from": "mimos@2.0.2",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.14.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz",
+              "from": "mime-db@1.14.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz"
             }
           }
         },
         "peekaboo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+          "from": "peekaboo@1.0.0",
           "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
         },
         "qs": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "from": "qs@4.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "shot": {
           "version": "1.5.3",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz",
+          "from": "shot@1.5.3",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz"
         },
         "statehood": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
+          "from": "statehood@2.1.1",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz"
         },
         "subtext": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
+          "from": "subtext@1.1.1",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -5903,49 +6134,49 @@
         },
         "topo": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz",
+          "from": "topo@1.0.3",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
         },
         "vision": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz",
+          "from": "vision@2.0.1",
           "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz"
         },
         "wreck": {
           "version": "6.0.0",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz",
+          "from": "wreck@6.0.0",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz"
         }
       }
     },
     "hapi-auth-hawk": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-3.0.1.tgz",
+      "from": "hapi-auth-hawk@3.0.1",
       "resolved": "https://registry.npmjs.org/hapi-auth-hawk/-/hapi-auth-hawk-3.0.1.tgz",
       "dependencies": {
         "boom": {
           "version": "2.10.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "hoek": {
           "version": "2.16.3",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "from": "hawk@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "cryptiles": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
@@ -5954,29 +6185,29 @@
     },
     "hapi-fxa-oauth": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.2.0.tgz",
+      "from": "hapi-fxa-oauth@2.2.0",
       "resolved": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.2.0.tgz",
       "dependencies": {
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.6.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "from": "hoek@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             }
           }
         },
         "poolee": {
           "version": "0.4.15",
-          "from": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
+          "from": "poolee@0.4.15",
           "resolved": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
           "dependencies": {
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             }
           }
@@ -5985,92 +6216,92 @@
     },
     "hawk": {
       "version": "2.3.1",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "from": "hawk@2.3.1",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "boom": {
           "version": "2.10.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "from": "sntp@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "hkdf": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
+      "from": "hkdf@0.0.2",
       "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "joi": {
       "version": "6.9.1",
-      "from": "https://registry.npmjs.org/joi/-/joi-6.9.1.tgz",
+      "from": "joi@6.9.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.9.1.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
         },
         "moment": {
-          "version": "2.11.2",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+          "version": "2.13.0",
+          "from": "moment@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
         }
       }
     },
     "jws": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
+      "from": "jws@3.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
       "dependencies": {
         "jwa": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+          "from": "jwa@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
           "dependencies": {
             "base64url": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+              "from": "base64url@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
             },
             "buffer-equal-constant-time": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+              "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
             },
             "ecdsa-sig-formatter": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
+              "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
               "dependencies": {
                 "base64-url": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                  "version": "1.2.2",
+                  "from": "base64-url@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
                 }
               }
             }
@@ -6078,42 +6309,42 @@
         },
         "base64url": {
           "version": "1.0.6",
-          "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+          "from": "base64url@>=1.0.4 <1.1.0",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.4.10",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+              "from": "concat-stream@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "1.1.14",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
@@ -6122,49 +6353,49 @@
             },
             "meow": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+              "from": "meow@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -6175,12 +6406,12 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "object-assign": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                  "from": "object-assign@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                 }
               }
@@ -6196,54 +6427,54 @@
     },
     "load-grunt-tasks": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
+      "from": "load-grunt-tasks@3.1.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
           "dependencies": {
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.0 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6252,12 +6483,12 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -6268,49 +6499,49 @@
         },
         "multimatch": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "from": "multimatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "arrify": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -6323,51 +6554,51 @@
     },
     "mailparser": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mailparser/-/mailparser-0.5.1.tgz",
+      "from": "mailparser@0.5.1",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.5.1.tgz",
       "dependencies": {
         "mimelib": {
           "version": "0.2.19",
-          "from": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
+          "from": "mimelib@>=0.2.19 <0.3.0",
           "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.19.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+              "from": "addressparser@>=0.3.2 <0.4.0",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             }
           }
         },
         "encoding": {
           "version": "0.1.12",
-          "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "from": "encoding@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "from": "iconv-lite@>=0.4.13 <0.5.0",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
             }
           }
         },
         "mime": {
           "version": "1.3.4",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "from": "mime@>=1.3.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "uue": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/uue/-/uue-2.1.1.tgz",
+          "from": "uue@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uue/-/uue-2.1.1.tgz",
           "dependencies": {
             "array.prototype.findindex": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz",
+              "from": "array.prototype.findindex@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             }
           }
@@ -6376,168 +6607,168 @@
     },
     "mozlog": {
       "version": "2.0.3",
-      "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.3.tgz",
+      "from": "mozlog@2.0.3",
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.3.tgz",
       "dependencies": {
         "intel": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
           "dependencies": {
             "chalk": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+              "from": "strftime@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "nock": {
       "version": "1.7.1",
-      "from": "https://registry.npmjs.org/nock/-/nock-1.7.1.tgz",
+      "from": "nock@1.7.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.7.1.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+          "from": "chai@>=1.9.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+              "from": "assertion-error@1.0.0",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "from": "deep-eql@0.1.3",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "from": "type-detect@0.1.1",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
             }
           }
         },
+        "propagate": {
+          "version": "0.3.1",
+          "from": "propagate@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
         "debug": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "from": "debug@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
-        },
-        "propagate": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
     },
     "node-statsd": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
+      "from": "node-statsd@0.1.1",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz"
     },
     "node-uap": {
       "version": "0.0.3",
-      "from": "vladikoff/node-uap#9cdd16247",
-      "resolved": "git://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
+      "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
+      "resolved": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
       "dependencies": {
         "array.prototype.find": {
           "version": "2.0.0",
@@ -6604,8 +6835,8 @@
         },
         "uap-core": {
           "version": "0.5.0",
-          "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#c7c5284a1fc25e3345b0c5d8fc323cb01373dd13"
+          "from": "git://github.com/ua-parser/uap-core.git#02702aba680e53f9d5055acff195b96dfbf1e534",
+          "resolved": "git://github.com/ua-parser/uap-core.git#02702aba680e53f9d5055acff195b96dfbf1e534"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -6621,93 +6852,93 @@
     },
     "openid": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/openid/-/openid-1.0.0.tgz",
+      "from": "openid@1.0.0",
       "resolved": "https://registry.npmjs.org/openid/-/openid-1.0.0.tgz"
     },
     "poolee": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
+      "from": "poolee@1.0.0",
       "resolved": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
       "dependencies": {
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+          "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         }
       }
     },
     "proxyquire": {
       "version": "1.6.0",
-      "from": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.6.0.tgz",
+      "from": "proxyquire@1.6.0",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.6.0.tgz",
       "dependencies": {
         "fill-keys": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+          "from": "fill-keys@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
           "dependencies": {
             "is-object": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+              "from": "is-object@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "from": "merge-descriptors@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             }
           }
         },
         "module-not-found-error": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+          "from": "module-not-found-error@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.65.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+      "from": "request@2.65.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
       "dependencies": {
         "bl": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+          "from": "bl@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -6716,254 +6947,254 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "from": "caseless@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "extend": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "from": "extend@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+          "version": "1.0.0-rc4",
+          "from": "form-data@>=1.0.0-rc3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             }
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.10",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+          "from": "mime-types@>=2.1.7 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.22.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+              "from": "mime-db@>=1.22.0 <1.23.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "from": "node-uuid@>=1.4.3 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "qs": {
           "version": "5.2.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+          "from": "qs@>=5.2.0 <5.3.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+          "version": "2.2.2",
+          "from": "tough-cookie@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "http-signature": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+          "from": "http-signature@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+              "from": "ctype@0.5.3",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.1",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+          "from": "oauth-sign@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "from": "hawk@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "from": "hoek@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "from": "boom@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "from": "isstream@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "from": "har-validator@>=2.0.2 <2.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.4",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+              "version": "2.13.1",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                  "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -6974,149 +7205,149 @@
     },
     "scrypt-hash": {
       "version": "1.1.13",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.13.tgz",
+      "from": "scrypt-hash@1.1.13",
       "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.13.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "from": "bindings@1.2.1",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
           "version": "2.0.9",
-          "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
+          "from": "nan@2.0.9",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
         }
       }
     },
     "simplesmtp": {
       "version": "0.3.35",
-      "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
+      "from": "simplesmtp@0.3.35",
       "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.35.tgz",
       "dependencies": {
         "rai": {
           "version": "0.1.12",
-          "from": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz",
+          "from": "rai@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz"
         },
         "xoauth2": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
+          "from": "xoauth2@>=0.1.8 <0.2.0",
           "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
         }
       }
     },
     "sinon": {
       "version": "1.15.4",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
+      "from": "sinon@1.15.4",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "from": "formatio@1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.3 <1.0.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
+          "from": "lolex@1.1.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         },
         "samsam": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+          "from": "samsam@1.1.2",
           "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
         }
       }
     },
     "sjcl": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.2.tgz",
+      "from": "sjcl@1.0.2",
       "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.2.tgz"
     },
     "tap": {
       "version": "0.7.1",
-      "from": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
+      "from": "tap@0.7.1",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.2.tgz",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.2.tgz"
         },
         "deep-equal": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "from": "difflet@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+              "from": "traverse@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+              "from": "charm@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "from": "glob@>=4.3.5 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -7125,12 +7356,12 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -7139,56 +7370,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "from": "nopt@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "from": "runforcover@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "from": "bunker@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "from": "burrito@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                      "from": "traverse@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -7199,39 +7430,39 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+          "from": "yamlish@*",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
         }
       }
     },
     "through": {
       "version": "2.3.8",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "from": "through@2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
+      "from": "uuid@1.4.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     },
     "ws": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
+      "from": "ws@1.0.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
       "dependencies": {
         "options": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+          "from": "options@>=0.0.5",
           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
         },
         "ultron": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+          "from": "ultron@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "aws-sdk": "2.2.10",
     "binary-split": "0.1.2",
     "bluebird": "2.10.2",
-    "convict": "1.0.1",
+    "convict": "1.3.0",
     "email-addresses": "2.0.2",
     "envc": "2.4.0",
     "fxa-auth-mailer": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",


### PR DESCRIPTION
Let's see if this works.

I still get one warning from **nsp**, but we can't update the **hapi** dependency without doing a major version bump.

```
✗ grunt nsp
Running "nsp" task
Warning: (+) 1 vulnerabilities found
 Name     Installed   Patched    Path                                                              More Info
 moment   2.10.3      >=2.11.2   fxa-auth-server@1.60.0 > hapi@8.8.1 > joi@6.4.1 > moment@2.10.3   https://nodesecurity.io/advisories/55
 Use --force to continue.

Aborted due to warnings.
```
