### PR TITLE
chore(nsp): Add NSP exception for https://nodesecurity.io/advisories/121

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -5,6 +5,9 @@
     "https://nodesecurity.io/advisories/65",
 
     // for hapi/joi/moment dependency
-    "https://nodesecurity.io/advisories/55"
+    "https://nodesecurity.io/advisories/55",
+
+    // for hapi/call dependency
+    "https://nodesecurity.io/advisories/121"
   ]
 }


### PR DESCRIPTION
Per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1284668, it's safe for us to silence this warning for now in order to unbreak travis builds.  @seanmonstar r?