### PR TITLE
fix(config): increase flowId expiration to 2 hours

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -414,7 +414,7 @@ var conf = convict({
     flow_id_expiry: {
       doc: 'Time after which flowIds are considered stale.',
       format: 'duration',
-      default: '30 minutes',
+      default: '2 hours',
       env: 'FLOW_ID_EXPIRY'
     }
   },


### PR DESCRIPTION
@jrgm, I learned the lesson from yesterday and am tagging you for review on this config change.

In discussion with @rfk earlier, we decided that we want to loosen the expiry time on flowIds a little so that we're casting our net a bit wider for the flow metrics. Hence this.

r?