### PR TITLE
feat(devices): Add metrics on device updates, and a flag to disable them

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -314,6 +314,14 @@ var conf = convict({
     env: 'NEW_LOGIN_NOTIFICATION_ENABLED',
     default: true
   },
+  // A safety switch to disable device metadata updates,
+  // in case problems with the client logic cause server overload.
+  deviceUpdatesEnabled: {
+    doc: 'Are updates to device metadata enabled?',
+    format: Boolean,
+    env: 'DEVICE_UPDATES_ENABLED',
+    default: true
+  },
   oauth: {
     url: {
       format: 'url',

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,7 @@ The currently-defined error responses are:
 * status code 400, errno 124:  session already registered by another device
 * status code 400, errno 126:  account must be reset
 * status code 503, errno 201:  service temporarily unavailable to due high load (see [backoff protocol](#backoff-protocol))
+* status code 503, errno 202:  feature has been disabled for operational reasons
 * any status code, errno 999:  unknown error
 
 The follow error responses include additional parameters:

--- a/lib/error.js
+++ b/lib/error.js
@@ -15,6 +15,7 @@ var ERRNO = {
   DEVICE_UNKNOWN: 123,
   DEVICE_CONFLICT: 124,
   ENDPOINT_NOT_SUPPORTED: 116,
+  FEATURE_NOT_ENABLED: 202,
   INCORRECT_EMAIL_CASE: 120,
   INCORRECT_PASSWORD: 103,
   INVALID_JSON: 106,
@@ -354,6 +355,26 @@ AppError.serviceUnavailable = function (retryAfter) {
       code: 503,
       error: 'Service Unavailable',
       errno: ERRNO.SERVER_BUSY,
+      message: 'Service unavailable'
+    },
+    {
+      retryAfter: retryAfter
+    },
+    {
+      'retry-after': retryAfter
+    }
+  )
+}
+
+AppError.featureNotEnabled = function (retryAfter) {
+  if (!retryAfter) {
+    retryAfter = 30
+  }
+  return new AppError(
+    {
+      code: 503,
+      error: 'Feature not enabled',
+      errno: ERRNO.FEATURE_NOT_ENABLED,
       message: 'Service unavailable'
     },
     {

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -22,10 +22,10 @@ var TEST_EMAIL_INVALID = 'example@dotless-domain'
 var makeRoutes = function (options) {
   options = options || {}
 
-  var config = options.config || {
-    verifierVersion: 0,
-    smtp: {}
-  }
+  var config = options.config || {}
+  config.verifierVersion = config.verifierVersion || 0
+  config.smtp = config.smtp ||  {}
+
   var log = options.log || mocks.mockLog()
   var Password = require('../../lib/crypto/password')(log, config)
   var db = options.db || {}
@@ -211,5 +211,148 @@ test(
       t.equal(mockDB.account.callCount, 1)
       t.equal(mockCustoms.reset.callCount, 1)
     })
+  }
+)
+
+test(
+  'device updates dont write to the db if nothing has changed',
+  function (t) {
+    var uid = uuid.v4('binary')
+    var deviceId = crypto.randomBytes(16)
+    var mockRequest = {
+      auth: {
+        credentials: {
+          uid: uid.toString('hex'),
+          deviceId: deviceId,
+          deviceName: 'my awesome device',
+          deviceType: 'desktop',
+          deviceCallbackURL: '',
+          deviceCallbackPublicKey: '',
+        }
+      },
+      payload: {
+        id: deviceId.toString('hex'),
+        name: 'my awesome device'
+      }
+    }
+    var mockDB = {
+      updateDevice: sinon.spy(function () {
+        return P.resolve()
+      })
+    }
+    var mockLog = mocks.spyLog()
+    var accountRoutes = makeRoutes({
+      db: mockDB,
+      log: mockLog
+    })
+    return new P(function(resolve) {
+      getRoute(accountRoutes, '/account/device')
+        .handler(mockRequest, function(response) {
+          resolve(response)
+        })
+    })
+    .then(function(response) {
+      t.equal(mockDB.updateDevice.callCount, 0, 'updateDevice was not called')
+
+      t.equal(mockLog.increment.callCount, 1, 'a counter was incremented')
+      t.equal(mockLog.increment.firstCall.args[0], 'device.update.spurious')
+
+      t.deepEqual(response, mockRequest.payload)
+    })
+  }
+)
+
+test(
+  'device updates log metrics about what has changed',
+  function (t) {
+    var uid = uuid.v4('binary')
+    var deviceId = crypto.randomBytes(16)
+    var mockRequest = {
+      auth: {
+        credentials: {
+          uid: uid.toString('hex'),
+          tokenId: 'lookmumasessiontoken',
+          deviceId: 'aDifferentDeviceId',
+          deviceName: 'my awesome device',
+          deviceType: 'desktop',
+          deviceCallbackURL: '',
+          deviceCallbackPublicKey: '',
+        }
+      },
+      payload: {
+        id: deviceId.toString('hex'),
+        name: 'my even awesomer device',
+        type: 'phone',
+        pushCallback: 'https://push.services.mozilla.com/123456',
+        pushPublicKey: 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
+      }
+    }
+    var mockDB = {
+      updateDevice: sinon.spy(function (uid, sessionTokenId, deviceInfo) {
+        return P.resolve(deviceInfo)
+      })
+    }
+    var mockLog = mocks.spyLog()
+    var accountRoutes = makeRoutes({
+      db: mockDB,
+      log: mockLog
+    })
+    return new P(function(resolve) {
+      getRoute(accountRoutes, '/account/device')
+        .handler(mockRequest, function(response) {
+          resolve(response)
+        })
+    })
+    .then(function() {
+      t.equal(mockDB.updateDevice.callCount, 1, 'updateDevice was called')
+
+      t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
+      t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
+      t.equal(mockLog.increment.getCall(1).args[0], 'device.update.name')
+      t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
+      t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
+      t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
+    })
+  }
+)
+
+test(
+  'device updates can be disabled via config',
+  function (t) {
+    var uid = uuid.v4('binary')
+    var deviceId = crypto.randomBytes(16)
+    var mockRequest = {
+      auth: {
+        credentials: {
+          uid: uid.toString('hex'),
+          deviceId: deviceId
+        }
+      },
+      payload: {
+        id: deviceId.toString('hex'),
+        name: 'new device name'
+      }
+    }
+    var accountRoutes = makeRoutes({
+      config: {
+        deviceUpdatesEnabled: false
+      }
+    })
+
+    return new P(function(resolve) {
+      getRoute(accountRoutes, '/account/device')
+        .handler(mockRequest, function(response) {
+          resolve(response)
+        })
+    })
+    .then(
+      function(response) {
+        t.fail('should have thrown')
+      },
+      function(err) {
+        t.equal(err.output.statusCode, 503, 'correct status code is returned')
+        t.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED, 'correct errno is returned')
+      }
+    )
   }
 )


### PR DESCRIPTION
To help us with rolling out device metadata updates to release Firefox, this PR adds two things:

* More metrics on what has changed (if anything) to trigger the update
* A safety switch to let us easily pref the feature off if we get swamped

@jrgm what do you think?