### PR TITLE
Add additional logging for sign-in confirmation

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -263,7 +263,8 @@ module.exports = function (
                 // Log server-side metrics for confirming verification rates
                 log.info({
                   op: 'account.create.confirm.start',
-                  uid: account.uid.toString('hex')
+                  uid: account.uid.toString('hex'),
+                  tokenVerificationId: tokenVerificationId
                 })
               }
             })
@@ -275,7 +276,8 @@ module.exports = function (
                 log.error({
                   op: 'account.create.confirm.error',
                   uid: account.uid.toString('hex'),
-                  err: err
+                  err: err,
+                  tokenVerificationId: tokenVerificationId
                 })
               }
             })
@@ -1233,6 +1235,7 @@ module.exports = function (
                   log.error({
                     op: 'account.signin.confirm.invalid',
                     uid: account.uid.toString('hex'),
+                    code: request.payload.code,
                     error: err
                   })
                   throw err

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -258,9 +258,26 @@ module.exports = function (
               }).catch(function (err) {
                 log.error({ op: 'Account.verificationReminder.create', err: err })
               })
+
+              if (tokenVerificationId) {
+                // Log server-side metrics for confirming verification rates
+                log.info({
+                  op: 'account.create.confirm.start',
+                  uid: account.uid.toString('hex')
+                })
+              }
             })
             .catch(function (err) {
               log.error({ op: 'mailer.sendVerifyCode.1', err: err })
+
+              if (tokenVerificationId) {
+                // Log possible email bounce, used for confirming verification rates
+                log.error({
+                  op: 'account.create.confirm.error',
+                  uid: account.uid.toString('hex'),
+                  err: err
+                })
+              }
             })
           }
         }
@@ -512,6 +529,12 @@ module.exports = function (
           // the tokens are created verified.
           var shouldSendVerifyLoginEmail = requestHelper.wantsKeys(request) && emailRecord.emailVerified && doSigninConfirmation
           if (shouldSendVerifyLoginEmail) {
+            log.info({
+              op: 'account.signin.confirm.start',
+              uid: emailRecord.uid.toString('hex'),
+              tokenVerificationId: tokenVerificationId
+            })
+
             mailer.sendVerifyLoginEmail(
               emailRecord,
               tokenVerificationId,
@@ -1195,11 +1218,23 @@ module.exports = function (
                * 3) Verify account email if not already verified.
                */
               return db.verifyTokens(code, account)
+                .then(function () {
+                  log.info({
+                    op: 'account.signin.confirm.success',
+                    uid: account.uid.toString('hex'),
+                    code: request.payload.code
+                  })
+                })
                 .catch(function (err) {
                   if (err.errno === error.ERRNO.INVALID_VERIFICATION_CODE && butil.buffersAreEqual(code, account.emailCode)) {
                     // The code is just for the account, not for any sessions
                     return true
                   }
+                  log.error({
+                    op: 'account.signin.confirm.invalid',
+                    uid: account.uid.toString('hex'),
+                    error: err
+                  })
                   throw err
                 })
                 .then(function () {


### PR DESCRIPTION
This PR add some additional logging to help better evaluate sign-in confirmation feature.

Per #1363 , 

a = account.create.confirm.start (from create account) + account.signin.confirm.start (from login)
b = account.signin.confirm.success
c = acocunt.signin.confirm.error (from email bounce)  + acocunt.signin.confirm.invalid (from invalid token)

Fixes https://github.com/mozilla/fxa-auth-server/issues/1363