### PR TITLE
refactor(signin): Updated password/change/finish and account/reset

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -460,11 +460,15 @@ This sets the account password and resets wrapKb to a new random value.
 
 The accountResetToken is single-use, and is consumed regardless of whether the request succeeds or fails.
 
+The caller can optionally request a new `sessionToken` and `keyFetchToken`.
+
 ### Request
 
 ___Parameters___
 
 * authPW - the PBKDF2/HKDF stretched password as a hex string
+* sessionToken - (optional) boolean, whether to generate a new sessionToken; default is false
+* keys - (optional) whether to request new `keyFetchToken`, `keys=true`
 
 
 ___Headers___
@@ -477,16 +481,30 @@ curl -v \
 -H "Host: api-accounts.dev.lcip.org" \
 -H "Content-Type: application/json" \
 -H 'Authorization: Hawk id="d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c7509c5632ac35b28b48d", ts="1373391043", nonce="ohQjqb", hash="vBODPWhDhiRWM4tmI9qp+np+3aoqEFzdGuGk0h7bh9w=", mac="LAnpP3P2PXelC6hUoUaHP72nCqY5Iibaa3eeiGBqIIU="' \
-https://api-accounts.dev.lcip.org/v1/account/reset \
+https://api-accounts.dev.lcip.org/v1/account/reset?keys=true \
 -d '{
-  "authPW": "f9fae9253549b2428a403d6fa51e6fb43d2f8a302e132cf902ffade52c02e6a4"
+  "authPW": "f9fae9253549b2428a403d6fa51e6fb43d2f8a302e132cf902ffade52c02e6a4",
+  "sessionToken": true
   }
 }'
 ```
 
 ### Response
 
-Successful requests will produce a "200 OK" response with empty JSON body:
+Successful requests will produce a "200 OK" response with JSON body:
+
+```json
+{
+  "uid": "4c352927cd4f4a4aa03d7d1893d950b8",
+  "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d",
+  "keyFetchToken": "7d1893d950b8cd69856a2ec81cbfd7d1893d950b3362df9e56a2ec81cbf19d5c",
+  "authAt": 1392144866,
+  "verified": true
+}
+```
+
+
+If no `sessionToken` is requested the response is an empty JSON body:
 
 ```json
 {}
@@ -1025,12 +1043,15 @@ Failing requests may be due to the following errors:
 
 :lock: HAWK-authenticated with the passwordChangeToken.
 
-Change the password and update `wrapKb`.
+Change the password and update `wrapKb`. Optionally returns a `sessionToken` and
+`keyFetchToken`.
 
 ___Parameters___
 
 * authPW - the new PBKDF2/HKDF stretched password as a hex string
 * wrapKb - the new wrapKb value as a hex string
+* sessionToken - (optional) the current sessionToken as a hex string
+* keys - (optional) whether to request new `keyFetchToken`, `keys=true`
 
 ### Request
 
@@ -1042,17 +1063,31 @@ curl -v \
 https://api-accounts.dev.lcip.org/v1/password/change/finish \
 -d '{
   "authPW": "761443da0ab27b1fa18c98912af6291714e9600aa3499109c5632ac35b28a309",
-  "wrapKb": "20e3f5391e134596c27519979b93a45e6d0da34c75ac55c0520f2edfb0267614"
+  "wrapKb": "20e3f5391e134596c27519979b93a45e6d0da34c75ac55c0520f2edfb0267614",
+  "sessionToken": "93a4f5391e134596c27519979b93a45e6d0da34c75ac55c0520f2edfb0267614'
 }'
 ```
 
 ### Response
 
-Successful requests will produce a "200 OK" response with an empty JSON body:
+Successful requests will produce a "200 OK" response with JSON body:
+
+```json
+{
+  "uid": "4c352927cd4f4a4aa03d7d1893d950b8",
+  "sessionToken": "27cd4f4a4aa03d7d186a2ec81cbf19d5c8a604713362df9ee15c4f4a4aa03d7d",
+  "keyFetchToken": "7d1893d950b8cd69856a2ec81cbfd7d1893d950b3362df9e56a2ec81cbf19d5c",
+  "authAt": 1392144866,
+  "verified": true
+}
+```
+
+If a `sessionToken` was not requested, then an empty JSON body is returned:
 
 ```json
 {}
 ```
+
 
 Failing requests may be due to the following errors:
 

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Returns `true` if request has a keys=true query param.
+ *
+ * @param request
+ * @returns {boolean}
+ */
+function wantsKeys (request) {
+  return request.query.keys === 'true'
+}
+
+module.exports = {
+  wantsKeys: wantsKeys
+}

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -57,7 +57,11 @@ test(
       },
       payload: {
         authPW: crypto.randomBytes(32).toString('hex'),
-        wrapKb: crypto.randomBytes(32).toString('hex')
+        wrapKb: crypto.randomBytes(32).toString('hex'),
+        sessionToken: crypto.randomBytes(32).toString('hex')
+      },
+      query: {
+        keys: 'true'
       },
       app: {}
     }

--- a/test/local/verifier_upgrade_tests.js
+++ b/test/local/verifier_upgrade_tests.js
@@ -30,6 +30,7 @@ createDBServer().then(
     var email = Math.random() + '@example.com'
     var password = 'ok'
     var uid = null
+
     test(
       'upgrading verifierVersion upgrades the account on password change',
     function (t) {
@@ -73,14 +74,21 @@ createDBServer().then(
       )
       .then(
         function (server) {
-          return Client.changePassword(config.publicUrl, email, password, password)
+          var client
+          return Client.login(config.publicUrl, email, password, server.mailbox, {keys:true})
             .then(
-              function () {
-                return Client.login(config.publicUrl, email, password)
+              function (x) {
+                client = x
+                return client.keys()
               }
             )
             .then(
-              function (c) {
+              function () {
+                return client.changePassword(password)
+              }
+            )
+            .then(
+              function () {
                 return server.stop()
               }
             )

--- a/test/remote/account_reset_tests.js
+++ b/test/remote/account_reset_tests.js
@@ -1,0 +1,233 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var test = require('../ptaptest')
+var url = require('url')
+var Client = require('../client')
+var TestServer = require('../test_server')
+
+var config = require('../../config').getProperties()
+
+TestServer.start(config)
+  .then(function main(server) {
+
+    test(
+      'account reset w/o sessionToken',
+      function (t) {
+        var email = server.uniqueEmail()
+        var password = 'allyourbasearebelongtous'
+        var newPassword = 'ez'
+        var wrapKb, kA, client
+
+        return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+          .then(
+            function (x) {
+              client = x
+            }
+          )
+          .then(
+            function () {
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              wrapKb = keys.wrapKb
+              kA = keys.kA
+              return client.forgotPassword()
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForCode(email)
+            }
+          )
+          .then(
+            function (code) {
+              t.throws(function() {
+                client.resetPassword(newPassword)
+              })
+              return resetPassword(client, code, newPassword, {sessionToken: false})
+            }
+          )
+          .then(
+            function (response) {
+              t.notOk(response.sessionToken, 'session token is not in response')
+              t.notOk(response.keyFetchToken, 'keyFetchToken token is not in response')
+              t.notOk(response.verified, 'verified is not in response')
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForEmail(email)
+            }
+          )
+          .then(
+            function (emailData) {
+              var link = emailData.headers['x-link']
+              var query = url.parse(link, true).query
+              t.ok(query.email, 'email is in the link')
+            }
+          )
+          .then(
+            function () {
+              // make sure we can still login after password reset
+              return Client.login(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            }
+          )
+          .then(
+            function (x) {
+              client = x
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              t.ok(Buffer.isBuffer(keys.wrapKb), 'yep, wrapKb')
+              t.notDeepEqual(wrapKb, keys.wrapKb, 'wrapKb was reset')
+              t.deepEqual(kA, keys.kA, 'kA was not reset')
+              t.equal(client.kB.length, 32, 'kB exists, has the right length')
+            }
+          )
+      }
+    )
+
+    test(
+      'account reset with keys',
+      function (t) {
+        var email = server.uniqueEmail()
+        var password = 'allyourbasearebelongtous'
+        var newPassword = 'ez'
+        var wrapKb, kA, client
+
+        return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+          .then(
+            function (x) {
+              client = x
+            }
+          )
+          .then(
+            function () {
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              wrapKb = keys.wrapKb
+              kA = keys.kA
+              return client.forgotPassword()
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForCode(email)
+            }
+          )
+          .then(
+            function (code) {
+              t.throws(function() {
+                client.resetPassword(newPassword)
+              })
+              return resetPassword(client, code, newPassword,  {keys:true})
+            }
+          )
+          .then(
+            function (response) {
+              t.ok(response.sessionToken, 'session token is in response')
+              t.ok(response.keyFetchToken, 'keyFetchToken token is in response')
+              t.equal(response.verified, true,  'verified is true')
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForEmail(email)
+            }
+          )
+          .then(
+            function (emailData) {
+              var link = emailData.headers['x-link']
+              var query = url.parse(link, true).query
+              t.ok(query.email, 'email is in the link')
+            }
+          )
+          .then(
+            function () {
+              // make sure we can still login after password reset
+              return Client.login(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            }
+          )
+          .then(
+            function (x) {
+              client = x
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              t.ok(Buffer.isBuffer(keys.wrapKb), 'yep, wrapKb')
+              t.notDeepEqual(wrapKb, keys.wrapKb, 'wrapKb was reset')
+              t.deepEqual(kA, keys.kA, 'kA was not reset')
+              t.equal(client.kB.length, 32, 'kB exists, has the right length')
+            }
+          )
+      }
+    )
+
+    test(
+      'account reset w/o keys, with sessionToken',
+      function (t) {
+        var email = server.uniqueEmail()
+        var password = 'allyourbasearebelongtous'
+        var newPassword = 'ez'
+        var client
+
+        return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+          .then(
+            function (x) {
+              client = x
+            }
+          )
+          .then(
+            function () {
+              return client.forgotPassword()
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForCode(email)
+            }
+          )
+          .then(
+            function (code) {
+              t.throws(function() {
+                client.resetPassword(newPassword)
+              })
+              return resetPassword(client, code, newPassword)
+            }
+          )
+          .then(
+            function (response) {
+              t.ok(response.sessionToken, 'session token is in response')
+              t.notOk(response.keyFetchToken, 'keyFetchToken token is not in response')
+              t.equal(response.verified, true,  'verified is true')
+            }
+          )
+      }
+    )
+
+    test(
+      'teardown',
+      function (t) {
+        server.stop()
+        t.end()
+      }
+    )
+  })
+
+function resetPassword(client, code, newPassword, options) {
+  return client.verifyPasswordResetCode(code)
+    .then(function() {
+      return client.resetPassword(newPassword, {}, options)
+    })
+}

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var test = require('../ptaptest')
-var url = require('url')
 var Client = require('../client')
-var TestServer = require('../test_server')
-
-
 var config = require('../../config').getProperties()
+var test = require('../ptaptest')
+var TestServer = require('../test_server')
+var url = require('url')
 
 TestServer.start(config)
 .then(function main(server) {
@@ -19,11 +17,78 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var newPassword = 'foobar'
-      var kB = null
-      var kA = null
-      var client = null
-      var firstAuthPW
-      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+      var kB, kA, client, firstAuthPW, originalSessionTokenId
+
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+        .then(
+          function (x) {
+            client = x
+            originalSessionTokenId = client.sessionToken
+            firstAuthPW = x.authPW.toString('hex')
+            return client.keys()
+          }
+        )
+        .then(
+          function (keys) {
+            kB = keys.kB
+            kA = keys.kA
+          }
+        )
+        .then(
+          function () {
+            return client.changePassword(newPassword, undefined, client.sessionToken)
+          }
+        )
+        .then(
+          function (response) {
+            t.notEqual(response.sessionToken, originalSessionTokenId, 'session token has changed')
+            t.ok(response.keyFetchToken, 'key fetch token returned')
+            t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            var subject = emailData.headers['subject']
+            t.equal(subject, 'Your Firefox Account password has been changed', 'password email subject set correctly')
+            var link = emailData.headers['x-link']
+            var query = url.parse(link, true).query
+            t.ok(query.email, 'email is in the link')
+          }
+        )
+        .then(
+          function () {
+            return Client.login(config.publicUrl, email, newPassword, {keys:true})
+          }
+        )
+        .then(
+          function (x) {
+            client = x
+            return client.keys()
+          }
+        )
+        .then(
+          function (keys) {
+            t.deepEqual(keys.kB, kB, 'kB is preserved')
+            t.deepEqual(keys.kA, kA, 'kA is preserved')
+          }
+        )
+    }
+  )
+
+  test(
+    'password change w/o sessionToken',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'allyourbasearebelongtous'
+      var newPassword = 'foobar'
+      var kB, kA, client, firstAuthPW
+
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x
@@ -43,8 +108,34 @@ TestServer.start(config)
           }
         )
         .then(
-          function () {
+          function (response) {
+            t.notOk(response.sessionToken, 'no session token returned')
+            t.notOk(response.keyFetchToken, 'no key fetch token returned')
             t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            var subject = emailData.headers['subject']
+            t.equal(subject, 'Your Firefox Account password has been changed', 'password email subject set correctly')
+            var link = emailData.headers['x-link']
+            var query = url.parse(link, true).query
+            t.ok(query.email, 'email is in the link')
+          }
+        )
+        .then(
+          function () {
+            return Client.login(config.publicUrl, email, newPassword, {keys:true})
+          }
+        )
+        .then(
+          function (x) {
+            client = x
             return client.keys()
           }
         )
@@ -52,15 +143,6 @@ TestServer.start(config)
           function (keys) {
             t.deepEqual(keys.kB, kB, 'kB is preserved')
             t.deepEqual(keys.kA, kA, 'kA is preserved')
-
-            return server.mailbox.waitForEmail(email)
-          }
-        )
-        .then(
-          function (emailData) {
-            var link = emailData.headers['x-link']
-            var query = url.parse(link, true).query
-            t.ok(query.email, 'email is in the link')
           }
         )
     }
@@ -72,7 +154,7 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var client = null
-      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x
@@ -100,7 +182,7 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'wibble'
       var client
-      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (c) {
             client = c


### PR DESCRIPTION
PR https://github.com/mozilla/fxa-auth-server/pull/1232 is being split into two PRs. This PR contains updates to `/account/reset` and `/password/change/finish`. These endpoints return sessionToken and keyFetchTokens that allow the client not to have to re-login after performing the respective functions.

Corresponding content-server changes: https://github.com/mozilla/fxa-content-server/pull/3747

@shane-tomlinson @rfk, this what you had in mind? r?