### PR TITLE
refactor(reset): Adds sessionToken as an optional param

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1247,7 +1247,8 @@ module.exports = function (
         validate: {
           payload: {
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
-            metricsContext: metricsContext.schema
+            metricsContext: metricsContext.schema,
+            sessionToken: isA.boolean().optional()
           }
         }
       },


### PR DESCRIPTION
This PR adds the `sessionToken` param to the `/account/reset` endpoint. This is needed to support legacy and new clients that don't require a re-login.

@jbuck r?