### PR TITLE
fix(api): remove device registration from signup/login endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -169,7 +169,6 @@ ___Parameters___
 * redirectTo - (optional) a URL that the client should be redirected to after handling the request
 * resume - (optional) opaque url-encoded string that will be included in the verification link as a querystring parameter, useful for continuing an OAuth flow for example.
 * preVerifyToken - (optional) see below
-* device - (optional, experimental, **DO NOT USE**) object containing fields for device registration
 
 ### Request
 
@@ -322,7 +321,6 @@ ___Parameters___
 * authPW - the PBKDF2/HKDF stretched password as a hex string
 * service - (optional) opaque alphanumeric token to be included in verification links
 * reason - (optional) alphanumeric string indicating the reason for establishing a new session; may be "login" (the default) or "reconnect"
-* device - (optional, experimental, **DO NOT USE**) object containing fields for device registration
 
 ### Request
 
@@ -1507,18 +1505,18 @@ There are no standard failure modes for this endpoint.
 * `POST /get_random_bytes`
 * `POST /account/create`
 * `POST /account/login?keys=true`
+* `POST /account/device`
 * `GET /recovery_email/status`
 * `POST /recovery_email/verify_code`
 * `GET /account/keys`
 * `POST /certificate/sign`
-* `POST /account/device`
 
 ## Attach a new device
 
 * `POST /account/login?keys=true`
+* `POST /account/device`
 * `GET /account/keys`
 * `POST /certificate/sign`
-* `POST /account/device`
 
 ## Forgot password
 

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -367,18 +367,21 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var newPassword = 'foo'
       var client
-      return Client.createAndVerify(config.publicUrl, email, 'bar', server.mailbox, {
-        device: {
-          name: 'baz',
-          type: 'mobile',
-          pushCallback: 'https://example.com/qux',
-          pushPublicKey: base64url(Buffer.concat([new Buffer('\x04'), crypto.randomBytes(64)])),
-          pushAuthKey: base64url(crypto.randomBytes(16))
-        }
-      })
+      return Client.createAndVerify(config.publicUrl, email, 'bar', server.mailbox)
         .then(
           function (c) {
             client = c
+            return client.updateDevice({
+              name: 'baz',
+              type: 'mobile',
+              pushCallback: 'https://example.com/qux',
+              pushPublicKey: base64url(Buffer.concat([new Buffer('\x04'), crypto.randomBytes(64)])),
+              pushAuthKey: base64url(crypto.randomBytes(16))
+            })
+          }
+        )
+        .then(
+          function () {
             return client.devices()
           }
         )


### PR DESCRIPTION
@rfk @seanmonstar 

In light of [your conversation](https://github.com/mozilla/fxa-auth-server/pull/1263#issuecomment-221083580), I've gone ahead and removed device registration from the `/account/signup` and `/account/login` endpoints entirely.

r?