### PR TITLE
refactor(tests): eliminate duplicate setup in local route tests

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -423,7 +423,7 @@ var conf = convict({
       doc: 'If feature enabled, force sign-in confirmation for email addresses matching this regex.',
       format: Array,
       default: [
-        '@mozilla.com$'
+        '.+@mozilla\.com$'
       ],
       env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -17,7 +17,7 @@ var isA = require('joi')
 var error = require('../../lib/error')
 var log = require('../../lib/log')
 
-var TEST_EMAIL = 'foo@bloop.com'
+var TEST_EMAIL = 'foo@gmail.com'
 var TEST_EMAIL_INVALID = 'example@dotless-domain'
 
 var makeRoutes = function (options) {
@@ -56,247 +56,92 @@ var makeRoutes = function (options) {
   )
 }
 
-test(
-  'account with unverified invalid email gets deleted on status poll',
-  function (t) {
-    var mockDB = {
-      deleteAccount: sinon.spy(function() {
-        return P.resolve()
-      })
-    }
-    var mockRequest = {
-      auth: {
-        credentials: {
-          email: TEST_EMAIL_INVALID,
-          emailVerified: false
-        }
-      }
-    }
+function runTest (route, request, assertions) {
+  return new P(function (resolve) {
+    route.handler(request, function (response) {
+      resolve(response)
+    })
+  })
+  .then(assertions)
+}
 
-    var accountRoutes = makeRoutes({
-      db: mockDB
-    })
-    var route = getRoute(accountRoutes, '/recovery_email/status')
-
-    return new P(function(resolve) {
-      route.handler(mockRequest, function(response) {
-        resolve(response)
-      })
-    })
-    .then(function(response) {
-      t.equal(mockDB.deleteAccount.callCount, 1)
-      t.equal(mockDB.deleteAccount.firstCall.args[0].email, TEST_EMAIL_INVALID)
-      t.equal(response.errno, error.ERRNO.INVALID_TOKEN)
-    })
+test('/recovery_email/status', function (t) {
+  var config = {
+    signinConfirmation: {}
   }
-)
-
-test(
-  'account with verified invalid email does not get deleted on status poll',
-  function (t) {
-    var mockDB = {
-      deleteAccount: sinon.spy()
+  var mockDB = mocks.mockDB()
+  var pushCalled
+  var mockLog = mocks.mockLog({
+    increment: function (name) {
+      if (name === 'recovery_email_reason.push') {
+        pushCalled = true
+      }
     }
-    var mockRequest = {
-      auth: {
+  })
+  var accountRoutes = makeRoutes({
+    config: config,
+    db: mockDB,
+    log: mockLog
+  })
+  var route = getRoute(accountRoutes, '/recovery_email/status')
+
+  test('sign-in confirmation disabled', function (t) {
+    config.signinConfirmation.enabled = false
+
+    test('invalid email', function (t) {
+      var mockRequest = mocks.mockRequest({
         credentials: {
-          uid: uuid.v4('binary').toString('hex'),
-          email: TEST_EMAIL_INVALID,
-          emailVerified: true,
-          tokenVerified: true
+          email: TEST_EMAIL_INVALID
         }
-      }
-    }
-
-    var accountRoutes = makeRoutes({
-      db: mockDB
-    })
-    var route = getRoute(accountRoutes, '/recovery_email/status')
-
-    return new P(function(resolve) {
-      route.handler(mockRequest, function(response) {
-        resolve(response)
       })
-    })
-    .then(function(response) {
-      t.equal(mockDB.deleteAccount.callCount, 0)
-      t.deepEqual(response, {
-        email: TEST_EMAIL_INVALID,
-        verified: true,
-        emailVerified: true,
-        sessionVerified: true
-      })
-    })
-  }
-)
 
-test(
-  '/recovery_email/status logs query reason',
-  function (t) {
-    var pushCalled = false
-    var mockLog = mocks.mockLog({
-      increment: function (name) {
-        if (name === 'recovery_email_reason.push') {
-          pushCalled = true
-        }
-      }
-    })
-    var mockRequest = {
-      auth: {
-        credentials: {
-          email: TEST_EMAIL,
-          emailVerified: true
-        }
-      },
-      query: {
-        reason: 'push'
-      }
-    }
-    var accountRoutes = makeRoutes({
-      log: mockLog
-    })
+      test('unverified account', function (t) {
+        mockRequest.auth.credentials.emailVerified = false
 
-    getRoute(accountRoutes, '/recovery_email/status')
-      .handler(mockRequest, function() {
-        t.equal(pushCalled, true)
-        t.end()
-      })
-  }
-)
-
-test(
-  '/recovery_email/status with sign-in confirmation enabled, emailVerified=true, sessionVerified=true',
-  function (t) {
-
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 1.0
-      }
-    }
-
-    var mockDB = {
-      deleteAccount: sinon.spy()
-    }
-
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uuid.v4('binary').toString('hex'),
-          email: TEST_EMAIL,
-          emailVerified: true,
-          tokenVerified: true
-        }
-      }
-    }
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB
-    })
-
-    var route = getRoute(accountRoutes, '/recovery_email/status')
-    return new P(function(resolve) {
-      route.handler(mockRequest, function(response) {
-        resolve(response)
-      })
-    })
-    .then(function(response) {
-      t.deepEqual(response, {
-        email: TEST_EMAIL,
-        verified: true,
-        sessionVerified: true,
-        emailVerified: true
-      })
-    })
-  }
-)
-
-test(
-  '/recovery_email/status with sign-in confirmation enabled, emailVerified=true, sessionVerified=false',
-  function (t) {
-
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 1.0
-      }
-    }
-
-    var mockDB = {
-      deleteAccount: sinon.spy()
-    }
-
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uuid.v4('binary').toString('hex'),
-          email: TEST_EMAIL,
-          emailVerified: true,
-          tokenVerified: false
-        }
-      }
-    }
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB
-    })
-
-    var route = getRoute(accountRoutes, '/recovery_email/status')
-    return new P(function(resolve) {
-      route.handler(mockRequest, function(response) {
-        resolve(response)
-      })
-    })
-      .then(function(response) {
-        t.deepEqual(response, {
-          email: TEST_EMAIL,
-          verified: false,
-          sessionVerified: false,
-          emailVerified: true
+        return runTest(route, mockRequest, function (response) {
+          t.equal(mockDB.deleteAccount.callCount, 1)
+          t.equal(mockDB.deleteAccount.firstCall.args[0].email, TEST_EMAIL_INVALID)
+          t.equal(response.errno, error.ERRNO.INVALID_TOKEN)
         })
-      })
-  }
-)
+        .then(function () {
+          mockDB.deleteAccount.reset()
+        })
+      }, t)
 
-test(
-  '/recovery_email/status with sign-in confirmation disabled',
-  function (t) {
+      test('verified account', function (t) {
+        mockRequest.auth.credentials.uid = uuid.v4('binary').toString('hex')
+        mockRequest.auth.credentials.emailVerified = true
+        mockRequest.auth.credentials.tokenVerified = true
 
-    var configOptions = {
-      signinConfirmation: {
-        enabled: false
-      }
-    }
+        return runTest(route, mockRequest, function (response) {
+          t.equal(mockDB.deleteAccount.callCount, 0)
+          t.deepEqual(response, {
+            email: TEST_EMAIL_INVALID,
+            verified: true,
+            emailVerified: true,
+            sessionVerified: true
+          })
+        })
+      }, t)
+    }, t)
 
-    var mockDB = {
-      deleteAccount: sinon.spy()
-    }
-
-    var mockRequest = {
-      auth: {
+    test('valid email, verified account', function (t) {
+      pushCalled = false
+      var mockRequest = mocks.mockRequest({
         credentials: {
           uid: uuid.v4('binary').toString('hex'),
           email: TEST_EMAIL,
           emailVerified: true,
           tokenVerified: true
+        },
+        query: {
+          reason: 'push'
         }
-      }
-    }
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB
-    })
-
-    var route = getRoute(accountRoutes, '/recovery_email/status')
-    return new P(function(resolve) {
-      route.handler(mockRequest, function(response) {
-        resolve(response)
       })
-    })
-      .then(function(response) {
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(pushCalled, true)
+
         t.deepEqual(response, {
           email: TEST_EMAIL,
           verified: true,
@@ -304,451 +149,360 @@ test(
           sessionVerified: true
         })
       })
-  }
-)
+    }, t)
+  }, t)
 
-
-test(
-  'device should be notified when the account is reset',
-  function (t) {
-    var uid = uuid.v4('binary')
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex')
-        }
-      },
-      payload: {
-        authPW: crypto.randomBytes(32).toString('hex')
+  test('sign-in confirmation enabled', function (t) {
+    config.signinConfirmation.enabled = true
+    config.signinConfirmation.enabled = 1
+    var mockRequest = mocks.mockRequest({
+      credentials: {
+        uid: uuid.v4('binary').toString('hex'),
+        email: TEST_EMAIL
       }
-    }
-    var mockDB = {
-      resetAccount: sinon.spy(function () {
-        return P.resolve()
-      }),
-      account: sinon.spy(function () {
-        return P.resolve({
-          uid: uid,
-          verifierSetAt: 0,
-          email: TEST_EMAIL
-        })
-      })
-    }
-    var mockCustoms = {
-      reset: sinon.spy(function (email) {
-        return P.resolve()
-      })
-    }
-    var mockPush = {
-      notifyUpdate: sinon.spy(function () {})
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      customs: mockCustoms,
-      push: mockPush
     })
 
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/reset')
-        .handler(mockRequest, function(response) {
-          resolve(response)
+    test('verified account, verified session', function (t) {
+      mockRequest.auth.credentials.emailVerified = true
+      mockRequest.auth.credentials.tokenVerified = true
+
+      return runTest(route, mockRequest, function (response) {
+        t.deepEqual(response, {
+          email: TEST_EMAIL,
+          verified: true,
+          sessionVerified: true,
+          emailVerified: true
         })
-    })
-    .then(function(response) {
-      t.equal(mockDB.resetAccount.callCount, 1)
+      })
+    }, t)
 
-      t.equal(mockPush.notifyUpdate.callCount, 1)
-      t.equal(mockPush.notifyUpdate.firstCall.args[0], uid.toString('hex'))
-      t.equal(mockPush.notifyUpdate.firstCall.args[1], 'passwordReset')
+    test('verified account, unverified session', function (t) {
+      mockRequest.auth.credentials.emailVerified = true
+      mockRequest.auth.credentials.tokenVerified = false
 
-      t.equal(mockDB.account.callCount, 1)
-      t.equal(mockCustoms.reset.callCount, 1)
+      return runTest(route, mockRequest, function (response) {
+        t.deepEqual(response, {
+          email: TEST_EMAIL,
+          verified: false,
+          sessionVerified: false,
+          emailVerified: true
+        })
+      })
+    }, t)
+  }, t)
+})
+
+test('/account/reset', function (t) {
+  var uid = uuid.v4('binary')
+  var mockRequest = mocks.mockRequest({
+    credentials: {
+      uid: uid.toString('hex')
+    },
+    payload: {
+      authPW: crypto.randomBytes(32).toString('hex')
+    }
+  })
+  var mockDB = mocks.mockDB({
+    uid: uid,
+    email: TEST_EMAIL
+  })
+  var mockCustoms = {
+    reset: sinon.spy(function () {
+      return P.resolve()
     })
   }
-)
+  var mockPush = mocks.mockPush()
+  var accountRoutes = makeRoutes({
+    db: mockDB,
+    customs: mockCustoms,
+    push: mockPush
+  })
+  var route = getRoute(accountRoutes, '/account/reset')
 
-test(
-  'device updates dont write to the db if nothing has changed',
-  function (t) {
-    var uid = uuid.v4('binary')
-    var deviceId = crypto.randomBytes(16)
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex'),
-          deviceId: deviceId,
-          deviceName: 'my awesome device',
-          deviceType: 'desktop',
-          deviceCallbackURL: '',
-          deviceCallbackPublicKey: '',
-        }
-      },
-      payload: {
-        id: deviceId.toString('hex'),
-        name: 'my awesome device'
-      }
-    }
-    var mockDB = {
-      updateDevice: sinon.spy(function () {
-        return P.resolve()
-      })
-    }
-    var mockLog = mocks.spyLog()
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog
-    })
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function(response) {
-      t.equal(mockDB.updateDevice.callCount, 0, 'updateDevice was not called')
+  return runTest(route, mockRequest, function () {
+    t.equal(mockDB.resetAccount.callCount, 1)
 
-      t.equal(mockLog.increment.callCount, 1, 'a counter was incremented')
-      t.equal(mockLog.increment.firstCall.args[0], 'device.update.spurious')
+    t.equal(mockPush.notifyUpdate.callCount, 1)
+    t.equal(mockPush.notifyUpdate.firstCall.args[0], uid.toString('hex'))
+    t.equal(mockPush.notifyUpdate.firstCall.args[1], 'passwordReset')
 
-      t.deepEqual(response, mockRequest.payload)
-    })
-  }
-)
+    t.equal(mockDB.account.callCount, 1)
+    t.equal(mockCustoms.reset.callCount, 1)
+  })
+})
 
-test(
-  'device updates log metrics about what has changed',
-  function (t) {
-    var uid = uuid.v4('binary')
-    var deviceId = crypto.randomBytes(16)
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex'),
-          tokenId: 'lookmumasessiontoken',
-          deviceId: 'aDifferentDeviceId',
-          deviceName: 'my awesome device',
-          deviceType: 'desktop',
-          deviceCallbackURL: '',
-          deviceCallbackPublicKey: '',
-        }
-      },
-      payload: {
-        id: deviceId.toString('hex'),
-        name: 'my even awesomer device',
-        type: 'phone',
-        pushCallback: 'https://push.services.mozilla.com/123456',
-        pushPublicKey: 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
-      }
-    }
-    var mockDB = {
-      updateDevice: sinon.spy(function (uid, sessionTokenId, deviceInfo) {
-        return P.resolve(deviceInfo)
-      })
-    }
-    var mockLog = mocks.spyLog()
-    var mockPush = {
-      notifyDeviceConnected: sinon.spy(function () {})
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog,
-      push: mockPush
-    })
+test('/account/device', function (t) {
+  var config = {}
+  var uid = uuid.v4('binary')
+  var device = {}
+  var mockRequest = mocks.mockRequest({
+    credentials: {
+      uid: uid.toString('hex')
+    },
+    payload: device
+  })
+  var deviceCreatedAt = Date.now()
+  var deviceId = crypto.randomBytes(16).toString('hex')
+  var mockDB = mocks.mockDB({
+    device: device,
+    deviceCreatedAt: deviceCreatedAt,
+    deviceId: deviceId
+  })
+  var mockLog = mocks.spyLog()
+  var mockPush = mocks.mockPush()
+  var accountRoutes = makeRoutes({
+    config: config,
+    db: mockDB,
+    log: mockLog,
+    push: mockPush
+  })
+  var route = getRoute(accountRoutes, '/account/device')
 
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function() {
-      t.equal(mockDB.updateDevice.callCount, 1, 'updateDevice was called')
+  test('create', function (t) {
+    device.name = 'My Phone'
+    device.type = 'mobile'
+    device.pushCallback = 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef'
 
-      t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
-      t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
-      t.equal(mockLog.increment.getCall(1).args[0], 'device.update.name')
-      t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
-      t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
-      t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
-    })
-  }
-)
-
-test(
-  'device should be notified when another device is registered',
-  function (t) {
-    var device = {
-      name: 'My Phone',
-      type: 'mobile',
-      pushCallback: 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef'
-    }
-    var uid = uuid.v4('binary')
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex')
-        }
-      },
-      payload: device
-    }
-    var mockDB = {
-      createDevice: sinon.spy(function () {
-        device.id = crypto.randomBytes(16)
-        return P.resolve(device)
-      })
-    }
-    var mockPush = {
-      notifyDeviceConnected: sinon.spy(function () {})
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      push: mockPush
-    })
-
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function(response) {
+    return runTest(route, mockRequest, function (response) {
       t.equal(mockDB.createDevice.callCount, 1)
 
       t.equal(mockPush.notifyDeviceConnected.callCount, 1)
       t.equal(mockPush.notifyDeviceConnected.firstCall.args[0], mockRequest.auth.credentials.uid)
       t.equal(mockPush.notifyDeviceConnected.firstCall.args[1], device.name)
-      t.equal(mockPush.notifyDeviceConnected.firstCall.args[2], device.id.toString('hex'))
-    })
-  }
-)
+      t.equal(mockPush.notifyDeviceConnected.firstCall.args[2], deviceId)
 
-test(
-  'device should be notified when it is remotely disconnected',
-  function (t) {
-    var deviceId = 'deviceId'
-    var uid = uuid.v4('binary')
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex')
-        }
-      },
-      payload: {
-        id: deviceId
-      }
-    }
-    var mockDB = {
-      deleteDevice: sinon.spy(function () {
-        return P.resolve({})
+      t.equal(mockLog.event.callCount, 1)
+      t.equal(mockLog.event.args[0].length, 3)
+      t.equal(mockLog.event.args[0][0], 'device:create')
+      t.deepEqual(mockLog.event.args[0][2], {
+        uid: uid.toString('hex'),
+        id: deviceId,
+        type: 'mobile',
+        timestamp: deviceCreatedAt
       })
-    }
-    var mockPush = {
-      notifyDeviceDisconnected: sinon.spy(function () {
-        return P.resolve(true)
-      })
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      push: mockPush
     })
+  }, t)
 
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device/destroy')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function(response) {
-      t.equal(mockDB.deleteDevice.callCount, 1)
-
-      t.equal(mockPush.notifyDeviceDisconnected.callCount, 1)
-      t.equal(mockPush.notifyDeviceDisconnected.firstCall.args[0], mockRequest.auth.credentials.uid)
-      t.equal(mockPush.notifyDeviceDisconnected.firstCall.args[1], deviceId)
-    })
-  }
-)
-
-test(
-  'device updates can be disabled via config',
-  function (t) {
-    var uid = uuid.v4('binary')
+  test('update', function (t) {
     var deviceId = crypto.randomBytes(16)
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex'),
-          deviceId: deviceId
-        }
-      },
-      payload: {
-        id: deviceId.toString('hex'),
-        name: 'new device name'
-      }
-    }
-    var accountRoutes = makeRoutes({
-      config: {
-        deviceUpdatesEnabled: false
-      }
-    })
+    var credentials = mockRequest.auth.credentials
+    credentials.tokenId = 'lookmumasessiontoken'
+    credentials.deviceName = 'my awesome device'
+    credentials.deviceType = 'desktop'
+    credentials.deviceCallbackURL = ''
+    credentials.deviceCallbackPublicKey = ''
+    device.name = device.type = device.pushCallback = undefined
+    device.id = deviceId.toString('hex')
 
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(
-      function(response) {
+    test('identical data', function (t) {
+      mockRequest.auth.credentials.deviceId = deviceId
+      mockRequest.payload.name = 'my awesome device'
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockDB.updateDevice.callCount, 0, 'updateDevice was not called')
+
+        t.equal(mockLog.increment.callCount, 1, 'a counter was incremented')
+        t.equal(mockLog.increment.firstCall.args[0], 'device.update.spurious')
+
+        t.deepEqual(response, mockRequest.payload)
+      })
+      .then(function () {
+        mockLog.increment.reset()
+      })
+    }, t)
+
+    test('different data', function (t) {
+      mockRequest.auth.credentials.deviceId = crypto.randomBytes(16)
+      var payload = mockRequest.payload
+      payload.name = 'my even awesomer device'
+      payload.type = 'phone'
+      payload.pushCallback = 'https://push.services.mozilla.com/123456'
+      payload.pushPublicKey = 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockDB.updateDevice.callCount, 1, 'updateDevice was called')
+
+        t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
+        t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
+        t.equal(mockLog.increment.getCall(1).args[0], 'device.update.name')
+        t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
+        t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
+        t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
+      })
+    }, t)
+
+    test('device updates disabled', function (t) {
+      config.deviceUpdatesEnabled = false
+
+      return runTest(route, mockRequest, function () {
         t.fail('should have thrown')
-      },
-      function(err) {
+      })
+      .catch(function (err) {
         t.equal(err.output.statusCode, 503, 'correct status code is returned')
         t.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED, 'correct errno is returned')
-      }
-    )
-  }
-)
-
-test(
-  'login event from /account/create includes metrics context data',
-  function (t) {
-    var mockRequest = {
-      app: {
-        acceptLangage: 'en-US'
-      },
-      headers: {
-        'user-agent': 'test-user-agent'
-      },
-      payload: {
-        email: TEST_EMAIL,
-        authPW: crypto.randomBytes(32).toString('hex'),
-        service: 'sync',
-        metricsContext: {
-          entrypoint: 'preferences',
-          utmContent: 'some-content-string'
-        }
-      }
-    }
-    var mockDB = {
-      emailRecord: sinon.spy(function () {
-        return P.reject(new error.unknownAccount())
-      }),
-      createAccount: sinon.spy(function () {
-        return P.resolve({
-          uid: uuid.v4('binary'),
-          email: TEST_EMAIL,
-          emailVerified: false
-        })
       })
+    }, t)
+  }, t)
+})
+
+test('/account/device/destroy', function (t) {
+  var uid = uuid.v4('binary')
+  var deviceId = crypto.randomBytes(16).toString('hex')
+  var mockLog = mocks.mockLog({
+    event: sinon.spy()
+  })
+  var mockDB = mocks.mockDB()
+  var mockRequest = mocks.mockRequest({
+    credentials: {
+      uid: uid.toString('hex'),
+    },
+    payload: {
+      id: deviceId
     }
-    // We want to test what's actually written to stdout by the logger.
-    var mockLog = log('ERROR', 'test', {
-      stdout: {
-        on: sinon.spy(),
-        write: sinon.spy()
-      },
-      stderr: {
-        on: sinon.spy(),
-        write: sinon.spy()
+  })
+  var mockPush = mocks.mockPush()
+  var accountRoutes = makeRoutes({
+    db: mockDB,
+    log: mockLog,
+    push: mockPush
+  })
+  var route = getRoute(accountRoutes, '/account/device/destroy')
+
+  return runTest(route, mockRequest, function () {
+    t.equal(mockDB.deleteDevice.callCount, 1)
+
+    t.equal(mockPush.notifyDeviceDisconnected.callCount, 1)
+    t.equal(mockPush.notifyDeviceDisconnected.firstCall.args[0], mockRequest.auth.credentials.uid)
+    t.equal(mockPush.notifyDeviceDisconnected.firstCall.args[1], deviceId)
+
+    t.equal(mockLog.event.callCount, 1)
+    t.equal(mockLog.event.args[0].length, 3)
+    t.equal(mockLog.event.args[0][0], 'device:delete')
+    var details = mockLog.event.args[0][2]
+    t.equal(details.uid, uid.toString('hex'))
+    t.equal(details.id, deviceId)
+    t.ok(Date.now() - details.timestamp < 100)
+  })
+})
+
+test('/account/create', function (t) {
+  var mockRequest = mocks.mockRequest({
+    payload: {
+      email: TEST_EMAIL,
+      authPW: crypto.randomBytes(32).toString('hex'),
+      service: 'sync',
+      metricsContext: {
+        flowBeginTime: Date.now(),
+        flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+        entrypoint: 'preferences',
+        utmContent: 'some-content-string'
       }
-    })
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog
-    })
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/create')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function () {
-      t.equal(mockDB.createAccount.callCount, 1, 'createAccount was called')
+    }
+  })
+  var mockDB = mocks.mockDB({
+    email: TEST_EMAIL,
+    emailVerified: false,
+    uid: uuid.v4('binary')
+  }, {
+    emailRecord: new error.unknownAccount()
+  })
+  // We want to test what's actually written to stdout by the logger.
+  var mockLog = log('ERROR', 'test', {
+    stdout: {
+      on: sinon.spy(),
+      write: sinon.spy()
+    },
+    stderr: {
+      on: sinon.spy(),
+      write: sinon.spy()
+    }
+  })
+  mockLog.metricsContext.validate = sinon.spy()
+  var accountRoutes = makeRoutes({
+    db: mockDB,
+    log: mockLog
+  })
+  var route = getRoute(accountRoutes, '/account/create')
 
-      t.equal(mockLog.stdout.write.callCount, 1, 'an sqs event was logged')
-      var eventData = JSON.parse(mockLog.stdout.write.getCall(0).args[0])
-      t.equal(eventData.event, 'login', 'it was a login event')
-      t.equal(eventData.data.service, 'sync', 'it was for sync')
-      t.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email')
-      t.equal(eventData.data.metricsContext.entrypoint, 'preferences', 'it contained the entrypoint metrics field')
-      t.equal(eventData.data.metricsContext.utm_content, 'some-content-string', 'it contained the utm_content metrics field')
+  return runTest(route, mockRequest, function () {
+    t.equal(mockDB.createAccount.callCount, 1, 'createAccount was called')
 
-    }).finally(function () {
-      mockLog.close()
-    })
+    t.equal(mockLog.stdout.write.callCount, 1, 'an sqs event was logged')
+    var eventData = JSON.parse(mockLog.stdout.write.getCall(0).args[0])
+    t.equal(eventData.event, 'login', 'it was a login event')
+    t.equal(eventData.data.service, 'sync', 'it was for sync')
+    t.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email')
+    t.equal(eventData.data.metricsContext.entrypoint, 'preferences', 'it contained the entrypoint metrics field')
+    t.equal(eventData.data.metricsContext.utm_content, 'some-content-string', 'it contained the utm_content metrics field')
+
+    t.equal(mockLog.metricsContext.validate.callCount, 1, 'metricsContext.validate was called')
+    var call = mockLog.metricsContext.validate.getCall(0)
+    t.equal(call.args.length, 1, 'validate was called with a single argument')
+    t.deepEqual(call.args[0], mockRequest, 'validate was called with the request')
+  }).finally(function () {
+    mockLog.close()
+  })
+})
+
+test('/account/login', function (t) {
+  var config = {
+    newLoginNotificationEnabled: true
   }
-)
+  var mockRequest = mocks.mockRequest({
+    query: {
+      keys: 'true'
+    },
+    payload: {
+      authPW: crypto.randomBytes(32).toString('hex'),
+      email: TEST_EMAIL,
+      service: 'sync',
+      reason: 'signin',
+      metricsContext: {
+        context: 'fx_desktop_v3',
+        flowBeginTime: Date.now(),
+        flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+        entrypoint: 'preferences',
+        utmContent: 'some-content-string'
+      }
+    }
+  })
+  var uid = uuid.v4('binary')
+  var mockDB = mocks.mockDB({
+    email: TEST_EMAIL,
+    emailVerified: true,
+    uid: uid
+  })
+  // We want to test what's actually written to stdout by the logger.
+  var mockLog = log('ERROR', 'test', {
+    stdout: {
+      on: sinon.spy(),
+      write: sinon.spy()
+    },
+    stderr: {
+      on: sinon.spy(),
+      write: sinon.spy()
+    }
+  })
+  mockLog.metricsContext.validate = sinon.spy()
+  var mockMailer = mocks.mockMailer()
+  var accountRoutes = makeRoutes({
+    checkPassword: function () {
+      return P.resolve(true)
+    },
+    config: config,
+    customs: {
+      check: function () {
+        return P.resolve()
+      }
+    },
+    db: mockDB,
+    log: mockLog,
+    mailer: mockMailer
+  })
+  var route = getRoute(accountRoutes, '/account/login')
 
-test(
-  'login event from /account/login includes metrics context data',
-  function (t) {
-    var mockRequest = {
-      app: {
-        acceptLangage: 'en-US'
-      },
-      headers: {
-        'user-agent': 'test-user-agent'
-      },
-      query: {
-        keys: false
-      },
-      payload: {
-        email: TEST_EMAIL,
-        authPW: crypto.randomBytes(32).toString('hex'),
-        service: 'sync',
-        reason: 'signin',
-        metricsContext: {
-          entrypoint: 'preferences',
-          utmContent: 'some-content-string'
-        }
-      }
-    }
-    var uid = uuid.v4('binary')
-    var mockDB = {
-      emailRecord: sinon.spy(function () {
-        return P.resolve({
-          uid: uid,
-          email: TEST_EMAIL,
-          emailVerified: true
-        })
-      }),
-      createSessionToken: sinon.spy(function () {
-        return P.resolve({
-          uid: uid,
-          email: TEST_EMAIL,
-          emailVerified: true,
-          lastAuthAt: function () { return 0 }
-        })
-      }),
-      sessions: sinon.spy(function () {
-        return P.resolve([{}, {}, {}])
-      })
-    }
-    // We want to test what's actually written to stdout by the logger.
-    var mockLog = log('ERROR', 'test', {
-      stdout: {
-        on: sinon.spy(),
-        write: sinon.spy()
-      },
-      stderr: {
-        on: sinon.spy(),
-        write: sinon.spy()
-      }
-    })
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function () {
+  test('sign-in confirmation disabled', function (t) {
+    return runTest(route, mockRequest, function (response) {
       t.equal(mockDB.emailRecord.callCount, 1, 'db.emailRecord was called')
       t.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called')
       t.equal(mockDB.sessions.callCount, 1, 'db.sessions was called')
@@ -760,607 +514,164 @@ test(
       t.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email')
       t.equal(eventData.data.metricsContext.entrypoint, 'preferences', 'it contained the entrypoint metrics field')
       t.equal(eventData.data.metricsContext.utm_content, 'some-content-string', 'it contained the utm_content metrics field')
-    }).finally(function () {
-      mockLog.close()
-    })
-  }
-)
 
-test(
-  'login with disabled sign-in confirmation, sends new device email',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: false,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex:['mozilla.com$']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = uuid.v4('binary')
-    var mockRequest = mocks.mockRequest(TEST_EMAIL, 'true')
-    var mockDB = mocks.mockDB(uid, TEST_EMAIL, true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
-        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
-        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
-      })
-  }
-)
-
-test(
-  'login with enabled sign-in confirmation',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 1.0,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex:['mozilla.com$']
-      }
-    }
-
-    var uid = uuid.v4('binary')
-    var mockRequest = mocks.mockRequest(TEST_EMAIL, 'true')
-    var mockDB = mocks.mockDB(uid, TEST_EMAIL, true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
-        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
-        t.equal(response.verificationReason, 'login', 'verificationReason is login')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation enabled for specific uid',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.20,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex:['mozilla.com$']
-      }
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest(TEST_EMAIL, 'true')
-    var mockDB = mocks.mockDB(uid, TEST_EMAIL, true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
-        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
-        t.equal(response.verificationReason, 'login', 'verificationReason is login')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation enable for email regex',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.00,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
-      }
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest('test@mozilla.com', 'true')
-    var mockDB = mocks.mockDB(uid, 'test@mozilla.com', true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
-        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
-        t.equal(response.verificationReason, 'login', 'verificationReason is login')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation enable for email domain',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.00,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest('asdf@mozilla.com', 'true')
-    var mockDB = mocks.mockDB(uid, 'asdf@mozilla.com', true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
-        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
-        t.equal(response.verificationReason, 'login', 'verificationReason is login')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation enable for specific email',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.00,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest('fennec@fire.fox', 'true')
-    var mockDB = mocks.mockDB(uid, 'fennec@fire.fox', true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
-        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
-        t.equal(response.verificationReason, 'login', 'verificationReason is login')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation disabled for regex',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.00,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest('moz@fire.fox', 'true')
-    var mockDB = mocks.mockDB(uid, 'moz@fire.fox', true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
-        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
-        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation, invalid client, does not perform confirmation',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 1.00,
-        supportedClients: ['fx_desktop_v999'],
-        forceEmailRegex:['mozilla.com$']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest(TEST_EMAIL, 'true')
-    var mockDB = mocks.mockDB(uid, TEST_EMAIL, true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
-        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
-        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
-      })
-  }
-)
-
-test(
-  'login with sign-in confirmation enabled but not in sample range, sends new device email',
-  function (t) {
-    var configOptions = {
-      signinConfirmation: {
-        enabled: true,
-        sample_rate: 0.10,
-        supportedClients: ['fx_desktop_v3'],
-        forceEmailRegex:['mozilla.com$']
-      },
-      newLoginNotificationEnabled: true
-    }
-
-    var uid = '20162205efab47ecb6418c797acd743f'
-    var mockRequest = mocks.mockRequest(TEST_EMAIL, 'true')
-    var mockDB = mocks.mockDB(uid, TEST_EMAIL, true)
-    var mockMailer = mocks.mockMailer()
-
-    var accountRoutes = makeRoutes({
-      config: configOptions,
-      db: mockDB,
-      mailer: mockMailer,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function (response) {
-          resolve(response)
-        })
-    })
-      .then(function (response) {
-        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
-        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
-        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
-        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
-      })
-  }
-)
-
-test(
-  'device creation emits SNS event',
-  function (t) {
-    var uid = uuid.v4('binary')
-    var deviceId = crypto.randomBytes(16).toString('hex')
-    var mockLog = mocks.mockLog({
-      event: sinon.spy()
-    })
-    var timestamp = Date.now()
-    var mockDB = {
-      createDevice: sinon.spy(function (uid, sessionTokenId, deviceInfo) {
-        deviceInfo.createdAt = timestamp
-        deviceInfo.id = deviceId
-        return P.resolve(deviceInfo)
-      }),
-      devices: sinon.spy(function () {
-        return P.resolve([])
-      })
-    }
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex'),
-        }
-      },
-      payload: {
-        name: 'new device name',
-        type: 'phone',
-      }
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog
-    })
-
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(
-      function(response) {
-        t.equal(mockLog.event.callCount, 1)
-        t.equal(mockLog.event.args[0].length, 3)
-        t.equal(mockLog.event.args[0][0], 'device:create')
-        t.deepEqual(mockLog.event.args[0][2], {
-          uid: uid.toString('hex'),
-          id: deviceId,
-          type: 'phone',
-          timestamp: timestamp
-        })
-      },
-      function(err) {
-        t.fail('should have succeeded', err)
-      }
-    )
-  }
-)
-
-test(
-  'device deletion emits SNS event',
-  function (t) {
-    var uid = uuid.v4('binary')
-    var deviceId = crypto.randomBytes(16).toString('hex')
-    var mockLog = mocks.mockLog({
-      event: sinon.spy()
-    })
-    var mockDB = {
-      deleteDevice: sinon.spy(function (uid, sessionTokenId) {
-        return P.resolve(true)
-      }),
-      devices: sinon.spy(function () {
-        return P.resolve([{
-          id: deviceId,
-          name: 'My Phone',
-          type: 'mobile'
-        }])
-      }),
-    }
-    var mockRequest = {
-      auth: {
-        credentials: {
-          uid: uid.toString('hex'),
-        }
-      },
-      payload: {
-        id: deviceId
-      }
-    }
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog
-    })
-
-    return new P(function(resolve) {
-      getRoute(accountRoutes, '/account/device/destroy')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(
-      function(response) {
-        t.equal(mockLog.event.callCount, 1)
-        t.equal(mockLog.event.args[0].length, 3)
-        t.equal(mockLog.event.args[0][0], 'device:delete')
-        var details = mockLog.event.args[0][2]
-        t.equal(details.uid, uid.toString('hex'))
-        t.equal(details.id, deviceId)
-        t.ok(Date.now() - details.timestamp < 100)
-      },
-      function(err) {
-        t.fail('should have succeeded', err)
-      }
-    )
-  }
-)
-
-test(
-  '/account/create validates metrics context data',
-  function (t) {
-    var mockRequest = {
-      app: {
-        acceptLangage: 'en-US'
-      },
-      headers: {
-        'user-agent': 'test-user-agent'
-      },
-      payload: {
-        email: TEST_EMAIL,
-        authPW: crypto.randomBytes(32).toString('hex'),
-        service: 'sync',
-        metricsContext: {
-          flowBeginTime: Date.now(),
-          flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
-          entrypoint: 'preferences'
-        }
-      }
-    }
-    var mockLog = mocks.mockLog()
-    mockLog.metricsContext = mocks.mockMetricsContext()
-    var mockDB = {
-      emailRecord: sinon.spy(function () {
-        return P.resolve({})
-      })
-    }
-    var accountRoutes = makeRoutes({
-      log: mockLog,
-      db: mockDB
-    })
-    return new P(function (resolve, reject) {
-      getRoute(accountRoutes, '/account/create')
-        .handler(mockRequest, function(response) {
-          resolve(response)
-        })
-    })
-    .then(function () {
       t.equal(mockLog.metricsContext.validate.callCount, 1, 'metricsContext.validate was called')
       var call = mockLog.metricsContext.validate.getCall(0)
       t.equal(call.args.length, 1, 'validate was called with a single argument')
       t.deepEqual(call.args[0], mockRequest, 'validate was called with the request')
-    })
-  }
-)
 
-test(
-  '/account/login validates metrics context data',
-  function (t) {
-    var mockRequest = {
-      app: {
-        acceptLangage: 'en-US'
-      },
-      headers: {
-        'user-agent': 'test-user-agent'
-      },
-      query: {
-        keys: false
-      },
-      payload: {
-        email: TEST_EMAIL,
-        authPW: crypto.randomBytes(32).toString('hex'),
-        service: 'sync',
-        reason: 'signin',
-        metricsContext: {
-          flowBeginTime: Date.now(),
-          flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
-          entrypoint: 'preferences'
-        }
-      }
+      t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+      t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+      t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
+      t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
+    }).then(function () {
+      mockMailer.sendNewDeviceLoginNotification.reset()
+    })
+  }, t)
+
+  test('sign-in confirmation enabled', function (t) {
+    config.signinConfirmation = {
+      enabled: true,
+      supportedClients: [ 'fx_desktop_v3' ],
+      forceEmailRegex: [ '.+@mozilla\.com$', 'fennec@fire.fox' ]
     }
-    var mockDB = {
-      emailRecord: sinon.spy(function () {
-        return P.resolve({})
-      }),
-      createSessionToken: sinon.spy(function () {
-        return P.resolve({})
-      }),
-      sessions: sinon.spy(function () {
-        return P.resolve([{}, {}, {}])
+
+    test('always on', function (t) {
+      config.signinConfirmation.sample_rate = 1
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
+        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
+        t.equal(response.verificationReason, 'login', 'verificationReason is login')
+      }).then(function () {
+        mockMailer.sendVerifyLoginEmail.reset()
       })
-    }
-    var mockLog = mocks.mockLog()
-    mockLog.metricsContext = mocks.mockMetricsContext()
-    var accountRoutes = makeRoutes({
-      db: mockDB,
-      log: mockLog,
-      checkPassword: function () {
-        return P.resolve(true)
-      }
-    })
-    return new P(function (resolve) {
-      getRoute(accountRoutes, '/account/login')
-        .handler(mockRequest, function(response) {
-          resolve(response)
+    }, t)
+
+    test('on for sample', function (t) {
+      // Force uid to '01...'
+      uid.fill(0, 0, 1)
+      uid.fill(1, 1, 2)
+      config.signinConfirmation.sample_rate = 0.02
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
+        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
+        t.equal(response.verificationReason, 'login', 'verificationReason is login')
+      }).then(function () {
+        mockMailer.sendVerifyLoginEmail.reset()
+      })
+    }, t)
+
+    test('off for sample', function (t) {
+      config.signinConfirmation.sample_rate = 0.01
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
+        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
+      }).then(function () {
+        mockMailer.sendNewDeviceLoginNotification.reset()
+      })
+    }, t)
+
+    test('on for email regex match', function (t) {
+      mockRequest.payload.email = 'test@mozilla.com'
+      mockDB.emailRecord = function () {
+        return P.resolve({
+          authSalt: crypto.randomBytes(32),
+          data: crypto.randomBytes(32),
+          email: 'test@mozilla.com',
+          emailVerified: true,
+          kA: crypto.randomBytes(32),
+          lastAuthAt: function () {
+            return Date.now()
+          },
+          uid: uid,
+          wrapWrapKb: crypto.randomBytes(32)
         })
-    })
-    .then(function () {
-      t.equal(mockLog.metricsContext.validate.callCount, 1, 'metricsContext.validate was called')
-      var call = mockLog.metricsContext.validate.getCall(0)
-      t.equal(call.args.length, 1, 'validate was called with a single argument')
-      t.deepEqual(call.args[0], mockRequest, 'validate was called with the request')
-    })
-  }
-)
+      }
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
+        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
+        t.equal(response.verificationReason, 'login', 'verificationReason is login')
+      }).then(function () {
+        mockMailer.sendVerifyLoginEmail.reset()
+      })
+    }, t)
+
+    test('on for specific email', function (t) {
+      mockRequest.payload.email = 'fennec@fire.fox'
+      mockDB.emailRecord = function () {
+        return P.resolve({
+          authSalt: crypto.randomBytes(32),
+          data: crypto.randomBytes(32),
+          email: 'fennec@fire.fox',
+          emailVerified: true,
+          kA: crypto.randomBytes(32),
+          lastAuthAt: function () {
+            return Date.now()
+          },
+          uid: uid,
+          wrapWrapKb: crypto.randomBytes(32)
+        })
+      }
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
+        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
+        t.equal(response.verificationReason, 'login', 'verificationReason is login')
+      }).then(function () {
+        mockMailer.sendVerifyLoginEmail.reset()
+      })
+    }, t)
+
+    test('off for email regex mismatch', function (t) {
+      mockRequest.payload.email = 'moz@fire.fox'
+      mockDB.emailRecord = function () {
+        return P.resolve({
+          authSalt: crypto.randomBytes(32),
+          data: crypto.randomBytes(32),
+          email: 'moz@fire.fox',
+          emailVerified: true,
+          kA: crypto.randomBytes(32),
+          lastAuthAt: function () {
+            return Date.now()
+          },
+          uid: uid,
+          wrapWrapKb: crypto.randomBytes(32)
+        })
+      }
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
+        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
+      }).then(function () {
+        mockMailer.sendNewDeviceLoginNotification.reset()
+      })
+    }, t)
+
+    test('off for unsupported client', function (t) {
+      config.signinConfirmation.supportedClients = [ 'fx_desktop_v999' ]
+
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
+        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
+      })
+      .finally(function () {
+        mockLog.close()
+      })
+    }, t)
+  }, t)
+})
+

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -4,8 +4,6 @@
 
 require('ass')
 
-var sinon = require('sinon')
-
 var test = require('../ptaptest')
 var mocks = require('../mocks')
 var getRoute = require('../routes_helpers').getRoute
@@ -65,29 +63,12 @@ test(
       },
       app: {}
     }
-    var mockDB = {
-      deletePasswordChangeToken: sinon.spy(function () {
-        return P.resolve()
-      }),
-      resetAccount: sinon.spy(function () {
-        return P.resolve()
-      }),
-      account: sinon.spy(function () {
-        return P.resolve({
-          uid: uid,
-          verifierSetAt: 0,
-          email: TEST_EMAIL
-        })
-      })
-    }
-    var mockPush = {
-      notifyUpdate: sinon.spy(function () {})
-    }
-    var mockMailer = {
-      sendPasswordChangedNotification: sinon.spy(function () {
-        return P.resolve()
-      })
-    }
+    var mockDB = mocks.mockDB({
+      email: TEST_EMAIL,
+      uid: uid
+    })
+    var mockPush = mocks.mockPush()
+    var mockMailer = mocks.mockMailer()
     var passwordRoutes = makeRoutes({
       db: mockDB,
       push: mockPush,

--- a/test/ptaptest.js
+++ b/test/ptaptest.js
@@ -33,9 +33,10 @@ require('ass')
 
 var tap = require('tap')
 
-module.exports = function(name, testfunc) {
+module.exports = function(name, testfunc, parentTest) {
+  var t = parentTest || tap
   if (!testfunc) {
-    return tap.test(name)
+    return t.test(name)
   }
   var wrappedtestfunc = function(t) {
     var res = testfunc(t)
@@ -54,5 +55,5 @@ module.exports = function(name, testfunc) {
       }
     }
   }
-  return tap.test(name, wrappedtestfunc)
+  return t.test(name, wrappedtestfunc)
 }


### PR DESCRIPTION
The recent explosions in `tests/local/account_routes` resulted in a lot of a duplication and not much order, with assertions for the different endpoints all kind of jumbled up with each other.

To fix this, I've done the following:

* Made the test wrapper in `test/ptaptest` more composable by adding an optional third argument, `parentTest`. This allows us to nest tests inside each other while still making use of the boilerplate code for calling `t.end()` and logging errors, which the wrapper provides.

* Refactored all of the tests in `tests/local/account_routes` so that they are grouped by endpoint. Each endpoint has one and only one base test, with child tests added whenever some variation in the setup is necessary. Doing this allowed us to delete ~600 lines of setup code without removing or changing any assertions. Another benefit I've noticed in doing this is that it makes any gaps in our assertions more obvious, because now everything is logically clustered.

* Removed all of the duplicated ad hoc mocking logic into exports from `test/mocks`. Mostly this was able to lean on existing work that had already been done, there are just a few changes made to some mocks where they needed to be more generic.

The downside of all this is that the diff is essentially white noise. You're probably better off reviewing the test module as a self-contained unit.

~~To try and make the reviewer's job a bit easier, I've been careful not to modify any of the assertions. So before these changes there were 93 assertions in that module and after these changes there are still 93 assertions in that module. Hopefully that helps somewhat.~~

@rfk and/or @vbudhram, r?