### PR TITLE
refactor(logging): eliminate the event argument from stash and gather

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -177,7 +177,7 @@ Lug.prototype.summary = function (request, response) {
 
 Lug.prototype.notifyAttachedServices = function (name, request, data) {
   var self = this
-  return this.metricsContext.gather({}, request, name)
+  return this.metricsContext.gather({}, request)
     .then(
       function (metricsContextData) {
         var e = {
@@ -250,7 +250,7 @@ Lug.prototype.flowEvent = function (event, request) {
   return this.metricsContext.gather({
     event: event,
     userAgent: request.headers['user-agent']
-  }, request, event).then(
+  }, request).then(
     function (info) {
       if (info.flow_id) {
         info.event = event

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1547,7 +1547,7 @@ module.exports = function (
                     .then(function () {
                       log.timing('account.verified', Date.now() - account.createdAt)
                       log.increment('account.verified')
-                      return log.notifyAttachedServices('verified', request, {
+                      return log.notifyAttachedServices('verified', fakeRequestObject, {
                         email: account.email,
                         uid: account.uid,
                         locale: account.locale

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -239,7 +239,7 @@ module.exports = function (
             .then(
               function (result) {
                 sessionToken = result
-                return metricsContext.stash(sessionToken, 'account.signed', form.metricsContext)
+                return metricsContext.stash(sessionToken, form.metricsContext)
               }
             )
             .then(
@@ -249,7 +249,7 @@ module.exports = function (
                 return metricsContext.stash({
                   uid: account.uid,
                   id: account.emailCode.toString('hex')
-                }, 'account.verified', form.metricsContext)
+                }, form.metricsContext)
               }
             )
         }
@@ -312,7 +312,7 @@ module.exports = function (
               .then(
                 function (result) {
                   keyFetchToken = result
-                  return metricsContext.stash(keyFetchToken, 'account.keyfetch', form.metricsContext)
+                  return metricsContext.stash(keyFetchToken, form.metricsContext)
                 }
               )
           }
@@ -639,7 +639,7 @@ module.exports = function (
             .then(
               function (result) {
                 sessionToken = result
-                return metricsContext.stash(sessionToken, 'account.signed', form.metricsContext)
+                return metricsContext.stash(sessionToken, form.metricsContext)
               }
             )
             .then(
@@ -650,7 +650,7 @@ module.exports = function (
                   return metricsContext.stash({
                     uid: emailRecord.uid,
                     id: tokenVerificationId.toString('hex')
-                  }, 'account.confirmed', form.metricsContext)
+                  }, form.metricsContext)
                 }
               }
             )
@@ -677,7 +677,7 @@ module.exports = function (
                   .then(
                     function (result) {
                       keyFetchToken = result
-                      return metricsContext.stash(keyFetchToken, 'account.keyfetch', form.metricsContext)
+                      return metricsContext.stash(keyFetchToken, form.metricsContext)
                     }
                   )
                 }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -669,25 +669,22 @@ test('/account/create', function (t) {
     t.equal(mockMetricsContext.stash.callCount, 3, 'metricsContext.stash was called three times')
 
     args = mockMetricsContext.stash.args[0]
-    t.equal(args.length, 3, 'metricsContext.stash was passed three arguments first time')
+    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments first time')
     t.deepEqual(args[0].tokenId, sessionTokenId, 'first argument was session token')
     t.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
-    t.equal(args[1], 'account.signed', 'second argument was event name')
-    t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
     args = mockMetricsContext.stash.args[1]
-    t.equal(args.length, 3, 'metricsContext.stash was passed three arguments second time')
+    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
     t.equal(args[0].id, emailCode.toString('hex'), 'first argument was synthesized token')
     t.deepEqual(args[0].uid, uid, 'token.uid was correct')
-    t.deepEqual(args[1], 'account.verified', 'second argument was event name')
-    t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
     args = mockMetricsContext.stash.args[2]
-    t.equal(args.length, 3, 'metricsContext.stash was passed three arguments third time')
+    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments third time')
     t.deepEqual(args[0].tokenId, keyFetchTokenId, 'first argument was key fetch token')
     t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
-    t.deepEqual(args[1], 'account.keyfetch', 'second argument was event name')
-    t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
     var securityEvent = mockDB.securityEvent
     t.equal(securityEvent.callCount, 1, 'db.securityEvent is called')
@@ -843,18 +840,16 @@ test('/account/login', function (t) {
         t.equal(mockMetricsContext.stash.callCount, 2, 'metricsContext.stash was called twice')
 
         args = mockMetricsContext.stash.args[0]
-        t.equal(args.length, 3, 'metricsContext.stash was passed three arguments first time')
+        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments first time')
         t.deepEqual(args[0].tokenId, sessionTokenId, 'first argument was session token')
         t.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
-        t.equal(args[1], 'account.signed', 'second argument was event name')
-        t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
         args = mockMetricsContext.stash.args[1]
-        t.equal(args.length, 3, 'metricsContext.stash was passed three arguments second time')
+        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
         t.deepEqual(args[0].tokenId, keyFetchTokenId, 'first argument was key fetch token')
         t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
-        t.deepEqual(args[1], 'account.keyfetch', 'second argument was event name')
-        t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
+        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
         t.equal(mockMailer.sendNewDeviceLoginNotification.getCall(0).args[1].location.city, 'Mountain View')
@@ -965,14 +960,11 @@ test('/account/login', function (t) {
         t.equal(response.verificationReason, 'login', 'verificationReason is login')
 
         t.equal(mockMetricsContext.stash.callCount, 3, 'metricsContext.stash was called three times')
-        t.equal(mockMetricsContext.stash.args[0][1], 'account.signed', 'first call was for account.signed')
         var args = mockMetricsContext.stash.args[1]
-        t.equal(args.length, 3, 'metricsContext.stash was passed three arguments second time')
+        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
         t.ok(/^[0-9a-f]{32}$/.test(args[0].id), 'first argument was synthesized token')
         t.deepEqual(args[0].uid, uid, 'token.uid was correct')
-        t.deepEqual(args[1], 'account.confirmed', 'second argument was event name')
-        t.equal(args[2], mockRequest.payload.metricsContext, 'third argument was metrics context')
-        t.deepEqual(mockMetricsContext.stash.args[2][1], 'account.keyfetch', 'third call was for account.keyfetch')
+        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
 
         t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
         t.equal(mockMailer.sendVerifyLoginEmail.getCall(0).args[2].location.city, 'Mountain View')

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -140,14 +140,13 @@ test(
     }).then(function () {
       t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
       var args = metricsContext.gather.args[0]
-      t.equal(args.length, 3, 'metricsContext.gather was passed three arguments')
+      t.equal(args.length, 2, 'metricsContext.gather was passed two arguments')
       t.equal(typeof args[0], 'object', 'first argument was object')
       t.notEqual(args[0], null, 'first argument was not null')
       t.equal(Object.keys(args[0]).length, 2, 'first argument had two properties')
       t.equal(args[0].event, 'account.created', 'event property was correct')
       t.equal(args[0].userAgent, 'foo', 'userAgent property was correct')
       t.equal(args[1], request, 'second argument was request object')
-      t.equal(args[2], 'account.created', 'third argument was event name')
 
       t.equal(logger.info.callCount, 2, 'logger.info was called twice')
       t.equal(logger.info.args[0][0], 'activityEvent', 'first call was activityEvent')


### PR DESCRIPTION
Part 1/3, related to #1284.

I'm splitting this PR up as per our conversation in retro, because it is a three-part refactoring. It's not clear to me whether each part will be 👍 or 👎, so I've decided to get them reviewed independently as I finish each one. This is (I hope) the least contentious of the three parts.

Way back when I first implemented the metrics context stuff, I opted to stash the data in memcached using a key that included the event name. Doing this enabled us to delete the data on read, which was important because it wasn't configured to expire.

However, we've since set an expiry time on this data so there is no need to delete on read and there is no need to include the event name in the key. This PR implements those changes and, in doing so, makes it much easier for us to emit new flow events in the future because there is no longer a requirement to stash the data for every event we wish to emit.

If you want to test it locally, just check the logs to make sure that flow events are still emitted as you expect, e.g.:

```
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476363973170,"flow_id":"a00eef05f83d383c3e94cd9618b285c928c073e4f74ffe4d2b1ad1112a04dd71","flow_time":12153,"context":"web"}
flowEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476363982138,"flow_id":"a00eef05f83d383c3e94cd9618b285c928c073e4f74ffe4d2b1ad1112a04dd71","flow_time":21121,"context":"web"}
```

@vbudhram r?

