### PR TITLE
fix(email): Refactor to send `sendEmailIfUnverified` via query

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -207,7 +207,7 @@ module.exports = function (
           var enableTokenVerification = requestHelper.shouldEnableTokenVerification(account, config, request)
 
           // Verified sessions should only be created for preverified tokens
-          // and when sign-in confirmation is disabled
+          // and when sign-in confirmation is disabled or not needed.
           if (preVerified || ! enableTokenVerification) {
             tokenVerificationId = undefined
           }
@@ -544,7 +544,7 @@ module.exports = function (
           // Delegate sending emails for unverified users to auth-server.
           // Will be removed once all clients have been updated not to send verify emails.
           // https://github.com/mozilla/fxa-auth-server/issues/1325
-          var shouldSendVerifyAccountEmail = requestHelper.shouldSendVerifyAccountEmail(request)
+          var shouldSendVerifyAccountEmail = requestHelper.shouldSendVerifyAccountEmail(emailRecord, request)
           emailSent = false
 
           if (shouldSendVerifyAccountEmail) {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -549,7 +549,7 @@ module.exports = function (
 
           if (shouldSendVerifyAccountEmail) {
             // Only use tokenVerificationId if it is set, otherwise use the corresponding email code
-            // This covers the cases where sign-in confirmation is disabled.
+            // This covers the cases where sign-in confirmation is disabled or not needed.
             var emailCode = tokenVerificationId ? tokenVerificationId : emailRecord.emailCode
             emailSent = true
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -548,10 +548,12 @@ module.exports = function (
           emailSent = false
 
           if (shouldSendVerifyAccountEmail) {
-            // Resend the account verification email using the tokenVerificationId so that the session
-            // that initiated the login will also get verified.
+            // Only use tokenVerificationId if it is set, otherwise use the corresponding email code
+            // This covers the cases where sign-in confirmation is disabled.
+            var emailCode = tokenVerificationId ? tokenVerificationId : emailRecord.emailCode
             emailSent = true
-            return mailer.sendVerifyCode(emailRecord, tokenVerificationId, {
+
+            return mailer.sendVerifyCode(emailRecord, emailCode, {
               service: service,
               redirectTo: redirectTo,
               resume: resume,
@@ -625,13 +627,13 @@ module.exports = function (
             authAt: sessionToken.lastAuthAt()
           }
 
+          response.emailSent = emailSent
+
           if (! requestHelper.wantsKeys(request)) {
             return P.resolve(response)
           }
 
           response.keyFetchToken = keyFetchToken.data.toString('hex')
-
-          response.emailSent = emailSent
 
           if(! emailRecord.emailVerified) {
             response.verified = false

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -62,7 +62,26 @@ function shouldEnableTokenVerification(account, config, request) {
   return uidNum < (config.signinConfirmation.sample_rate * 100)
 }
 
+/**
+ * Returns whether or not to send the verify account email on a login
+ * attempt.
+ *
+ * @param request
+ * @returns {boolean}
+ */
+function shouldSendVerifyAccountEmail(request) {
+
+  var sendEmailIfUnverified = request.query.sendEmailIfUnverified
+
+  // Only the content-server sends metrics context. For all non content-server
+  // requests, send the verification email.
+  var context = !!(request.payload && request.payload.metricsContext)
+
+  return !context || !!sendEmailIfUnverified
+}
+
 module.exports = {
   wantsKeys: wantsKeys,
-  shouldEnableTokenVerification: shouldEnableTokenVerification
+  shouldEnableTokenVerification: shouldEnableTokenVerification,
+  shouldSendVerifyAccountEmail: shouldSendVerifyAccountEmail
 }

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -64,12 +64,12 @@ function shouldEnableTokenVerification(account, config, request) {
 
 /**
  * Returns whether or not to send the verify account email on a login
- * attempt.
+ * attempt. This never sends a verification email to an already verified email.
  *
  * @param request
  * @returns {boolean}
  */
-function shouldSendVerifyAccountEmail(request) {
+function shouldSendVerifyAccountEmail(account, request) {
 
   var sendEmailIfUnverified = request.query.sendEmailIfUnverified
 
@@ -77,7 +77,7 @@ function shouldSendVerifyAccountEmail(request) {
   // requests, send the verification email.
   var context = !!(request.payload && request.payload.metricsContext)
 
-  return !context || !!sendEmailIfUnverified
+  return (!context || !!sendEmailIfUnverified) && !account.emailVerified
 }
 
 module.exports = {

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -40,8 +40,7 @@ var makeRoutes = function (options, requireMocks) {
   var db = options.db || mocks.mockDB()
   var isPreVerified = require('../../lib/preverifier')(error, config)
   var customs = options.customs || {
-    check: function () { return P.resolve(true) },
-    flag: function () { return P.resolve(true) }
+    check: function () { return P.resolve(true) }
   }
   var checkPassword = options.checkPassword || require('../../lib/routes/utils/password_check')(log, config, Password, customs, db)
   var push = options.push || require('../../lib/push')(log, db)

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -755,9 +755,6 @@ test('/account/login', function (t) {
     customs: {
       check: function () {
         return P.resolve()
-      },
-      flag: function () {
-        return P.resolve()
       }
     },
     db: mockDB,
@@ -1154,6 +1151,7 @@ test('/account/login', function (t) {
       })
     }).finally(function () {
       mockLog.close()
+      mockMailer.sendVerifyCode.reset()
     })
   })
 
@@ -1182,7 +1180,7 @@ test('/account/login', function (t) {
         t.equal(response.verified, false, 'response indicates account is unverified')
         t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
         t.equal(response.verificationReason, 'signup', 'verificationReason is signup')
-        t.notOk(response.emailSent, 'email sent, not set')
+        t.equal(response.emailSent, false, 'email not sent')
       })
     })
 
@@ -1227,7 +1225,7 @@ test('/account/login', function (t) {
         t.equal(response.verified, false, 'response indicates account is unverified')
         t.equal(response.verificationMethod, 'email', 'verificationMethod is email')
         t.equal(response.verificationReason, 'signup', 'verificationReason is signup')
-        t.notOk(response.emailSent, 'email sent, not set')
+        t.equal(response.emailSent, true, 'email not sent')
       }).then(function () {
         mockMailer.sendVerifyCode.reset()
       })


### PR DESCRIPTION
This PR changes https://github.com/mozilla/fxa-auth-server/pull/1435, to send `sendEmailIfUnverified` via query params. For all unverified login requests coming from a non content-server context, a verification email will be sent.

@shane-tomlinson This what you had in mind? r?