### PR TITLE
fix(node6): update to scrypt-hash@1.1.14 for node6 compat

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8431,9 +8431,9 @@
       }
     },
     "scrypt-hash": {
-      "version": "1.1.13",
-      "from": "scrypt-hash@1.1.13",
-      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.13.tgz",
+      "version": "1.1.14",
+      "from": "scrypt-hash@1.1.14",
+      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.14.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
@@ -8441,9 +8441,9 @@
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
-          "version": "2.0.9",
-          "from": "nan@2.0.9",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+          "version": "2.4.0",
+          "from": "nan@2.4.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
     "poolee": "1.0.1",
     "request": "2.74.0",
-    "scrypt-hash": "1.1.13",
+    "scrypt-hash": "1.1.14",
     "through": "2.3.8",
     "uuid": "1.4.1",
     "web-push": "2.1.1"


### PR DESCRIPTION
... which is really just upgrading to use nan@2.4.0 for node6 compatibility.

r? - @vladikoff 