### PR TITLE
fix(deps): use poolee@1.0.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -299,7 +299,7 @@
     },
     "fxa-auth-db-mysql": {
       "version": "0.68.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#ffe8ec1f9d7b6390b31b2f6c2769a8108532d0be",
       "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#ffe8ec1f9d7b6390b31b2f6c2769a8108532d0be",
       "dependencies": {
         "base64url": {
@@ -884,7 +884,7 @@
     },
     "fxa-auth-mailer": {
       "version": "1.68.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#24594dc97a94a44ae05068e7dd31675b02e185eb",
       "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#24594dc97a94a44ae05068e7dd31675b02e185eb",
       "dependencies": {
         "bluebird": {
@@ -1347,15 +1347,15 @@
                           "from": "ansi-styles@>=2.2.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
-                        "aproba": {
-                          "version": "1.0.4",
-                          "from": "aproba@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
-                        },
                         "are-we-there-yet": {
                           "version": "1.1.2",
                           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
                           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                        },
+                        "aproba": {
+                          "version": "1.0.4",
+                          "from": "aproba@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
                         },
                         "asn1": {
                           "version": "0.2.3",
@@ -1482,6 +1482,11 @@
                           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
+                        "extend": {
+                          "version": "3.0.0",
+                          "from": "extend@>=3.0.0 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                        },
                         "extsprintf": {
                           "version": "1.0.2",
                           "from": "extsprintf@1.0.2",
@@ -1491,11 +1496,6 @@
                           "version": "0.6.1",
                           "from": "forever-agent@>=0.6.1 <0.7.0",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                        },
-                        "extend": {
-                          "version": "3.0.0",
-                          "from": "extend@>=3.0.0 <3.1.0",
-                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                         },
                         "form-data": {
                           "version": "1.0.0-rc4",
@@ -2728,6 +2728,18 @@
             }
           }
         },
+        "poolee": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
+          "dependencies": {
+            "keep-alive-agent": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+            }
+          }
+        },
         "request": {
           "version": "2.69.0",
           "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
@@ -3764,21 +3776,9 @@
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.5",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                         }
                       }
                     }
@@ -4017,9 +4017,9 @@
           }
         },
         "glob": {
-          "version": "7.0.5",
+          "version": "7.0.6",
           "from": "glob@>=7.0.0 <7.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -4226,9 +4226,9 @@
               }
             },
             "esprima": {
-              "version": "2.7.2",
+              "version": "2.7.3",
               "from": "esprima@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
             }
           }
         },
@@ -4299,7 +4299,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4732,21 +4732,9 @@
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.5",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                         }
                       }
                     }
@@ -4922,7 +4910,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -4960,21 +4948,9 @@
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.5",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                         }
                       }
                     }
@@ -5142,21 +5118,9 @@
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.5",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
                         }
                       }
                     }
@@ -5328,7 +5292,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5681,9 +5645,9 @@
                   }
                 },
                 "esprima": {
-                  "version": "2.7.2",
+                  "version": "2.7.3",
                   "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
                 }
               }
             },
@@ -5810,9 +5774,9 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "dependencies": {
             "glob": {
-              "version": "7.0.5",
+              "version": "7.0.6",
               "from": "glob@>=7.0.5 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
@@ -6610,7 +6574,7 @@
         },
         "encoding": {
           "version": "0.1.12",
-          "from": "encoding@>=0.1.11 <0.2.0",
+          "from": "encoding@*",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
           "dependencies": {
             "iconv-lite": {
@@ -6687,7 +6651,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@1.1.3",
+              "from": "chalk@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -6857,7 +6821,7 @@
     },
     "node-uap": {
       "version": "0.0.3",
-      "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
+      "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
       "resolved": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
       "dependencies": {
         "array.prototype.find": {
@@ -6925,8 +6889,8 @@
         },
         "uap-core": {
           "version": "0.5.0",
-          "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#8cc97fa97abda51a476bd8bcba424a8d0704aad1"
+          "from": "git://github.com/ua-parser/uap-core.git#b2c4e29269b6015f9ad5c71edef07e891166bde2",
+          "resolved": "git://github.com/ua-parser/uap-core.git#b2c4e29269b6015f9ad5c71edef07e891166bde2"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -6941,9 +6905,9 @@
       }
     },
     "poolee": {
-      "version": "1.0.0",
-      "from": "poolee@1.0.0",
-      "resolved": "https://registry.npmjs.org/poolee/-/poolee-1.0.0.tgz",
+      "version": "1.0.1",
+      "from": "poolee@1.0.1",
+      "resolved": "https://registry.npmjs.org/poolee/-/poolee-1.0.1.tgz",
       "dependencies": {
         "keep-alive-agent": {
           "version": "0.0.1",
@@ -7073,14 +7037,21 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
+          "version": "1.0.1",
           "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "dependencies": {
             "async": {
-              "version": "1.5.2",
-              "from": "async@>=1.5.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+              "version": "2.0.1",
+              "from": "async@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "4.15.0",
+                  "from": "lodash@>=4.8.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+                }
+              }
             }
           }
         },
@@ -7243,9 +7214,9 @@
               }
             },
             "sshpk": {
-              "version": "1.9.2",
+              "version": "1.10.0",
               "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -7286,6 +7257,18 @@
                   "version": "0.1.1",
                   "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.0",
+                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                  "dependencies": {
+                    "tweetnacl": {
+                      "version": "0.14.3",
+                      "from": "tweetnacl@>=0.14.3 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -7429,9 +7412,9 @@
       "resolved": "https://registry.npmjs.org/tap/-/tap-6.3.2.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.1",
+          "version": "3.4.3",
           "from": "bluebird@>=3.3.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.3.tgz"
         },
         "clean-yaml-object": {
           "version": "0.1.0",
@@ -7536,9 +7519,9 @@
           }
         },
         "glob": {
-          "version": "7.0.5",
-          "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "version": "7.0.6",
+          "from": "glob@>=7.0.0 <7.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -7617,7 +7600,7 @@
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
-              "from": "argparse@>=1.0.7 <2.0.0",
+              "from": "argparse@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "dependencies": {
                 "sprintf-js": {
@@ -7628,9 +7611,9 @@
               }
             },
             "esprima": {
-              "version": "2.7.2",
+              "version": "2.7.3",
               "from": "esprima@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
             }
           }
         },
@@ -7907,15 +7890,15 @@
               "from": "camelcase@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
             },
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-            },
             "center-align": {
               "version": "0.1.3",
               "from": "center-align@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
             },
             "code-point-at": {
               "version": "1.0.0",
@@ -8007,15 +7990,15 @@
               "from": "fs.realpath@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
-            "get-caller-file": {
-              "version": "1.0.1",
-              "from": "get-caller-file@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
-            },
             "get-stdin": {
               "version": "4.0.1",
               "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "get-caller-file": {
+              "version": "1.0.1",
+              "from": "get-caller-file@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
             },
             "glob-base": {
               "version": "0.3.0",
@@ -8027,15 +8010,15 @@
               "from": "glob-parent@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
-            "globals": {
-              "version": "8.18.0",
-              "from": "globals@>=8.3.0 <9.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-            },
             "graceful-fs": {
               "version": "4.1.4",
               "from": "graceful-fs@>=4.1.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+            },
+            "globals": {
+              "version": "8.18.0",
+              "from": "globals@>=8.3.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
@@ -8047,15 +8030,15 @@
               "from": "has-flag@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             },
-            "hosted-git-info": {
-              "version": "2.1.5",
-              "from": "hosted-git-info@>=2.1.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-            },
             "imurmurhash": {
               "version": "0.1.4",
               "from": "imurmurhash@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+            },
+            "hosted-git-info": {
+              "version": "2.1.5",
+              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
             },
             "inflight": {
               "version": "1.0.5",
@@ -8127,15 +8110,15 @@
               "from": "is-glob@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
             },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-            },
             "is-number": {
               "version": "2.1.0",
               "from": "is-number@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+            },
+            "is-posix-bracket": {
+              "version": "0.1.1",
+              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
             },
             "is-primitive": {
               "version": "2.0.0",
@@ -8674,14 +8657,14 @@
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "unicode-length": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "from": "unicode-length@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
               "dependencies": {
                 "punycode": {
-                  "version": "2.0.0",
-                  "from": "punycode@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.0.0.tgz"
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.3.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
@@ -8851,9 +8834,9 @@
           }
         },
         "bluebird": {
-          "version": "3.4.1",
+          "version": "3.4.3",
           "from": "bluebird@>=3.3.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.3.tgz"
         },
         "buffer-compare-shim": {
           "version": "1.0.0",
@@ -8862,7 +8845,7 @@
           "dependencies": {
             "buffer-compare": {
               "version": "0.0.1",
-              "from": "buffer-compare@0.0.1",
+              "from": "buffer-compare@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-0.0.1.tgz"
             }
           }
@@ -8874,7 +8857,7 @@
           "dependencies": {
             "buffer-compare": {
               "version": "0.0.1",
-              "from": "buffer-compare@0.0.1",
+              "from": "buffer-compare@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-0.0.1.tgz"
             }
           }
@@ -8962,7 +8945,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mozlog": "2.0.5",
     "node-statsd": "0.1.1",
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
-    "poolee": "1.0.0",
+    "poolee": "1.0.1",
     "request": "2.74.0",
     "scrypt-hash": "1.1.13",
     "through": "2.3.8",


### PR DESCRIPTION
Update to fix a leak. I don't know if we need to get an updated version of fxa-auth-mailer that uses poolee@1.0.1 too. Thoughts? @vladikoff 