### PR TITLE
 fix(security): Update to use the fixed version of the call library

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6111,9 +6111,9 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
         },
         "call": {
-          "version": "2.0.1",
-          "from": "call@2.0.1",
-          "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
+          "version": "3.0.2",
+          "from": "call@3.0.2",
+          "resolved": "https://registry.npmjs.org/call/-/call-3.0.2.tgz"
         },
         "catbox": {
           "version": "4.3.0",


### PR DESCRIPTION
Is it suffice to update the call library version of the current hapijs library in shrinkwrap to get around https://nodesecurity.io/advisories/121?

@vladikoff @jbuck @jrgm 