### PR TITLE
fix(log): Add comments and clarify naming for logging methods.

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -185,7 +185,7 @@ module.exports = function (
           .then(
             function () {
               if (account.emailVerified) {
-                return log.event('verified', request, {
+                return log.notifyAttachedServices('verified', request, {
                   email: account.email,
                   uid: account.uid,
                   locale: account.locale
@@ -196,7 +196,7 @@ module.exports = function (
           .then(
             function () {
               if (service === 'sync') {
-                return log.event('login', request, {
+                return log.notifyAttachedServices('login', request, {
                   service: 'sync',
                   uid: account.uid,
                   email: account.email,
@@ -492,7 +492,7 @@ module.exports = function (
 
         function emitSyncLoginEvent () {
           if (service === 'sync' && request.payload.reason === 'signin') {
-            return log.event('login', request, {
+            return log.notifyAttachedServices('login', request, {
               service: 'sync',
               uid: emailRecord.uid,
               email: emailRecord.email,
@@ -1000,7 +1000,7 @@ module.exports = function (
             .then(
               function () {
                 if (operation === 'createDevice') {
-                  return log.event('device:create', request, {
+                  return log.notifyAttachedServices('device:create', request, {
                     uid: sessionToken.uid,
                     id: result.id,
                     type: result.type,
@@ -1098,7 +1098,7 @@ module.exports = function (
           )
           .then(
             function () {
-              return log.event('device:delete', request, {
+              return log.notifyAttachedServices('device:delete', request, {
                 uid: uid,
                 id: id,
                 timestamp: Date.now()
@@ -1308,7 +1308,7 @@ module.exports = function (
                     .then(function () {
                       log.timing('account.verified', Date.now() - account.createdAt)
                       log.increment('account.verified')
-                      return log.event('verified', request, {
+                      return log.notifyAttachedServices('verified', request, {
                         email: account.email,
                         uid: account.uid,
                         locale: account.locale
@@ -1554,7 +1554,7 @@ module.exports = function (
             )
             .then(
               function () {
-                return log.event('reset', request, {
+                return log.notifyAttachedServices('reset', request, {
                   uid: account.uid.toString('hex') + '@' + config.domain,
                   generation: account.verifierSetAt
                 })
@@ -1686,7 +1686,7 @@ module.exports = function (
                 )
                 .then(
                   function () {
-                    return log.event('delete', request, {
+                    return log.notifyAttachedServices('delete', request, {
                       uid: uid + '@' + config.domain
                     })
                   }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -292,8 +292,8 @@ test('/account/device', function (t) {
       t.equal(args[1], mockRequest, 'second argument was request object')
       t.deepEqual(args[2], { uid: uid.toString('hex'), device_id: deviceId }, 'third argument contained uid')
 
-      t.equal(mockLog.event.callCount, 1)
-      args = mockLog.event.args[0]
+      t.equal(mockLog.notifyAttachedServices.callCount, 1)
+      args = mockLog.notifyAttachedServices.args[0]
       t.equal(args.length, 3)
       t.equal(args[0], 'device:create')
       t.equal(args[1], mockRequest)
@@ -306,7 +306,7 @@ test('/account/device', function (t) {
     })
     .then(function () {
       mockLog.activityEvent.reset()
-      mockLog.event.reset()
+      mockLog.notifyAttachedServices.reset()
     })
   }, t)
 
@@ -356,7 +356,7 @@ test('/account/device', function (t) {
         t.equal(args[1], mockRequest, 'second argument was request object')
         t.deepEqual(args[2], { uid: uid.toString('hex'), device_id: deviceId.toString('hex') }, 'third argument contained uid')
 
-        t.equal(mockLog.event.callCount, 0, 'log.event was not called')
+        t.equal(mockLog.notifyAttachedServices.callCount, 0, 'log.notifyAttachedServices was not called')
 
         t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
         t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
@@ -416,8 +416,8 @@ test('/account/device/destroy', function (t) {
     t.equal(args[1], mockRequest, 'second argument was request object')
     t.deepEqual(args[2], { uid: uid.toString('hex'), device_id: deviceId }, 'third argument contained uid and deviceId')
 
-    t.equal(mockLog.event.callCount, 1)
-    args = mockLog.event.args[0]
+    t.equal(mockLog.notifyAttachedServices.callCount, 1)
+    args = mockLog.notifyAttachedServices.args[0]
     t.equal(args.length, 3)
     t.equal(args[0], 'device:delete')
     t.equal(args[1], mockRequest)
@@ -900,7 +900,7 @@ test('/recovery_email/verify_code', function (t) {
     return runTest(route, mockRequest, function (response) {
       t.equal(mockDB.verifyTokens.callCount, 1, 'calls verifyTokens')
       t.equal(mockDB.verifyEmail.callCount, 1, 'calls verifyEmail')
-      t.equal(mockLog.event.callCount, 1, 'logs verified')
+      t.equal(mockLog.notifyAttachedServices.callCount, 1, 'logs verified')
 
       t.equal(mockLog.activityEvent.callCount, 1, 'activityEvent was called once')
       t.equal(mockMailer.sendPostVerifyEmail.callCount, 1, 'sendPostVerifyEmail was called once')
@@ -1032,9 +1032,9 @@ test('/account/destroy', function (t) {
     t.equal(args[0].email, email, 'db.deleteAccount was passed email record')
     t.deepEqual(args[0].uid, uid, 'email record had correct uid')
 
-    t.equal(mockLog.event.callCount, 1, 'log.event was called once')
-    args = mockLog.event.args[0]
-    t.equal(args.length, 3, 'log.event was passed three arguments')
+    t.equal(mockLog.notifyAttachedServices.callCount, 1, 'log.notifyAttachedServices was called once')
+    args = mockLog.notifyAttachedServices.args[0]
+    t.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments')
     t.equal(args[0], 'delete', 'first argument was event name')
     t.equal(args[1], mockRequest, 'second argument was request object')
     t.equal(args[2].uid, uid.toString('hex') + '@wibble', 'third argument was event data')

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -68,7 +68,7 @@ test(
     t.equal(typeof log.warn, 'function', 'log.warn method was exported')
     t.equal(typeof log.info, 'function', 'log.info method was exported')
     t.equal(typeof log.begin, 'function', 'log.begin method was exported')
-    t.equal(typeof log.event, 'function', 'log.event method was exported')
+    t.equal(typeof log.notifyAttachedServices, 'function', 'log.notifyAttachedServices method was exported')
     t.equal(typeof log.activityEvent, 'function', 'log.activityEvent method was exported')
     t.equal(typeof log.increment, 'function', 'log.increment method was exported')
     t.equal(typeof log.stat, 'function', 'log.stat method was exported')

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -18,7 +18,7 @@ var DB_METHOD_NAMES = ['account', 'createAccount', 'createDevice', 'createKeyFet
                        'updateDevice', 'verifyEmail', 'verifyTokens']
 
 var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error', 'begin', 'warn', 'timing',
-                        'activityEvent', 'event']
+                        'activityEvent', 'notifyAttachedServices']
 
 var MAILER_METHOD_NAMES = ['sendVerifyCode', 'sendVerifyLoginEmail',
                            'sendNewDeviceLoginNotification', 'sendPasswordChangedNotification',


### PR DESCRIPTION
Our `log` object has a lot of methods and it's not always obvious which one to use when.  By far the worst offender here is `log.event`, which has a generic name but a very specific job.  I've the `log.js` module, added some high-level comments to it, and and renamed `log.event` to `log.notifyAttachedServices` in an attempt to avoid future confusion.

@philbooth r?