### PR TITLE
fix(logging): ignore account.signed flow events from the content server

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -239,6 +239,12 @@ Lug.prototype.flowEvent = function (event, request) {
     return P.resolve()
   }
 
+  if (event === 'account.signed' && request.query && request.query.service === 'content-server') {
+    // HACK: Prevent the content server from distorting our flow completion rates.
+    //       Longer term we need to replace this with something better, obviously.
+    return P.resolve()
+  }
+
   return this.metricsContext.gather({
     event: event,
     userAgent: request.headers['user-agent']

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -400,10 +400,10 @@ test(
 
 test(
   'log.flowEvent with bad event name',
-  function (t) {
-    return log.flowEvent(undefined).then(function () {
+  t => {
+    return log.flowEvent(undefined).then(() => {
       t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
+      const args = logger.error.args[0]
       t.equal(args[0], 'log.flowEvent', 'correct op')
       t.equal(args[1].missingEvent, true, 'correct flag')
 
@@ -411,6 +411,7 @@ test(
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
       t.equal(logger.info.callCount, 0, 'logger.info was not called')
+      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
 
       logger.error.reset()
     })
@@ -419,18 +420,19 @@ test(
 
 test(
   'log.flowEvent with a bad request',
-  function (t) {
-    return log.flowEvent('account.login').then(function () {
+  t => {
+    return log.flowEvent('account.signed').then(() => {
       t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
+      const args = logger.error.args[0]
       t.equal(args[0], 'log.flowEvent', 'correct op')
-      t.equal(args[1].event, 'account.login', 'correct event name')
+      t.equal(args[1].event, 'account.signed', 'correct event name')
       t.equal(args[1].badRequest, true, 'correct flag')
 
       t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
       t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
       t.equal(logger.info.callCount, 0, 'logger.info was not called')
+      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
 
       logger.error.reset()
     })
@@ -438,9 +440,37 @@ test(
 )
 
 test(
+  'log.flowEvent with content server account.signed event',
+  t => {
+    return log.flowEvent('account.signed', {
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flow_id: 'bar',
+          service: 'baz'
+        },
+        service: 'qux'
+      },
+      query: {
+        service: 'content-server'
+      }
+    }).then(() => {
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+      t.equal(logger.info.callCount, 0, 'logger.info was not called')
+      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    })
+  }
+)
+
+test(
   'log.flowEvent properly logs with no errors',
-  function (t) {
-    return log.flowEvent('account.login', {
+  t => {
+    return log.flowEvent('account.signed', {
       headers: {
         'user-agent': 'foo'
       },
@@ -451,13 +481,13 @@ test(
         },
         service: 'qux'
       }
-    }).then(function () {
+    }).then(() => {
       t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
 
       t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      var args = logger.info.args[0]
+      const args = logger.info.args[0]
       t.equal(args[0], 'flowEvent', 'correct event name')
-      t.equal(args[1].event, 'account.login', 'correct event name')
+      t.equal(args[1].event, 'account.signed', 'correct event name')
       t.equal(args[1].flow_id, 'bar', 'correct flow id')
       t.equal(args[1].service, 'baz', 'correct metrics data')
 
@@ -474,7 +504,7 @@ test(
 
 test(
   'log.flowEvent with flow event and missing flow_id',
-  function (t) {
+  t => {
     return log.flowEvent('account.login', {
       headers: {
         'user-agent': 'foo'
@@ -482,13 +512,13 @@ test(
       payload: {
         metricsContext: {}
       }
-    }).then(function () {
+    }).then(() => {
       t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
 
       t.equal(logger.info.callCount, 0, 'logger.info was not called')
 
       t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
+      const args = logger.error.args[0]
       t.equal(args.length, 2, 'logger.error was passed two arguments')
       t.equal(args[0], 'log.flowEvent')
       t.deepEqual(args[1], {
@@ -505,7 +535,7 @@ test(
 
 test(
   'log.flowEvent with optional flow event and missing flow_id',
-  function (t) {
+  t => {
     return log.flowEvent('device.created', {
       headers: {
         'user-agent': 'foo'
@@ -513,7 +543,7 @@ test(
       payload: {
         metricsContext: {}
       }
-    }).then(function () {
+    }).then(() => {
       t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
       t.equal(logger.info.callCount, 0, 'logger.info was not called')
       t.equal(logger.error.callCount, 0, 'logger.error was not called')

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -20,7 +20,10 @@ var statsd = {
 }
 var metricsContext = {
   gather: sinon.spy(function (data, request) {
-    return P.resolve(request.payload && request.payload.metricsContext)
+    return P.resolve(request.payload && {
+      flow_id: request.payload.metricsContext.flowId,
+      service: request.payload.metricsContext.service
+    })
   })
 }
 var mocks = {
@@ -128,7 +131,7 @@ test(
       },
       payload: {
         metricsContext: {
-          flow_id: 'bar'
+          flowId: 'bar'
         }
       }
     }
@@ -166,7 +169,7 @@ test(
 )
 
 test(
-  'log.activityEvent with flow event and missing flow_id',
+  'log.activityEvent with flow event and missing flowId',
   function (t) {
     var request = {
       headers: {
@@ -209,7 +212,7 @@ test(
 )
 
 test(
-  'log.activityEvent with optional flow event and missing flow_id',
+  'log.activityEvent with optional flow event and missing flowId',
   function (t) {
     var request = {
       headers: {
@@ -448,7 +451,7 @@ test(
       },
       payload: {
         metricsContext: {
-          flow_id: 'bar',
+          flowId: 'bar',
           service: 'baz'
         },
         service: 'qux'
@@ -476,7 +479,7 @@ test(
       },
       payload: {
         metricsContext: {
-          flow_id: 'bar',
+          flowId: 'bar',
           service: 'baz'
         },
         service: 'qux'
@@ -503,7 +506,7 @@ test(
 )
 
 test(
-  'log.flowEvent with flow event and missing flow_id',
+  'log.flowEvent with flow event and missing flowId',
   t => {
     return log.flowEvent('account.login', {
       headers: {
@@ -534,7 +537,7 @@ test(
 )
 
 test(
-  'log.flowEvent with optional flow event and missing flow_id',
+  'log.flowEvent with optional flow event and missing flowId',
   t => {
     return log.flowEvent('device.created', {
       headers: {


### PR DESCRIPTION
GitHub's most annoying feature is definitely it's refusal to re-open a closed PR after you've force-pushed the branch. Because this is exactly the same PR as #1461 was, with a couple of changes to the log tests.

Anyway, to repeat what I said there:

> This is a temporary hack to improve the accuracy of the sign-in funnel metrics as part of train 70. Longer term I will do something nicer than this, I'm just not sure what it is yet. Making this fix now allows us to get more accurate flow metrics sooner.
>
> See the related discussion in #1457, this PR doesn't fix that issue but whatever replaces it will.
>
> @vladikoff or @vbudhram, r?