### PR TITLE
Restrict device name to display-safe unicode characters

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -5,6 +5,7 @@
 var validators = require('./validators')
 var HEX_STRING = validators.HEX_STRING
 var BASE64_JWT = validators.BASE64_JWT
+var DISPLAY_SAFE_UNICODE = validators.DISPLAY_SAFE_UNICODE
 
 var butil = require('../crypto/butil')
 var openid = require('openid')
@@ -62,7 +63,7 @@ module.exports = function (
             resume: isA.string().max(2048).optional(),
             preVerifyToken: isA.string().max(2048).regex(BASE64_JWT).optional(),
             device: isA.object({
-              name: isA.string().max(255).required(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               // We're not yet ready to store pubkey values, don't let clients submit them.
@@ -81,7 +82,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().required(),
-              name: isA.string().max(255).required(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -301,7 +302,7 @@ module.exports = function (
             reason: isA.string().max(16).optional(),
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).optional(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               // We're not yet ready to store pubkey values, don't let clients submit them.
@@ -321,7 +322,7 @@ module.exports = function (
             device: isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
               createdAt: isA.number().positive().optional(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).optional().allow('')
@@ -810,14 +811,14 @@ module.exports = function (
           payload: isA.alternatives().try(
             isA.object({
               id: isA.string().length(32).regex(HEX_STRING).required(),
-              name: isA.string().max(255).optional(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).optional(),
               type: isA.string().max(16).optional(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               // We're not yet ready to store pubkey values, don't let clients submit them.
               pushPublicKey: isA.string().length(64).regex(HEX_STRING).allow('').forbidden()
             }).or('name', 'type', 'pushCallback', 'pushPublicKey'),
             isA.object({
-              name: isA.string().max(255).required(),
+              name: isA.string().max(255).regex(DISPLAY_SAFE_UNICODE).required(),
               type: isA.string().max(16).required(),
               pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
               // We're not yet ready to store pubkey values, don't let clients submit them.
@@ -829,6 +830,8 @@ module.exports = function (
           schema: {
             id: isA.string().length(32).regex(HEX_STRING).required(),
             createdAt: isA.number().positive().optional(),
+            // We previously allowed devices to register with arbitrry unicode names,
+            // so we can't assert DISPLAY_SAFE_UNICODE in the response schema.
             name: isA.string().max(255).optional(),
             type: isA.string().max(16).optional(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow(''),
@@ -873,6 +876,8 @@ module.exports = function (
             id: isA.string().length(32).regex(HEX_STRING).required(),
             isCurrentDevice: isA.boolean().required(),
             lastAccessTime: isA.number().min(0).required().allow(null),
+            // We previously allowed devices to register with arbitrry unicode names,
+            // so we can't assert DISPLAY_SAFE_UNICODE in the response schema.
             name: isA.string().max(255).required(),
             type: isA.string().max(16).required(),
             pushCallback: isA.string().uri({ scheme: 'https' }).max(255).optional().allow('').allow(null),

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -258,7 +258,7 @@ TestServer.start(config)
   )
 
   test(
-    'device registration with the net-yet-accepted pushPublicKey field',
+    'device registration with the not-yet-accepted pushPublicKey field',
     function (t) {
       var email = server.uniqueEmail()
       var password = 'test password'

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -291,6 +291,37 @@ TestServer.start(config)
   )
 
   test(
+    'device registration with unsupported characters in the name',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            var deviceInfo = {
+              id: crypto.randomBytes(16).toString('hex'),
+              name: 'unicodepooforyou: \uD83D\uDCA9',
+              type: 'mobile',
+            }
+            return client.updateDevice(deviceInfo)
+              .then(
+                function () {
+                  t.fail('request should have failed')
+                }
+              )
+              .catch(
+                function (err) {
+                  t.equal(err.code, 400, 'err.code was 400')
+                  t.equal(err.errno, 107, 'err.errno was 107')
+                  t.equal(err.validation.keys[0], 'name', 'name was rejected')
+                }
+              )
+          }
+        )
+    }
+  )
+
+  test(
     'device registration from a different session',
     function (t) {
       var email = server.uniqueEmail()


### PR DESCRIPTION
The device name is a displayable string (although we don't currently display it anywhere) so we should apply the same filtering as e.g. the user's own display name string.