### PR TITLE
fix(signin): Let /password/change/finish accept session tokens by id.

### DIFF
--- a/test/mocks.js
+++ b/test/mocks.js
@@ -13,8 +13,8 @@ var crypto = require('crypto')
 
 var DB_METHOD_NAMES = ['account', 'createAccount', 'createDevice', 'createKeyFetchToken',
                        'createSessionToken', 'devices', 'deleteAccount', 'deleteDevice',
-                       'deletePasswordChangeToken', 'deleteVerificationReminder', 'emailRecord', 'resetAccount', 'sessions',
-                       'updateDevice', 'verifyTokens', 'verifyEmail']
+                       'deletePasswordChangeToken', 'deleteVerificationReminder', 'emailRecord', 'resetAccount',
+                       'sessionTokenWithVerificationStatus', 'sessions', 'updateDevice', 'verifyTokens', 'verifyEmail']
 
 var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error', 'begin', 'warn',
                         'activityEvent', 'event', 'timing']

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -8,6 +8,16 @@ var test = require('../ptaptest')
 var TestServer = require('../test_server')
 var url = require('url')
 
+var tokens = require('../../lib/tokens')({ trace: function() {}})
+function getSessionTokenId(sessionTokenHex) {
+  return tokens.SessionToken.fromHex(sessionTokenHex)
+    .then(
+      function (token) {
+        return token.id
+      }
+    )
+}
+
 process.env.SIGNIN_CONFIRMATION_ENABLED = true
 process.env.SIGNIN_CONFIRMATION_RATE = 1.0
 
@@ -20,13 +30,13 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var newPassword = 'foobar'
-      var kB, kA, client, firstAuthPW, originalSessionTokenId
+      var kB, kA, client, firstAuthPW, originalSessionToken
 
       return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x
-            originalSessionTokenId = client.sessionToken
+            originalSessionToken = client.sessionToken
             firstAuthPW = x.authPW.toString('hex')
             return client.keys()
           }
@@ -80,13 +90,18 @@ TestServer.start(config)
         )
         .then(
           function () {
-            return client.changePassword(newPassword, undefined, client.sessionToken)
+            return getSessionTokenId(client.sessionToken)
+          }
+        )
+        .then(
+          function (sessionTokenId) {
+            return client.changePassword(newPassword, undefined, sessionTokenId)
           }
         )
         .then(
           function (response) {
             // Verify correct change password response
-            t.notEqual(response.sessionToken, originalSessionTokenId, 'session token has changed')
+            t.notEqual(response.sessionToken, originalSessionToken, 'session token has changed')
             t.ok(response.keyFetchToken, 'key fetch token returned')
             t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
           }
@@ -144,13 +159,13 @@ TestServer.start(config)
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var newPassword = 'foobar'
-      var kB, kA, client, firstAuthPW, originalSessionTokenId
+      var kB, kA, client, firstAuthPW, originalSessionToken
 
       return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x
-            originalSessionTokenId = client.sessionToken
+            originalSessionToken = client.sessionToken
             firstAuthPW = x.authPW.toString('hex')
             return client.keys()
           }
@@ -173,12 +188,17 @@ TestServer.start(config)
         )
         .then(
           function () {
-            return client.changePassword(newPassword, undefined, client.sessionToken)
+            return getSessionTokenId(client.sessionToken)
+          }
+        )
+        .then(
+          function (sessionTokenId) {
+            return client.changePassword(newPassword, undefined, sessionTokenId)
           }
         )
         .then(
           function (response) {
-            t.notEqual(response.sessionToken, originalSessionTokenId, 'session token has changed')
+            t.notEqual(response.sessionToken, originalSessionToken, 'session token has changed')
             t.ok(response.keyFetchToken, 'key fetch token returned')
             t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
           }
@@ -222,6 +242,62 @@ TestServer.start(config)
           function (keys) {
             t.deepEqual(keys.kB, kB, 'kB is preserved')
             t.deepEqual(keys.kA, kA, 'kA is preserved')
+          }
+        )
+    }
+  )
+
+  test(
+    'password change, with raw session data rather than session token id',
+    function (t) {
+      var email = server.uniqueEmail()
+      var password = 'allyourbasearebelongtous'
+      var newPassword = 'foobar'
+      var client, firstAuthPW, originalSessionToken
+
+      return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+        .then(
+          function (x) {
+            client = x
+            originalSessionToken = client.sessionToken
+            firstAuthPW = x.authPW.toString('hex')
+            return client.keys()
+          }
+        )
+        .then(
+          function () {
+            return client.emailStatus()
+          }
+        )
+        .then(
+          function (status) {
+            t.equal(status.verified, true, 'account is verified')
+          }
+        )
+        .then(
+          function () {
+            return client.changePassword(newPassword, undefined, client.sessionToken)
+          }
+        )
+        .then(
+          function (response) {
+            t.notEqual(response.sessionToken, originalSessionToken, 'session token has changed')
+            t.ok(response.keyFetchToken, 'key fetch token returned')
+            t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
+          }
+        )
+        .then(
+          function () {
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            var subject = emailData.headers['subject']
+            t.equal(subject, 'Your Firefox Account password has been changed', 'password email subject set correctly')
+            var link = emailData.headers['x-link']
+            var query = url.parse(link, true).query
+            t.ok(query.email, 'email is in the link')
           }
         )
     }


### PR DESCRIPTION
@shane-tomlinson @vbudhram for your consideration...

The way that the /password/change/finish endpoint currently works, is that it accepts *raw sessionToken data bytes* in the request body.  This is the only place in the code that the clients sends session data in raw form over the wire - in all other places, we derive a "token id" and "token key" and use those to make a signed request in a way that's resistant to a MITM attack.

On the auth-server side, the effect is that we have to call `tokens.SessionToken.fromHex` on the submitted value in order to derive the token id, before we can actually look up the token.

I think we should change this route to accept the token id instead of the raw token, to keep the security model of these things consistent.  Since it's an API change we'd have to do it in three parts, of which this is the first:

1. Change auth-server to accept either the token id, or the raw token bytes
2. Change content-server to send the token id instead of the raw token bytes
3. Change auth-server to stop accepting the raw token bytes, and only accept the id

Does this make sense?  I know there's a lot of complexity around the handling of these tokens, so I could easily be missing something here.