### PR TITLE
fix(server): reinstate default user agent fallback

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -83,7 +83,7 @@ module.exports = function (
 
   DB.prototype.createSessionToken = function (authToken, userAgentString) {
     log.trace({ op: 'DB.createSessionToken', uid: authToken && authToken.uid })
-    return SessionToken.create(userAgent.call(authToken, userAgentString))
+    return SessionToken.create(userAgent.call(authToken, userAgentString, log))
       .then(
         function (sessionToken) {
           return this.pool.put(

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -555,7 +555,7 @@ module.exports = function (
                       ip: ip,
                       location: geoData.location,
                       timeZone: geoData.timeZone
-                    }, request.headers['user-agent'])
+                    }, request.headers['user-agent'], log)
                   )
                 }
               )
@@ -584,7 +584,7 @@ module.exports = function (
                       resume: resume,
                       service: service,
                       timeZone: geoData.timeZone
-                    }, request.headers['user-agent'])
+                    }, request.headers['user-agent'], log)
                   )
                 }
               )
@@ -1213,7 +1213,7 @@ module.exports = function (
               redirectTo: request.payload.redirectTo,
               resume: request.payload.resume,
               acceptLanguage: request.app.acceptLanguage
-            }, request.headers['user-agent'])
+            }, request.headers['user-agent'], log)
           ))
           .done(
             function () {

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -65,7 +65,7 @@ module.exports = function (log, inherits, Token) {
 
     var freshData = userAgent.call({
       lastAccessTime: Date.now()
-    }, userAgentString)
+    }, userAgentString, log)
 
     if (this.isFresh(freshData)) {
       return false

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -25,7 +25,9 @@ var MOBILE_OS_FAMILIES = {
   'Windows Phone': null
 }
 
-module.exports = function (userAgentString) {
+var ELLIPSIS = '\u2026'
+
+module.exports = function (userAgentString, log) {
   var userAgentData = ua.parse(userAgentString)
 
   this.uaBrowser = getFamily(userAgentData.ua) || null
@@ -33,6 +35,11 @@ module.exports = function (userAgentString) {
   this.uaOS = getFamily(userAgentData.os) || null
   this.uaOSVersion = getVersion(userAgentData.os) || null
   this.uaDeviceType = getDeviceType(userAgentData) || null
+
+  if (! this.uaBrowser && ! this.uaOS) {
+    // In the worst case, fall back to a truncated user agent string
+    this.uaBrowser = truncate(userAgentString || '', log)
+  }
 
   return this
 }
@@ -63,5 +70,34 @@ function getDeviceType (data) {
 
 function isMobileOS (os) {
   return os.family in MOBILE_OS_FAMILIES
+}
+
+function truncate (userAgentString, log) {
+  log.info({
+    op: 'userAgent:truncate',
+    userAgent: userAgentString
+  })
+
+  // Completely arbitrary truncation length. This should be a very rare
+  // condition, so we just want something that is long enough to convey
+  // some meaningful information without being too messy.
+  var length = 60
+
+  if (userAgentString.length < length) {
+    return userAgentString
+  }
+
+  if (/.+\(.+\)/.test(userAgentString)) {
+    var openingIndex = userAgentString.indexOf('(')
+    var closingIndex = userAgentString.indexOf(')')
+
+    if (openingIndex < closingIndex && closingIndex < 100) {
+      // If there is a closing parenthesis within a reasonable length,
+      // allow the string to be a bit longer than our arbitrary maximum.
+      length = closingIndex + 1
+    }
+  }
+
+  return userAgentString.substr(0, length) + ELLIPSIS
 }
 


### PR DESCRIPTION
This has now received approval from legal. The fix just ensures that placeholder devices get a name based on the user agent string, if we failed to parse it for whatever reason.

In lieu of a legacy device to test on, I did the following:

1. Commented out [the call to `this.updateDeviceRegistration` in `setSignedInUser`](https://dxr.mozilla.org/mozilla-central/source/services/fxaccounts/FxAccounts.jsm#556), in a local build of Firefox:

   <img width="553" alt="screen shot 2016-08-17 at 09 20 10" src="https://cloud.githubusercontent.com/assets/64367/17729379/dea6583e-645b-11e6-8dfd-b9a492f292e6.png" />

2. Changed my user agent to something silly:

   <img width="789" alt="Screenshot of the user agent string in about:config" src="https://cloud.githubusercontent.com/assets/64367/17729154/b944c1a8-645a-11e6-826e-b6652a5f9803.png" />

3. Signed in and navigated to the devices view:

   <img width="787" alt="Screenshot of the truncated user agent string as the device name" src="https://cloud.githubusercontent.com/assets/64367/17729164/c6f0dcc4-645a-11e6-9368-db999cf781d9.png" />

The limits used for truncation are completely arbitrary, I'm open to other suggestions if anyone has them. In reality, this code should be executed very rarely.

@vladikoff, r?