### PR TITLE
fix(server): remove metricsContext from payloads where it is never sent

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -911,8 +911,7 @@ module.exports = function (
         },
         validate: {
           payload: {
-            id: isA.string().length(32).regex(HEX_STRING).required(),
-            metricsContext: metricsContext.schema
+            id: isA.string().length(32).regex(HEX_STRING).required()
           }
         },
         response: {
@@ -1103,8 +1102,7 @@ module.exports = function (
             uid: isA.string().max(32).regex(HEX_STRING).required(),
             code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
             service: isA.string().max(16).alphanum().optional(),
-            reminder: isA.string().max(32).alphanum().optional(),
-            metricsContext: metricsContext.schema
+            reminder: isA.string().max(32).alphanum().optional()
           }
         }
       },
@@ -1345,7 +1343,6 @@ module.exports = function (
         validate: {
           payload: {
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
-            metricsContext: metricsContext.schema,
             sessionToken: isA.boolean().optional()
           }
         }
@@ -1439,10 +1436,6 @@ module.exports = function (
               .then(
                 function (result) {
                   sessionToken = result
-                  return metricsContext.stash(sessionToken, [
-                    'device.created',
-                    'account.signed'
-                  ], request.payload.metricsContext)
                 }
               )
           }
@@ -1464,7 +1457,6 @@ module.exports = function (
               .then(
                 function (result) {
                   keyFetchToken = result
-                  return metricsContext.stash(keyFetchToken, 'account.keyfetch', request.payload.metricsContext)
                 }
               )
           }
@@ -1499,8 +1491,7 @@ module.exports = function (
         validate: {
           payload: {
             email: validators.email().required(),
-            authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
-            metricsContext: metricsContext.schema
+            authPW: isA.string().min(64).max(64).regex(HEX_STRING).required()
           }
         }
       },

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -56,8 +56,8 @@ module.exports = function (
     checkPassword,
     push
   )
-  var session = require('./session')(log, isA, error, db, metricsContext)
-  var sign = require('./sign')(log, isA, error, signer, db, config.domain, metricsContext)
+  var session = require('./session')(log, isA, error, db)
+  var sign = require('./sign')(log, isA, error, signer, db, config.domain)
   var util = require('./util')(
     log,
     crypto,

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (log, isA, error, db, metricsContext) {
+module.exports = function (log, isA, error, db) {
 
   var routes = [
     {

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (log, isA, error, signer, db, domain, metricsContext) {
+module.exports = function (log, isA, error, signer, db, domain) {
 
   const HOUR = 1000 * 60 * 60
 
@@ -27,8 +27,7 @@ module.exports = function (log, isA, error, signer, db, domain, metricsContext) 
               g: isA.string(),
               version: isA.string()
             }).required(),
-            duration: isA.number().integer().min(0).max(24 * HOUR).required(),
-            metricsContext: metricsContext.schema
+            duration: isA.number().integer().min(0).max(24 * HOUR).required()
           }
         }
       },

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -268,13 +268,6 @@ ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, heade
     options.sessionToken = true
   }
 
-  // Default to desktop client context
-  if (!options.metricsContext) {
-    options.metricsContext = {
-      context: 'fx_desktop_v3'
-    }
-  }
-
   return tokens.AccountResetToken.fromHex(accountResetTokenHex)
     .then(
       function (token) {
@@ -284,7 +277,6 @@ ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, heade
           token,
           {
             authPW: authPW.toString('hex'),
-            metricsContext: options.metricsContext || undefined,
             sessionToken: options.sessionToken
           },
           headers
@@ -366,8 +358,7 @@ ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, dura
           token,
           {
             publicKey: publicKey,
-            duration: duration,
-            metricsContext: options.metricsContext || undefined
+            duration: duration
           },
           {
             'accept-language': locale

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -219,54 +219,6 @@ TestServer.start(config)
   )
 
   test(
-    'certificate sign works with minimal metricsContext metadata',
-    function (t) {
-      var duration = 1000 * 60 * 60 * 24 // 24 hours
-      return Client.createAndVerify(config.publicUrl, server.uniqueEmail(), 'foo', server.mailbox)
-        .then(
-          function (client) {
-            return client.sign(publicKey, duration, null, {
-              metricsContext: {
-                flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
-                flowBeginTime: 1
-              }
-            })
-          }
-        )
-        .then(
-          function (cert) {
-            t.ok(cert, 'signed certificate')
-          }
-        )
-    }
-  )
-
-  test(
-    'certificate sign fails with invalid metricsContext flowId',
-    function (t) {
-      var duration = 1000 * 60 * 60 * 24 // 24 hours
-      return Client.createAndVerify(config.publicUrl, server.uniqueEmail(), 'foo', server.mailbox)
-        .then(
-          function (client) {
-            return client.sign(publicKey, duration, null, {
-              metricsContext: {
-                flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
-                flowBeginTime: 1
-              }
-            })
-          }
-        )
-        .then(
-          function () {
-            t.fail('certificate sign should have failed')
-          }, function (err) {
-            t.ok(err, 'certificate sign failed')
-          }
-        )
-    }
-  )
-
-  test(
     'teardown',
     function (t) {
       server.stop()

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -414,46 +414,6 @@ TestServer.start(config)
   )
 
   test(
-    'reset password with minimal metricsContext metadata',
-    function (t) {
-      var email = server.uniqueEmail()
-      var client
-      return Client.createAndVerify(config.publicUrl, email, 'foo', server.mailbox)
-        .then(
-          function (c) {
-            client = c
-            return client.forgotPassword()
-          }
-        )
-        .then(
-          function () {
-            return server.mailbox.waitForCode(email)
-          }
-        )
-        .then(
-          function (code) {
-            return resetPassword(client, code, 'bar', {
-              metricsContext: {
-                flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
-                flowBeginTime: 1
-              }
-            })
-          }
-        )
-        .then(
-          function () {
-            return Client.login(config.publicUrl, email, 'bar')
-          }
-        )
-        .then(
-          function (c) {
-            t.ok(c, 'reset password')
-          }
-        )
-    }
-  )
-
-  test(
     'teardown',
     function (t) {
       server.stop()


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/1345.

The content server only sends a `metricsContext` payload to `/account/create` and `/account/login`. The code for receiving it on other endpoints is redundant and makes client code more confusing because it introduces different ways to pass a `service` parameter.

https://github.com/mozilla/fxa-js-client/pull/205 has been opened to remove the redundant options from the client library. This PR is okay for simultaneous review because those client options aren't actually used by anyone.

@rfk, do you foresee any problems with us doing this?