### PR TITLE
fix(server): fix bad sessionTokenId arg in call to updateDevice

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -279,7 +279,7 @@ module.exports = function (log, db) {
                 device.pushCallback = ''
                 device.pushPublicKey = ''
                 device.pushAuthKey = ''
-                return db.updateDevice(uid, device.id, device).catch(function (err) {
+                return db.updateDevice(uid, null, device).catch(function (err) {
                   reportPushError(err, uid, deviceId)
                 }).then(function() {
                   incrementPushAction(events.resetSettings)

--- a/test/local/push_tests.js
+++ b/test/local/push_tests.js
@@ -367,15 +367,19 @@ test(
   'push resets device push data when push server responds with a 400 level error',
   function (t) {
     var mockDb = {
-      updateDevice: function () {
+      updateDevice: sinon.spy(function () {
         return P.resolve()
-      }
+      })
     }
 
     var thisMockLog = mockLog({
       info: function (log) {
         if (log.name === 'push.account_verify.reset_settings') {
           // web-push failed
+          t.equal(mockDb.updateDevice.callCount, 1, 'db.updateDevice was called once')
+          var args = mockDb.updateDevice.args[0]
+          t.equal(args.length, 3, 'db.updateDevice was passed three arguments')
+          t.equal(args[1], null, 'sessionTokenId argument was null')
           t.end()
         }
       }


### PR DESCRIPTION
Fixes #1323, which was causing session tokens not to be deleted when disconnecting from Sync.

So, by extension, this should also address https://github.com/mozilla/fxa-bugzilla-mirror/issues/150.

@vladikoff, @shane-tomlinson r?