### PR TITLE
fix(server): reinstate placeholder devices for sync sessions

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -439,9 +439,17 @@ module.exports = function (
               type: item.type,
               pushCallback: item.callbackURL,
               pushPublicKey: item.callbackPublicKey,
-              pushAuthKey: item.callbackAuthKey
+              pushAuthKey: item.callbackAuthKey,
+              uaBrowser: item.uaBrowser,
+              uaBrowserVersion: item.uaBrowserVersion,
+              uaOS: item.uaOS,
+              uaOSVersion: item.uaOSVersion,
+              uaDeviceType: item.uaDeviceType
             }, {
-              ignore: [ 'name', 'type', 'pushCallback', 'pushPublicKey', 'pushAuthKey' ]
+              ignore: [
+                'name', 'type', 'pushCallback', 'pushPublicKey', 'pushAuthKey',
+                'uaBrowser', 'uaBrowserVersion', 'uaOS', 'uaOSVersion', 'uaDeviceType'
+              ]
             })
           })
         },

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = function (log, db, push) {
+  return {
+    upsert: upsert,
+    synthesizeName: synthesizeName
+  }
+
+  function upsert (request, sessionToken, deviceInfo) {
+    var operation, event, result
+    if (deviceInfo.id) {
+      operation = 'updateDevice'
+      event = 'device.updated'
+    } else {
+      operation = 'createDevice'
+      event = 'device.created'
+    }
+    var isPlaceholderDevice = Object.keys(deviceInfo).length === 0
+
+    return db[operation](sessionToken.uid, sessionToken.tokenId, deviceInfo)
+      .then(function (device) {
+        result = device
+        return log.activityEvent(event, request, {
+          uid: sessionToken.uid.toString('hex'),
+          device_id: result.id.toString('hex'),
+          is_placeholder: isPlaceholderDevice
+        })
+      })
+      .then(function () {
+        if (operation === 'createDevice') {
+          push.notifyDeviceConnected(sessionToken.uid, result.name, result.id.toString('hex'))
+          if (isPlaceholderDevice) {
+            log.info({
+              op: 'device:createPlaceholder',
+              uid: sessionToken.uid,
+              id: result.id
+            })
+          }
+          return log.notifyAttachedServices('device:create', request, {
+            uid: sessionToken.uid,
+            id: result.id,
+            type: result.type,
+            timestamp: result.createdAt,
+            isPlaceholder: isPlaceholderDevice
+          })
+        }
+      })
+      .then(function () {
+        return result
+      })
+  }
+
+  function synthesizeName (device) {
+    var browserPart = part('uaBrowser')
+    var osPart = part('uaOS')
+
+    if (browserPart) {
+      if (osPart) {
+        return browserPart + ', ' + osPart
+      }
+
+      return browserPart
+    }
+
+    return osPart || ''
+
+    function part (key) {
+      if (device[key]) {
+        var versionKey = key + 'Version'
+
+        if (device[versionKey]) {
+          return device[key] + ' ' + device[versionKey]
+        }
+
+        return device[key]
+      }
+    }
+  }
+}
+

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -26,6 +26,7 @@ module.exports = function (
   var idp = require('./idp')(log, serverPublicKeys)
   var checkPassword = require('./utils/password_check')(log, config, Password, customs, db)
   var push = require('../push')(log, db)
+  var devices = require('../devices')(log, db, push)
   var account = require('./account')(
     log,
     crypto,
@@ -41,7 +42,8 @@ module.exports = function (
     isPreVerified,
     checkPassword,
     push,
-    metricsContext
+    metricsContext,
+    devices
   )
   var password = require('./password')(
     log,
@@ -57,7 +59,7 @@ module.exports = function (
     push
   )
   var session = require('./session')(log, isA, error, db)
-  var sign = require('./sign')(log, isA, error, signer, db, config.domain)
+  var sign = require('./sign')(log, P, isA, error, signer, db, config.domain, devices)
   var util = require('./util')(
     log,
     crypto,

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -56,7 +56,8 @@ var makeRoutes = function (options, requireMocks) {
     isPreVerified,
     checkPassword,
     push,
-    metricsContext
+    metricsContext,
+    options.devices || require('../../lib/devices')(log, db, push)
   )
 }
 
@@ -247,146 +248,101 @@ test('/account/reset', function (t) {
 })
 
 test('/account/device', function (t) {
-  t.plan(2)
+  t.plan(4)
   var config = {}
   var uid = uuid.v4('binary')
-  var device = {}
+  var deviceId = crypto.randomBytes(16)
   var mockRequest = mocks.mockRequest({
     credentials: {
-      uid: uid.toString('hex')
+      deviceCallbackPublicKey: '',
+      deviceCallbackURL: '',
+      deviceId: deviceId,
+      deviceName: 'my awesome device',
+      deviceType: 'desktop',
+      tokenId: crypto.randomBytes(16),
+      uid: uid
     },
-    payload: device
+    payload: {
+      id: deviceId.toString('hex'),
+      name: 'my awesome device'
+    }
   })
-  var deviceCreatedAt = Date.now()
-  var deviceId = crypto.randomBytes(16).toString('hex')
-  var mockDB = mocks.mockDB({
-    device: device,
-    deviceCreatedAt: deviceCreatedAt,
-    deviceId: deviceId
-  })
+  var mockDevices = mocks.mockDevices()
   var mockLog = mocks.spyLog()
-  var mockPush = mocks.mockPush()
   var accountRoutes = makeRoutes({
     config: config,
-    db: mockDB,
-    log: mockLog,
-    push: mockPush
+    devices: mockDevices,
+    log: mockLog
   })
   var route = getRoute(accountRoutes, '/account/device')
 
-  t.test('create', function (t) {
-    device.name = 'My Phone'
-    device.type = 'mobile'
-    device.pushCallback = 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef'
-
+  t.test('identical data', function (t) {
     return runTest(route, mockRequest, function (response) {
-      t.equal(mockDB.createDevice.callCount, 1)
+      t.equal(mockLog.increment.callCount, 1, 'a counter was incremented')
+      t.equal(mockLog.increment.firstCall.args[0], 'device.update.spurious')
 
-      t.equal(mockPush.notifyDeviceConnected.callCount, 1)
-      t.equal(mockPush.notifyDeviceConnected.firstCall.args[0], mockRequest.auth.credentials.uid)
-      t.equal(mockPush.notifyDeviceConnected.firstCall.args[1], device.name)
-      t.equal(mockPush.notifyDeviceConnected.firstCall.args[2], deviceId)
-
-      t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
-      var args = mockLog.activityEvent.args[0]
-      t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
-      t.equal(args[0], 'device.created', 'first argument was event name')
-      t.equal(args[1], mockRequest, 'second argument was request object')
-      t.deepEqual(args[2], { uid: uid.toString('hex'), device_id: deviceId }, 'third argument contained uid')
-
-      t.equal(mockLog.notifyAttachedServices.callCount, 1)
-      args = mockLog.notifyAttachedServices.args[0]
-      t.equal(args.length, 3)
-      t.equal(args[0], 'device:create')
-      t.equal(args[1], mockRequest)
-      t.deepEqual(args[2], {
-        uid: uid.toString('hex'),
-        id: deviceId,
-        type: 'mobile',
-        timestamp: deviceCreatedAt
-      })
+      t.deepEqual(response, mockRequest.payload)
     })
     .then(function () {
-      mockDB.createDevice.reset()
-      mockLog.activityEvent.reset()
-      mockLog.notifyAttachedServices.reset()
-      mockPush.notifyDeviceConnected.reset()
+      mockLog.increment.reset()
     })
   })
 
-  t.test('update', function (t) {
-    t.plan(3)
-    var deviceId = crypto.randomBytes(16)
-    var credentials = mockRequest.auth.credentials
-    credentials.tokenId = 'lookmumasessiontoken'
-    credentials.deviceName = 'my awesome device'
-    credentials.deviceType = 'desktop'
-    credentials.deviceCallbackURL = ''
-    credentials.deviceCallbackPublicKey = ''
-    device.name = device.type = device.pushCallback = undefined
-    device.id = deviceId.toString('hex')
+  t.test('different data', function (t) {
+    mockRequest.auth.credentials.deviceId = crypto.randomBytes(16)
+    var payload = mockRequest.payload
+    payload.name = 'my even awesomer device'
+    payload.type = 'phone'
+    payload.pushCallback = 'https://push.services.mozilla.com/123456'
+    payload.pushPublicKey = 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
 
-    t.test('identical data', function (t) {
-      mockRequest.auth.credentials.deviceId = deviceId
-      mockRequest.payload.name = 'my awesome device'
+    return runTest(route, mockRequest, function (response) {
+      t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
+      t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
+      t.equal(mockLog.increment.getCall(1).args[0], 'device.update.name')
+      t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
+      t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
+      t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
 
-      return runTest(route, mockRequest, function (response) {
-        t.equal(mockDB.updateDevice.callCount, 0, 'updateDevice was not called')
-
-        t.equal(mockLog.increment.callCount, 1, 'a counter was incremented')
-        t.equal(mockLog.increment.firstCall.args[0], 'device.update.spurious')
-
-        t.deepEqual(response, mockRequest.payload)
-      })
-      .then(function () {
-        mockLog.increment.reset()
-      })
+      t.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
+      var args = mockDevices.upsert.args[0]
+      t.equal(args.length, 3, 'devices.upsert was passed three arguments')
+      t.equal(args[0], mockRequest, 'first argument was request object')
+      t.deepEqual(args[1].tokenId, mockRequest.auth.credentials.tokenId, 'second argument was session token')
+      t.deepEqual(args[1].uid, uid, 'sessionToken.uid was correct')
+      t.deepEqual(args[2], mockRequest.payload, 'third argument was payload')
     })
-
-    t.test('different data', function (t) {
-      mockRequest.auth.credentials.deviceId = crypto.randomBytes(16)
-      var payload = mockRequest.payload
-      payload.name = 'my even awesomer device'
-      payload.type = 'phone'
-      payload.pushCallback = 'https://push.services.mozilla.com/123456'
-      payload.pushPublicKey = 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
-
-      return runTest(route, mockRequest, function (response) {
-        t.equal(mockDB.updateDevice.callCount, 1, 'updateDevice was called')
-
-        t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
-        var args = mockLog.activityEvent.args[0]
-        t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
-        t.equal(args[0], 'device.updated', 'first argument was event name')
-        t.equal(args[1], mockRequest, 'second argument was request object')
-        t.deepEqual(args[2], { uid: uid.toString('hex'), device_id: deviceId.toString('hex') }, 'third argument contained uid')
-
-        t.equal(mockLog.notifyAttachedServices.callCount, 0, 'log.notifyAttachedServices was not called')
-
-        t.equal(mockLog.increment.callCount, 5, 'the counters were incremented')
-        t.equal(mockLog.increment.getCall(0).args[0], 'device.update.sessionToken')
-        t.equal(mockLog.increment.getCall(1).args[0], 'device.update.name')
-        t.equal(mockLog.increment.getCall(2).args[0], 'device.update.type')
-        t.equal(mockLog.increment.getCall(3).args[0], 'device.update.pushCallback')
-        t.equal(mockLog.increment.getCall(4).args[0], 'device.update.pushPublicKey')
-      })
-      .then(function () {
-        mockDB.updateDevice.reset()
-        mockLog.activityEvent.reset()
-        mockLog.increment.reset()
-      })
+    .then(function () {
+      mockLog.increment.reset()
+      mockDevices.upsert.reset()
     })
+  })
 
-    t.test('device updates disabled', function (t) {
-      config.deviceUpdatesEnabled = false
+  t.test('with no id in payload', function (t) {
+    mockRequest.payload.id = undefined
 
-      return runTest(route, mockRequest, function () {
-        t.fail('should have thrown')
-      })
-      .catch(function (err) {
-        t.equal(err.output.statusCode, 503, 'correct status code is returned')
-        t.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED, 'correct errno is returned')
-      })
+    return runTest(route, mockRequest, function (response) {
+      t.equal(mockLog.increment.callCount, 0, 'log.increment was not called')
+
+      t.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
+      var args = mockDevices.upsert.args[0]
+      t.equal(args[2].id, mockRequest.auth.credentials.deviceId.toString('hex'), 'payload.id defaulted to credentials.deviceId')
+    })
+    .then(function () {
+      mockLog.increment.reset()
+      mockDevices.upsert.reset()
+    })
+  }, t)
+
+  t.test('device updates disabled', function (t) {
+    config.deviceUpdatesEnabled = false
+
+    return runTest(route, mockRequest, function () {
+      t.fail('should have thrown')
+    })
+    .catch(function (err) {
+      t.equal(err.output.statusCode, 503, 'correct status code is returned')
+      t.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED, 'correct errno is returned')
     })
   })
 })
@@ -631,6 +587,7 @@ test('/account/create', function (t) {
     return P.resolve()
   })
   var mockMailer = mocks.mockMailer()
+  var mockPush = mocks.mockPush()
   var accountRoutes = makeRoutes({
     db: mockDB,
     log: mockLog,
@@ -645,7 +602,8 @@ test('/account/create', function (t) {
           return P.resolve('wibble')
         }
       }
-    }
+    },
+    push: mockPush
   })
   var route = getRoute(accountRoutes, '/account/create')
 
@@ -766,6 +724,7 @@ test('/account/login', function (t) {
     return P.resolve()
   })
   var mockMailer = mocks.mockMailer()
+  var mockPush = mocks.mockPush()
   var accountRoutes = makeRoutes({
     checkPassword: function () {
       return P.resolve(true)
@@ -779,7 +738,8 @@ test('/account/login', function (t) {
     db: mockDB,
     log: mockLog,
     mailer: mockMailer,
-    metricsContext: mockMetricsContext
+    metricsContext: mockMetricsContext,
+    push: mockPush
   })
   var route = getRoute(accountRoutes, '/account/login')
 
@@ -1360,3 +1320,58 @@ test('/account/destroy', function (t) {
     t.equal(args[2].uid, uid.toString('hex'), 'third argument was event data')
   })
 })
+
+test('/account/devices', function (t) {
+  var mockRequest = mocks.mockRequest({
+    credentials: {
+      uid: crypto.randomBytes(16),
+      tokenId: crypto.randomBytes(16)
+    },
+    payload: {}
+  })
+  var unnamedDevice = { sessionToken: crypto.randomBytes(16) }
+  var mockDB = mocks.mockDB({
+    devices: [
+      { name: 'current session', type: 'mobile', sessionToken: mockRequest.auth.credentials.tokenId },
+      { name: 'has no type', sessionToken: crypto.randomBytes(16) },
+      { name: 'has device type', sessionToken: crypto.randomBytes(16), uaDeviceType: 'wibble' },
+      unnamedDevice
+    ]
+  })
+  var mockDevices = mocks.mockDevices()
+  var accountRoutes = makeRoutes({
+    db: mockDB,
+    devices: mockDevices
+  })
+  var route = getRoute(accountRoutes, '/account/devices')
+
+  return runTest(route, mockRequest, function (response) {
+    t.ok(Array.isArray(response), 'response is array')
+    t.equal(response.length, 4, 'response contains 4 items')
+
+    t.equal(response[0].name, 'current session')
+    t.equal(response[0].type, 'mobile')
+    t.equal(response[0].sessionToken, undefined)
+    t.equal(response[0].isCurrentDevice, true)
+
+    t.equal(response[1].name, 'has no type')
+    t.equal(response[1].type, 'desktop')
+    t.equal(response[1].sessionToken, undefined)
+    t.equal(response[1].isCurrentDevice, false)
+
+    t.equal(response[2].name, 'has device type')
+    t.equal(response[2].type, 'wibble')
+    t.equal(response[2].isCurrentDevice, false)
+
+    t.equal(response[3].name, null)
+
+    t.equal(mockDB.devices.callCount, 1, 'db.devices was called once')
+    t.equal(mockDB.devices.args[0].length, 1, 'db.devices was passed one argument')
+    t.deepEqual(mockDB.devices.args[0][0], mockRequest.auth.credentials.uid, 'db.devices was passed uid')
+
+    t.equal(mockDevices.synthesizeName.callCount, 1, 'mockDevices.synthesizeName was called once')
+    t.equal(mockDevices.synthesizeName.args[0].length, 1, 'mockDevices.synthesizeName was passed one argument')
+    t.equal(mockDevices.synthesizeName.args[0][0], unnamedDevice, 'mockDevices.synthesizeName was passed unnamed device')
+  })
+})
+

--- a/test/local/devices_tests.js
+++ b/test/local/devices_tests.js
@@ -1,0 +1,241 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var uuid = require('uuid')
+var crypto = require('crypto')
+var test = require('../ptaptest')
+var mocks = require('../mocks')
+
+var modulePath = '../../lib/devices'
+
+test('require', function (t) {
+  t.plan(3)
+  t.equal(typeof require(modulePath), 'function', 'require returns function')
+  t.equal(require(modulePath).length, 3, 'returned function expects three arguments')
+
+  t.test('instantiate', function (t) {
+    t.plan(8)
+    var log = mocks.spyLog()
+    var deviceCreatedAt = Date.now()
+    var deviceId = crypto.randomBytes(16)
+    var device = {
+      name: 'foo',
+      type: 'bar'
+    }
+    var db = mocks.mockDB({
+      device: device,
+      deviceCreatedAt: deviceCreatedAt,
+      deviceId: deviceId
+    })
+    var push = mocks.mockPush()
+    var devices = require(modulePath)(log, db, push)
+
+    t.equal(typeof devices, 'object', 'devices is object')
+    t.equal(Object.keys(devices).length, 2, 'devices has two properties')
+
+    t.equal(typeof devices.upsert, 'function', 'devices has upsert method')
+    t.equal(devices.upsert.length, 3, 'devices.upsert expects three arguments')
+
+    t.equal(typeof devices.synthesizeName, 'function', 'devices has synthesizeName method')
+    t.equal(devices.synthesizeName.length, 1, 'devices.synthesizeName expects 1 argument')
+
+    t.test('devices.upsert', function (t) {
+      t.plan(3)
+      var request = {}
+      var sessionToken = {
+        tokenId: crypto.randomBytes(16),
+        uid: uuid.v4('binary')
+      }
+
+      t.test('create', function (t) {
+        return devices.upsert(request, sessionToken, device)
+          .then(function (result) {
+            t.deepEqual(result, {
+              id: deviceId,
+              name: device.name,
+              type: device.type,
+              createdAt: deviceCreatedAt
+            }, 'result was correct')
+
+            t.equal(db.updateDevice.callCount, 0, 'db.updateDevice was not called')
+
+            t.equal(db.createDevice.callCount, 1, 'db.createDevice was called once')
+            var args = db.createDevice.args[0]
+            t.equal(args.length, 3, 'db.createDevice was passed three arguments')
+            t.deepEqual(args[0], sessionToken.uid, 'first argument was uid')
+            t.deepEqual(args[1], sessionToken.tokenId, 'second argument was sessionTokenId')
+            t.equal(args[2], device, 'third argument was device')
+
+            t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+            args = log.activityEvent.args[0]
+            t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
+            t.equal(args[0], 'device.created', 'first argument was event name')
+            t.equal(args[1], request, 'second argument was request object')
+            t.deepEqual(args[2], {
+              uid: sessionToken.uid.toString('hex'),
+              device_id: deviceId.toString('hex'),
+              is_placeholder: false
+            }, 'third argument contained uid, device_id and is_placeholder')
+
+            t.equal(log.info.callCount, 0, 'log.info was not called')
+
+            t.equal(log.notifyAttachedServices.callCount, 1, 'log.notifyAttachedServices was called once')
+            args = log.notifyAttachedServices.args[0]
+            t.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments')
+            t.equal(args[0], 'device:create', 'first argument was event name')
+            t.equal(args[1], request, 'second argument was request object')
+            t.deepEqual(args[2], {
+              uid: sessionToken.uid,
+              id: deviceId,
+              type: device.type,
+              timestamp: deviceCreatedAt,
+              isPlaceholder: false
+            }, 'third argument was event data')
+
+            t.equal(push.notifyDeviceConnected.callCount, 1, 'push.notifyDeviceConnected was called once')
+            args = push.notifyDeviceConnected.args[0]
+            t.equal(args.length, 3, 'push.notifyDeviceConnected was passed three arguments')
+            t.equal(args[0], sessionToken.uid, 'first argument was uid')
+            t.equal(args[1], device.name, 'second arguent was device name')
+            t.equal(args[2], deviceId.toString('hex'), 'third argument was device id')
+          })
+          .then(function () {
+            db.createDevice.reset()
+            push.notifyDeviceConnected.reset()
+            log.activityEvent.reset()
+            log.notifyAttachedServices.reset()
+          })
+      })
+
+      t.test('create placeholder', function (t) {
+        return devices.upsert(request, sessionToken, {})
+          .then(function (result) {
+            t.equal(db.updateDevice.callCount, 0, 'db.updateDevice was not called')
+            t.equal(db.createDevice.callCount, 1, 'db.createDevice was called once')
+
+            t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+            t.equal(log.activityEvent.args[0][2].is_placeholder, true, 'is_placeholder was correct')
+
+            t.equal(log.info.callCount, 1, 'log.info was called once')
+            t.equal(log.info.args[0].length, 1, 'log.info was passed one argument')
+            t.deepEqual(log.info.args[0][0], {
+              op: 'device:createPlaceholder',
+              uid: sessionToken.uid,
+              id: result.id
+            }, 'argument was event data')
+
+            t.equal(log.notifyAttachedServices.callCount, 1, 'log.notifyAttachedServices was called once')
+            t.equal(log.notifyAttachedServices.args[0][2].isPlaceholder, true, 'isPlaceholder was correct')
+
+            t.equal(push.notifyDeviceConnected.callCount, 1, 'push.notifyDeviceConnected was called once')
+          })
+          .then(function () {
+            db.createDevice.reset()
+            push.notifyDeviceConnected.reset()
+            log.activityEvent.reset()
+            log.info.reset()
+            log.notifyAttachedServices.reset()
+          })
+      })
+
+      t.test('update', function (t) {
+        var deviceInfo = {
+          id: deviceId,
+          name: device.name,
+          type: device.type
+        }
+        return devices.upsert(request, sessionToken, deviceInfo)
+          .then(function (result) {
+            t.equal(result, deviceInfo, 'result was correct')
+
+            t.equal(db.createDevice.callCount, 0, 'db.createDevice was not called')
+
+            t.equal(db.updateDevice.callCount, 1, 'db.updateDevice was called once')
+            var args = db.updateDevice.args[0]
+            t.equal(args.length, 3, 'db.createDevice was passed three arguments')
+            t.deepEqual(args[0], sessionToken.uid, 'first argument was uid')
+            t.deepEqual(args[1], sessionToken.tokenId, 'second argument was sessionTokenId')
+            t.deepEqual(args[2], {
+              id: deviceId,
+              name: device.name,
+              type: device.type
+            }, 'device info was unmodified')
+
+            t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+            args = log.activityEvent.args[0]
+            t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
+            t.equal(args[0], 'device.updated', 'first argument was event name')
+            t.equal(args[1], request, 'second argument was request object')
+            t.deepEqual(args[2], {
+              uid: sessionToken.uid.toString('hex'),
+              device_id: deviceId.toString('hex'),
+              is_placeholder: false
+            }, 'third argument contained uid and device_id')
+
+            t.equal(log.info.callCount, 0, 'log.info was not called')
+
+            t.equal(log.notifyAttachedServices.callCount, 0, 'log.notifyAttachedServices was not called')
+
+            t.equal(push.notifyDeviceConnected.callCount, 0, 'push.notifyDeviceConnected was not called')
+          })
+          .then(function () {
+            db.createDevice.reset()
+            log.activityEvent.reset()
+            log.notifyAttachedServices.reset()
+          })
+      })
+    })
+
+    t.test('devices.synthesizeName', function (t) {
+      t.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux'
+      }), 'foo bar, baz qux', 'result is correct when all ua properties are set')
+
+      t.equal(devices.synthesizeName({
+        uaBrowserVersion: 'foo',
+        uaOS: 'bar',
+        uaOSVersion: 'baz'
+      }), 'bar baz', 'result is correct when uaBrowser property is missing')
+
+      t.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaOS: 'bar',
+        uaOSVersion: 'baz'
+      }), 'foo, bar baz', 'result is correct when uaBrowserVersion property is missing')
+
+      t.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOSVersion: 'baz'
+      }), 'foo bar', 'result is correct when uaOS property is missing')
+
+      t.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz'
+      }), 'foo bar, baz', 'result is correct when uaOSVersion property is missing')
+
+      t.equal(devices.synthesizeName({
+        uaBrowser: 'wibble',
+        uaBrowserVersion: 'blee'
+      }), 'wibble blee', 'result is correct when both uaOS properties are missing')
+
+      t.equal(devices.synthesizeName({
+        uaOS: 'foo'
+      }), 'foo', 'result is correct when only uaOS property is present')
+
+      t.equal(devices.synthesizeName({
+        uaOSVersion: 'foo'
+      }), '', 'result defaults to the empty string')
+
+      t.end()
+    })
+  })
+})
+

--- a/test/local/sign_routes.js
+++ b/test/local/sign_routes.js
@@ -14,11 +14,15 @@ var test = require('../ptaptest')
 test(
   '/certificate/sign',
   function (t) {
+    t.plan(4)
+    var deviceId = crypto.randomBytes(16)
+    var mockDevices = mocks.mockDevices({
+      deviceId: deviceId
+    })
     var mockLog = mocks.spyLog()
     var mockRequest = mocks.mockRequest({
       credentials: {
         accountCreatedAt: Date.now(),
-        deviceId: crypto.randomBytes(16),
         emailVerified: true,
         lastAuthAt: function () {
           return Date.now()
@@ -37,47 +41,105 @@ test(
       },
       query: {}
     })
-    var signRoutes = makeRoutes({
-      config: {
-        memcache: {
-          address: '127.0.0.1:11211',
-          idle: 100
-        }
-      },
-      log: mockLog
-    })
 
-    return new P(function (resolve) {
-      getRoute(signRoutes, '/certificate/sign')
-        .handler(mockRequest, resolve)
-    })
-    .then(
-      function () {
-        t.equal(mockLog.activityEvent.callCount, 1)
-        t.equal(mockLog.activityEvent.args[0].length, 3)
-        t.equal(mockLog.activityEvent.args[0][0], 'account.signed')
-        t.equal(mockLog.activityEvent.args[0][1], mockRequest)
-        t.deepEqual(mockLog.activityEvent.args[0][2], {
+    t.test('without service', function (t) {
+      return runTest({
+        devices: mockDevices,
+        log: mockLog
+      }, mockRequest, function () {
+        t.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
+        var args = mockDevices.upsert.args[0]
+        t.equal(args.length, 3, 'devices.upsert was passed one argument')
+        t.equal(args[0], mockRequest, 'first argument was request object')
+        t.equal(args[1], mockRequest.auth.credentials, 'second argument was sessionToken')
+        t.deepEqual(args[2], {}, 'third argument was empty object')
+
+        t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
+        args = mockLog.activityEvent.args[0]
+        t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
+        t.equal(args[0], 'account.signed', 'first argument was event name')
+        t.equal(args[1], mockRequest, 'second argument was request object')
+        t.deepEqual(args[2], {
           uid: mockRequest.auth.credentials.uid.toString('hex'),
           account_created_at: mockRequest.auth.credentials.accountCreatedAt,
-          device_id: mockRequest.auth.credentials.deviceId.toString('hex')
-        })
-      },
-      function () {
-        t.fail('request should have succeeded')
-      }
-    )
+          device_id: deviceId.toString('hex')
+        }, 'third argument was event data')
+      })
+      .then(function () {
+        mockLog.activityEvent.reset()
+        mockDevices.upsert.reset()
+      })
+    })
+
+    t.test('with service=sync', function (t) {
+      mockRequest.query.service = 'sync'
+
+      return runTest({
+        devices: mockDevices,
+        log: mockLog
+      }, mockRequest, function () {
+        t.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
+        t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
+      })
+      .then(function () {
+        mockLog.activityEvent.reset()
+        mockDevices.upsert.reset()
+      })
+    })
+
+    t.test('with service=foo', function (t) {
+      mockRequest.query.service = 'foo'
+
+      return runTest({
+        devices: mockDevices,
+        log: mockLog
+      }, mockRequest, function () {
+        t.equal(mockDevices.upsert.callCount, 0, 'devices.upsert was not called')
+        t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
+        t.equal(mockLog.activityEvent.args[0][2].device_id, undefined, 'device_id was undefined')
+      })
+      .then(function () {
+        mockLog.activityEvent.reset()
+        mockDevices.upsert.reset()
+      })
+    })
+
+    t.test('with deviceId', function (t) {
+      mockRequest.query.service = 'sync'
+      mockRequest.auth.credentials.deviceId = crypto.randomBytes(16)
+
+      return runTest({
+        devices: mockDevices,
+        log: mockLog
+      }, mockRequest, function () {
+        t.equal(mockDevices.upsert.callCount, 0, 'devices.upsert was not called')
+        t.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
+        t.equal(mockLog.activityEvent.args[0][2].device_id, mockRequest.auth.credentials.deviceId.toString('hex'), 'device_id was correct')
+      })
+      .then(function () {
+        mockLog.activityEvent.reset()
+        mockDevices.upsert.reset()
+      })
+    })
   }
 )
+
+function runTest (options, request, assertions) {
+  return new P(function (resolve) {
+    getRoute(makeRoutes(options), '/certificate/sign')
+      .handler(request, resolve)
+  })
+  .then(assertions)
+}
 
 function makeRoutes (options) {
   options = options || {}
 
   var log = options.log || mocks.mockLog()
-  var config = options.config || {}
 
   return require('../../lib/routes/sign')(
     log,
+    P,
     isA,
     error,
     options.signer || {
@@ -90,7 +152,7 @@ function makeRoutes (options) {
       updateLocale: function () {}
     },
     options.domain || 'wibble',
-    options.metricsContext || require('../../lib/metrics/context')(log, config)
+    options.devices
   )
 }
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -16,7 +16,7 @@ var DB_METHOD_NAMES = ['account', 'createAccount', 'createDevice', 'createKeyFet
                        'deleteDevice', 'deleteKeyFetchToken', 'deletePasswordChangeToken',
                        'deleteVerificationReminder', 'devices', 'emailRecord', 'resetAccount',
                        'sessions', 'sessionTokenWithVerificationStatus', 'updateDevice',
-                       'verifyEmail', 'verifyTokens']
+                       'updateLocale', 'updateSessionToken', 'verifyEmail', 'verifyTokens']
 
 var LOG_METHOD_NAMES = ['trace', 'increment', 'info', 'error', 'begin', 'warn', 'timing',
                         'activityEvent', 'notifyAttachedServices']
@@ -33,6 +33,7 @@ var PUSH_METHOD_NAMES = ['notifyDeviceConnected', 'notifyDeviceDisconnected', 'n
 
 module.exports = {
   mockDB: mockDB,
+  mockDevices: mockDevices,
   mockLog: mockLog,
   spyLog: spyLog,
   mockMailer: mockObject(MAILER_METHOD_NAMES),
@@ -103,7 +104,7 @@ function mockDB (data, errors) {
       })
     }),
     devices: sinon.spy(function () {
-      return P.resolve([])
+      return P.resolve(data.devices || [])
     }),
     emailRecord: sinon.spy(function () {
       if (errors.emailRecord) {
@@ -124,7 +125,7 @@ function mockDB (data, errors) {
       })
     }),
     sessions: sinon.spy(function () {
-      return P.resolve([])
+      return P.resolve(data.sessions || [])
     }),
     updateDevice: sinon.spy(function (uid, sessionTokenId, device) {
       return P.resolve(device)
@@ -147,6 +148,23 @@ function mockObject (methodNames) {
 
       return object
     }, {})
+  }
+}
+
+function mockDevices (data) {
+  data = data || {}
+
+  return {
+    upsert: sinon.spy(function () {
+      return P.resolve({
+        id: data.deviceId || crypto.randomBytes(16),
+        name: data.deviceName || 'mock device name',
+        type: data.deviceType || 'desktop'
+      })
+    }),
+    synthesizeName: sinon.spy(function () {
+      return data.deviceName || null
+    })
   }
 }
 
@@ -185,7 +203,7 @@ function spyLog (methods) {
 function mockRequest (data) {
   return {
     app: {
-      acceptLangage: 'en-US',
+      acceptLanguage: 'en-US',
       clientAddress: '8.8.8.8'
     },
     auth: {


### PR DESCRIPTION
@seanmonstar r?

I forgot to create an issue to cover this one but it reinstates placeholder devices, which initially got merged in #1299 before being reverted in #1344. The original issue for the feature was #1196.

It was reverted because of two problems:

1. Vanilla web sessions started showing up in the devices view. That problem was fixed by https://github.com/mozilla/fxa-js-client/pull/205 and https://github.com/mozilla/fxa-content-server/pull/3957.

2. The device name was blank. That problem is fixed in this PR by ensuring that `db.devices` returns the parsed user agent info (line 443 of `lib/db.js`, tests at line 296 of `test/remote/db_tests.js`), which is also why the extra deletes are added to `/account/devices` handler.

Tested locally, but I also hope/plan to have it running in AWS if I can resolve my deployment woe.

For local testing, I failed to get Firefox running in an emulator for either Android or iOS. So instead I hacked a local build of desktop Firefox and commented out device registration, for screenshot/demo purposes.

Here's a screenshot of a placeholder device from the aforementioned local build of desktop Firefox:

<img width="762" alt="Screenshot of Firefox Accounts devices view, showing a placeholder device record." src="https://cloud.githubusercontent.com/assets/64367/17482259/dde6c4ea-5d78-11e6-9aa0-4913d33af47f.png" />


