### PR TITLE
 fix(signin): Fixes multiple emails sent on login

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -502,8 +502,11 @@ module.exports = function (
           }
         }
 
-        function sendNewDeviceLoginNotification () {
-          if (!doSigninConfirmation && config.newLoginNotificationEnabled && requestHelper.wantsKeys(request)) {
+        function sendNewDeviceLoginNotification() {
+          // New device notification emails should only be sent for requesting keys and
+          // not performing a sign-in confirmation.
+          var shouldSendNewDeviceLoginEmail = config.newLoginNotificationEnabled && requestHelper.wantsKeys(request) && !doSigninConfirmation
+          if (shouldSendNewDeviceLoginEmail) {
             // The response doesn't have to wait for this,
             // so we don't return the promise.
             mailer.sendNewDeviceLoginNotification(
@@ -517,11 +520,10 @@ module.exports = function (
         }
 
         function sendVerifyLoginEmail() {
-          // Verify login emails are only sent if the login is requesting keys and the feature is enabled.
-          // In the scenario where keys are requested, but feature is disabled, the tokens are
-          // created verified.
-          var shouldSendVerifyLoginEmail = requestHelper.wantsKeys(request) && doSigninConfirmation
-
+          // Verify sign-in emails are only sent for verified accounts and requesting keys and if they fall within
+          // the sample rate of roll-out. In the scenario where keys are requested, but feature is disabled
+          // the tokens are created verified.
+          var shouldSendVerifyLoginEmail = requestHelper.wantsKeys(request) && emailRecord.emailVerified && doSigninConfirmation
           if (shouldSendVerifyLoginEmail) {
             mailer.sendVerifyLoginEmail(
               emailRecord,

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -903,6 +903,7 @@ test('/recovery_email/verify_code', function (t) {
       t.equal(mockLog.event.callCount, 1, 'logs verified')
 
       t.equal(mockLog.activityEvent.callCount, 1, 'activityEvent was called once')
+      t.equal(mockMailer.sendPostVerifyEmail.callCount, 1, 'sendPostVerifyEmail was called once')
 
       var args = mockLog.activityEvent.args[0]
       t.equal(args.length, 3, 'activityEvent was passed three arguments')
@@ -926,6 +927,7 @@ test('/recovery_email/verify_code', function (t) {
     })
     .then(function () {
       mockLog.activityEvent.reset()
+      mockMailer.sendPostVerifyEmail.reset()
     })
   }, t)
 
@@ -935,6 +937,7 @@ test('/recovery_email/verify_code', function (t) {
     return runTest(route, mockRequest, function (response) {
       t.equal(mockLog.activityEvent.callCount, 2, 'activityEvent was called twice')
       t.equal(mockLog.activityEvent.args[0][0], 'account.verified', 'first call was account.verified')
+      t.equal(mockMailer.sendPostVerifyEmail.callCount, 1, 'sendPostVerifyEmail was called once')
 
       var args = mockLog.activityEvent.args[1]
       t.equal(args.length, 3, 'activityEvent was passed three arguments second time')
@@ -948,6 +951,7 @@ test('/recovery_email/verify_code', function (t) {
     })
     .then(function () {
       mockLog.activityEvent.reset()
+      mockMailer.sendPostVerifyEmail.reset()
     })
   }, t)
 })

--- a/test/remote/account_signin_verification_enable_tests.js
+++ b/test/remote/account_signin_verification_enable_tests.js
@@ -9,8 +9,8 @@ var Client = require('../client')
 test(
   'signin confirmation can be disabled',
   function (t) {
-    process.env.SIGNIN_CONFIRMATION_ENABLED = false
     var config = require('../../config').getProperties()
+    process.env.SIGNIN_CONFIRMATION_ENABLED = false
     var server, email, client
     var password = 'allyourbasearebelongtous'
 


### PR DESCRIPTION
Based on our IRC chat, here is a table defining the expected emails (inorder) when logging in with the different states of the auth-server.

|    |      Sign-in Confirmation On      |  Sign-in Confirmation Off |
|----------|:-------------:|------:|
|Unverified Account |  Verify your Firefox Account, Account Verified | Verify your Firefox Account, New sign-in to Firefox, Account Verified |
|Verified Account |  Confirm sign-in to Firefox | New sign-in to Firefox |

@shane-tomlinson @rfk These seem reasonable? r?

Fixes #1314 