### PR TITLE
fix(server): ensure tokens get a fresh createdAt timestamp

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -213,7 +213,7 @@ module.exports = function (
               emailCode: account.emailCode,
               emailVerified: account.emailVerified,
               verifierSetAt: account.verifierSetAt,
-              createdAt: optionallyOverrideCreatedAt(),
+              createdAt: parseInt(query._createdAt),
               tokenVerificationId: tokenVerificationId
             }, userAgentString)
             .then(
@@ -235,13 +235,6 @@ module.exports = function (
                 }, 'account.verified', form.metricsContext)
               }
             )
-        }
-
-        function optionallyOverrideCreatedAt () {
-          var createdAt = parseInt(query._createdAt)
-          if (createdAt < Date.now() && ! config.isProduction) {
-            return createdAt
-          }
         }
 
         function sendVerifyCode () {

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -21,7 +21,12 @@ module.exports = function (log, inherits, Token) {
     this.emailVerified = !!details.emailVerified
     this.verifierSetAt = details.verifierSetAt
     this.locale = details.locale || null
-    this.accountCreatedAt = details.createdAt
+
+    if (details.createdAt > 0) {
+      this.accountCreatedAt = details.createdAt
+    } else {
+      this.accountCreatedAt = null
+    }
 
     // Tokens are considered verified if no tokenVerificationId exists
     this.tokenVerificationId = details.tokenVerificationId || null

--- a/lib/tokens/token.js
+++ b/lib/tokens/token.js
@@ -23,6 +23,8 @@
  *
  */
 
+var config = require('../../config').getProperties()
+
 module.exports = function (log, crypto, P, hkdf, Bundle, error) {
 
   // Token constructor.
@@ -38,7 +40,19 @@ module.exports = function (log, crypto, P, hkdf, Bundle, error) {
     this.algorithm = 'sha256'
     this.uid = details.uid || null
     this.lifetime = details.lifetime || Infinity
-    this.createdAt = details.createdAt >= 0 ? details.createdAt : Date.now()
+    this.createdAt = optionallyOverrideCreatedAt(details.createdAt)
+  }
+
+  function optionallyOverrideCreatedAt (timestamp) {
+    var now = Date.now()
+
+    if (! config.isProduction && timestamp >= 0 && timestamp < now) {
+      // In the wild, all tokens should have a fresh createdAt timestamp.
+      // For testing purposes only, allow createdAt to be overridden.
+      return timestamp
+    }
+
+    return now
   }
 
   // Create a new token of the given type.

--- a/test/local/session_token_tests.js
+++ b/test/local/session_token_tests.js
@@ -13,6 +13,7 @@ var SessionToken = tokens.SessionToken
 var TOKEN_FRESHNESS_THRESHOLD = require('../../lib/tokens/session_token').TOKEN_FRESHNESS_THREADHOLD
 
 var ACCOUNT = {
+  createdAt: Date.now(),
   uid: 'xxx',
   email: Buffer('test@example.com').toString('hex'),
   emailCode: '123456',
@@ -64,6 +65,23 @@ test(
           t.equal(token.tokenVerificationId, token2.tokenVerificationId)
         }
       )
+  }
+)
+
+test(
+  'create with NaN createdAt',
+  function (t) {
+    return SessionToken.create({
+      createdAt: NaN,
+      email: 'foo',
+      uid: 'bar'
+    }).then(
+      function (token) {
+        var now = Date.now()
+        t.ok(token.createdAt > now - 1000 && token.createdAt <= now)
+        t.equal(token.accountCreatedAt, null)
+      }
+    )
   }
 )
 

--- a/test/local/token_tests.js
+++ b/test/local/token_tests.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var crypto = require('crypto')
+var hkdf = require('../../lib/crypto/hkdf')
+var mocks = require('../mocks')
+var P = require('../../lib/promise')
+var sinon = require('sinon')
+var test = require('tap').test
+
+var Bundle = {
+  bundle: sinon.spy(),
+  unbundle: sinon.spy()
+}
+var log = mocks.spyLog()
+var modulePath = '../../lib/tokens/token'
+
+test('NODE_ENV=dev', function (t) {
+  process.env.NODE_ENV = 'dev'
+  var Token = require(modulePath)(log, crypto, P, hkdf, Bundle, null)
+
+  t.plan(4)
+
+  t.test('Token constructor was exported', function (t) {
+    t.equal(typeof Token, 'function', 'Token is function')
+    t.equal(Token.name, 'Token', 'function is called Token')
+    t.equal(Token.length, 2, 'function expects two arguments')
+    t.end()
+  })
+
+  t.test('Token constructor sets createdAt', function (t) {
+    var now = Date.now() - 1
+    var token = new Token({}, { createdAt: now })
+
+    t.equal(token.createdAt, now, 'token.createdAt is correct')
+    t.end()
+  })
+
+  t.test('Token constructor does not set createdAt if it is negative', function (t) {
+    var notNow = -Date.now()
+    var token = new Token({}, { createdAt: notNow })
+
+    t.ok(token.createdAt > 0, 'token.createdAt seems correct')
+    t.end()
+  })
+
+  t.test('Token constructor does not set createdAt if it is in the future', function (t) {
+    var notNow = Date.now() + 1000
+    var token = new Token({}, { createdAt: notNow })
+
+    t.ok(token.createdAt > 0 && token.createdAt < notNow, 'token.createdAt seems correct')
+    t.end()
+  })
+})
+
+test('NODE_ENV=prod', function (t) {
+  process.env.NODE_ENV = 'prod'
+  delete require.cache[require.resolve(modulePath)]
+  delete require.cache[require.resolve('../../config')]
+  var Token = require(modulePath)(log, crypto, P, hkdf, Bundle, null)
+
+  t.plan(1)
+
+  t.test('Token constructor does not set createdAt', function (t) {
+    var notNow = Date.now() - 1
+    var token = new Token({}, { createdAt: notNow })
+
+    t.ok(token.createdAt > notNow, 'token.createdAt seems correct')
+    t.end()
+  })
+})
+

--- a/test/remote/base_path_tests.js
+++ b/test/remote/base_path_tests.js
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+process.env.PUBLIC_URL = 'http://127.0.0.1:9000/auth'
+
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
 var Client = require('../client')
 var P = require('../../lib/promise')
 var request = require('request')
 
-process.env.PUBLIC_URL = 'http://127.0.0.1:9000/auth'
 var config = require('../../config').getProperties()
 
 TestServer.start(config)


### PR DESCRIPTION
Fixes #1383.

The ideal fix for this would have been always to set `createdAt` to `Date.now()` in the `Token` constructor. Unfortunately, [these tests](https://github.com/mozilla/fxa-auth-server/pull/1198/files#diff-192be473e813a7f161eb81eb38511e09R339) need to retain the ability to set `createdAt` to something else, so that they can make assertions against a zero `lastAccessTime` from the db.

Instead, as a second-best option, I've pulled the implementation of `optionallyOverrideCreatedAt` down from the `/account/create` route handler into the base `Token` object. This ensures that the timestamp can be overridden from the tests but not in a production environment.

@vladikoff r?