### PR TITLE
fix(signin): Add keyFetchToken verification state support

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -436,7 +436,10 @@ var conf = convict({
         'fx_firstrun_v2',
         'fx_desktop_v1',
         'fx_desktop_v2',
-        'fx_desktop_v3'
+        'fx_desktop_v3',
+        'fx_ios_v1',
+        'fx_ios_v2',
+        'fx_fennec_v1'
       ],
       env: 'SIGNIN_CONFIRMATION_SUPPORTED_CLIENTS'
     },

--- a/lib/db.js
+++ b/lib/db.js
@@ -126,7 +126,8 @@ module.exports = function (
                 authKey: keyFetchToken.authKey,
                 uid: keyFetchToken.uid,
                 keyBundle: keyFetchToken.keyBundle,
-                createdAt: keyFetchToken.createdAt
+                createdAt: keyFetchToken.createdAt,
+                tokenVerificationId: keyFetchToken.tokenVerificationId
               },
               'inplace'
             )
@@ -331,6 +332,23 @@ module.exports = function (
   DB.prototype.keyFetchToken = function (id) {
     log.trace({ op: 'DB.keyFetchToken', id: id })
     return this.pool.get('/keyFetchToken/' + id.toString('hex'))
+      .then(
+        function (body) {
+          var data = bufferize(body)
+          return KeyFetchToken.fromId(id, data)
+        },
+        function (err) {
+          if (isNotFoundError(err)) {
+            err = error.invalidToken()
+          }
+          throw err
+        }
+      )
+  }
+
+  DB.prototype.keyFetchTokenWithVerificationStatus = function (id) {
+    log.trace({ op: 'DB.keyFetchTokenWithVerificationStatus', id: id })
+    return this.pool.get('/keyFetchToken/' + id.toString('hex') + '/verified')
       .then(
         function (body) {
           var data = bufferize(body)

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -285,7 +285,8 @@ module.exports = function (
                     uid: account.uid,
                     kA: account.kA,
                     wrapKb: wrapKb,
-                    emailVerified: account.emailVerified
+                    emailVerified: account.emailVerified,
+                    tokenVerificationId: tokenVerificationId
                   })
                 }
               )
@@ -477,7 +478,8 @@ module.exports = function (
                     uid: emailRecord.uid,
                     kA: emailRecord.kA,
                     wrapKb: wrapKb,
-                    emailVerified: emailRecord.emailVerified
+                    emailVerified: emailRecord.emailVerified,
+                    tokenVerificationId: doSigninConfirmation ? tokenVerificationId : undefined
                   })
                   .then(
                     function (result) {
@@ -845,7 +847,7 @@ module.exports = function (
       path: '/account/keys',
       config: {
         auth: {
-          strategy: 'keyFetchToken'
+          strategy: 'keyFetchTokenWithVerificationStatus'
         },
         response: {
           schema: {
@@ -856,7 +858,9 @@ module.exports = function (
       handler: function accountKeys(request, reply) {
         log.begin('Account.keys', request)
         var keyFetchToken = request.auth.credentials
-        if (!keyFetchToken.emailVerified) {
+
+        var verified = keyFetchToken.tokenVerified && keyFetchToken.emailVerified
+        if (!verified) {
           // don't delete the token on use until the account is verified
           return reply(error.unverifiedAccount())
         }

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -266,6 +266,8 @@ module.exports = function (
 
         function createKeyFetchToken() {
           if (wantsKeys) {
+            // Create a verified keyFetchToken. This is deliberately verified because we don't
+            // want to perform an email confirmation loop.
             return db.createKeyFetchToken({
                 uid: account.uid,
                 kA: account.kA,

--- a/lib/server.js
+++ b/lib/server.js
@@ -142,6 +142,16 @@ function create(log, error, config, routes, db) {
       }
     )
     server.auth.strategy(
+      // This strategy fetches the keyFetchToken with its
+      // verification state. It doesn't check that state.
+      'keyFetchTokenWithVerificationStatus',
+      'hawk',
+      {
+        getCredentialsFunc: makeCredentialFn(db.keyFetchTokenWithVerificationStatus.bind(db)),
+        hawk: hawkOptions
+      }
+    )
+    server.auth.strategy(
       'accountResetToken',
       'hawk',
       {

--- a/lib/tokens/key_fetch_token.js
+++ b/lib/tokens/key_fetch_token.js
@@ -8,6 +8,10 @@ module.exports = function (log, inherits, Token, P, error) {
     Token.call(this, keys, details)
     this.keyBundle = details.keyBundle
     this.emailVerified = !!details.emailVerified
+
+    // Tokens are considered verified if no tokenVerificationId exists
+    this.tokenVerificationId = details.tokenVerificationId || null
+    this.tokenVerified = this.tokenVerificationId ? false : true
   }
   inherits(KeyFetchToken, Token)
 

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -251,6 +251,7 @@ Client.prototype.changePassword = function (newPassword, headers, sessionToken) 
       function (json) {
         this.keyFetchToken = json.keyFetchToken
         this.passwordChangeToken = json.passwordChangeToken
+        return this.keys()
       }.bind(this)
     )
     .then(

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -489,6 +489,174 @@ TestServer.start(config)
     )
 
     test(
+      'account keys, return keys on verified account',
+      function (t) {
+        var email = server.uniqueEmail()
+        var password = 'allyourbasearebelongtous'
+        var client = null
+        var tokenCode
+
+        return Client.create(config.publicUrl, email, password, {keys:true})
+          .then(
+            function (c) {
+              client = c
+              return client.emailStatus()
+            }
+          )
+          .then(
+            function (status) {
+              t.equal(status.verified, false, 'account is not verified')
+              t.equal(status.emailVerified, false, 'account email is not verified')
+              t.equal(status.sessionVerified, false, 'account session is not verified')
+            }
+          )
+          .then(
+            function () {
+              return server.mailbox.waitForEmail(email)
+            }
+          )
+          .then(
+            function (emailData) {
+              t.equal(emailData.subject, 'Verify your Firefox Account')
+              tokenCode = emailData.headers['x-verify-code']
+              t.ok(tokenCode, 'sent verify code')
+            }
+          )
+          .then(
+            function () {
+              // Unverified accounts can not retrieve keys
+              return client.keys()
+            }
+          )
+          .catch(function(err){
+            t.equal(err.errno, 104, 'Correct error number')
+            t.equal(err.code, 400, 'Correct error code')
+            t.equal(err.message, 'Unverified account', 'Correct error message')
+          })
+
+          .then(
+            function () {
+              // Verify the account will set emails and tokens verified, which
+              // will user to retrieve keys.
+              return client.verifyEmail(tokenCode)
+            }
+          )
+          .then(
+            function () {
+              return client.emailStatus()
+            }
+          )
+          .then(
+            function (status) {
+              t.equal(status.verified, true, 'account is verified')
+              t.equal(status.emailVerified, true, 'account email is verified')
+              t.equal(status.sessionVerified, true, 'account session is  verified')
+            }
+          )
+          .then(
+            function () {
+              // Once verified, keys can be returned
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              t.ok(keys.kA, 'has kA keys')
+              t.ok(keys.kB, 'has kB keys')
+              t.ok(keys.wrapKb, 'has wrapKb keys')
+            }
+          )
+      }
+    )
+
+    test(
+      'account keys, return keys on verified login',
+      function (t) {
+        var email = server.uniqueEmail()
+        var password = 'allyourbasearebelongtous'
+        var client = null
+        var tokenCode
+
+        return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+          .then(
+            function (c) {
+              // Trigger confirm sign-in
+              client = c
+              return client.login({keys: true})
+            }
+          )
+          .then(
+            function (c) {
+              client = c
+              return server.mailbox.waitForEmail(email)
+            }
+          )
+          .then(
+            function (emailData) {
+              t.equal(emailData.subject, 'Confirm new sign-in to Firefox')
+              tokenCode = emailData.headers['x-verify-code']
+              t.ok(tokenCode, 'sent verify code')
+            }
+          )
+          .then(
+            function () {
+              return client.keys()
+            }
+          )
+          .catch(function(err){
+            // Because of unverified sign-in, requests for keys will fail
+            t.equal(err.errno, 104, 'Correct error number')
+            t.equal(err.code, 400, 'Correct error code')
+            t.equal(err.message, 'Unverified account', 'Correct error message')
+          })
+          .then(
+            function () {
+              return client.emailStatus()
+            }
+          )
+          .then(
+            function (status) {
+              // Verify status of account, only email should be verified
+              t.equal(status.verified, false, 'account is not verified')
+              t.equal(status.emailVerified, true, 'account email is verified')
+              t.equal(status.sessionVerified, false, 'account session is not verified')
+            }
+          )
+          .then(
+            function () {
+              // Verify the account will set tokens verified.
+              return client.verifyEmail(tokenCode)
+            }
+          )
+          .then(
+            function () {
+              return client.emailStatus()
+            }
+          )
+          .then(
+            function (status) {
+              t.equal(status.verified, true, 'account is verified')
+              t.equal(status.emailVerified, true, 'account email is verified')
+              t.equal(status.sessionVerified, true, 'account session is  verified')
+            }
+          )
+          .then(
+            function () {
+              // Can retrieve keys now that account tokens verified
+              return client.keys()
+            }
+          )
+          .then(
+            function (keys) {
+              t.ok(keys.kA, 'has kA keys')
+              t.ok(keys.kB, 'has kB keys')
+              t.ok(keys.wrapKb, 'has wrapKb keys')
+            }
+          )
+      }
+    )
+
+    test(
       'teardown',
       function (t) {
         server.stop()

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -85,7 +85,6 @@ TestServer.start(config)
             t.equal(status.verified, false, 'account is unverified')
             t.equal(status.emailVerified, true, 'account email is verified')
             t.equal(status.sessionVerified, false, 'account session is unverified')
-            return client.keys()
           }
         )
         .then(
@@ -135,7 +134,7 @@ TestServer.start(config)
         )
         .then(
           function () {
-            return Client.login(config.publicUrl, email, newPassword, {keys:true})
+            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
           }
         )
         .then(
@@ -229,7 +228,7 @@ TestServer.start(config)
         )
         .then(
           function () {
-            return Client.login(config.publicUrl, email, newPassword, {keys:true})
+            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
           }
         )
         .then(
@@ -353,7 +352,7 @@ TestServer.start(config)
         )
         .then(
           function () {
-            return Client.login(config.publicUrl, email, newPassword, {keys:true})
+            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
           }
         )
         .then(


### PR DESCRIPTION
This PR adds support for account verification status check via `/account/keys`.

- [x]  `/account/keys` checks status of keyFetchToken and return `Unverified account` if not verified
- [x] `/account/login` creates keyFetchToken with same verification state as sessionToken
- [x] `/password/change/start` correctly handles keyFetchTokens

Fixes #1287 