### PR TITLE
feat(signin): Enable sign-in confirmation rollout on all devices.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -420,30 +420,6 @@ var conf = convict({
       doc: 'signin confirmation sample rate, between 0.0 and 1.0',
       default: 1.0,
       env: 'SIGNIN_CONFIRMATION_RATE'
-    },
-    supportedClients: {
-      doc: 'support sign-in confirmation for only these clients',
-      format: Array,
-      default: [
-        'iframe',
-        'fx_firstrun_v1',
-        'fx_firstrun_v2',
-        'fx_desktop_v1',
-        'fx_desktop_v2',
-        'fx_desktop_v3',
-        'fx_ios_v1',
-        'fx_ios_v2',
-        'fx_fennec_v1'
-      ],
-      env: 'SIGNIN_CONFIRMATION_SUPPORTED_CLIENTS'
-    },
-    forceEmailRegex: {
-      doc: 'If feature enabled, force sign-in confirmation for email addresses matching this regex.',
-      format: Array,
-      default: [
-        '.+@mozilla\.com$'
-      ],
-      env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }
   }
 })

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -27,26 +27,15 @@ function shouldEnableSigninConfirmation(account, config, request) {
     return false
   }
 
-  // Check for valid context
-  var context = request.payload && request.payload.metricsContext && request.payload.metricsContext.context
-  var isValidContext = context && (config.signinConfirmation.supportedClients.indexOf(context) > -1)
-  if (!isValidContext) {
-    return false
-  }
-
-  // If feature enabled, always enable for email addresses matching this regex
-  var email = account.email
-  var isValidEmail = config.signinConfirmation.forceEmailRegex.some(function (reg) {
-    var emailReg = new RegExp(reg)
-    return emailReg.test(email)
-  })
-
-  if (isValidEmail) {
+  // For legacy devices that make direct API requests
+  // (and hence don't submit metrics) we always do sign-in confirmation.
+  if (!request.payload || !request.payload.metricsContext) {
     return true
   }
 
-  // Check to see if user in roll-out cohort. Cohort is determined by
-  // user's uid
+  // For devices that log in via web-content, only do sign-in confirmation
+  // if they're within in roll-out sample cohort.  We make this check
+  // deterministic by basing it on the userid.
   var uid = account.uid.toString('hex')
   var uidNum = parseInt(uid.substr(0, 4), 16) % 100
   return uidNum < (config.signinConfirmation.sample_rate * 100)


### PR DESCRIPTION
Now that we're confident the sign-in confirmation flow will work for all types of devices, we can remove the logic that limits it to certain `context` values and certain email addresses, moving to a simpler sample-rate-based rollout approach.