### PR TITLE
fix(config): Remove unused URL opions from mailer config.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -197,13 +197,6 @@ var conf = convict({
       env: 'RESET_URL',
       arg: 'reset-url'
     },
-    accountUnlockUrl: {
-      doc: 'Deprecated. uses contentServer.url',
-      format: String,
-      default: undefined,
-      env: 'UNLOCK_URL',
-      arg: 'unlock-url'
-    },
     initiatePasswordResetUrl: {
       doc: 'Deprecated. uses contentServer.url',
       format: String,
@@ -223,11 +216,6 @@ var conf = convict({
       doc: 'url to IOS product page',
       format: String,
       default: 'https://www.mozilla.org/firefox/ios/'
-    },
-    signInUrl: {
-      doc: 'Deprecated. uses contentServer.url',
-      format: String,
-      default: 'undefined'
     },
     supportUrl: {
       doc: 'url to Mozilla Support product page',
@@ -492,10 +480,8 @@ conf.validate({ strict: true })
 conf.set('domain', url.parse(conf.get('publicUrl')).host)
 
 // derive fxa-auth-mailer configuration from our content-server url
-conf.set('smtp.signInUrl', conf.get('contentServer.url') + '/signin')
 conf.set('smtp.verificationUrl', conf.get('contentServer.url') + '/v1/verify_email')
 conf.set('smtp.passwordResetUrl', conf.get('contentServer.url') + '/v1/complete_reset_password')
-conf.set('smtp.accountUnlockUrl', conf.get('contentServer.url') + '/v1/complete_unlock_account')
 conf.set('smtp.initiatePasswordResetUrl', conf.get('contentServer.url') + '/reset_password')
 conf.set('smtp.initiatePasswordChangeUrl', conf.get('contentServer.url') + '/settings/change_password')
 conf.set('smtp.verifyLoginUrl', conf.get('contentServer.url') + '/complete_signin')

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -884,8 +884,8 @@
     },
     "fxa-auth-mailer": {
       "version": "1.68.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#24594dc97a94a44ae05068e7dd31675b02e185eb",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#24594dc97a94a44ae05068e7dd31675b02e185eb",
+      "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#b455d7491ce9b2e6826d6581cbca3d012819689c",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#b455d7491ce9b2e6826d6581cbca3d012819689c",
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-mailer/issues/203; @shane-tomlinson r?