### PR TITLE
feat(signin): Always do sign-in confirmation on suspicious requests.

### DIFF
--- a/lib/customs.js
+++ b/lib/customs.js
@@ -52,6 +52,9 @@ module.exports = function (log, error) {
           }
           throw error.requestBlocked()
         }
+        if (result.suspect) {
+          request.app.isSuspiciousRequest = true
+        }
       },
       function (err) {
         log.error({ op: 'customs.check.1', email: email, action: action, err: err })


### PR DESCRIPTION
This is an alternative proposal to #1355, taking a smaller step to enabling this flow on all devices.  Here, the rules work as follows:

* The customs-server can flag a request as being suspicious, rather than outright needing to be blocked.  We always do sign-in confirmation for such requests.
* The list of forced email addresses, is now checked before the list of devices.  This means anyone using an @restmail.net or @mozilla.com address will get sign-in confirmation on all their devices, allowing preliminary testing of various legacy devices.
* After those two checks, we keep the current logic of rolling out to a percentage of known-to-be-working-properly device types.

@shane-tomlinson r?