### PR TITLE
fix(verify): Don't sent post-verify email when `service` is blank.

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1218,10 +1218,8 @@ module.exports = function (
                     })
                     .then(function () {
                       // Our post-verification email is very specific to sync,
-                      // so don't send it if we're sure this is not for sync.
-                      // Older clients will not send a 'service' param here
-                      // so we can't always be sure.
-                      if (! service || service === 'sync') {
+                      // so only send it if we're sure this is for sync.
+                      if (service === 'sync') {
                         return mailer.sendPostVerifyEmail(
                           account.email,
                           {

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -100,8 +100,10 @@ Client.createAndVerify = function (origin, email, password, mailbox, options) {
           )
           .then(
             function () {
-              // clear the post verified email
-              return mailbox.waitForEmail(email)
+              // clear the post verified email, if one was sent
+              if (options && options.service === 'sync') {
+                return mailbox.waitForEmail(email)
+              }
             }
           )
           .then(


### PR DESCRIPTION
Once train-64 ships, we can remove the backwards-compatibility check that sends a post-verification email when `service` is missing or empty.  The content-server will always provide a `service=sync` parameter when verifying for sync.

@seanmonstar r? (although don't merge until after train-64 has been cut).  Fixes #1249.