### PR TITLE
feat(hpkp): Add hpkp headers to all requests

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -479,25 +479,29 @@ var conf = convict({
     }
   },
   hpkpConfig: {
+    enabled: {
+      default: true,
+      doc: 'Feature flag for appending HPKP headers'
+    },
+    includeSubDomains: {
+      default: true,
+      doc: 'Include Sub-Domains',
+      env: 'HPKP_INCLUDE_SUBDOMAINS'
+    },
     max_age: {
-      doc: 'Max age for HPKP headers',
-      default: 0,
+      default: 1,
+      doc: 'Max age for HPKP headers (milliseconds)',
       env: 'HPKP_MAX_AGE'
     },
     pin_sha256: {
-      doc: 'Supported pin-sha256s',
-      format: Array,
       default: [
         '5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=',
         'PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw=',
         'r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E='
       ],
-      env: 'HPKP_PIN_SHA256'
-    },
-    includeSubDomains: {
-      doc: 'Include Sub-Domains',
-      default: true,
-      env: 'HPKP_INCLUDE_SUBDOMAINS'
+      doc: 'Supported pin-sha256s',
+      env: 'HPKP_PIN_SHA256',
+      format: Array
     }
   }
 })

--- a/config/index.js
+++ b/config/index.js
@@ -477,6 +477,28 @@ var conf = convict({
       ],
       env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }
+  },
+  hpkpConfig: {
+    max_age: {
+      doc: 'Max age for HPKP headers',
+      default: 0,
+      env: 'HPKP_MAX_AGE'
+    },
+    pin_sha256: {
+      doc: 'Supported pin-sha256s',
+      format: Array,
+      default: [
+        '5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=',
+        'PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw=',
+        'r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E='
+      ],
+      env: 'HPKP_PIN_SHA256'
+    },
+    includeSubDomains: {
+      doc: 'Include Sub-Domains',
+      default: true,
+      env: 'HPKP_INCLUDE_SUBDOMAINS'
+    }
   }
 })
 

--- a/lib/hpkp.js
+++ b/lib/hpkp.js
@@ -12,7 +12,7 @@
  */
 module.exports = function (maxAge, sha256Pins, includeSubdomains) {
 
-  var hpkpParts = [];
+  var hpkpParts = []
 
   sha256Pins.forEach(function (pinSha) {
     hpkpParts.push('pin-sha256="' + pinSha + '"')

--- a/lib/hpkp.js
+++ b/lib/hpkp.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Hapi middleware to append HPKP headers to all responses.
+ *
+ * @param maxAge
+ * @param sha256Pins
+ * @param includeSubdomains
+ * @returns {Function}
+ */
+module.exports = function (maxAge, sha256Pins, includeSubdomains) {
+
+  var hpkpParts = [];
+
+  sha256Pins.forEach(function (pinSha) {
+    hpkpParts.push('pin-sha256="' + pinSha + '"')
+  })
+
+  hpkpParts.push('max-age=' + maxAge)
+
+  if (includeSubdomains) {
+    hpkpParts.push('includeSubdomains')
+  }
+
+  var hpkpHeader = hpkpParts.join('; ')
+
+  return function (request, reply) {
+    var response = request.response
+
+    if (response.header) {
+      response.header('Public-Key-Pins', hpkpHeader)
+    }
+
+    return reply.continue()
+  }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -243,6 +243,22 @@ function create(log, error, config, routes, db) {
     }
   )
 
+  var hpkpHeader
+  if (config.hpkpConfig) {
+    // Build HPKP header value
+    hpkpHeader = 'max-age=' + config.hpkpConfig.max_age + '; '
+
+    if (config.hpkpConfig.includeSubDomains) {
+      hpkpHeader = hpkpHeader + 'includeSubDomains; '
+    }
+
+    config.hpkpConfig.pin_sha256.forEach(function (pinSha) {
+      hpkpHeader = hpkpHeader + 'pin-sha256=\"' + pinSha + '\"; '
+    })
+
+    hpkpHeader = hpkpHeader.trim()
+  }
+
   server.ext(
     'onPreResponse',
     function (request, reply) {
@@ -254,6 +270,12 @@ function create(log, error, config, routes, db) {
         }
       }
       response.header('Timestamp', '' + Math.floor(Date.now() / 1000))
+
+      // Set HPKP header
+      if (hpkpHeader) {
+        response.header('Public-Key-Pins', hpkpHeader)
+      }
+
       log.summary(request, response)
       reply(response)
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 var path = require('path')
 var url = require('url')
 var Hapi = require('hapi')
-
+var hpkp = require('./hpkp')
 var HEX_STRING = require('./routes/validators').HEX_STRING
 
 
@@ -243,20 +243,8 @@ function create(log, error, config, routes, db) {
     }
   )
 
-  var hpkpHeader
-  if (config.hpkpConfig) {
-    // Build HPKP header value
-    hpkpHeader = 'max-age=' + config.hpkpConfig.max_age + '; '
-
-    if (config.hpkpConfig.includeSubDomains) {
-      hpkpHeader = hpkpHeader + 'includeSubDomains; '
-    }
-
-    config.hpkpConfig.pin_sha256.forEach(function (pinSha) {
-      hpkpHeader = hpkpHeader + 'pin-sha256=\"' + pinSha + '\"; '
-    })
-
-    hpkpHeader = hpkpHeader.trim()
+  if (config.hpkpConfig && config.hpkpConfig.enabled) {
+    server.ext('onPreResponse', hpkp(config.hpkpConfig.max_age, config.hpkpConfig.pin_sha256, config.hpkpConfig.includeSubDomains))
   }
 
   server.ext(
@@ -270,11 +258,6 @@ function create(log, error, config, routes, db) {
         }
       }
       response.header('Timestamp', '' + Math.floor(Date.now() / 1000))
-
-      // Set HPKP header
-      if (hpkpHeader) {
-        response.header('Public-Key-Pins', hpkpHeader)
-      }
 
       log.summary(request, response)
       reply(response)

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -92,9 +92,12 @@ TestServer.start(config)
       url: config.publicUrl + '/'
     }
 
-    var expectedHeader = 'max-age=0; includeSubDomains; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="; pin-sha256="PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";'
+    var headerValue = 'pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="; ' +
+      'pin-sha256="PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw="; ' +
+      'pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E="; ' +
+      'max-age=1; includeSubdomains';
     request(options, function (err, res, body) {
-      t.equal(res.headers['public-key-pins'], expectedHeader, 'HPKP header was set correctly')
+      t.equal(res.headers['public-key-pins'], headerValue, 'HPKP header was set correctly')
       t.end()
     })
   })

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -95,7 +95,7 @@ TestServer.start(config)
     var headerValue = 'pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="; ' +
       'pin-sha256="PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw="; ' +
       'pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E="; ' +
-      'max-age=1; includeSubdomains';
+      'max-age=1; includeSubdomains'
     request(options, function (err, res, body) {
       t.equal(res.headers['public-key-pins'], headerValue, 'HPKP header was set correctly')
       t.end()

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -87,6 +87,18 @@ TestServer.start(config)
     testCORSHeader(false)
   )
 
+  test('returns correct HPKP header', function (t) {
+    var options = {
+      url: config.publicUrl + '/'
+    }
+
+    var expectedHeader = 'max-age=0; includeSubDomains; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="; pin-sha256="PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";'
+    request(options, function (err, res, body) {
+      t.equal(res.headers['public-key-pins'], expectedHeader, 'HPKP header was set correctly')
+      t.end()
+    })
+  })
+
   test(
     '/verify_email redirects',
     function (t) {


### PR DESCRIPTION
This adds the HPKP header to all requests.

Header:
```
Public-Key-Pins: max-age=2592000; includeSubDomains; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="; pin-sha256="PZXN3lRAy+8tBKk2Ox6F7jIlnzr2Yzmwqc3JnyfXoCw="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
```

Ref: https://github.com/mozilla/fxa-bugzilla-mirror/issues/179