### PR TITLE
feat(security): record event names and ip addresses for important events

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -465,6 +465,13 @@ var conf = convict({
       ],
       env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }
+  },
+  securityHistory: {
+    enabled: {
+      doc: 'enable security history',
+      default: true,
+      env: 'SECURITY_HISTORY_ENABLED'
+    }
   }
 })
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -772,6 +772,24 @@ module.exports = function (
     return this.pool.del('/verificationReminders', reminderData)
   }
 
+  DB.prototype.securityEvent = function (event) {
+    log.trace({
+      op: 'DB.securityEvent',
+      securityEvent: event
+    })
+
+    return this.pool.post('/securityEvents', event)
+  }
+
+  DB.prototype.securityEvents = function (params) {
+    log.trace({
+      op: 'DB.securityEvents',
+      params: params
+    })
+
+    return this.pool.get('/securityEvents', params)
+  }
+
   return DB
 }
 

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -9,7 +9,7 @@
  * @returns {boolean}
  */
 function wantsKeys (request) {
-  return request.query.keys === 'true'
+  return request.query && request.query.keys === 'true'
 }
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -300,7 +300,7 @@
     "fxa-auth-db-mysql": {
       "version": "0.69.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#22e27d16d635927d2facfe8382030ec10447e600",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#7de6154e9a1898480a2ee31ad19699c5c0e864e1",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -427,6 +427,11 @@
               }
             }
           }
+        },
+        "ip": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz"
         },
         "mysql": {
           "version": "2.11.1",

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -233,7 +233,8 @@ test('/account/reset', function (t) {
   })
   var mockDB = mocks.mockDB({
     uid: uid,
-    email: TEST_EMAIL
+    email: TEST_EMAIL,
+    wrapWrapKb: crypto.randomBytes(32)
   })
   var mockCustoms = {
     reset: sinon.spy(function () {
@@ -243,6 +244,11 @@ test('/account/reset', function (t) {
   var mockLog = mocks.spyLog()
   var mockPush = mocks.mockPush()
   var accountRoutes = makeRoutes({
+    config: {
+      securityHistory: {
+        enabled: true
+      }
+    },
     customs: mockCustoms,
     db: mockDB,
     log: mockLog,
@@ -250,7 +256,8 @@ test('/account/reset', function (t) {
   })
   var route = getRoute(accountRoutes, '/account/reset')
 
-  return runTest(route, mockRequest, function () {
+  var clientAddress = mockRequest.app.clientAddress
+  return runTest(route, mockRequest, function (res) {
     t.equal(mockDB.resetAccount.callCount, 1)
 
     t.equal(mockPush.notifyPasswordReset.callCount, 1)
@@ -265,6 +272,12 @@ test('/account/reset', function (t) {
     t.equal(args[0], 'account.reset', 'first argument was event name')
     t.equal(args[1], mockRequest, 'second argument was request object')
     t.deepEqual(args[2], { uid: uid.toString('hex') }, 'third argument contained uid')
+
+    t.equal(mockDB.securityEvent.callCount, 1, 'db.securityEvent was called')
+    var securityEvent = mockDB.securityEvent.args[0][0]
+    t.equal(securityEvent.uid, uid)
+    t.equal(securityEvent.ipAddr, clientAddress)
+    t.equal(securityEvent.name, 'account.reset')
   })
 })
 
@@ -572,6 +585,7 @@ test('/account/create', function (t) {
       keys: 'true'
     }
   })
+  var clientAddress = mockRequest.app.clientAddress
   var emailCode = crypto.randomBytes(16)
   var keyFetchTokenId = crypto.randomBytes(16)
   var sessionTokenId = crypto.randomBytes(16)
@@ -610,6 +624,11 @@ test('/account/create', function (t) {
   var mockMailer = mocks.mockMailer()
   var mockPush = mocks.mockPush()
   var accountRoutes = makeRoutes({
+    config: {
+      securityHistory: {
+        enabled: true
+      }
+    },
     db: mockDB,
     log: mockLog,
     mailer: mockMailer,
@@ -672,15 +691,25 @@ test('/account/create', function (t) {
     t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
     t.deepEqual(args[1], 'account.keyfetch', 'second argument was event name')
     t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+
+    var securityEvent = mockDB.securityEvent
+    t.equal(securityEvent.callCount, 1, 'db.securityEvent is called')
+    securityEvent = securityEvent.args[0][0]
+    t.equal(securityEvent.name, 'account.create')
+    t.equal(securityEvent.uid, uid)
+    t.equal(securityEvent.ipAddr, clientAddress)
   }).finally(function () {
     mockLog.close()
   })
 })
 
 test('/account/login', function (t) {
-  t.plan(3)
+  t.plan(5)
   var config = {
-    newLoginNotificationEnabled: true
+    newLoginNotificationEnabled: true,
+    securityHistory: {
+      enabled: true
+    }
   }
   var mockRequest = mocks.mockRequest({
     query: {
@@ -1383,6 +1412,100 @@ test('/account/login', function (t) {
     })
   })
 
+  t.test('checks security history', function (t) {
+    t.plan(3)
+    var record
+    mockLog.info = sinon.spy(function(arg) {
+      if (arg.op.indexOf('Account.history') === 0) {
+        record = arg
+      }
+    })
+    var clientAddress = mockRequest.app.clientAddress
+
+    t.test('with a seen ip address', function (t) {
+      record = undefined
+      var securityQuery
+      mockDB.securityEvents = sinon.spy(function (arg) {
+        securityQuery = arg
+        return P.resolve([
+          {
+            name: 'account.login',
+            createdAt: Date.now(),
+            verified: true
+          }
+        ])
+      })
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockDB.securityEvents.callCount, 1, 'db.securityEvents was called')
+        t.equal(securityQuery.uid, uid)
+        t.equal(securityQuery.ipAddr, clientAddress)
+
+        t.equal(!!record, true, 'log.info was called for Account.history')
+        t.equal(record.op, 'Account.history.verified')
+        t.equal(record.uid, uid.toString('hex'))
+        t.equal(record.events, 1)
+        t.equal(record.recency, 'day')
+      })
+    })
+
+    t.test('with a seen, unverified ip address', function (t) {
+      record = undefined
+      var securityQuery
+      mockDB.securityEvents = sinon.spy(function (arg) {
+        securityQuery = arg
+        return P.resolve([
+          {
+            name: 'account.login',
+            createdAt: Date.now(),
+            verified: false
+          }
+        ])
+      })
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockDB.securityEvents.callCount, 1, 'db.securityEvents was called')
+        t.equal(securityQuery.uid, uid)
+        t.equal(securityQuery.ipAddr, clientAddress)
+
+        t.equal(!!record, true, 'log.info was called for Account.history')
+        t.equal(record.op, 'Account.history.unverified')
+        t.equal(record.uid, uid.toString('hex'))
+        t.equal(record.events, 1)
+      })
+    })
+
+    t.test('with a new ip address', function (t) {
+      record = undefined
+
+      var securityQuery
+      mockDB.securityEvents = sinon.spy(function (arg) {
+        securityQuery = arg
+        return P.resolve([])
+      })
+      return runTest(route, mockRequest, function (response) {
+        t.equal(mockDB.securityEvents.callCount, 1, 'db.securityEvents was called')
+        t.equal(securityQuery.uid, uid)
+        t.equal(securityQuery.ipAddr, clientAddress)
+
+        t.equal(record, undefined, 'log.info was not called for Account.history.verified')
+      })
+    })
+
+  })
+
+  t.test('records security event', function (t) {
+    var clientAddress = mockRequest.app.clientAddress
+    var securityQuery
+    mockDB.securityEvent = sinon.spy(function (arg) {
+      securityQuery = arg
+      return P.resolve()
+    })
+    return runTest(route, mockRequest, function (response) {
+      t.equal(mockDB.securityEvent.callCount, 1, 'db.securityEvent was called')
+      t.equal(securityQuery.uid, uid)
+      t.equal(securityQuery.ipAddr, clientAddress)
+      t.equal(securityQuery.name, 'account.login')
+    })
+  })
 })
 
 test('/recovery_email/verify_code', function (t) {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -15,8 +15,9 @@ var DB_METHOD_NAMES = ['account', 'createAccount', 'createDevice', 'createKeyFet
                        'createPasswordForgotToken', 'createSessionToken', 'deleteAccount',
                        'deleteDevice', 'deleteKeyFetchToken', 'deletePasswordChangeToken',
                        'deleteVerificationReminder', 'devices', 'emailRecord', 'resetAccount',
-                       'sessions', 'sessionTokenWithVerificationStatus', 'updateDevice',
-                       'updateLocale', 'updateSessionToken', 'verifyEmail', 'verifyTokens']
+                       'securityEvent', 'securityEvents', 'sessions',
+                       'sessionTokenWithVerificationStatus', 'updateDevice', 'updateLocale',
+                       'updateSessionToken', 'verifyEmail', 'verifyTokens']
 
 var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error', 'begin', 'warn', 'timing',
                         'activityEvent', 'flowEvent', 'notifyAttachedServices']
@@ -53,7 +54,8 @@ function mockDB (data, errors) {
         emailCode: data.emailCode,
         emailVerified: data.emailVerified,
         uid: data.uid,
-        verifierSetAt: Date.now()
+        verifierSetAt: Date.now(),
+        wrapWrapKb: data.wrapWrapKb
       })
     }),
     createAccount: sinon.spy(function () {
@@ -123,6 +125,9 @@ function mockDB (data, errors) {
         uid: data.uid,
         wrapWrapKb: crypto.randomBytes(32)
       })
+    }),
+    securityEvents: sinon.spy(function () {
+      return P.resolve([])
     }),
     sessions: sinon.spy(function () {
       return P.resolve(data.sessions || [])


### PR DESCRIPTION
We will start to record a history of security events, which will include the event name, IP address, and uid.

There could be other or new events, but for now, they are:

- `account.create`
- `account.login`
- `account.reset`

This is actually trickier than what one might imagine at first thought. We don't want to mark an IP address of an attacker as "all good". Until sign-in confirmation is at 100%, it is possible that we do that. So, it might make sense to also add a `account.confirmed` event, recorded when a user follows the sign-in confirmation link from their email.

Then, there is the matter of what events are worthy of skipping sign-in confirmation. Probably only `account.confirmed`. However, a user may answer the sign-in confirmation on their mobile device, with a different IP address than the machine that they are trying to login.

Then, we end up with this history:

```
xxx.xxx.xxx.xxx | <uid> | account.login
yyy.yyy.yyy.yyy | <uid> | account.confirmed
```

Maybe solving that is something we do farther down the road, and figure out how to tie those 2 events together, such that `xxx.xxx.xxx.xxx` is marked safe because it has a related `account.confirmed` event.

As for having all these events instead of just a `account.confirmed` event, it would be useful to have these events if/when we decide to show a "Security History" UI to the user.

------

Related db PR: https://github.com/mozilla/fxa-auth-db-mysql/pull/141