### PR TITLE
fix(e2e-email): fix e2e-email for all locales

### DIFF
--- a/scripts/e2e-email/localeQuirks.js
+++ b/scripts/e2e-email/localeQuirks.js
@@ -15,6 +15,7 @@ var translationQuirks = {
   'Verify your Firefox Account': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es-AR',
     'ff',
@@ -25,6 +26,7 @@ var translationQuirks = {
   'Firefox Account Verified': [
     'en',
     'en-GB',
+    'ar',
     'es-AR',
     'ff',
     'he',
@@ -35,6 +37,7 @@ var translationQuirks = {
   'Reset your Firefox Account password': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es-AR',
     'ff',
@@ -45,6 +48,7 @@ var translationQuirks = {
   'Re-verify your Firefox Account': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es-AR',
     'ff',
@@ -55,6 +59,7 @@ var translationQuirks = {
   'New sign-in to Firefox': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es',
     'es-AR',
@@ -74,6 +79,7 @@ var translationQuirks = {
   'Your Firefox Account password has been changed': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es-AR',
     'ff',
@@ -84,6 +90,7 @@ var translationQuirks = {
   'Your Firefox Account password has been reset': [
     'en',
     'en-GB',
+    'ar',
     'bg',
     'es-AR',
     'ff',

--- a/scripts/e2e-email/validate-email.js
+++ b/scripts/e2e-email/validate-email.js
@@ -40,6 +40,12 @@ var messageContentChecks = [
     xheaders: [],
   },
   {
+    subject: 'New sign-in to Sync',
+    pathname: '/settings/change_password',
+    args: [ 'email' ],
+    xheaders: [],
+  },
+  {
     subject: 'Your Firefox Account password has been changed',
     pathname: '/reset_password',
     args: [ 'email' ],
@@ -123,7 +129,7 @@ function ensureNonZeroContent(body, errmsg, lang) {
 
 function verifyMailbox(mbox) {
   var lang = langFromEmail(mbox[0].headers.to)
-  if (mbox.length !== 6) {
+  if (mbox.length !== 7) {
     return reportError(lang, 'Missing email response, count: ' + mbox.length)
   }
 


### PR DESCRIPTION
repairs this test by getting `/account/keys`, using instance methods (not creating more logins), and restoring the check for new login (that was removed when we stopped sending this notification). 

Also note: `ar` email doesn't appear to be translated (like a lot of other locales note in `localeQuirks.js`).

r? @vbudhram 