### PR TITLE
Hide session token lastAccessTime updates behind a feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ secret*
 *.pyc
 /.vagrant
 .nyc_output
+npm-debug.log

--- a/bin/email_bouncer.js
+++ b/bin/email_bouncer.js
@@ -5,12 +5,12 @@
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'fxa-email-bouncer')
 var error = require('../lib/error')
-var Token = require('../lib/tokens')(log, config.tokenLifetimes)
+var Token = require('../lib/tokens')(log, config)
 var SQSReceiver = require('../lib/sqs')(log)
 var bounces = require('../lib/bounces')(log, error)
 
 var DB = require('../lib/db')(
-  config.db.backend,
+  config,
   log,
   error,
   Token.SessionToken,

--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -34,7 +34,7 @@ function main() {
   }
 
   var error = require('../lib/error')
-  var Token = require('../lib/tokens')(log, config.tokenLifetimes)
+  var Token = require('../lib/tokens')(log, config)
   var Password = require('../lib/crypto/password')(log, config)
 
   var signer = require('../lib/signer')(config.secretKeyFile, config.domain)
@@ -79,7 +79,7 @@ function main() {
         mailer = m
 
         var DB = require('../lib/db')(
-          config.db.backend,
+          config,
           log,
           error,
           Token.SessionToken,

--- a/config/index.js
+++ b/config/index.js
@@ -433,11 +433,13 @@ var conf = convict({
   signinConfirmation: {
     enabled: {
       doc: 'enable signin confirmation',
+      format: Boolean,
       default: false,
       env: 'SIGNIN_CONFIRMATION_ENABLED'
     },
     sample_rate: {
       doc: 'signin confirmation sample rate, between 0.0 and 1.0',
+      format: Number,
       default: 1.0,
       env: 'SIGNIN_CONFIRMATION_RATE'
     },
@@ -461,7 +463,7 @@ var conf = convict({
       doc: 'If feature enabled, force sign-in confirmation for email addresses matching this regex.',
       format: Array,
       default: [
-        '.+@mozilla\.com$'
+        '.+@mozilla\\.com$'
       ],
       env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     }
@@ -471,6 +473,25 @@ var conf = convict({
       doc: 'enable security history',
       default: true,
       env: 'SECURITY_HISTORY_ENABLED'
+    }
+  },
+  lastAccessTimeUpdates: {
+    enabled: {
+      doc: 'enable updates to the lastAccessTime session token property',
+      format: Boolean,
+      default: false,
+      env: 'LASTACCESSTIME_UPDATES_ENABLED'
+    },
+    sampleRate: {
+      doc: 'sample rate for updates to the lastAccessTime session token property, in the range 0..1',
+      format: Number,
+      default: 1,
+      env: 'LASTACCESSTIME_UPDATES_SAMPLE_RATE'
+    },
+    enabledEmailAddresses: {
+      doc: 'regex matching enabled email addresses for updates to the lastAccessTime session token property',
+      default: '.+@mozilla\\.com$',
+      env: 'LASTACCESSTIME_UPDATES_EMAIL_ADDRESSES'
     }
   }
 })

--- a/lib/features.js
+++ b/lib/features.js
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const crypto = require('crypto')
+
+module.exports = config => {
+  const lastAccessTimeUpdates = config.lastAccessTimeUpdates
+  const signinConfirmation = config.signinConfirmation
+
+  return {
+    /**
+     * Predicate that indicates whether updates to sessionToken.lastAccessTime
+     * are enabled for a given user, based on their uid and email address.
+     *
+     * @param uid   Buffer or String
+     * @param email String
+     */
+    isLastAccessTimeEnabledForUser (uid, email) {
+      return lastAccessTimeUpdates.enabled && (
+        isSampledUser(lastAccessTimeUpdates.sampleRate, uid, 'lastAccessTimeUpdates') ||
+        new RegExp(lastAccessTimeUpdates.enabledEmailAddresses).test(email)
+      )
+    },
+
+    /**
+     * Predicate that indicates whether sign-in confirmation is enabled
+     * for a given user, based on their uid and email address.
+     *
+     * @param uid   Buffer or String
+     * @param email String
+     */
+    isSigninConfirmationEnabledForUser (uid, email, request) {
+      if (! signinConfirmation.enabled) {
+        return false
+      }
+
+      // Always create unverified tokens if customs-server
+      // has said the request is suspicious.
+      if (request.app.isSuspiciousRequest) {
+        return true
+      }
+
+      // Or if the email address matches one of these regexes.
+      if (signinConfirmation.forceEmailRegex.some(regex => new RegExp(regex).test(email))) {
+        return true
+      }
+
+      // While we're testing this feature, there may be some funky
+      // edge-cases in device login flows that haven't been fully tested.
+      // Temporarily avoid them for regular users by checking the `context` flag,
+      // and create pre-verified sessions for unsupported clients.
+      // This check will go away in the final version of this feature.
+      const context = request.payload &&
+        request.payload.metricsContext &&
+        request.payload.metricsContext.context
+      if (signinConfirmation.supportedClients.indexOf(context) === -1) {
+        return false
+      }
+
+      // Check to see if user in roll-out cohort.
+      return isSampledUser(signinConfirmation.sample_rate, uid, 'signinConfirmation')
+    },
+
+    /**
+     * Predicate that indicates whether a user belongs to the sampled cohort,
+     * based on a sample rate, their uid and a key that identifies the feature.
+     *
+     * @param sampleRate Number in the range 0..1
+     * @param uid        Buffer or String
+     * @param key        String
+     */
+    isSampledUser: isSampledUser
+  }
+}
+
+const HASH_LENGTH = hash('', '').length
+const MAX_SAFE_HEX = Number.MAX_SAFE_INTEGER.toString(16)
+const MAX_SAFE_HEX_LENGTH = MAX_SAFE_HEX.length - MAX_SAFE_HEX.indexOf('f')
+const COHORT_DIVISOR = parseInt(Array(MAX_SAFE_HEX_LENGTH).fill('f').join(''), 16)
+
+function isSampledUser (sampleRate, uid, key) {
+  if (sampleRate === 1) {
+    return true
+  }
+
+  if (sampleRate === 0) {
+    return false
+  }
+
+  if (Buffer.isBuffer(uid)) {
+    uid = uid.toString('hex')
+  }
+
+  // Extract the maximum entropy we can safely handle as a number then reduce
+  // it to a value between 0 and 1 for comparison against the sample rate.
+  const cohort = parseInt(
+    hash(uid, key).substr(HASH_LENGTH - MAX_SAFE_HEX_LENGTH),
+    16
+  ) / COHORT_DIVISOR
+  return cohort < sampleRate
+}
+
+function hash (uid, key) {
+  // Note that we don't need anything cryptographically secure here,
+  // speed and a good distribution are the requirements.
+  const h = crypto.createHash('sha1')
+  h.update(uid)
+  h.update(key)
+  return h.digest('hex')
+}
+

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -54,6 +54,7 @@ module.exports = function (
     supportedLanguages: config.i18n.supportedLanguages,
     defaultLanguage: config.i18n.defaultLanguage
   })
+  const features = require('../features')(config)
 
   var securityHistoryEnabled = config.securityHistory && config.securityHistory.enabled
 
@@ -211,7 +212,8 @@ module.exports = function (
         }
 
         function createSessionToken () {
-          var enableTokenVerification = requestHelper.shouldEnableTokenVerification(account, config, request)
+          const enableTokenVerification =
+            features.isSigninConfirmationEnabledForUser(account.uid, account.email, request)
 
           // Verified sessions should only be created for preverified tokens
           // and when sign-in confirmation is disabled or not needed.
@@ -419,7 +421,7 @@ module.exports = function (
                 //  * the request wants keys, since unverified sessions are fine to use for e.g. oauth login.
                 //  * the email is verified, since content-server triggers a resend of the verification
                 //    email on unverified accounts, which doubles as sign-in confirmation.
-                if (! requestHelper.shouldEnableTokenVerification(emailRecord, config, request)) {
+                if (! features.isSigninConfirmationEnabledForUser(emailRecord.uid, emailRecord.email, request)) {
                   tokenVerificationId = undefined
                   mustVerifySession = false
                   doSigninConfirmation = false

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -13,56 +13,6 @@ function wantsKeys (request) {
 }
 
 /**
- * Returns whether or not to use token-verification feature on a request.
- *
- * @param account
- * @param config
- * @param request
- * @returns {boolean}
- */
-function shouldEnableTokenVerification(account, config, request) {
-
-  var confirmLogin = config.signinConfirmation && config.signinConfirmation.enabled
-  if (!confirmLogin) {
-    return false
-  }
-
-  // Always create unverified tokens if customs-server
-  // has said the request is suspicious.
-  if (request.app.isSuspiciousRequest) {
-    return true
-  }
-
-  // Or if the email address matching one of these regexes.
-  var email = account.email
-  var isValidEmail = config.signinConfirmation.forceEmailRegex.some(function (reg) {
-    var emailReg = new RegExp(reg)
-    return emailReg.test(email)
-  })
-
-  if (isValidEmail) {
-    return true
-  }
-
-  // While we're testing this feature, there may be some funky
-  // edge-cases in device login flows that haven't been fully tested.
-  // Temporarily avoid them for regular users by checking the `context` flag,
-  // and create pre-verified sessions for unsupported clients.
-  // This check will go away in the final version of this feature.
-  var context = request.payload && request.payload.metricsContext && request.payload.metricsContext.context
-  var isValidContext = context && (config.signinConfirmation.supportedClients.indexOf(context) > -1)
-  if (!isValidContext) {
-    return false
-  }
-
-  // Check to see if user in roll-out cohort.
-  // Cohort is determined by user's uid.
-  var uid = account.uid.toString('hex')
-  var uidNum = parseInt(uid.substr(0, 4), 16) % 100
-  return uidNum < (config.signinConfirmation.sample_rate * 100)
-}
-
-/**
  * Returns whether or not to send the verify account email on a login
  * attempt. This never sends a verification email to an already verified email.
  *
@@ -82,6 +32,5 @@ function shouldSendVerifyAccountEmail(account, request) {
 
 module.exports = {
   wantsKeys: wantsKeys,
-  shouldEnableTokenVerification: shouldEnableTokenVerification,
   shouldSendVerifyAccountEmail: shouldSendVerifyAccountEmail
 }

--- a/lib/tokens/index.js
+++ b/lib/tokens/index.js
@@ -2,34 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var crypto = require('crypto')
-var inherits = require('util').inherits
+const crypto = require('crypto')
+const inherits = require('util').inherits
 
-var P = require('../promise')
-var hkdf = require('../crypto/hkdf')
-var butil = require('../crypto/butil')
+const P = require('../promise')
+const hkdf = require('../crypto/hkdf')
+const butil = require('../crypto/butil')
 
-var error = require('../error')
+const error = require('../error')
 
-module.exports = function (log, lifetimes) {
-  lifetimes = lifetimes || {
+module.exports = (log, config) => {
+  config = config || {}
+  const lifetimes = config.tokenLifetimes || {
     accountResetToken: 1000 * 60 * 15,
     passwordChangeToken: 1000 * 60 * 15,
     passwordForgotToken: 1000 * 60 * 15
   }
-  var Bundle = require('./bundle')(crypto, P, hkdf, butil, error)
-  var Token = require('./token')(log, crypto, P, hkdf, Bundle, error)
+  const Bundle = require('./bundle')(crypto, P, hkdf, butil, error)
+  const Token = require('./token')(log, crypto, P, hkdf, Bundle, error)
 
-  var KeyFetchToken = require('./key_fetch_token')(log, inherits, Token, P, error)
-  var AccountResetToken = require('./account_reset_token')(
+  const KeyFetchToken = require('./key_fetch_token')(log, inherits, Token, P, error)
+  const AccountResetToken = require('./account_reset_token')(
     log,
     inherits,
     Token,
     crypto,
     lifetimes.accountResetToken
   )
-  var SessionToken = require('./session_token')(log, inherits, Token)
-  var PasswordForgotToken = require('./password_forgot_token')(
+  const SessionToken = require('./session_token')(log, inherits, Token, config)
+  const PasswordForgotToken = require('./password_forgot_token')(
     log,
     inherits,
     Token,
@@ -37,7 +38,7 @@ module.exports = function (log, lifetimes) {
     lifetimes.passwordForgotToken
   )
 
-  var PasswordChangeToken = require('./password_change_token')(
+  const PasswordChangeToken = require('./password_change_token')(
     log,
     inherits,
     Token,

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -10,7 +10,8 @@ var ONE_HOUR = 60 * 60 * 1000
 // See https://github.com/mozilla/fxa-auth-server/pull/1169
 var TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * ONE_HOUR // 50 years or post Y2038 ;-)
 
-module.exports = function (log, inherits, Token) {
+module.exports = (log, inherits, Token, config) => {
+  const features = require('../features')(config)
 
   function SessionToken(keys, details) {
     Token.call(this, keys, details)
@@ -82,7 +83,10 @@ module.exports = function (log, inherits, Token) {
       this.uaOS === freshData.uaOS &&
       this.uaOSVersion === freshData.uaOSVersion &&
       this.uaDeviceType === freshData.uaDeviceType &&
-      this.lastAccessTime + TOKEN_FRESHNESS_THRESHOLD > freshData.lastAccessTime
+      (
+        ! features.isLastAccessTimeEnabledForUser(this.uid, this.email) ||
+        this.lastAccessTime + TOKEN_FRESHNESS_THRESHOLD > freshData.lastAccessTime
+      )
 
     log.info({
       op: 'SessionToken.isFresh',

--- a/scripts/e2e-email/index.js
+++ b/scripts/e2e-email/index.js
@@ -7,7 +7,7 @@ const crypto = require('crypto')
 const commander = require('commander')
 
 const P = require('../../lib/promise')
-const Client = require('../../test/client')
+const Client = require('../../test/client')()
 const mailbox = require('../../test/mailbox')
 const validateEmail = require('./validate-email')
 

--- a/scripts/must-reset.js
+++ b/scripts/must-reset.js
@@ -23,7 +23,7 @@ var error = require('../lib/error')
 var log = require('../lib/log')(config.log.level)
 var P = require('../lib/promise')
 var path = require('path')
-var Token = require('../lib/tokens')(log, config.tokenLifetimes)
+var Token = require('../lib/tokens')(log, config)
 
 commandLineOptions
   .option('-i, --input <filename>', 'JSON input file')
@@ -37,7 +37,7 @@ requiredOptions.forEach(checkRequiredOption)
 
 
 var DB = require('../lib/db')(
-  config.db.backend,
+  config,
   log,
   error,
   Token.SessionToken,

--- a/test/bench/bot.js
+++ b/test/bench/bot.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
-var Client = require('../client')
+var Client = require('../client')()
 
 var config = {
   origin: 'http://127.0.0.1:9000',

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -2,599 +2,601 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var EventEmitter = require('events').EventEmitter
-var util = require('util')
+module.exports = config => {
+  var EventEmitter = require('events').EventEmitter
+  var util = require('util')
 
-var hawk = require('hawk')
-var P = require('../../lib/promise')
-var request = require('request')
+  var hawk = require('hawk')
+  var P = require('../../lib/promise')
+  var request = require('request')
 
-var tokens = require('../../lib/tokens')({ trace: function() {}})
+  const tokens = require('../../lib/tokens')({ trace: function() {}}, config)
 
-util.inherits(ClientApi, EventEmitter)
-function ClientApi(origin) {
-  EventEmitter.call(this)
-  this.origin = origin
-  this.baseURL = origin + '/v1'
-  this.timeOffset = 0
-}
+  util.inherits(ClientApi, EventEmitter)
+  function ClientApi(origin) {
+    EventEmitter.call(this)
+    this.origin = origin
+    this.baseURL = origin + '/v1'
+    this.timeOffset = 0
+  }
 
-ClientApi.prototype.Token = tokens
+  ClientApi.prototype.Token = tokens
 
-function hawkHeader(token, method, url, payload, offset) {
-  var verify = {
-    credentials: token
-  }
-  if (payload) {
-    verify.contentType = 'application/json'
-    verify.payload = JSON.stringify(payload)
-  }
-  if (offset) {
-    verify.localtimeOffsetMsec = offset
-  }
-  return hawk.client.header(url, method, verify).field
-}
-
-ClientApi.prototype.doRequest = function (method, url, token, payload, headers) {
-  var d = P.defer()
-  if (typeof headers === 'undefined') {
-    headers = {}
-  }
-  // We do a shallow clone to avoid tainting the caller's copy of `headers`.
-  headers = JSON.parse(JSON.stringify(headers))
-  if (token && !headers.Authorization) {
-    headers.Authorization = hawkHeader(token, method, url, payload, this.timeOffset)
-  }
-  var options = {
-    url: url,
-    method: method,
-    headers: headers,
-    json: payload || true
-  }
-  if (headers['accept-language'] === undefined) { delete headers['accept-language']}
-  this.emit('startRequest', options)
-  request(options, function (err, res, body) {
-    if (res && res.headers.timestamp) {
-      // Record time skew
-      this.timeOffset = Date.now() - parseInt(res.headers.timestamp, 10) * 1000
+  function hawkHeader(token, method, url, payload, offset) {
+    var verify = {
+      credentials: token
     }
-
-    this.emit('endRequest', options, err, res)
-    if (err || body.error || res.statusCode !== 200) {
-      return d.reject(err || body)
+    if (payload) {
+      verify.contentType = 'application/json'
+      verify.payload = JSON.stringify(payload)
     }
+    if (offset) {
+      verify.localtimeOffsetMsec = offset
+    }
+    return hawk.client.header(url, method, verify).field
+  }
 
-    var allowedOrigin = res.headers['access-control-allow-origin']
-    if (allowedOrigin) {
-      // Requiring config outside this condition causes the local tests to fail
-      // because tokenLifetimes.passwordChangeToken is -1
-      var config = require('../../config')
-      if (config.get('corsOrigin').indexOf(allowedOrigin) < 0) {
-        return d.reject(new Error('Unexpected allowed origin: ' + allowedOrigin))
+  ClientApi.prototype.doRequest = function (method, url, token, payload, headers) {
+    var d = P.defer()
+    if (typeof headers === 'undefined') {
+      headers = {}
+    }
+    // We do a shallow clone to avoid tainting the caller's copy of `headers`.
+    headers = JSON.parse(JSON.stringify(headers))
+    if (token && !headers.Authorization) {
+      headers.Authorization = hawkHeader(token, method, url, payload, this.timeOffset)
+    }
+    var options = {
+      url: url,
+      method: method,
+      headers: headers,
+      json: payload || true
+    }
+    if (headers['accept-language'] === undefined) { delete headers['accept-language']}
+    this.emit('startRequest', options)
+    request(options, function (err, res, body) {
+      if (res && res.headers.timestamp) {
+        // Record time skew
+        this.timeOffset = Date.now() - parseInt(res.headers.timestamp, 10) * 1000
+      }
+
+      this.emit('endRequest', options, err, res)
+      if (err || body.error || res.statusCode !== 200) {
+        return d.reject(err || body)
+      }
+
+      var allowedOrigin = res.headers['access-control-allow-origin']
+      if (allowedOrigin) {
+        // Requiring config outside this condition causes the local tests to fail
+        // because tokenLifetimes.passwordChangeToken is -1
+        var config = require('../../config')
+        if (config.get('corsOrigin').indexOf(allowedOrigin) < 0) {
+          return d.reject(new Error('Unexpected allowed origin: ' + allowedOrigin))
+        }
+      }
+
+      d.resolve(body)
+    }.bind(this))
+    return d.promise
+  }
+
+  /*
+   *  Creates a user account.
+   *
+   *  ___Parameters___
+   *
+   *  * email - the primary email for this account
+   *  * verifier - the derived SRP verifier
+   *  * salt - SPR salt
+   *  * params
+   *      * srp
+   *          * alg - hash function for SRP (sha256)
+   *          * N_bits - SPR group bits (2048)
+   *      * stretch
+   *          * rounds - number of rounds of password stretching
+   *
+   *   ___Response___
+   *   {}
+   *
+   */
+  ClientApi.prototype.accountCreate = function (email, authPW, options) {
+    options = options || {}
+
+    // Default to desktop client context
+    if (!options.metricsContext) {
+      options.metricsContext = {
+        context: 'fx_desktop_v3'
       }
     }
 
-    d.resolve(body)
-  }.bind(this))
-  return d.promise
-}
-
-/*
- *  Creates a user account.
- *
- *  ___Parameters___
- *
- *  * email - the primary email for this account
- *  * verifier - the derived SRP verifier
- *  * salt - SPR salt
- *  * params
- *      * srp
- *          * alg - hash function for SRP (sha256)
- *          * N_bits - SPR group bits (2048)
- *      * stretch
- *          * rounds - number of rounds of password stretching
- *
- *   ___Response___
- *   {}
- *
- */
-ClientApi.prototype.accountCreate = function (email, authPW, options) {
-  options = options || {}
-
-  // Default to desktop client context
-  if (!options.metricsContext) {
-    options.metricsContext = {
-      context: 'fx_desktop_v3'
-    }
-  }
-
-  var url = this.baseURL + '/account/create' + getQueryString(options)
-  return this.doRequest(
-    'POST',
-    url,
-    null,
-    {
-      email: email,
-      authPW: authPW.toString('hex'),
-      preVerified: options.preVerified || undefined,
-      service: options.service || undefined,
-      redirectTo: options.redirectTo || undefined,
-      resume: options.resume || undefined,
-      preVerifyToken: options.preVerifyToken || undefined,
-      device: options.device || undefined,
-      metricsContext: options.metricsContext || undefined
-    },
-    {
-      'accept-language': options.lang
-    }
-  )
-}
-
-ClientApi.prototype.accountLogin = function (email, authPW, opts) {
-  if (!opts) {
-    opts = { keys: true }
-  }
-
-  // Default to desktop client context
-  if (!opts.metricsContext) {
-    opts.metricsContext = {
-      context: 'fx_desktop_v3'
-    }
-  }
-
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/account/login' + getQueryString(opts),
-    null,
-    {
-      email: email,
-      authPW: authPW.toString('hex'),
-      service: opts.service || undefined,
-      resume: opts.resume || undefined,
-      reason: opts.reason || undefined,
-      device: opts.device || undefined,
-      metricsContext: opts.metricsContext || undefined
-    },
-    {
-      'accept-language': opts.lang
-    }
-  )
-}
-
-ClientApi.prototype.accountKeys = function (keyFetchTokenHex) {
-  return tokens.KeyFetchToken.fromHex(keyFetchTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/account/keys',
-          token
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.accountDevices = function (sessionTokenHex) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/account/devices',
-          token
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.accountDevice = function (sessionTokenHex, info) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/account/device',
-          token,
-          info
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.deviceDestroy = function (sessionTokenHex, id) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/account/device/destroy',
-          token,
-          {
-            id: id
-          }
-        )
-      }.bind(this)
-    )
-}
-
-
-ClientApi.prototype.accountStatusByEmail = function (email) {
-  if (email) {
+    var url = this.baseURL + '/account/create' + getQueryString(options)
     return this.doRequest(
       'POST',
-      this.baseURL + '/account/status',
+      url,
       null,
       {
-        email: email
+        email: email,
+        authPW: authPW.toString('hex'),
+        preVerified: options.preVerified || undefined,
+        service: options.service || undefined,
+        redirectTo: options.redirectTo || undefined,
+        resume: options.resume || undefined,
+        preVerifyToken: options.preVerifyToken || undefined,
+        device: options.device || undefined,
+        metricsContext: options.metricsContext || undefined
+      },
+      {
+        'accept-language': options.lang
       }
     )
   }
-  else {
-    return this.doRequest('POST', this.baseURL + '/account/status')
-  }
-}
 
-ClientApi.prototype.accountStatus = function (uid, sessionTokenHex) {
-  if (sessionTokenHex) {
-    return tokens.SessionToken.fromHex(sessionTokenHex)
+  ClientApi.prototype.accountLogin = function (email, authPW, opts) {
+    if (!opts) {
+      opts = { keys: true }
+    }
+
+    // Default to desktop client context
+    if (!opts.metricsContext) {
+      opts.metricsContext = {
+        context: 'fx_desktop_v3'
+      }
+    }
+
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/account/login' + getQueryString(opts),
+      null,
+      {
+        email: email,
+        authPW: authPW.toString('hex'),
+        service: opts.service || undefined,
+        resume: opts.resume || undefined,
+        reason: opts.reason || undefined,
+        device: opts.device || undefined,
+        metricsContext: opts.metricsContext || undefined
+      },
+      {
+        'accept-language': opts.lang
+      }
+    )
+  }
+
+  ClientApi.prototype.accountKeys = function (keyFetchTokenHex) {
+    return tokens.KeyFetchToken.fromHex(keyFetchTokenHex)
       .then(
         function (token) {
           return this.doRequest(
             'GET',
-            this.baseURL + '/account/status',
+            this.baseURL + '/account/keys',
             token
           )
         }.bind(this)
       )
   }
-  else if (uid) {
+
+  ClientApi.prototype.accountDevices = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'GET',
+            this.baseURL + '/account/devices',
+            token
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.accountDevice = function (sessionTokenHex, info) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/account/device',
+            token,
+            info
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.deviceDestroy = function (sessionTokenHex, id) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/account/device/destroy',
+            token,
+            {
+              id: id
+            }
+          )
+        }.bind(this)
+      )
+  }
+
+
+  ClientApi.prototype.accountStatusByEmail = function (email) {
+    if (email) {
+      return this.doRequest(
+        'POST',
+        this.baseURL + '/account/status',
+        null,
+        {
+          email: email
+        }
+      )
+    }
+    else {
+      return this.doRequest('POST', this.baseURL + '/account/status')
+    }
+  }
+
+  ClientApi.prototype.accountStatus = function (uid, sessionTokenHex) {
+    if (sessionTokenHex) {
+      return tokens.SessionToken.fromHex(sessionTokenHex)
+        .then(
+          function (token) {
+            return this.doRequest(
+              'GET',
+              this.baseURL + '/account/status',
+              token
+            )
+          }.bind(this)
+        )
+    }
+    else if (uid) {
+      return this.doRequest(
+        'GET',
+        this.baseURL + '/account/status?uid=' + uid
+      )
+    }
+    else {
+      // for testing the error response only
+      return this.doRequest('GET', this.baseURL + '/account/status')
+    }
+  }
+
+  ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, headers, options) {
+    options = options || {}
+    var qs = getQueryString(options)
+
+    // Default behavior is to request sessionToken
+    if (options.sessionToken === undefined) {
+      options.sessionToken = true
+    }
+
+    return tokens.AccountResetToken.fromHex(accountResetTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/account/reset' + qs,
+            token,
+            {
+              authPW: authPW.toString('hex'),
+              sessionToken: options.sessionToken
+            },
+            headers
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.accountDestroy = function (email, authPW) {
     return this.doRequest(
-      'GET',
-      this.baseURL + '/account/status?uid=' + uid
+      'POST',
+      this.baseURL + '/account/destroy',
+      null,
+      {
+        email: email,
+        authPW: authPW.toString('hex')
+      }
     )
   }
-  else {
-    // for testing the error response only
-    return this.doRequest('GET', this.baseURL + '/account/status')
+
+  ClientApi.prototype.recoveryEmailStatus = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'GET',
+            this.baseURL + '/recovery_email/status',
+            token
+          )
+        }.bind(this)
+      )
   }
-}
 
-ClientApi.prototype.accountReset = function (accountResetTokenHex, authPW, headers, options) {
-  options = options || {}
-  var qs = getQueryString(options)
+  ClientApi.prototype.recoveryEmailResendCode = function (sessionTokenHex, options) {
+    options = options || {}
 
-  // Default behavior is to request sessionToken
-  if (options.sessionToken === undefined) {
-    options.sessionToken = true
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/recovery_email/resend_code',
+            token,
+            {
+              service: options.service || undefined,
+              redirectTo: options.redirectTo || undefined,
+              resume: options.resume || undefined
+            }
+          )
+        }.bind(this)
+      )
   }
 
-  return tokens.AccountResetToken.fromHex(accountResetTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/account/reset' + qs,
-          token,
-          {
+  ClientApi.prototype.recoveryEmailVerifyCode = function (uid, code, options) {
+    options = options || {}
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/recovery_email/verify_code',
+      null,
+      {
+        uid: uid,
+        code: code,
+        service: options.service || undefined
+      },
+      {
+        'accept-language': options.lang
+      }
+    )
+  }
+
+  ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration, locale, options) {
+    options = options || {}
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/certificate/sign',
+            token,
+            {
+              publicKey: publicKey,
+              duration: duration
+            },
+            {
+              'accept-language': locale
+            }
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.getRandomBytes = function () {
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/get_random_bytes'
+    )
+  }
+
+  ClientApi.prototype.passwordChangeStart = function (email, oldAuthPW, headers) {
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/password/change/start',
+      null,
+      {
+        email: email,
+        oldAuthPW: oldAuthPW.toString('hex')
+      },
+      headers
+    )
+  }
+
+  ClientApi.prototype.passwordChangeFinish = function (passwordChangeTokenHex, authPW, wrapKb, headers, sessionToken) {
+    var options = {}
+    return tokens.PasswordChangeToken.fromHex(passwordChangeTokenHex)
+      .then(
+        function (token) {
+          var requestData = {
             authPW: authPW.toString('hex'),
-            sessionToken: options.sessionToken
-          },
-          headers
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.accountDestroy = function (email, authPW) {
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/account/destroy',
-    null,
-    {
-      email: email,
-      authPW: authPW.toString('hex')
-    }
-  )
-}
-
-ClientApi.prototype.recoveryEmailStatus = function (sessionTokenHex) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/recovery_email/status',
-          token
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.recoveryEmailResendCode = function (sessionTokenHex, options) {
-  options = options || {}
-
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/recovery_email/resend_code',
-          token,
-          {
-            service: options.service || undefined,
-            redirectTo: options.redirectTo || undefined,
-            resume: options.resume || undefined
+            wrapKb: wrapKb.toString('hex')
           }
-        )
-      }.bind(this)
-    )
-}
 
-ClientApi.prototype.recoveryEmailVerifyCode = function (uid, code, options) {
-  options = options || {}
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/recovery_email/verify_code',
-    null,
-    {
-      uid: uid,
-      code: code,
-      service: options.service || undefined
-    },
-    {
-      'accept-language': options.lang
-    }
-  )
-}
-
-ClientApi.prototype.certificateSign = function (sessionTokenHex, publicKey, duration, locale, options) {
-  options = options || {}
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/certificate/sign',
-          token,
-          {
-            publicKey: publicKey,
-            duration: duration
-          },
-          {
-            'accept-language': locale
+          if (sessionToken) {
+            // Support legacy clients and new clients
+            requestData.sessionToken = sessionToken
+            options.keys = true
           }
-        )
-      }.bind(this)
-    )
-}
 
-ClientApi.prototype.getRandomBytes = function () {
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/get_random_bytes'
-  )
-}
-
-ClientApi.prototype.passwordChangeStart = function (email, oldAuthPW, headers) {
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/password/change/start',
-    null,
-    {
-      email: email,
-      oldAuthPW: oldAuthPW.toString('hex')
-    },
-    headers
-  )
-}
-
-ClientApi.prototype.passwordChangeFinish = function (passwordChangeTokenHex, authPW, wrapKb, headers, sessionToken) {
-  var options = {}
-  return tokens.PasswordChangeToken.fromHex(passwordChangeTokenHex)
-    .then(
-      function (token) {
-        var requestData = {
-          authPW: authPW.toString('hex'),
-          wrapKb: wrapKb.toString('hex')
-        }
-
-        if (sessionToken) {
-          // Support legacy clients and new clients
-          requestData.sessionToken = sessionToken
-          options.keys = true
-        }
-
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/password/change/finish' + getQueryString(options),
-          token,
-          requestData,
-          headers
-        )
-      }.bind(this)
-    )
-}
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/password/change/finish' + getQueryString(options),
+            token,
+            requestData,
+            headers
+          )
+        }.bind(this)
+      )
+  }
 
 
-ClientApi.prototype.passwordForgotSendCode = function (email, options, lang) {
-  options = options || {}
-  var headers = {}
-  if (lang) {
-    headers = {
-      'accept-language': lang
+  ClientApi.prototype.passwordForgotSendCode = function (email, options, lang) {
+    options = options || {}
+    var headers = {}
+    if (lang) {
+      headers = {
+        'accept-language': lang
+      }
     }
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/password/forgot/send_code' + getQueryString(options),
+      null,
+      {
+        email: email,
+        service: options.service || undefined,
+        redirectTo: options.redirectTo || undefined,
+        resume: options.resume || undefined
+      },
+      headers
+    )
   }
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/password/forgot/send_code' + getQueryString(options),
-    null,
-    {
-      email: email,
-      service: options.service || undefined,
-      redirectTo: options.redirectTo || undefined,
-      resume: options.resume || undefined
-    },
-    headers
-  )
-}
 
-ClientApi.prototype.passwordForgotResendCode = function (passwordForgotTokenHex, email, options) {
-  options = options || {}
-  return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/password/forgot/resend_code' + getQueryString(options),
-          token,
-          {
-            email: email,
-            service: options.service || undefined,
-            redirectTo: options.redirectTo || undefined,
-            resume: options.resume || undefined
-          }
-        )
-      }.bind(this)
+  ClientApi.prototype.passwordForgotResendCode = function (passwordForgotTokenHex, email, options) {
+    options = options || {}
+    return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/password/forgot/resend_code' + getQueryString(options),
+            token,
+            {
+              email: email,
+              service: options.service || undefined,
+              redirectTo: options.redirectTo || undefined,
+              resume: options.resume || undefined
+            }
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.passwordForgotVerifyCode = function (passwordForgotTokenHex, code, headers) {
+    return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/password/forgot/verify_code',
+            token,
+            {
+              code: code
+            },
+            headers
+          )
+        }.bind(this)
     )
-}
+  }
 
-ClientApi.prototype.passwordForgotVerifyCode = function (passwordForgotTokenHex, code, headers) {
-  return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/password/forgot/verify_code',
-          token,
-          {
-            code: code
-          },
-          headers
-        )
-      }.bind(this)
+  ClientApi.prototype.passwordForgotStatus = function (passwordForgotTokenHex) {
+    return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'GET',
+            this.baseURL + '/password/forgot/status',
+            token
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.accountLock = function (email, authPW) {
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/account/lock',
+      null,
+      {
+        email: email,
+        authPW: authPW.toString('hex')
+      }
     )
-}
+  }
 
-ClientApi.prototype.passwordForgotStatus = function (passwordForgotTokenHex) {
-  return tokens.PasswordForgotToken.fromHex(passwordForgotTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/password/forgot/status',
-          token
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.accountLock = function (email, authPW) {
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/account/lock',
-    null,
-    {
-      email: email,
-      authPW: authPW.toString('hex')
+  ClientApi.prototype.accountUnlockResendCode = function (email, options, lang) {
+    options = options || {}
+    var headers = {}
+    if (lang) {
+      headers = {
+        'accept-language': lang
+      }
     }
-  )
-}
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/account/unlock/resend_code',
+      null,
+      {
+        email: email,
+        service: options.service || undefined,
+        redirectTo: options.redirectTo || undefined,
+        resume: options.resume || undefined
+      },
+      headers
+    )
+  }
 
-ClientApi.prototype.accountUnlockResendCode = function (email, options, lang) {
-  options = options || {}
-  var headers = {}
-  if (lang) {
-    headers = {
-      'accept-language': lang
+  ClientApi.prototype.accountUnlockVerifyCode = function (uid, code) {
+    return this.doRequest(
+      'POST',
+      this.baseURL + '/account/unlock/verify_code',
+      null,
+      {
+        uid: uid,
+        code: code
+      }
+    )
+  }
+
+  ClientApi.prototype.sessionDestroy = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'POST',
+            this.baseURL + '/session/destroy',
+            token
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.sessionStatus = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        function (token) {
+          return this.doRequest(
+            'GET',
+            this.baseURL + '/session/status',
+            token
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.prototype.accountProfile = function (sessionTokenHex, headers) {
+    var o = sessionTokenHex ? tokens.SessionToken.fromHex(sessionTokenHex) : P.resolve(null)
+    return o.then(
+        function (token) {
+          return this.doRequest(
+            'GET',
+            this.baseURL + '/account/profile',
+            token,
+            undefined,
+            headers
+          )
+        }.bind(this)
+      )
+  }
+
+  ClientApi.heartbeat = function (origin) {
+    return (new ClientApi(origin)).doRequest('GET', origin + '/__heartbeat__')
+  }
+
+  function getQueryString (options) {
+    var qs = '?'
+
+    if (options.keys) {
+      qs += 'keys=true&'
     }
-  }
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/account/unlock/resend_code',
-    null,
-    {
-      email: email,
-      service: options.service || undefined,
-      redirectTo: options.redirectTo || undefined,
-      resume: options.resume || undefined
-    },
-    headers
-  )
-}
 
-ClientApi.prototype.accountUnlockVerifyCode = function (uid, code) {
-  return this.doRequest(
-    'POST',
-    this.baseURL + '/account/unlock/verify_code',
-    null,
-    {
-      uid: uid,
-      code: code
+    if (options.serviceQuery) {
+      qs += 'service=' + options.serviceQuery + '&'
     }
-  )
-}
 
-ClientApi.prototype.sessionDestroy = function (sessionTokenHex) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'POST',
-          this.baseURL + '/session/destroy',
-          token
-        )
-      }.bind(this)
-    )
-}
+    if (options.createdAt) {
+      qs += '_createdAt=' + options.createdAt
+    }
 
-ClientApi.prototype.sessionStatus = function (sessionTokenHex) {
-  return tokens.SessionToken.fromHex(sessionTokenHex)
-    .then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/session/status',
-          token
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.prototype.accountProfile = function (sessionTokenHex, headers) {
-  var o = sessionTokenHex ? tokens.SessionToken.fromHex(sessionTokenHex) : P.resolve(null)
-  return o.then(
-      function (token) {
-        return this.doRequest(
-          'GET',
-          this.baseURL + '/account/profile',
-          token,
-          undefined,
-          headers
-        )
-      }.bind(this)
-    )
-}
-
-ClientApi.heartbeat = function (origin) {
-  return (new ClientApi(origin)).doRequest('GET', origin + '/__heartbeat__')
-}
-
-function getQueryString (options) {
-  var qs = '?'
-
-  if (options.keys) {
-    qs += 'keys=true&'
+    return qs
   }
 
-  if (options.serviceQuery) {
-    qs += 'service=' + options.serviceQuery + '&'
-  }
-
-  if (options.createdAt) {
-    qs += '_createdAt=' + options.createdAt
-  }
-
-  return qs
+  return ClientApi
 }
-
-module.exports = ClientApi

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -2,286 +2,287 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var P = require('../../lib/promise')
-var ClientApi = require('./api')
-var butil = require('../../lib/crypto/butil')
-var pbkdf2 = require('../../lib/crypto/pbkdf2')
-var hkdf = require('../../lib/crypto/hkdf')
-var tokens = require('../../lib/tokens')({ trace: function () {}})
+module.exports = config => {
+  var P = require('../../lib/promise')
+  const ClientApi = require('./api')(config)
+  var butil = require('../../lib/crypto/butil')
+  var pbkdf2 = require('../../lib/crypto/pbkdf2')
+  var hkdf = require('../../lib/crypto/hkdf')
+  const tokens = require('../../lib/tokens')({ trace: function () {}}, config)
 
-function Client(origin) {
-  this.uid = null
-  this.authAt = 0
-  this.api = new ClientApi(origin)
-  this.email = null
-  this.emailVerified = false
-  this.authToken = null
-  this.sessionToken = null
-  this.accountResetToken = null
-  this.keyFetchToken = null
-  this.passwordForgotToken = null
-  this.kA = null
-  this.wrapKb = null
-  this.options = {}
-}
-
-Client.Api = ClientApi
-
-Client.prototype.setupCredentials = function (email, password) {
-  this.email = email
-  return pbkdf2.derive(Buffer(password), hkdf.KWE('quickStretch', email), 1000, 32)
-    .then(
-      function (stretch) {
-        return hkdf(stretch, 'authPW', null, 32)
-          .then(
-            function (authPW) {
-              this.authPW = authPW
-              return hkdf(stretch, 'unwrapBKey', null, 32)
-            }.bind(this)
-          )
-      }.bind(this)
-    )
-    .then(
-      function (unwrapBKey) {
-        this.unwrapBKey = unwrapBKey
-        return this
-      }.bind(this)
-    )
-}
-
-Client.create = function (origin, email, password, options) {
-  var c = new Client(origin)
-  c.options = options || {}
-
-  return c.setupCredentials(email, password)
-    .then(
-      function() {
-        return c.create()
-      }
-    )
-}
-
-Client.login = function (origin, email, password, opts) {
-  var c = new Client(origin)
-
-  return c.setupCredentials(email, password)
-    .then(
-      function (c) {
-        return c.auth(opts)
-      }
-    )
-}
-
-Client.changePassword = function (origin, email, oldPassword, newPassword, headers) {
-  var c = new Client(origin)
-
-  return c.setupCredentials(email, oldPassword)
-    .then(
-      function () {
-        return c.changePassword(newPassword, headers)
-        .then(
-          function () {
-            return c
-          }
-        )
-      }
-    )
-}
-
-Client.createAndVerify = function (origin, email, password, mailbox, options) {
-  return Client.create(origin, email, password, options)
-    .then(
-      function (client) {
-        return mailbox.waitForCode(email)
-          .then(
-            function (code) {
-              return client.verifyEmail(code, options)
-            }
-          )
-          .then(
-            function () {
-              // clear the post verified email, if one was sent
-              if (options && options.service === 'sync') {
-                return mailbox.waitForEmail(email)
-              }
-            }
-          )
-          .then(
-            function () {
-              return client
-            }
-          )
-      }
-    )
-}
-
-Client.loginAndVerify = function (origin, email, password, mailbox, options) {
-  if (! options ) {
-    options = {}
+  function Client(origin) {
+    this.uid = null
+    this.authAt = 0
+    this.api = new ClientApi(origin)
+    this.email = null
+    this.emailVerified = false
+    this.authToken = null
+    this.sessionToken = null
+    this.accountResetToken = null
+    this.keyFetchToken = null
+    this.passwordForgotToken = null
+    this.kA = null
+    this.wrapKb = null
+    this.options = {}
   }
 
-  options.keys = options.keys || true
+  Client.Api = ClientApi
 
-  return Client.login(origin, email, password, options)
-    .then(
-      function (client) {
-        return mailbox.waitForCode(email)
-          .then(
-            function (code) {
-              return client.verifyEmail(code, options)
-            }
-          )
-          .then(
-            function () {
-              return client
-            }
-          )
-      }
-    )
-}
-
-Client.prototype.create = function () {
-  return this.api.accountCreate(
-    this.email,
-    this.authPW,
-    this.options
-  )
-  .then(
-    function (a) {
-      this.uid = a.uid
-      this.authAt = a.authAt
-      this.sessionToken = a.sessionToken
-      this.keyFetchToken = a.keyFetchToken
-      this.device = a.device
-      return this
-    }.bind(this)
-  )
-}
-
-Client.prototype._clear = function () {
-  this.authToken = null
-  this.sessionToken = null
-  this.srpSession = null
-  this.accountResetToken = null
-  this.keyFetchToken = null
-  this.passwordForgotToken = null
-  this.kA = null
-  this.wrapKb = null
-}
-
-Client.prototype.stringify = function () {
-  return JSON.stringify(this)
-}
-
-Client.prototype.auth = function (opts) {
-  return this.api.accountLogin(this.email, this.authPW, opts)
-    .then(
-      function (data) {
-        this.uid = data.uid
-        this.sessionToken = data.sessionToken
-        this.keyFetchToken = data.keyFetchToken || null
-        this.emailVerified = data.verified
-        this.authAt = data.authAt
-        this.device = data.device
-        this.verificationReason = data.verificationReason
-        this.verificationMethod = data.verificationMethod
-        this.verified = data.verified
-        return this
-      }.bind(this)
-    )
-}
-
-Client.prototype.login = function (opts) {
-  return this.auth(opts)
-}
-
-Client.prototype.destroySession = function () {
-  var p = P.resolve(null)
-  if (this.sessionToken) {
-    p = this.api.sessionDestroy(this.sessionToken)
+  Client.prototype.setupCredentials = function (email, password) {
+    this.email = email
+    return pbkdf2.derive(Buffer(password), hkdf.KWE('quickStretch', email), 1000, 32)
       .then(
-        function () {
-          this.sessionToken = null
-          return {}
+        function (stretch) {
+          return hkdf(stretch, 'authPW', null, 32)
+            .then(
+              function (authPW) {
+                this.authPW = authPW
+                return hkdf(stretch, 'unwrapBKey', null, 32)
+              }.bind(this)
+            )
+        }.bind(this)
+      )
+      .then(
+        function (unwrapBKey) {
+          this.unwrapBKey = unwrapBKey
+          return this
         }.bind(this)
       )
   }
-  return p
-}
 
-Client.prototype.verifyEmail = function (code, options) {
-  return this.api.recoveryEmailVerifyCode(this.uid, code, options)
-}
+  Client.create = function (origin, email, password, options) {
+    var c = new Client(origin)
+    c.options = options || {}
 
-Client.prototype.emailStatus = function () {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
+    return c.setupCredentials(email, password)
+      .then(
+        function() {
+          return c.create()
+        }
+      )
+  }
+
+  Client.login = function (origin, email, password, opts) {
+    var c = new Client(origin)
+
+    return c.setupCredentials(email, password)
+      .then(
+        function (c) {
+          return c.auth(opts)
+        }
+      )
+  }
+
+  Client.changePassword = function (origin, email, oldPassword, newPassword, headers) {
+    var c = new Client(origin)
+
+    return c.setupCredentials(email, oldPassword)
+      .then(
+        function () {
+          return c.changePassword(newPassword, headers)
+          .then(
+            function () {
+              return c
+            }
+          )
+        }
+      )
+  }
+
+  Client.createAndVerify = function (origin, email, password, mailbox, options) {
+    return Client.create(origin, email, password, options)
+      .then(
+        function (client) {
+          return mailbox.waitForCode(email)
+            .then(
+              function (code) {
+                return client.verifyEmail(code, options)
+              }
+            )
+            .then(
+              function () {
+                // clear the post verified email, if one was sent
+                if (options && options.service === 'sync') {
+                  return mailbox.waitForEmail(email)
+                }
+              }
+            )
+            .then(
+              function () {
+                return client
+              }
+            )
+        }
+      )
+  }
+
+  Client.loginAndVerify = function (origin, email, password, mailbox, options) {
+    if (! options ) {
+      options = {}
+    }
+
+    options.keys = options.keys || true
+
+    return Client.login(origin, email, password, options)
+      .then(
+        function (client) {
+          return mailbox.waitForCode(email)
+            .then(
+              function (code) {
+                return client.verifyEmail(code, options)
+              }
+            )
+            .then(
+              function () {
+                return client
+              }
+            )
+        }
+      )
+  }
+
+  Client.prototype.create = function () {
+    return this.api.accountCreate(
+      this.email,
+      this.authPW,
+      this.options
+    )
+    .then(
+      function (a) {
+        this.uid = a.uid
+        this.authAt = a.authAt
+        this.sessionToken = a.sessionToken
+        this.keyFetchToken = a.keyFetchToken
+        this.device = a.device
+        return this
+      }.bind(this)
+    )
+  }
+
+  Client.prototype._clear = function () {
+    this.authToken = null
+    this.sessionToken = null
+    this.srpSession = null
+    this.accountResetToken = null
+    this.keyFetchToken = null
+    this.passwordForgotToken = null
+    this.kA = null
+    this.wrapKb = null
+  }
+
+  Client.prototype.stringify = function () {
+    return JSON.stringify(this)
+  }
+
+  Client.prototype.auth = function (opts) {
+    return this.api.accountLogin(this.email, this.authPW, opts)
+      .then(
+        function (data) {
+          this.uid = data.uid
+          this.sessionToken = data.sessionToken
+          this.keyFetchToken = data.keyFetchToken || null
+          this.emailVerified = data.verified
+          this.authAt = data.authAt
+          this.device = data.device
+          this.verificationReason = data.verificationReason
+          this.verificationMethod = data.verificationMethod
+          this.verified = data.verified
+          return this
+        }.bind(this)
+      )
+  }
+
+  Client.prototype.login = function (opts) {
+    return this.auth(opts)
+  }
+
+  Client.prototype.destroySession = function () {
+    var p = P.resolve(null)
+    if (this.sessionToken) {
+      p = this.api.sessionDestroy(this.sessionToken)
+        .then(
+          function () {
+            this.sessionToken = null
+            return {}
+          }.bind(this)
+        )
+    }
+    return p
+  }
+
+  Client.prototype.verifyEmail = function (code, options) {
+    return this.api.recoveryEmailVerifyCode(this.uid, code, options)
+  }
+
+  Client.prototype.emailStatus = function () {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
       function () {
         return this.api.recoveryEmailStatus(this.sessionToken)
       }.bind(this)
     )
-}
+  }
 
-Client.prototype.requestVerifyEmail = function () {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
-    function () {
-      return this.api.recoveryEmailResendCode(this.sessionToken, this.options)
-    }.bind(this)
-  )
-}
+  Client.prototype.requestVerifyEmail = function () {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
+      function () {
+        return this.api.recoveryEmailResendCode(this.sessionToken, this.options)
+      }.bind(this)
+    )
+  }
 
-Client.prototype.sign = function (publicKey, duration, locale, options) {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
+  Client.prototype.sign = function (publicKey, duration, locale, options) {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
       function () {
         return this.api.certificateSign(this.sessionToken, publicKey, duration, locale, options)
       }.bind(this)
     )
     .then(
-    function (x) {
-      return x.cert
-    }
-  )
-}
-
-Client.prototype.changePassword = function (newPassword, headers, sessionToken) {
-  return this.api.passwordChangeStart(this.email, this.authPW, headers)
-    .then(
-      function (json) {
-        this.keyFetchToken = json.keyFetchToken
-        this.passwordChangeToken = json.passwordChangeToken
-        return this.keys()
-      }.bind(this)
+      function (x) {
+        return x.cert
+      }
     )
-    .then(
-      function (/* keys */) {
-        return this.setupCredentials(this.email, newPassword)
-      }.bind(this)
-    )
-    .then(
-      function () {
-        this.wrapKb = butil.xorBuffers(this.kB, this.unwrapBKey)
-        return this.api.passwordChangeFinish(this.passwordChangeToken, this.authPW, this.wrapKb, headers, sessionToken)
-      }.bind(this)
-    )
-    .then(
-      function (res) {
-        this._clear()
+  }
 
-        // Update to new tokens if needed
-        this.sessionToken = res.sessionToken ? res.sessionToken : this.sessionToken
-        this.authAt = res.authAt ? res.authAt : this.authAt
-        this.keyFetchToken = res.keyFetchToken ? res.keyFetchToken : this.keyFetchToken
+  Client.prototype.changePassword = function (newPassword, headers, sessionToken) {
+    return this.api.passwordChangeStart(this.email, this.authPW, headers)
+      .then(
+        function (json) {
+          this.keyFetchToken = json.keyFetchToken
+          this.passwordChangeToken = json.passwordChangeToken
+          return this.keys()
+        }.bind(this)
+      )
+      .then(
+        function (/* keys */) {
+          return this.setupCredentials(this.email, newPassword)
+        }.bind(this)
+      )
+      .then(
+        function () {
+          this.wrapKb = butil.xorBuffers(this.kB, this.unwrapBKey)
+          return this.api.passwordChangeFinish(this.passwordChangeToken, this.authPW, this.wrapKb, headers, sessionToken)
+        }.bind(this)
+      )
+      .then(
+        function (res) {
+          this._clear()
 
-        return res
-      }.bind(this)
-    )
-}
+          // Update to new tokens if needed
+          this.sessionToken = res.sessionToken ? res.sessionToken : this.sessionToken
+          this.authAt = res.authAt ? res.authAt : this.authAt
+          this.keyFetchToken = res.keyFetchToken ? res.keyFetchToken : this.keyFetchToken
 
-Client.prototype.keys = function () {
-  var o = this.keyFetchToken ? P.resolve(null) : this.login()
-  return o.then(
+          return res
+        }.bind(this)
+      )
+  }
+
+  Client.prototype.keys = function () {
+    var o = this.keyFetchToken ? P.resolve(null) : this.login()
+    return o.then(
       function () {
         return this.api.accountKeys(this.keyFetchToken)
       }.bind(this)
@@ -309,136 +310,135 @@ Client.prototype.keys = function () {
         throw err
       }.bind(this)
     )
-}
+  }
 
-Client.prototype.devices = function () {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
-    function () {
-      return this.api.accountDevices(this.sessionToken)
-    }.bind(this)
-  )
-}
+  Client.prototype.devices = function () {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
+      function () {
+        return this.api.accountDevices(this.sessionToken)
+      }.bind(this)
+    )
+  }
 
-Client.prototype.updateDevice = function (info) {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
-    function () {
-      return this.api.accountDevice(this.sessionToken, info)
-    }.bind(this)
-  )
-  .then(
-    function (device) {
-      if (! this.device || this.device.id === device.id) {
-        this.device = device
-      }
-      return device
-    }.bind(this)
-  )
-}
+  Client.prototype.updateDevice = function (info) {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
+      function () {
+        return this.api.accountDevice(this.sessionToken, info)
+      }.bind(this)
+    )
+    .then(
+      function (device) {
+        if (! this.device || this.device.id === device.id) {
+          this.device = device
+        }
+        return device
+      }.bind(this)
+    )
+  }
 
-Client.prototype.destroyDevice = function (id) {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
-    function () {
-      return this.api.deviceDestroy(this.sessionToken, id)
-    }.bind(this)
-  )
-  .then(
-    function () {
-      delete this.sessionToken
-    }.bind(this)
-  )
-}
+  Client.prototype.destroyDevice = function (id) {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
+      function () {
+        return this.api.deviceDestroy(this.sessionToken, id)
+      }.bind(this)
+    )
+    .then(
+      function () {
+        delete this.sessionToken
+      }.bind(this)
+    )
+  }
 
-Client.prototype.sessionStatus = function () {
-  var o = this.sessionToken ? P.resolve(null) : this.login()
-  return o.then(
+  Client.prototype.sessionStatus = function () {
+    var o = this.sessionToken ? P.resolve(null) : this.login()
+    return o.then(
       function () {
         return this.api.sessionStatus(this.sessionToken)
       }.bind(this)
     )
-}
-
-Client.prototype.accountProfile = function (oauthToken) {
-  if (oauthToken) {
-    return this.api.accountProfile(null, { Authorization: 'Bearer ' + oauthToken })
-  } else {
-    var o = this.sessionToken ? P.resolve(null) : this.login()
-    return o.then(
-      function () {
-        return this.api.accountProfile(this.sessionToken)
-      }.bind(this)
-    )
   }
-}
 
-Client.prototype.destroyAccount = function () {
-  return this.api.accountDestroy(this.email, this.authPW)
-    .then(this._clear.bind(this))
-}
-
-Client.prototype.forgotPassword = function (lang) {
-
-  return this.api.passwordForgotSendCode(this.email, this.options, lang)
-    .then(
-      function (x) {
-        this.passwordForgotToken = x.passwordForgotToken
-      }.bind(this)
-    )
-}
-
-Client.prototype.reforgotPassword = function () {
-  return this.api.passwordForgotResendCode(this.passwordForgotToken, this.email)
-}
-
-Client.prototype.verifyPasswordResetCode = function (code, headers) {
-  return this.api.passwordForgotVerifyCode(this.passwordForgotToken, code, headers)
-    .then(
-      function (result) {
-        this.accountResetToken = result.accountResetToken
-      }.bind(this)
-    )
-}
-
-Client.prototype.lockAccount = function () {
-  return this.api.accountLock(this.email, this.authPW)
-}
-
-Client.prototype.resendAccountUnlockCode = function (lang) {
-  return this.api.accountUnlockResendCode(this.email, this.options, lang)
-}
-
-Client.prototype.verifyAccountUnlockCode = function (uid, code) {
-  return this.api.accountUnlockVerifyCode(uid, code)
-}
-
-Client.prototype.resetPassword = function (newPassword, headers, options) {
-  if (!this.accountResetToken) {
-    throw new Error('call verifyPasswordResetCode before calling resetPassword')
+  Client.prototype.accountProfile = function (oauthToken) {
+    if (oauthToken) {
+      return this.api.accountProfile(null, { Authorization: 'Bearer ' + oauthToken })
+    } else {
+      var o = this.sessionToken ? P.resolve(null) : this.login()
+      return o.then(
+        function () {
+          return this.api.accountProfile(this.sessionToken)
+        }.bind(this)
+      )
+    }
   }
-  // this will generate a new wrapKb on the server
-  return this.setupCredentials(this.email, newPassword)
-    .then(
-      function (/* bundle */) {
-        return this.api.accountReset(
-          this.accountResetToken,
-          this.authPW,
-          headers,
-          options
-        )
-          .then(function (response) {
-            // Update to the new verified tokens
-            this.sessionToken = response.sessionToken
-            this.keyFetchToken = response.keyFetchToken
 
-            return response
-          })
+  Client.prototype.destroyAccount = function () {
+    return this.api.accountDestroy(this.email, this.authPW)
+      .then(this._clear.bind(this))
+  }
 
-      }.bind(this)
-    )
+  Client.prototype.forgotPassword = function (lang) {
+
+    return this.api.passwordForgotSendCode(this.email, this.options, lang)
+      .then(
+        function (x) {
+          this.passwordForgotToken = x.passwordForgotToken
+        }.bind(this)
+      )
+  }
+
+  Client.prototype.reforgotPassword = function () {
+    return this.api.passwordForgotResendCode(this.passwordForgotToken, this.email)
+  }
+
+  Client.prototype.verifyPasswordResetCode = function (code, headers) {
+    return this.api.passwordForgotVerifyCode(this.passwordForgotToken, code, headers)
+      .then(
+        function (result) {
+          this.accountResetToken = result.accountResetToken
+        }.bind(this)
+      )
+  }
+
+  Client.prototype.lockAccount = function () {
+    return this.api.accountLock(this.email, this.authPW)
+  }
+
+  Client.prototype.resendAccountUnlockCode = function (lang) {
+    return this.api.accountUnlockResendCode(this.email, this.options, lang)
+  }
+
+  Client.prototype.verifyAccountUnlockCode = function (uid, code) {
+    return this.api.accountUnlockVerifyCode(uid, code)
+  }
+
+  Client.prototype.resetPassword = function (newPassword, headers, options) {
+    if (!this.accountResetToken) {
+      throw new Error('call verifyPasswordResetCode before calling resetPassword')
+    }
+    // this will generate a new wrapKb on the server
+    return this.setupCredentials(this.email, newPassword)
+      .then(
+        function (/* bundle */) {
+          return this.api.accountReset(
+            this.accountResetToken,
+            this.authPW,
+            headers,
+            options
+          )
+            .then(function (response) {
+              // Update to the new verified tokens
+              this.sessionToken = response.sessionToken
+              this.keyFetchToken = response.keyFetchToken
+
+              return response
+            })
+
+        }.bind(this)
+      )
+  }
+
+  return Client
 }
-
-//TODO recovery methods, session status/destroy
-
-module.exports = Client

--- a/test/local/features_tests.js
+++ b/test/local/features_tests.js
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const test = require('../ptaptest')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+let hashResult = Array(40).fill('0')
+const hash = {
+  update: sinon.spy(),
+  digest: sinon.spy(() => hashResult)
+}
+const crypto = {
+  createHash: sinon.spy(() => hash)
+}
+
+const config = {
+  lastAccessTimeUpdates: {},
+  signinConfirmation: {}
+}
+
+const features = proxyquire('../../lib/features', {
+  crypto: crypto
+})(config)
+
+test(
+  'interface is correct',
+  t => {
+    t.equal(typeof features, 'object', 'object type should be exported')
+    t.equal(Object.keys(features).length, 3, 'object should have two properties')
+    t.equal(typeof features.isSampledUser, 'function', 'isSampledUser should be function')
+    t.equal(typeof features.isLastAccessTimeEnabledForUser, 'function', 'isLastAccessTimeEnabledForUser should be function')
+    t.equal(typeof features.isSigninConfirmationEnabledForUser, 'function', 'isSigninConfirmationEnabledForUser should be function')
+
+    t.equal(crypto.createHash.callCount, 1, 'crypto.createHash should have been called once on require')
+    let args = crypto.createHash.args[0]
+    t.equal(args.length, 1, 'crypto.createHash should have been passed one argument')
+    t.equal(args[0], 'sha1', 'crypto.createHash algorithm should have been sha1')
+
+    t.equal(hash.update.callCount, 2, 'hash.update should have been called twice on require')
+    args = hash.update.args[0]
+    t.equal(args.length, 1, 'hash.update should have been passed one argument first time')
+    t.equal(typeof args[0], 'string', 'hash.update data should have been a string first time')
+    args = hash.update.args[1]
+    t.equal(args.length, 1, 'hash.update should have been passed one argument second time')
+    t.equal(typeof args[0], 'string', 'hash.update data should have been a string second time')
+
+    t.equal(hash.digest.callCount, 1, 'hash.digest should have been called once on require')
+    args = hash.digest.args[0]
+    t.equal(args.length, 1, 'hash.digest should have been passed one argument')
+    t.equal(args[0], 'hex', 'hash.digest ecnoding should have been hex')
+
+    crypto.createHash.reset()
+    hash.update.reset()
+    hash.digest.reset()
+
+    t.end()
+  }
+)
+
+test(
+  'isSampledUser',
+  t => {
+    let uid = Buffer.alloc(32, 0xff)
+    let sampleRate = 1
+    hashResult = Array(40).fill('f').join('')
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'foo'), true, 'should always return true if sample rate is 1')
+
+    t.equal(crypto.createHash.callCount, 0, 'crypto.createHash should not have been called')
+    t.equal(hash.update.callCount, 0, 'hash.update should not have been called')
+    t.equal(hash.digest.callCount, 0, 'hash.digest should not have been called')
+
+    sampleRate = 0
+    hashResult = Array(40).fill('0').join('')
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'foo'), false, 'should always return false if sample rate is 0')
+
+    t.equal(crypto.createHash.callCount, 0, 'crypto.createHash should not have been called')
+    t.equal(hash.update.callCount, 0, 'hash.update should not have been called')
+    t.equal(hash.digest.callCount, 0, 'hash.digest should not have been called')
+
+    sampleRate = 0.05
+    // First 27 characters are ignored, last 13 are 0.04 * 0xfffffffffffff
+    hashResult = '0000000000000000000000000000a3d70a3d70a6'
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'foo'), true, 'should return true if sample rate is greater than the extracted cohort value')
+
+    t.equal(crypto.createHash.callCount, 1, 'crypto.createHash should have been called once')
+    let args = crypto.createHash.args[0]
+    t.equal(args.length, 1, 'crypto.createHash should have been passed one argument')
+    t.equal(args[0], 'sha1', 'crypto.createHash algorithm should have been sha1')
+
+    t.equal(hash.update.callCount, 2, 'hash.update should have been called twice')
+    args = hash.update.args[0]
+    t.equal(args.length, 1, 'hash.update should have been passed one argument first time')
+    t.equal(args[0], uid.toString('hex'), 'hash.update data should have been stringified uid first time')
+    args = hash.update.args[1]
+    t.equal(args.length, 1, 'hash.update should have been passed one argument second time')
+    t.equal(args[0], 'foo', 'hash.update data should have been key second time')
+
+    t.equal(hash.digest.callCount, 1, 'hash.digest should have been called once')
+    args = hash.digest.args[0]
+    t.equal(args.length, 1, 'hash.digest should have been passed one argument')
+    t.equal(args[0], 'hex', 'hash.digest ecnoding should have been hex')
+
+    crypto.createHash.reset()
+    hash.update.reset()
+    hash.digest.reset()
+
+    sampleRate = 0.04
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'bar'), false, 'should return false if sample rate is equal to the extracted cohort value')
+
+    t.equal(crypto.createHash.callCount, 1, 'crypto.createHash should have been called once')
+    t.equal(hash.update.callCount, 2, 'hash.update should have been called twice')
+    t.equal(hash.update.args[0][0], uid.toString('hex'), 'hash.update data should have been stringified uid first time')
+    t.equal(hash.update.args[1][0], 'bar', 'hash.update data should have been key second time')
+    t.equal(hash.digest.callCount, 1, 'hash.digest should have been called once')
+
+    crypto.createHash.reset()
+    hash.update.reset()
+    hash.digest.reset()
+
+    sampleRate = 0.03
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'foo'), false, 'should return false if sample rate is less than the extracted cohort value')
+
+    crypto.createHash.reset()
+    hash.update.reset()
+    hash.digest.reset()
+
+    uid = Array(64).fill('7').join('')
+    sampleRate = 0.03
+    // First 27 characters are ignored, last 13 are 0.02 * 0xfffffffffffff
+    hashResult = '000000000000000000000000000051eb851eb852'
+
+    t.equal(features.isSampledUser(sampleRate, uid, 'wibble'), true, 'should return true if sample rate is greater than the extracted cohort value')
+
+    t.equal(hash.update.callCount, 2, 'hash.update should have been called twice')
+    t.equal(hash.update.args[0][0], uid, 'hash.update data should have been stringified uid first time')
+    t.equal(hash.update.args[1][0], 'wibble', 'hash.update data should have been key second time')
+
+    crypto.createHash.reset()
+    hash.update.reset()
+    hash.digest.reset()
+
+    t.end()
+  }
+)
+
+test(
+  'isLastAccessTimeEnabledForUser',
+  t => {
+    const uid = 'foo'
+    const email = 'bar@mozilla.com'
+    // First 27 characters are ignored, last 13 are 0.02 * 0xfffffffffffff
+    hashResult = '000000000000000000000000000051eb851eb852'
+
+    config.lastAccessTimeUpdates.enabled = true
+    config.lastAccessTimeUpdates.sampleRate = 0
+    config.lastAccessTimeUpdates.enabledEmailAddresses = '.+@mozilla\\.com$'
+    t.equal(features.isLastAccessTimeEnabledForUser(uid, email), true, 'should return true when email address matches')
+
+    config.lastAccessTimeUpdates.enabledEmailAddresses = '.+@mozilla\\.org$'
+    t.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when email address does not match')
+
+    config.lastAccessTimeUpdates.sampleRate = 0.03
+    t.equal(features.isLastAccessTimeEnabledForUser(uid, email), true, 'should return true when sample rate matches')
+
+    config.lastAccessTimeUpdates.sampleRate = 0.02
+    t.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when sample rate does not match')
+
+    config.lastAccessTimeUpdates.enabled = false
+    config.lastAccessTimeUpdates.sampleRate = 0.03
+    config.lastAccessTimeUpdates.enabledEmailAddresses = '.+@mozilla\\.com$'
+    t.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when feature is disabled')
+
+    t.end()
+  }
+)
+
+test(
+  'isSigninConfirmationEnabledForUser',
+  t => {
+    const uid = 'wibble'
+    const email = 'blee@mozilla.com'
+    const request = {
+      app: {
+        isSuspiciousRequest: true
+      },
+      payload: {
+        metricsContext: {
+          context: 'iframe'
+        }
+      }
+    }
+    // First 27 characters are ignored, last 13 are 0.02 * 0xfffffffffffff
+    hashResult = '000000000000000000000000000051eb851eb852'
+
+    config.signinConfirmation.enabled = true
+    config.signinConfirmation.sample_rate = 0.03
+    config.signinConfirmation.forceEmailRegex = [ 'wibble', '.+@mozilla\\.com$' ]
+    config.signinConfirmation.supportedClients = [ 'wibble', 'iframe' ]
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), true, 'should return true when request is suspicious')
+
+    config.signinConfirmation.sample_rate = 0.02
+    request.app.isSuspiciousRequest = false
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), true, 'should return true when email address matches')
+
+    config.signinConfirmation.forceEmailRegex[1] = '.+@mozilla\\.org$'
+    request.payload.metricsContext.context = 'iframe'
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), false, 'should return false when email address and sample rate do not match')
+
+    config.signinConfirmation.sample_rate = 0.03
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), true, 'should return true when sample rate and context match')
+
+    request.payload.metricsContext.context = ''
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), false, 'should return false when context does not match')
+
+    config.signinConfirmation.enabled = false
+    config.signinConfirmation.forceEmailRegex[1] = '.+@mozilla\\.com$'
+    request.payload.metricsContext.context = 'iframe'
+    t.equal(features.isSigninConfirmationEnabledForUser(uid, email, request), false, 'should return false when feature is disabled')
+
+    t.end()
+  }
+)
+

--- a/test/local/request_helper_tests.js
+++ b/test/local/request_helper_tests.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const test = require('../ptaptest')
+const requestHelper = require('../../lib/routes/utils/request_helper')
+
+test(
+  'interface is correct',
+  t => {
+    t.equal(typeof requestHelper, 'object', 'object type should be exported')
+    t.equal(Object.keys(requestHelper).length, 2, 'object should have two properties')
+    t.equal(typeof requestHelper.wantsKeys, 'function', 'wantsKeys should be function')
+    t.equal(typeof requestHelper.shouldSendVerifyAccountEmail, 'function', 'shouldSendVerifyAccountEmail should be function')
+
+    t.end()
+  }
+)
+
+test(
+  'wantsKeys',
+  t => {
+    t.equal(!! requestHelper.wantsKeys({}), false, 'should return falsey if request.query is not set')
+    t.equal(requestHelper.wantsKeys({ query: {} }), false, 'should return false if query.keys is not set')
+    t.equal(requestHelper.wantsKeys({ query: { keys: 'wibble' } }), false, 'should return false if keys is not true')
+    t.equal(requestHelper.wantsKeys({ query: { keys: 'true' } }), true, 'should return true if keys is true')
+
+    t.end()
+  }
+)
+
+test(
+  'shouldSendVerifyAccountEmail',
+  t => {
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: false,
+    }, {
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), true, 'should return true when request has no payload and account is not verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: true,
+    }, {
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), false, 'should return false when request has no payload and account is verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: false,
+    }, {
+      payload: {},
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), true, 'should return true when payload has no metrics context and account is not verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: true,
+    }, {
+      payload: {},
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), false, 'should return false when payload has no metrics context and account is verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: false,
+    }, {
+      payload: {
+        metricsContext: {}
+      },
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), true, 'should return true when payload has metrics context and sendEmailIfUnverified is set and account is not verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: true,
+    }, {
+      payload: {
+        metricsContext: {}
+      },
+      query: {
+        sendEmailIfUnverified: 'true'
+      }
+    }), false, 'should return false when payload has metrics context and sendEmailIfUnverified is set and account is verified')
+
+    t.equal(requestHelper.shouldSendVerifyAccountEmail({
+      emailVerified: false,
+    }, {
+      payload: {
+        metricsContext: {}
+      },
+      query: {}
+    }), false, 'should return false when payload has metrics context and sendEmailIfUnverified is not set and account is not verified')
+
+    t.end()
+  }
+)
+

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -5,7 +5,7 @@
 var test = require('tap').test
 var TestServer = require('../test_server')
 var crypto = require('crypto')
-var Client = require('../client')
+const Client = require('../client')()
 var config = require('../../config').getProperties()
 // XXX: update this later to avoid issues.
 process.env.NODE_ENV = 'dev'

--- a/test/remote/account_destroy_tests.js
+++ b/test/remote/account_destroy_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 var config = require('../../config').getProperties()
 

--- a/test/remote/account_locale_tests.js
+++ b/test/remote/account_locale_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 var config = require('../../config').getProperties()
 var key = {

--- a/test/remote/account_login_tests.js
+++ b/test/remote/account_login_tests.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var Client = require('../client')
+const Client = require('../client')()
 var crypto = require('crypto')
 var test = require('tap').test
 var TestServer = require('../test_server')

--- a/test/remote/account_preverified_token_tests.js
+++ b/test/remote/account_preverified_token_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var JWTool = require('fxa-jwtool')
 
 var config = require('../../config').getProperties()

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -5,7 +5,7 @@
 var path = require('path')
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 process.env.CONFIG_FILES = path.join(__dirname, '../config/mock_oauth.json')
 var config = require('../../config').getProperties()

--- a/test/remote/account_reset_tests.js
+++ b/test/remote/account_reset_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var url = require('url')
-var Client = require('../client')
+const Client = require('../client')()
 var TestServer = require('../test_server')
 
 var config = require('../../config').getProperties()

--- a/test/remote/account_signin_verification_enable_tests.js
+++ b/test/remote/account_signin_verification_enable_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 test(
   'signin confirmation can be disabled',

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var config = require('../../config').getProperties()
 var url = require('url')
 var jwtool = require('fxa-jwtool')

--- a/test/remote/account_status_tests.js
+++ b/test/remote/account_status_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 var config = require('../../config').getProperties()
 

--- a/test/remote/account_unlock_tests.js
+++ b/test/remote/account_unlock_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 var config = require('../../config').getProperties()
 

--- a/test/remote/base_path_tests.js
+++ b/test/remote/base_path_tests.js
@@ -6,7 +6,7 @@ process.env.PUBLIC_URL = 'http://127.0.0.1:9000/auth'
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var P = require('../../lib/promise')
 var request = require('request')
 

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var jwtool = require('fxa-jwtool')
 
 var config = require('../../config').getProperties()

--- a/test/remote/concurrent_tests.js
+++ b/test/remote/concurrent_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var P = require('../../lib/promise')
 
 var config = require('../../config').getProperties()

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -4,11 +4,16 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var config = require('../../config').getProperties()
 var crypto = require('crypto')
 var base64url = require('base64url')
 var P = require('../../lib/promise')
+
+// HACK: Force-enable devices.lastAccessTime in the spawned server process
+process.env.LASTACCESSTIME_UPDATES_ENABLED = 'true'
+process.env.LASTACCESSTIME_UPDATES_EMAIL_ADDRESSES = '.*'
+process.env.LASTACCESSTIME_UPDATES_SAMPLE_RATE = '1'
 
 TestServer.start(config)
 .then(function main(server) {

--- a/test/remote/email_validity_tests.js
+++ b/test/remote/email_validity_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var P = require('../../lib/promise')
 
 var config = require('../../config').getProperties()

--- a/test/remote/flow_tests.js
+++ b/test/remote/flow_tests.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var test = require('tap').test
-var Client = require('../client')
+const Client = require('../client')()
 var TestServer = require('../test_server')
 var jwtool = require('fxa-jwtool')
 

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var P = require('../../lib/promise')
 var hawk = require('hawk')
 var request = require('request')

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var Client = require('../client')
+const Client = require('../client')()
 var config = require('../../config').getProperties()
 var test = require('../ptaptest')
 var TestServer = require('../test_server')

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var url = require('url')
-var Client = require('../client')
+const Client = require('../client')()
 var TestServer = require('../test_server')
 var crypto = require('crypto')
 var base64url = require('base64url')

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -14,8 +14,8 @@ var log = { trace: console.log, info: console.log } // eslint-disable-line no-co
 var config = require('../../config').getProperties()
 var TestServer = require('../test_server')
 var Token = require('../../lib/tokens')(log)
-var DB = require('../../lib/db')(
-  config.db.backend,
+const DB = require('../../lib/db')(
+  config,
   log,
   Token.error,
   Token.SessionToken,

--- a/test/remote/recovery_email_resend_code_tests.js
+++ b/test/remote/recovery_email_resend_code_tests.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var test = require('../ptaptest')
-var Client = require('../client')
+const Client = require('../client')()
 var TestServer = require('../test_server')
 
 var config = require('../../config').getProperties()

--- a/test/remote/recovery_email_verify_tests.js
+++ b/test/remote/recovery_email_verify_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var url = require('url')
-var Client = require('../client')
+const Client = require('../client')()
 var TestServer = require('../test_server')
 
 var config = require('../../config').getProperties()

--- a/test/remote/session_destroy_tests.js
+++ b/test/remote/session_destroy_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 var config = require('../../config').getProperties()
 

--- a/test/remote/token_expiry_tests.js
+++ b/test/remote/token_expiry_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('../ptaptest')
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 
 process.env.PASSWORD_CHANGE_TOKEN_TTL = '1'
 var config = require('../../config').getProperties()

--- a/test/remote/verification_reminder_db_tests.js
+++ b/test/remote/verification_reminder_db_tests.js
@@ -11,7 +11,7 @@ var config = require('../../config').getProperties()
 var TestServer = require('../test_server')
 var Token = require('../../lib/tokens')(log)
 var DB = require('../../lib/db')(
-  config.db.backend,
+  config,
   log,
   Token.error,
   Token.SessionToken,

--- a/test/remote/verifier_upgrade_tests.js
+++ b/test/remote/verifier_upgrade_tests.js
@@ -4,7 +4,7 @@
 
 var test = require('tap').test
 var TestServer = require('../test_server')
-var Client = require('../client')
+const Client = require('../client')()
 var createDBServer = require('fxa-auth-db-mysql')
 var log = { trace: console.log } // eslint-disable-line no-console
 
@@ -15,7 +15,7 @@ process.env.SIGNIN_CONFIRMATION_ENABLED = false
 
 var Token = require('../../lib/tokens')(log)
 var DB = require('../../lib/db')(
-  config.db.backend,
+  config,
   log,
   Token.error,
   Token.SessionToken,


### PR DESCRIPTION
Fixes #1460.

This turned into a much bigger change than I anticipated for a few reasons. I'll call them out in more detail with inline comments but briefly:

* In order to re-use the uid/cohort logic from sign-in confirmation, I extracted that function from the request helpers to a new module for all our feature-flag related stuff, called `lib/features.js`.

* The new features module needs config and both places I wanted to call it from, `lib/db.js` and `lib/tokens/session-token.js`, had no config object before this change. Passing it to them (so it could be mocked by the tests) involved touching approximately 1 metric shed-load of other stuff.

* The remote devices tests need to enable the new feature flag but there was no mechanism for passing mocked config into the spawned server process. In lieu of a better idea, I hacked the values on to `process.env` in `test/test_server.js`.

That doesn't seem like a big deal now I write it down, but sorting it all out took me 2 days.

Anyway, apart from those complications, the change is straightforward. There is a new feature flag, which we check when updating the session token and when returning the device list.

It probably goes without saying, but I haven't changed the token freshness threshold in this PR, so `lastAccessTime` updates are now disabled by both belt and, indeed, braces.

@vbudhram, tagging you for r? because this touches sign-in confirmation, which is your baby.

@rfk, tagging you for r? to check whether the feature flag works as you intended.