### PR TITLE
fix(password): Remove raw token support

### DIFF
--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -24,8 +24,6 @@ module.exports = function (
   push
   ) {
 
-  var Tokens = require('../tokens/index')(log)
-
   function failVerifyAttempt(passwordForgotToken) {
     return (passwordForgotToken.failAttempt()) ?
       db.deletePasswordForgotToken(passwordForgotToken) :

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -163,30 +163,9 @@ module.exports = function (
           if (sessionTokenId) {
             var tokenId = Buffer(sessionTokenId, 'hex')
             return db.sessionTokenWithVerificationStatus(tokenId)
-              .catch(
-                function (err) {
-                  // Older versions of content-server passed the raw token data
-                  // rather than the id; handle both for b/w compatibility.
-                  if (err.errno !== error.ERRNO.INVALID_TOKEN) {
-                    throw err
-                  }
-                  return Tokens.SessionToken.fromHex(sessionTokenId)
-                    .then(
-                      function (tokenData) {
-                        tokenId = tokenData.tokenId
-                        return db.sessionTokenWithVerificationStatus(tokenId)
-                      }
-                    )
-                }
-              )
               .then(
                 function (tokenData) {
                   verifiedStatus = tokenData.tokenVerified
-                }
-              )
-              .catch(
-                function () {
-                  verifiedStatus = false
                 }
               )
           } else {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -126,6 +126,11 @@ function mockDB (data, errors) {
     }),
     updateDevice: sinon.spy(function (uid, sessionTokenId, device) {
       return P.resolve(device)
+    }),
+    sessionTokenWithVerificationStatus: sinon.spy(function () {
+      return P.resolve({
+        tokenVerified: true
+      })
     })
   })
 }

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -247,19 +247,17 @@ TestServer.start(config)
   )
 
   test(
-    'password change, with raw session data rather than session token id, return invalid token',
+    'password change, with raw session data rather than session token id, return invalid token error',
     function (t) {
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var newPassword = 'foobar'
-      var client, firstAuthPW, originalSessionToken
+      var client
 
       return Client.createAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x
-            originalSessionToken = client.sessionToken
-            firstAuthPW = x.authPW.toString('hex')
             return client.keys()
           }
         )

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -247,7 +247,7 @@ TestServer.start(config)
   )
 
   test(
-    'password change, with raw session data rather than session token id',
+    'password change, with raw session data rather than session token id, return invalid token',
     function (t) {
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
@@ -279,24 +279,14 @@ TestServer.start(config)
           }
         )
         .then(
-          function (response) {
-            t.notEqual(response.sessionToken, originalSessionToken, 'session token has changed')
-            t.ok(response.keyFetchToken, 'key fetch token returned')
-            t.notEqual(client.authPW.toString('hex'), firstAuthPW, 'password has changed')
-          }
-        )
-        .then(
           function () {
-            return server.mailbox.waitForEmail(email)
+            t.fail()
           }
         )
-        .then(
-          function (emailData) {
-            var subject = emailData.headers['subject']
-            t.equal(subject, 'Your Firefox Account password has been changed', 'password email subject set correctly')
-            var link = emailData.headers['x-link']
-            var query = url.parse(link, true).query
-            t.ok(query.email, 'email is in the link')
+        .catch(
+          function (err) {
+            t.equal(err.errno, 110, 'Invalid token error')
+            t.equal(err.message, 'Invalid authentication token in request signature')
           }
         )
     }


### PR DESCRIPTION
This PR removes accepting raw session token data on password changes. Any request sending this data will receive an invalid verification code error.

Fixes #1351 