### PR TITLE
feat(reset): Accept metricsContext bundle on password-reset endpoints.

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -56,7 +56,8 @@ module.exports = function (
     config.verifierVersion,
     customs,
     checkPassword,
-    push
+    push,
+    metricsContext
   )
   var session = require('./session')(log, isA, error, db)
   var sign = require('./sign')(log, P, isA, error, signer, db, config.domain, devices)

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -21,7 +21,8 @@ module.exports = function (
   verifierVersion,
   customs,
   checkPassword,
-  push
+  push,
+  metricsContext
   ) {
 
   function failVerifyAttempt(passwordForgotToken) {
@@ -302,7 +303,8 @@ module.exports = function (
             email: validators.email().required(),
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: validators.redirectTo(redirectDomain).optional(),
-            resume: isA.string().max(2048).optional()
+            resume: isA.string().max(2048).optional(),
+            metricsContext: metricsContext.schema
           }
         },
         response: {
@@ -377,7 +379,8 @@ module.exports = function (
             email: validators.email().required(),
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: validators.redirectTo(redirectDomain).optional(),
-            resume: isA.string().max(2048).optional()
+            resume: isA.string().max(2048).optional(),
+            metricsContext: metricsContext.schema
           }
         },
         response: {
@@ -434,7 +437,8 @@ module.exports = function (
         },
         validate: {
           payload: {
-            code: isA.string().min(32).max(32).regex(HEX_STRING).required()
+            code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
+            metricsContext: metricsContext.schema
           }
         },
         response: {

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -26,6 +26,7 @@ var makeRoutes = function (options) {
   var Password = require('../../lib/crypto/password')(log, config)
   var customs = options.customs || {}
   var checkPassword = require('../../lib/routes/utils/password_check')(log, config, Password, customs, db)
+  var metricsContext = options.metricsContext || log.metricsContext || require('../../lib/metrics/context')(log, config)
   return require('../../lib/routes/password')(
     log,
     isA,
@@ -37,7 +38,8 @@ var makeRoutes = function (options) {
     config.verifierVersion,
     options.customs || {},
     checkPassword,
-    options.push || {}
+    options.push || {},
+    metricsContext
   )
 }
 


### PR DESCRIPTION
This updates the auth-server API to accept a metricsContext bundle on the password-reset endpoints.  It will be needed before we can start emitting password-reset-related flow events as described in https://github.com/mozilla/fxa-content-server/issues/4004

Obviously there will need to be some work done to actually *use* the metricsContext bundle, this just accepts it in the API so that we can ship content-server code that submits it as part of the next train.  I think we should try to get it into train-71 if possible, @philbooth r?