### PR TITLE
chore(scipts): Add stricter error handling to bash scripts

### DIFF
--- a/scripts/start-local-mysql.sh
+++ b/scripts/start-local-mysql.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 node ./scripts/gen_keys.js
 node ./test/mail_helper.js &
 MH=$!

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 node ./scripts/gen_keys.js
 node ./test/mail_helper.js &
 MH=$!

--- a/scripts/start-travis-auth-db-mysql.sh
+++ b/scripts/start-travis-auth-db-mysql.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ev
+set -evuo pipefail
 
 node ./scripts/gen_keys.js
 

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 glob=$*
 if [ "$glob" == "" ]; then
   glob="test/local test/remote"


### PR DESCRIPTION
The internet said this was a good idea [1] so I added it to all our bash scripts that aren't obviously doing their own error handling.  Might help with problems like [2]?

[1] http://redsymbol.net/articles/unofficial-bash-strict-mode/
[2] https://github.com/mozilla/fxa-auth-server/commit/37f0fe4637b84e4ce370c0e9f5244d2a8fc86add#commitcomment-18148096