### PR TITLE
fix(emails): On login, delegate email sending to auth-server

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -551,8 +551,10 @@ module.exports = function (
             sendEmailIfUnverified = request.payload.sendEmailIfUnverified
           }
 
-          var shouldSEndVerifyAccountEmail = sendEmailIfUnverified && !emailRecord.emailVerified
-          if (shouldSEndVerifyAccountEmail) {
+          var shouldSendVerifyAccountEmail = sendEmailIfUnverified && !emailRecord.emailVerified
+          if (shouldSendVerifyAccountEmail) {
+            // Resend the account verification email using the tokenVerificationId so that the session
+            // that initiated the login will also get verified.
             return mailer.sendVerifyCode(emailRecord, tokenVerificationId, {
               service: service,
               redirectTo: redirectTo,

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -332,6 +332,9 @@ module.exports = function (
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             // Obsolete contentToken param, here for backwards compat.
             contentToken: isA.string().optional(),
+            // Delegate sending emails for unverified users to auth-server.
+            // Will be removed once all clients have been updated not to send verify emails.
+            // https://github.com/mozilla/fxa-auth-server/issues/1325
             sendEmailIfUnverified: isA.boolean().optional(),
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: isA.string().uri().optional(),

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -342,7 +342,6 @@ module.exports = function (
         },
         response: {
           schema: {
-            emailSent: isA.boolean().optional(),
             uid: isA.string().regex(HEX_STRING).required(),
             sessionToken: isA.string().regex(HEX_STRING).required(),
             keyFetchToken: isA.string().regex(HEX_STRING).optional(),

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -332,6 +332,7 @@ module.exports = function (
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             // Obsolete contentToken param, here for backwards compat.
             contentToken: isA.string().optional(),
+            sendEmailIfUnverified: isA.boolean().optional(),
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: isA.string().uri().optional(),
             resume: isA.string().optional(),
@@ -341,6 +342,7 @@ module.exports = function (
         },
         response: {
           schema: {
+            emailSent: isA.boolean().optional(),
             uid: isA.string().regex(HEX_STRING).required(),
             sessionToken: isA.string().regex(HEX_STRING).required(),
             keyFetchToken: isA.string().regex(HEX_STRING).optional(),
@@ -380,6 +382,7 @@ module.exports = function (
           .then(createSessionToken)
           .then(createKeyFetchToken)
           .then(emitSyncLoginEvent)
+          .then(sendVerifyAccountEmail)
           .then(sendNewDeviceLoginNotification)
           .then(sendVerifyLoginEmail)
           .then(createResponse)
@@ -534,6 +537,27 @@ module.exports = function (
               email: emailRecord.email,
               deviceCount: sessions.length,
               userAgent: request.headers['user-agent']
+            })
+          }
+        }
+
+        function sendVerifyAccountEmail() {
+          // For legacy clients, behavior is to not send an email to verify their account
+          // and have the requestor send it.
+          var sendEmailIfUnverified = false
+
+          // If a value was passed, use that instead
+          if (request.payload.sendEmailIfUnverified !== undefined) {
+            sendEmailIfUnverified = request.payload.sendEmailIfUnverified
+          }
+
+          var shouldSEndVerifyAccountEmail = sendEmailIfUnverified && !emailRecord.emailVerified
+          if (shouldSEndVerifyAccountEmail) {
+            return mailer.sendVerifyCode(emailRecord, tokenVerificationId, {
+              service: service,
+              redirectTo: redirectTo,
+              resume: resume,
+              acceptLanguage: request.app.acceptLanguage
             })
           }
         }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -1172,10 +1172,10 @@ test('/account/login', function (t) {
 
     t.test('without `sendEmailIfUnverified` param', function (t) {
       return runTest(route, mockRequest, function (response) {
-        t.equal(mockMailer.sendVerifyCode.callCount, 0, 'mailer.sendVerifyCode was called')
+        t.equal(mockMailer.sendVerifyCode.callCount, 0, 'mailer.sendVerifyCode was not called')
         t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(response.verified, false, 'response indicates account is verified')
+        t.equal(response.verified, false, 'response indicates account is unverified')
         t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
         t.equal(response.verificationReason, 'signup', 'verificationReason is signup')
       })
@@ -1187,7 +1187,7 @@ test('/account/login', function (t) {
         t.equal(mockMailer.sendVerifyCode.callCount, 1, 'mailer.sendVerifyCode was called')
         t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
-        t.equal(response.verified, false, 'response indicates account is verified')
+        t.equal(response.verified, false, 'response indicates account is unverified')
         t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
         t.equal(response.verificationReason, 'signup', 'verificationReason is signup')
       }).then(function () {

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -118,7 +118,7 @@ test('/recovery_email/status', function (t) {
         .then(function () {
           mockDB.deleteAccount.reset()
         })
-      }, t)
+      })
 
       t.test('verified account', function (t) {
         mockRequest.auth.credentials.uid = uuid.v4('binary').toString('hex')
@@ -678,7 +678,7 @@ test('/account/create', function (t) {
 })
 
 test('/account/login', function (t) {
-  t.plan(3)
+  t.plan(4)
   var config = {
     newLoginNotificationEnabled: true
   }
@@ -1154,6 +1154,7 @@ test('/account/login', function (t) {
   })
 
   t.test('sign-in unverified account', function (t) {
+    t.plan(2)
     mockDB.emailRecord = function () {
       return P.resolve({
         authSalt: crypto.randomBytes(32),


### PR DESCRIPTION
This PR adds the ability for the auth-server to receive a query param `sendEmailIfUnverified` on the `/account/login` endpoint, specifying whether or not it should the verify account email for unverified accounts.

Ref: #1325 