### PR TITLE
chore(tests): allow passing a glob to npm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Run tests with:
 
     npm test
 
+To select a specific glob of tests to run:
+
+    npm test -- test/local/account_routes.js test/local/password_*
+
 * Note: stop the auth-server before running tests. Otherwise, they will fail with obscure errors.
 
 ## Reference Client

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar scripts/test-local.sh && grunt",
+    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar scripts/test-local.sh",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
     "test-quick": "npm run tq",

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+glob=$*
+if [ "$glob" == "" ]; then
+  glob="test/local test/remote"
+fi
+
 ./scripts/gen_keys.js
 ./scripts/check-i18n.js
-./scripts/tap-coverage.js test/local test/remote 2>/dev/null
+./scripts/tap-coverage.js $glob 2>/dev/null
+grunt eslint copyright


### PR DESCRIPTION
This allows one to do something like `NO_COVERAGE=1 npm test -- test/local/account_routes.js` to quickly run the account tests.