### PR TITLE
fix(logs): look in response.source for uid

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -150,7 +150,8 @@ Lug.prototype.summary = function (request, response) {
   }
   line.uid = (request.auth && request.auth.credentials) ?
     request.auth.credentials.uid :
-    payload.uid || query.uid || response.uid || '00'
+    payload.uid || query.uid || response.uid ||
+    (response.source && response.source.uid) || '00'
   line.service = payload.service || query.service
   line.reason = payload.reason || query.reason
   line.redirectTo = payload.redirectTo || query.redirectTo


### PR DESCRIPTION
Diving through hapi code, this is the trail I took to decide to inspect `response.source`:

1. `reply(data)` https://github.com/hapijs/hapi/blob/v8.8.1/lib/reply.js#L65
2. `reply.response(data)` https://github.com/hapijs/hapi/blob/v8.8.1/lib/reply.js#L128
3. `Response.wrap(data)` https://github.com/hapijs/hapi/blob/v8.8.1/lib/response.js#L56
4. `new Response(data, ...)` https://github.com/hapijs/hapi/blob/v8.8.1/lib/response.js#L15
5. `Response._setSource(data, ...)` https://github.com/hapijs/hapi/blob/v8.8.1/lib/response.js#L88

There doesn't appear to be a public API to inspect the waiting JSON response, so this may be brittle and require updating when we upgrade hapi.