### PR TITLE
fix(logging): not all activity events are flow events

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -92,27 +92,23 @@ if that header is set to `1`.
 
 #### Flow event structure
 
-Flow events are JSON data.
-Some fields are common to all events,
-others are event-specific.
-Some fields are optional depending on context,
-others are mandatory.
+Flow events are JSON data
+containg the following fields:
 
-|Event|Mandatory fields|Optional fields|
-|-----|----------------|---------------|
-|`account.created`|`event`, `flow_id`, `flow_time`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.verified`|`event`, `flow_id`, `flow_time`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.login`|`event`, `flow_id`, `flow_time`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.confirmed`|`event`, `flow_id`, `flow_time`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.keyfetch`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `flow_id`, `flow_time`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.signed`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `flow_id`, `flow_time`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.reset`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.reminder`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`account.deleted`|`event`, `time`, `userAgent`|`context`, `entrypoint` `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`device.created`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `flow_id`, `flow_time`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`device.updated`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `flow_id`, `flow_time`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`device.deleted`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
-|`customs.blocked`|`event`, `time`, `userAgent`|`context`, `entrypoint`, `flow_id`, `flow_time`, `migration`, `service`, `utm_campaign`, `utm_content`, `utm_medium`, `utm_source`, `utm_term`|
+* `event`
+* `flow_id`
+* `flow_time`
+* `time`
+* `userAgent`
+* `context` (optional)
+* `entrypoint` (optional)
+* `migration` (optional)
+* `service` (optional)
+* `utm_campaign` (optional)
+* `utm_content` (optional)
+* `utm_medium` (optional)
+* `utm_source` (optional)
+* `utm_term` (optional)
 
 ##### Example event
 

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -69,6 +69,7 @@ test(
     t.equal(typeof log.begin, 'function', 'log.begin method was exported')
     t.equal(typeof log.notifyAttachedServices, 'function', 'log.notifyAttachedServices method was exported')
     t.equal(typeof log.activityEvent, 'function', 'log.activityEvent method was exported')
+    t.equal(typeof log.flowEvent, 'function', 'log.flowEvent method was exported')
     t.equal(typeof log.increment, 'function', 'log.increment method was exported')
     t.equal(typeof log.stat, 'function', 'log.stat method was exported')
     t.equal(typeof log.summary, 'function', 'log.summary method was exported')
@@ -91,19 +92,10 @@ test(
     return log.activityEvent('bar', request, {
       uid: 'baz'
     }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-      var args = metricsContext.gather.args[0]
-      t.equal(args.length, 3, 'metricsContext.gather was passed three arguments')
-      t.equal(typeof args[0], 'object', 'first argument was object')
-      t.notEqual(args[0], null, 'first argument was not null')
-      t.equal(Object.keys(args[0]).length, 2, 'first argument had two properties')
-      t.equal(args[0].event, 'bar', 'event property was correct')
-      t.equal(args[0].userAgent, 'foo', 'userAgent property was correct')
-      t.equal(args[1], request, 'second argument was request object')
-      t.equal(args[2], 'bar', 'third argument was event name')
+      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
 
-      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
-      args = logger.info.args[0]
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
+      var args = logger.info.args[0]
       t.equal(args.length, 2, 'logger.info was passed two arguments')
       t.equal(args[0], 'activityEvent', 'first argument was correct')
       t.equal(typeof args[1], 'object', 'second argument was object')
@@ -111,14 +103,133 @@ test(
       t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
       t.equal(args[1].uid, 'baz', 'uid property was correct')
 
-      // flow event data
-      t.equal(logger.info.args[1][0], 'flowEvent', 'correct op name')
-      t.equal(logger.info.args[1][1].event, 'bar', 'correct event name')
-
       t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
       args = statsd.write.args[0]
       t.equal(args.length, 1, 'statsd.write was passed one argument')
       t.equal(args[0], logger.info.args[0][1], 'statsd.write argument was correct')
+
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+      logger.info.reset()
+      statsd.write.reset()
+    })
+  }
+)
+
+test(
+  'log.activityEvent with flow event',
+  function (t) {
+    var request = {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flow_id: 'bar'
+        }
+      }
+    }
+    return log.activityEvent('account.created', request, {
+      uid: 'baz'
+    }).then(function () {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+      var args = metricsContext.gather.args[0]
+      t.equal(args.length, 3, 'metricsContext.gather was passed three arguments')
+      t.equal(typeof args[0], 'object', 'first argument was object')
+      t.notEqual(args[0], null, 'first argument was not null')
+      t.equal(Object.keys(args[0]).length, 2, 'first argument had two properties')
+      t.equal(args[0].event, 'account.created', 'event property was correct')
+      t.equal(args[0].userAgent, 'foo', 'userAgent property was correct')
+      t.equal(args[1], request, 'second argument was request object')
+      t.equal(args[2], 'account.created', 'third argument was event name')
+
+      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
+      t.equal(logger.info.args[0][0], 'activityEvent', 'first call was activityEvent')
+      t.equal(logger.info.args[1][0], 'flowEvent', 'second call was flowEvent')
+      t.equal(logger.info.args[1][1].event, 'account.created', 'flowEvent had correct event name')
+
+      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+      metricsContext.gather.reset()
+      logger.info.reset()
+      statsd.write.reset()
+    })
+  }
+)
+
+test(
+  'log.activityEvent with flow event and missing flow_id',
+  function (t) {
+    var request = {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {}
+      }
+    }
+    return log.activityEvent('account.created', request, {
+      uid: 'bar'
+    }).then(function () {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
+      t.equal(logger.info.args[0][0], 'activityEvent', 'call was activityEvent')
+
+      t.equal(logger.error.callCount, 1, 'logger.error was called once')
+      var args = logger.error.args[0]
+      t.equal(args.length, 2, 'logger.error was passed two arguments')
+      t.equal(args[0], 'log.flowEvent')
+      t.deepEqual(args[1], {
+        op: 'log.flowEvent',
+        event: 'account.created',
+        missingFlowId: true
+      }, 'error data was correct')
+
+      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+      metricsContext.gather.reset()
+      logger.info.reset()
+      logger.error.reset()
+      statsd.write.reset()
+    })
+  }
+)
+
+test(
+  'log.activityEvent with optional flow event and missing flow_id',
+  function (t) {
+    var request = {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {}
+      }
+    }
+    return log.activityEvent('account.signed', request, {
+      uid: 'bar'
+    }).then(function () {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
+      t.equal(logger.info.args[0][0], 'activityEvent', 'call was activityEvent')
+
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+
+      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
 
       t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
       t.equal(logger.error.callCount, 0, 'logger.error was not called')
@@ -144,15 +255,8 @@ test(
     }, {
       uid: 'ugg'
     }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-      var args = metricsContext.gather.args[0]
-      t.equal(args[0].event, 'wibble', 'event property was correct')
-      t.equal(args[0].userAgent, undefined, 'userAgent property was undefined')
-      t.equal(typeof args[1], 'object', 'second argument was object')
-      t.notEqual(args[1], null, 'second argument was not null')
-
-      t.equal(logger.info.callCount, 2, 'logger.info was called once')
-      args = logger.info.args[0]
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
+      var args = logger.info.args[0]
       t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
       t.equal(args[1].service, 'blee', 'service property was correct')
       t.equal(args[1].uid, 'ugg', 'service property was correct')
@@ -166,7 +270,6 @@ test(
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
 
-      metricsContext.gather.reset()
       logger.info.reset()
       statsd.write.reset()
     })
@@ -187,18 +290,9 @@ test(
     }, {
       uid: 'baz'
     }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-      t.equal(metricsContext.gather.args[0][0].event, 'foo', 'event property was correct')
-
-      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
       t.equal(logger.info.args[0][1].service, 'bar', 'service property was correct')
 
-      // flow event data
-      t.equal(logger.info.args[1][0], 'flowEvent', 'correct op name')
-      t.equal(logger.info.args[1][1].event, 'foo', 'correct event name')
-      t.equal(logger.info.args[1][1].service, 'bar', 'correct service name for the flow event')
-
-
       t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
       t.equal(statsd.write.args[0][0], logger.info.args[0][1], 'statsd.write argument was correct')
 
@@ -207,47 +301,6 @@ test(
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
 
-      metricsContext.gather.reset()
-      logger.info.reset()
-      statsd.write.reset()
-    })
-  }
-)
-
-test(
-  'log.activityEvent with service metricsContext property and service payload parameter',
-  function (t) {
-    return log.activityEvent('foo', {
-      headers: {},
-      payload: {
-        metricsContext: {
-          service: 'bar'
-        },
-        service: 'baz'
-      }
-    }, {
-      uid: 'qux'
-    }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-
-      // activity event data
-      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
-      t.equal(logger.info.args[0][1].service, 'baz', 'service property was correct for the activity event')
-
-      // flow event data
-      t.equal(logger.info.args[1][0], 'flowEvent', 'correct op name')
-      t.equal(logger.info.args[1][1].event, 'foo', 'correct event name')
-      t.equal(logger.info.args[1][1].service, 'bar', 'correct service name for the flow event')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-      t.equal(statsd.write.args[0][0], logger.info.args[0][1], 'statsd.write argument was correct')
-
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      metricsContext.gather.reset()
       logger.info.reset()
       statsd.write.reset()
     })
@@ -269,10 +322,7 @@ test(
       uid: 42,
       wibble: 'blee'
     }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-      t.equal(Object.keys(metricsContext.gather.args[0][0]).length, 2, 'first argument had two properties')
-
-      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
       var args = logger.info.args[0]
       t.equal(Object.keys(args[1]).length, 5, 'second argument had 5 properties')
       t.equal(args[1].baz, 'qux', 'first extra data property was correct')
@@ -286,7 +336,6 @@ test(
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
 
-      metricsContext.gather.reset()
       logger.info.reset()
       statsd.write.reset()
     })
@@ -349,7 +398,6 @@ test(
   }
 )
 
-
 test(
   'log.flowEvent with bad event name',
   function (t) {
@@ -372,10 +420,11 @@ test(
 test(
   'log.flowEvent with a bad request',
   function (t) {
-    return log.flowEvent('some.event').then(function () {
+    return log.flowEvent('account.login').then(function () {
       t.equal(logger.error.callCount, 1, 'logger.error was called once')
       var args = logger.error.args[0]
       t.equal(args[0], 'log.flowEvent', 'correct op')
+      t.equal(args[1].event, 'account.login', 'correct event name')
       t.equal(args[1].badRequest, true, 'correct flag')
 
       t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
@@ -391,33 +440,88 @@ test(
 test(
   'log.flowEvent properly logs with no errors',
   function (t) {
-    return log.flowEvent('some.event', {
+    return log.flowEvent('account.login', {
       headers: {
-        'user-agent': 'bar'
+        'user-agent': 'foo'
       },
       payload: {
         metricsContext: {
-          service: 'bar'
+          flow_id: 'bar',
+          service: 'baz'
         },
-        service: 'baz'
+        service: 'qux'
       }
     }).then(function () {
-      t.equal(logger.info.callCount, 1, 'logger.info was called')
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
       var args = logger.info.args[0]
       t.equal(args[0], 'flowEvent', 'correct event name')
-      t.equal(args[1].service, 'bar', 'correct metrics data')
-      t.equal(args[1].event, 'some.event', 'correct event name')
+      t.equal(args[1].event, 'account.login', 'correct event name')
+      t.equal(args[1].flow_id, 'bar', 'correct flow id')
+      t.equal(args[1].service, 'baz', 'correct metrics data')
 
       t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
       t.equal(logger.error.callCount, 0, 'logger.error was not called')
 
+      metricsContext.gather.reset()
+      logger.info.reset()
+    })
+  }
+)
+
+test(
+  'log.flowEvent with flow event and missing flow_id',
+  function (t) {
+    return log.flowEvent('account.login', {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {}
+      }
+    }).then(function () {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+      t.equal(logger.info.callCount, 0, 'logger.info was not called')
+
+      t.equal(logger.error.callCount, 1, 'logger.error was called once')
+      var args = logger.error.args[0]
+      t.equal(args.length, 2, 'logger.error was passed two arguments')
+      t.equal(args[0], 'log.flowEvent')
+      t.deepEqual(args[1], {
+        op: 'log.flowEvent',
+        event: 'account.login',
+        missingFlowId: true
+      }, 'error data was correct')
+
+      metricsContext.gather.reset()
       logger.error.reset()
     })
   }
 )
 
+test(
+  'log.flowEvent with optional flow event and missing flow_id',
+  function (t) {
+    return log.flowEvent('device.created', {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {}
+      }
+    }).then(function () {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+      t.equal(logger.info.callCount, 0, 'logger.info was not called')
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+
+      metricsContext.gather.reset()
+    })
+  }
+)
 
 test(
   'log.error removes PII from error objects',


### PR DESCRIPTION
It just occurred to me that we over-simplified the relationship between activity events and flow events in #1409 (my fault for not thinking things through properly when reviewing).

There are a number of activity events which should never have a corresponding flow event. And there are a few others that should only have a flow event if `metricsContext.gather` returns a `flowId`.

This change ensures that we limit the flow events only to those that actually constitute part of the sign-up or sign-in flow. And if we encounter any flow events that do not have a `flowId` we now log an error, which we weren't doing previously.

Doing this also meant we could ditch that really ugly table from the docs, because all of the events now have a uniform structure.

@vladikoff, r?

Sign-up log excerpt:
```
activityEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","service":"sync","uid":"85c9370f720c4d5996000d263c01f683"}
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471301451352,"flow_id":"d0de54d2cfca756509df5a8bb572fb806bb492085aff32c304599411263695c4","flow_time":8890,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","service":"sync","uid":"85c9370f720c4d5996000d263c01f683"}
flowEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471301464074,"flow_id":"d0de54d2cfca756509df5a8bb572fb806bb492085aff32c304599411263695c4","flow_time":21612,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"85c9370f720c4d5996000d263c01f683"}
flowEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471301476234,"flow_id":"d0de54d2cfca756509df5a8bb572fb806bb492085aff32c304599411263695c4","flow_time":33772,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"device.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"85c9370f720c4d5996000d263c01f683","device_id":"181ee195fd7169a76c09547e93a3fb3b","is_placeholder":true}
flowEvent {"event":"device.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471301476269,"flow_id":"d0de54d2cfca756509df5a8bb572fb806bb492085aff32c304599411263695c4","flow_time":33807,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"85c9370f720c4d5996000d263c01f683","account_created_at":1471301451354,"device_id":"181ee195fd7169a76c09547e93a3fb3b"}
activityEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"85c9370f720c4d5996000d263c01f683","account_created_at":1471301451354,"device_id":"181ee195fd7169a76c09547e93a3fb3b"}
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471301476277,"flow_id":"d0de54d2cfca756509df5a8bb572fb806bb492085aff32c304599411263695c4","flow_time":33815,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
```

Sign-in log excerpt:
```
activityEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","service":"sync","uid":"542d61c6649e403b9eb7d6bf91193f68"}
flowEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471300641922,"flow_id":"7261e24d1c76dcd61737f3e5bbb618e4c091dd53e382f711b58880166f4a050a","flow_time":7541,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","service":"sync","uid":"542d61c6649e403b9eb7d6bf91193f68"}
flowEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471300653153,"flow_id":"7261e24d1c76dcd61737f3e5bbb618e4c091dd53e382f711b58880166f4a050a","flow_time":18772,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"542d61c6649e403b9eb7d6bf91193f68"}
flowEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471300657118,"flow_id":"7261e24d1c76dcd61737f3e5bbb618e4c091dd53e382f711b58880166f4a050a","flow_time":22737,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"device.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"542d61c6649e403b9eb7d6bf91193f68","device_id":"300cb20c6e8252caae5053ffa9c3e134","is_placeholder":true}
flowEvent {"event":"device.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471300657150,"flow_id":"7261e24d1c76dcd61737f3e5bbb618e4c091dd53e382f711b58880166f4a050a","flow_time":22769,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","uid":"542d61c6649e403b9eb7d6bf91193f68","account_created_at":1471300641924,"device_id":"300cb20c6e8252caae5053ffa9c3e134"}
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) Gecko/20100101 Firefox/50.0","time":1471300657155,"flow_id":"7261e24d1c76dcd61737f3e5bbb618e4c091dd53e382f711b58880166f4a050a","flow_time":22774,"context":"fx_desktop_v2","entrypoint":"menupanel","service":"sync"}
```
