### PR TITLE
feat(signin): Add regex for enabling signin confirmation

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -420,7 +420,7 @@ var conf = convict({
       env: 'SIGNIN_CONFIRMATION_SUPPORTED_CLIENTS'
     },
     forceEmailRegex: {
-      doc: 'If feature enabled, force sign-in confirmation for any of these email regex',
+      doc: 'If feature enabled, force sign-in confirmation for email addresses matching this regex.',
       format: Array,
       default: [
         '@mozilla.com$'

--- a/config/index.js
+++ b/config/index.js
@@ -419,13 +419,13 @@ var conf = convict({
       ],
       env: 'SIGNIN_CONFIRMATION_SUPPORTED_CLIENTS'
     },
-    forceEmails: {
-      doc: 'If feature enabled, force sign-in confirmation for these email domains',
+    forceEmailRegex: {
+      doc: 'If feature enabled, force sign-in confirmation for any of these email regex',
       format: Array,
       default: [
-        '@mozilla.com'
+        '@mozilla.com$'
       ],
-      env: 'SIGNIN_CONFIRMATION_FORCE_EMAILS'
+      env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }
   }
 })

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -34,7 +34,7 @@ function shouldEnableSigninConfirmation(account, config, request) {
     return false
   }
 
-  // If feature enabled, always enable for these email regex.
+  // If feature enabled, always enable for email addresses matching this regex
   var email = account.email
   var isValidEmail = config.signinConfirmation.forceEmailRegex.some(function (reg) {
     var emailReg = new RegExp(reg)

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -34,10 +34,13 @@ function shouldEnableSigninConfirmation(account, config, request) {
     return false
   }
 
-  // If feature enabled, always enable for these emails
+  // If feature enabled, always enable for these email regex.
   var email = account.email
-  var emailDomain = account.email.substring(email.indexOf('@'), email.length).toLocaleLowerCase()
-  var isValidEmail = config.signinConfirmation.forceEmails.indexOf(emailDomain) > -1
+  var isValidEmail = config.signinConfirmation.forceEmailRegex.some(function (reg) {
+    var emailReg = new RegExp(reg)
+    return emailReg.test(email)
+  })
+
   if (isValidEmail) {
     return true
   }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -17,7 +17,7 @@ var isA = require('joi')
 var error = require('../../lib/error')
 var log = require('../../lib/log')
 
-var TEST_EMAIL = 'foo@gmail.com'
+var TEST_EMAIL = 'foo@bloop.com'
 var TEST_EMAIL_INVALID = 'example@dotless-domain'
 
 var makeRoutes = function (options) {
@@ -773,7 +773,7 @@ test(
       signinConfirmation: {
         enabled: false,
         supportedClients: ['fx_desktop_v3'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex:['mozilla.com$']
       },
       newLoginNotificationEnabled: true
     }
@@ -815,7 +815,7 @@ test(
         enabled: true,
         sample_rate: 1.0,
         supportedClients: ['fx_desktop_v3'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex:['mozilla.com$']
       }
     }
 
@@ -856,7 +856,7 @@ test(
         enabled: true,
         sample_rate: 0.20,
         supportedClients: ['fx_desktop_v3'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex:['mozilla.com$']
       }
     }
 
@@ -890,14 +890,14 @@ test(
 )
 
 test(
-  'login with sign-in confirmation enabled for specific email',
+  'login with sign-in confirmation enable for email regex',
   function (t) {
     var configOptions = {
       signinConfirmation: {
         enabled: true,
         sample_rate: 0.00,
         supportedClients: ['fx_desktop_v3'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
       }
     }
 
@@ -931,6 +931,90 @@ test(
 )
 
 test(
+  'login with sign-in confirmation enable for specific email',
+  function (t) {
+    var configOptions = {
+      signinConfirmation: {
+        enabled: true,
+        sample_rate: 0.00,
+        supportedClients: ['fx_desktop_v3'],
+        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
+      },
+      newLoginNotificationEnabled: true
+    }
+
+    var uid = '20162205efab47ecb6418c797acd743f'
+    var mockRequest = mocks.mockRequest('fennec@fire.fox', 'true')
+    var mockDB = mocks.mockDB(uid, 'fennec@fire.fox', true)
+    var mockMailer = mocks.mockMailer()
+
+    var accountRoutes = makeRoutes({
+      config: configOptions,
+      db: mockDB,
+      mailer: mockMailer,
+      checkPassword: function () {
+        return P.resolve(true)
+      }
+    })
+
+    return new P(function (resolve) {
+      getRoute(accountRoutes, '/account/login')
+        .handler(mockRequest, function (response) {
+          resolve(response)
+        })
+    })
+      .then(function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
+        t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
+        t.equal(response.verificationReason, 'login', 'verificationReason is login')
+      })
+  }
+)
+
+test(
+  'login with sign-in confirmation disabled for regex',
+  function (t) {
+    var configOptions = {
+      signinConfirmation: {
+        enabled: true,
+        sample_rate: 0.00,
+        supportedClients: ['fx_desktop_v3'],
+        forceEmailRegex: ['@mozilla.com$', 'fennec@fire.fox']
+      },
+      newLoginNotificationEnabled: true
+    }
+
+    var uid = '20162205efab47ecb6418c797acd743f'
+    var mockRequest = mocks.mockRequest('moz@fire.fox', 'true')
+    var mockDB = mocks.mockDB(uid, 'moz@fire.fox', true)
+    var mockMailer = mocks.mockMailer()
+
+    var accountRoutes = makeRoutes({
+      config: configOptions,
+      db: mockDB,
+      mailer: mockMailer,
+      checkPassword: function () {
+        return P.resolve(true)
+      }
+    })
+
+    return new P(function (resolve) {
+      getRoute(accountRoutes, '/account/login')
+        .handler(mockRequest, function (response) {
+          resolve(response)
+        })
+    })
+      .then(function (response) {
+        t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+        t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+        t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
+        t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
+      })
+  }
+)
+
+test(
   'login with sign-in confirmation, invalid client, does not perform confirmation',
   function (t) {
     var configOptions = {
@@ -938,7 +1022,7 @@ test(
         enabled: true,
         sample_rate: 1.00,
         supportedClients: ['fx_desktop_v999'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex:['mozilla.com$']
       },
       newLoginNotificationEnabled: true
     }
@@ -980,7 +1064,7 @@ test(
         enabled: true,
         sample_rate: 0.10,
         supportedClients: ['fx_desktop_v3'],
-        forceEmails:['@mozilla.com']
+        forceEmailRegex:['mozilla.com$']
       },
       newLoginNotificationEnabled: true
     }


### PR DESCRIPTION
This PR adds the ability to specify an array of regex for email addresses to enable sign-in confirmation. This will give us the ability to turn feature on/off for more specific group of audiences.

@philbooth I would ideally like to merge your testing changes in before merging this. Mind a review at your leisure?