### PR TITLE
feat(errors): Add API and docs for new "request blocked" errno 125.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,6 +84,7 @@ The currently-defined error responses are:
 * status code 400, errno 122:  account is not locked
 * status code 400, errno 123:  unknown device
 * status code 400, errno 124:  session already registered by another device
+* status code 400, errno 125:  request blocked for security reasons
 * status code 400, errno 126:  account must be reset
 * status code 503, errno 201:  service temporarily unavailable to due high load (see [backoff protocol](#backoff-protocol))
 * status code 503, errno 202:  feature has been disabled for operational reasons

--- a/lib/error.js
+++ b/lib/error.js
@@ -28,6 +28,7 @@ var ERRNO = {
   MISSING_CONTENT_LENGTH_HEADER: 112,
   MISSING_PARAMETER: 108,
   REQUEST_TOO_LARGE: 113,
+  REQUEST_BLOCKED: 125,
   SERVER_BUSY: 201,
   SERVER_CONFIG_ERROR: 100,
   THROTTLED: 114,
@@ -344,6 +345,15 @@ AppError.tooManyRequests = function (retryAfter) {
       'retry-after': retryAfter
     }
   )
+}
+
+AppError.requestBlocked = function () {
+  return new AppError({
+    code: 400,
+    error: 'Request blocked',
+    errno: ERRNO.REQUEST_BLOCKED,
+    message: 'The request was blocked for security reasons'
+  })
 }
 
 AppError.serviceUnavailable = function (retryAfter) {


### PR DESCRIPTION
We've already left space in our errno sequence for number 125, I don't see why we shouldn't at least document what it's for