### PR TITLE
Remove unused method db.createAccountResetToken

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -141,32 +141,6 @@ module.exports = function (
       )
   }
 
-  DB.prototype.createAccountResetToken = function (token /* authToken|passwordForgotToken */) {
-    log.trace({ op: 'DB.createAccountResetToken', uid: token && token.uid })
-    return AccountResetToken.create(token)
-      .then(
-        function (accountResetToken) {
-          return this.pool.put(
-            '/accountResetToken/' + accountResetToken.id,
-            unbuffer(
-              {
-                tokenId: accountResetToken.tokenId,
-                data: accountResetToken.data,
-                uid: accountResetToken.uid,
-                createdAt: accountResetToken.createdAt
-              },
-              'inplace'
-            )
-          )
-          .then(
-            function () {
-              return accountResetToken
-            }
-          )
-        }.bind(this)
-      )
-  }
-
   DB.prototype.createPasswordForgotToken = function (emailRecord) {
     log.trace({ op: 'DB.createPasswordForgotToken', uid: emailRecord && emailRecord.uid })
     return PasswordForgotToken.create(emailRecord)

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -162,7 +162,6 @@ test('/recovery_email/status', function (t) {
   t.test('sign-in confirmation enabled', function (t) {
     t.plan(2)
     config.signinConfirmation.enabled = true
-    config.signinConfirmation.enabled = 1
     var mockRequest = mocks.mockRequest({
       credentials: {
         uid: uuid.v4('binary').toString('hex'),

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -381,7 +381,7 @@ test(
       var tokenId
       return db.emailRecord(ACCOUNT.email)
       .then(function(emailRecord) {
-        return db.createAccountResetToken(emailRecord)
+        return db.forgotPasswordVerified(emailRecord)
       })
       .then(function(accountResetToken) {
         t.deepEqual(accountResetToken.uid, ACCOUNT.uid, 'account reset token uid should be the same as the account.uid')
@@ -519,7 +519,7 @@ test(
         return db.createSessionToken(emailRecord, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
       })
       .then(function(sessionToken) {
-        return db.createAccountResetToken(sessionToken)
+        return db.forgotPasswordVerified(sessionToken)
       })
       .then(function(accountResetToken) {
         return db.resetAccount(accountResetToken, ACCOUNT)


### PR DESCRIPTION
Fixes #1378.

Account reset tokens are created via `db.forgotPasswordVerified` instead. This begs the question of whether the `createAccountResetToken` in the db server is also redundant. I'll raise that in another issue.

@vladikoff r?