### PR TITLE
feat(logging): emit an account.confirmed activity event

### DIFF
--- a/test/mocks.js
+++ b/test/mocks.js
@@ -49,6 +49,8 @@ function mockDB (data, errors) {
     account: sinon.spy(function () {
       return P.resolve({
         email: data.email,
+        emailCode: data.emailCode,
+        emailVerified: data.emailVerified,
         uid: data.uid,
         verifierSetAt: Date.now()
       })
@@ -126,6 +128,12 @@ function mockDB (data, errors) {
     }),
     updateDevice: sinon.spy(function (uid, sessionTokenId, device) {
       return P.resolve(device)
+    }),
+    verifyTokens: sinon.spy(function () {
+      if (errors.verifyTokens) {
+        return P.reject(errors.verifyTokens)
+      }
+      return P.resolve()
     })
   })
 }


### PR DESCRIPTION
Fixes #1388.

Here is a sample log line showing the new event, along with the appropriately stashed metrics context data.

```
activityEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1470316397843,"flow_id":"8b3cdf7cfc9d4968f8e23e4dba36509b80170211360f9236f12e4bbbc5437d7b","flow_time":13063,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync","uid":"e73292390c9b420885565112f426988f"}
```

There's some minor additional rejigging in the route handler from where I decided to eliminate all the duplicate calls to `account.uid.toString('hex')`.

And the local test changes for `/recovery_email/verify_code` may look a bit hairier than anticipated because of whitespace changes from how the nesting changed, you may or may not want `?w=1` for that bit.

Otherwise it should be as expected. @vbudhram, r?