### PR TITLE
feat(push): document the format of the push payloads

### DIFF
--- a/docs/pushpayloads.schema.json
+++ b/docs/pushpayloads.schema.json
@@ -1,0 +1,90 @@
+{
+  "title":"FxA Push Payload schema",
+  "description":"This schema defines what is acceptable to send as a payload data with the Push API from the FxA servers to a device connected to FxA",
+  "$schema":"http://json-schema.org/draft-04/schema#",
+  "type":"object",
+  "allOf":[
+    {
+      "type":"object",
+      "required":[
+        "version",
+        "command"
+      ],
+      "properties":{
+        "version":{
+          "type":"integer",
+          "description":"The version of this push payload data instance. Bump this if you make changes to any part of this schema."
+        },
+        "command":{
+          "type":"string",
+          "description":"Helps the receiving device discriminate payloads"
+        }
+      }
+    },
+    {
+      "type":"object",
+      "anyOf":[
+        { "$ref":"#/definitions/newDevice" },
+        { "$ref":"#/definitions/collectionChanged" }
+      ]
+    }
+  ],
+  "definitions":{
+    "newDevice":{
+      "type":"object",
+      "required":[
+        "data"
+      ],
+      "properties":{
+        "command":{
+          "enum":[
+            "fxaccounts:new_device"
+          ]
+        },
+        "data":{
+          "type":"object",
+          "required":[
+            "deviceName"
+          ],
+          "properties":{
+            "deviceName":{
+              "type":"string",
+              "description":"The name of the device who joined this account"
+            }
+          }
+        }
+      }
+    },
+    "collectionsChanged":{
+      "type":"object",
+      "required":[
+        "data"
+      ],
+      "properties":{
+        "command":{
+          "enum":[
+            "sync:collection_changed"
+          ]
+        },
+        "data":{
+          "type":"object",
+          "required":[
+            "collections"
+          ],
+          "properties":{
+            "collections":{
+              "type":"array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "description":"A list of collections that were changed",
+              "items": {
+                "enum": [ "addons", "bookmarks", "history", "forms", "prefs",
+                  "tabs", "passwords", "clients" ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We want to define (and maybe validate in tests) what we send using the Push API from the fxa-auth-server to the Firefox Browser.
We settled on using JSON Schema for this, it looks mature enough and allows us to use good old JSON.
You can try this schema [here](http://www.jsonschemavalidator.net/)

Here's an example of a JSON payload with the current PR proposal (I'll update it in this comment when we amend the schema):

```
{
  version: 1,
  action: "fxaccounts:new_device",
  data: {
    deviceName: "dd"
  }
}
```

Any feedback on this?

ping @mhammond @ckarlof @rfk @kitcambridge @rnewman @edmoz @philbooth @vladikoff