### PR TITLE
WIP feat(email): Add an explicit error code for when email delivery fails.

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -14,6 +14,7 @@ var ERRNO = {
   ACCOUNT_UNVERIFIED: 104,
   DEVICE_UNKNOWN: 123,
   DEVICE_CONFLICT: 124,
+  EMAIL_REJECTED: 127,
   ENDPOINT_NOT_SUPPORTED: 116,
   FEATURE_NOT_ENABLED: 202,
   INCORRECT_EMAIL_CASE: 120,
@@ -458,6 +459,17 @@ AppError.deviceSessionConflict = function () {
       error: 'Bad Request',
       errno: ERRNO.DEVICE_CONFLICT,
       message: 'Session already registered by another device'
+    }
+  )
+}
+
+AppError.emailRejected = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: ERRNO.EMAIL_REJECTED,
+      message: 'Email delivery was rejected'
     }
   )
 }

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -3,10 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var P = require('./promise')
+var error = require('./error')
 var createMailer = require('fxa-auth-mailer')
 
 module.exports = function (config, log) {
   var defaultLanguage = config.i18n.defaultLanguage
+
+  function wrapMailerResult(result) {
+    return P.resolve(result)
+      .catch(
+        function (err) {
+          // XXX TODO: how can we tell whether it failed
+          // due to problem with the email, vs operation reasons?
+          log.error({ op: 'mailer.send.error', err: err })
+          throw error.emailRejected()
+        }
+      )
+  }
 
   return createMailer(
     log,
@@ -19,7 +32,7 @@ module.exports = function (config, log) {
   .then(
     function (mailer) {
       mailer.sendVerifyCode = function (account, code, opts) {
-        return P.resolve(mailer.verifyEmail(
+        return wrapMailerResult(mailer.verifyEmail(
           {
             email: account.email,
             uid: account.uid.toString('hex'),
@@ -32,7 +45,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendVerifyLoginEmail = function (account, code, opts) {
-        return P.resolve(mailer.verifyLoginEmail(
+        return wrapMailerResult(mailer.verifyLoginEmail(
           {
             acceptLanguage: opts.acceptLanguage || defaultLanguage,
             code: code.toString('hex'),
@@ -49,7 +62,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendRecoveryCode = function (token, code, opts) {
-        return P.resolve(mailer.recoveryEmail(
+        return wrapMailerResult(mailer.recoveryEmail(
           {
             email: token.email,
             token: token.data.toString('hex'),
@@ -62,7 +75,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendUnlockCode = function (account, code, opts) {
-        return P.resolve(mailer.unlockEmail(
+        return wrapMailerResult(mailer.unlockEmail(
           {
             email: account.email,
             uid: account.uid.toString('hex'),
@@ -75,7 +88,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendPasswordChangedNotification = function (email, opts) {
-        return P.resolve(mailer.passwordChangedEmail(
+        return wrapMailerResult(mailer.passwordChangedEmail(
           {
             email: email,
             acceptLanguage: opts.acceptLanguage || defaultLanguage
@@ -83,7 +96,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendPasswordResetNotification = function (email, opts) {
-        return P.resolve(mailer.passwordResetEmail(
+        return wrapMailerResult(mailer.passwordResetEmail(
           {
             email: email,
             acceptLanguage: opts.acceptLanguage || defaultLanguage
@@ -91,7 +104,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendNewDeviceLoginNotification = function (email, opts) {
-        return P.resolve(mailer.newDeviceLoginEmail(
+        return wrapMailerResult(mailer.newDeviceLoginEmail(
           {
             email: email,
             acceptLanguage: opts.acceptLanguage || defaultLanguage,
@@ -104,7 +117,7 @@ module.exports = function (config, log) {
         ))
       }
       mailer.sendPostVerifyEmail = function (email, opts) {
-        return P.resolve(mailer.postVerifyEmail(
+        return wrapMailerResult(mailer.postVerifyEmail(
           {
             email: email,
             acceptLanguage: opts.acceptLanguage || defaultLanguage

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -106,8 +106,8 @@ module.exports = function (
           .then(createPassword)
           .then(createAccount)
           .then(createSessionToken)
-          .then(sendVerifyCode)
           .then(createKeyFetchToken)
+          .then(sendVerifyCode)
           .then(createResponse)
           .done(reply, reply)
 
@@ -254,28 +254,6 @@ module.exports = function (
           }
         }
 
-        function sendVerifyCode () {
-          if (! account.emailVerified) {
-            mailer.sendVerifyCode(account, account.emailCode, {
-              service: form.service || query.service,
-              redirectTo: form.redirectTo,
-              resume: form.resume,
-              acceptLanguage: request.app.acceptLanguage
-            })
-            .then(function () {
-              // only create reminder if sendVerifyCode succeeds
-              verificationReminder.create({
-                uid: account.uid.toString('hex')
-              }).catch(function (err) {
-                log.error({ op: 'Account.verificationReminder.create', err: err })
-              })
-            })
-            .catch(function (err) {
-              log.error({ op: 'mailer.sendVerifyCode.1', err: err })
-            })
-          }
-        }
-
         function createKeyFetchToken () {
           if (requestHelper.wantsKeys(request)) {
             return password.unwrap(account.wrapWrapKb)
@@ -295,6 +273,37 @@ module.exports = function (
                   return metricsContext.stash(keyFetchToken, 'account.keyfetch', form.metricsContext)
                 }
               )
+          }
+        }
+
+        function sendVerifyCode () {
+          if (! account.emailVerified) {
+            return mailer.sendVerifyCode(account, account.emailCode, {
+              service: form.service || query.service,
+              redirectTo: form.redirectTo,
+              resume: form.resume,
+              acceptLanguage: request.app.acceptLanguage
+            })
+            .then(function () {
+              // only create reminder if sendVerifyCode succeeds
+              verificationReminder.create({
+                uid: account.uid.toString('hex')
+              }).catch(function (err) {
+                log.error({ op: 'Account.verificationReminder.create', err: err })
+              })
+            })
+            .catch(function (err) {
+              // If the email was rejected, delete the account.
+              if (err.errno !== error.ERRNO.EMAIL_REJECTED) {
+                throw err
+              }
+              return db.deleteAccount(sessionToken)
+                .then(
+                  function () {
+                    throw err
+                  }
+                )
+            })
           }
         }
 
@@ -523,7 +532,9 @@ module.exports = function (
           var shouldSendVerifyLoginEmail = requestHelper.wantsKeys(request) && doSigninConfirmation
 
           if (shouldSendVerifyLoginEmail) {
-            mailer.sendVerifyLoginEmail(
+            // The browser can't complete signin unless the email is receive,
+            // so we block on sending it and return an error if sending fails.
+            return mailer.sendVerifyLoginEmail(
               emailRecord,
               tokenVerificationId,
               userAgent.call({


### PR DESCRIPTION
@jrgm in the morning meeting today, you mentioned a long-standing issue with the auth-server where we eat email delivery failures rather than returning an error.  I couldn't find the original issue, but is this along the lines of the fix you'd hoped to see?