### PR TITLE
fix(scripts): nicely stringify regexps when logging config

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -24,13 +24,16 @@ function main() {
       log.info({ op: 'geodb.check', result: result })
     })
 
-  process.stdout.write(JSON.stringify({
-    event: 'config',
-    data: config
-  }) + '\n')
+  // RegExp instances serialise to empty objects, display regex strings instead.
+  const stringifiedConfig =
+    JSON.stringify(config, (k, v) =>
+      v && v.constructor === RegExp ? v.toString() : v
+    )
+
+  process.stdout.write('{"event":"config","data":' + stringifiedConfig + '}\n')
 
   if (config.env !== 'prod') {
-    log.info(config, 'starting config')
+    log.info(stringifiedConfig, 'starting config')
   }
 
   var error = require('../lib/error')


### PR DESCRIPTION
Fixes #1492.

@shane-tomlinson, as promised, this fixes the display of RegExp config settings on start-up. r?