### PR TITLE
refactor(logging): decorate request object with metricsContext methods

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -13,9 +13,6 @@ var log = require('../lib/log')(config.log.level)
 var getGeoData = require('../lib/geodb')(log)
 
 function main() {
-  var metricsContext = require('../lib/metrics/context')(log, config)
-  log.setMetricsContext(metricsContext)
-
   // Force the geo to load and run at startup, not waiting for it to run on
   // some route later.
   var knownIp = '63.245.221.32' // Mozilla MTV
@@ -108,8 +105,7 @@ function main() {
                 mailer,
                 Password,
                 config,
-                customs,
-                metricsContext
+                customs
               )
               server = Server.create(log, error, config, routes, db)
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -27,6 +27,8 @@ var butil = require('../crypto/butil')
 var userAgent = require('../userAgent')
 var requestHelper = require('../routes/utils/request_helper')
 
+const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema
+
 module.exports = function (
   log,
   crypto,
@@ -42,7 +44,6 @@ module.exports = function (
   isPreVerified,
   checkPassword,
   push,
-  metricsContext,
   devices
   ) {
 
@@ -77,7 +78,7 @@ module.exports = function (
             redirectTo: validators.redirectTo(config.smtp.redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
             preVerifyToken: isA.string().max(2048).regex(BASE64_JWT).optional(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },
         response: {
@@ -104,7 +105,7 @@ module.exports = function (
         var tokenVerificationId = emailCode
         var preVerified, password, verifyHash, account, sessionToken, keyFetchToken
 
-        metricsContext.validate(request)
+        request.validateMetricsContext()
 
         customs.check(request, email, 'accountCreate')
           .then(db.emailRecord.bind(db, email))
@@ -239,17 +240,17 @@ module.exports = function (
             .then(
               function (result) {
                 sessionToken = result
-                return metricsContext.stash(sessionToken, form.metricsContext)
+                return request.stashMetricsContext(sessionToken)
               }
             )
             .then(
               function () {
                 // There is no session token when we emit account.verified
                 // so stash the data against a synthesized "token" instead.
-                return metricsContext.stash({
+                return request.stashMetricsContext({
                   uid: account.uid,
                   id: account.emailCode.toString('hex')
-                }, form.metricsContext)
+                })
               }
             )
         }
@@ -312,7 +313,7 @@ module.exports = function (
               .then(
                 function (result) {
                   keyFetchToken = result
-                  return metricsContext.stash(keyFetchToken, form.metricsContext)
+                  return request.stashMetricsContext(keyFetchToken)
                 }
               )
           }
@@ -360,7 +361,7 @@ module.exports = function (
             resume: isA.string().optional(),
             reason: isA.string().max(16).optional(),
             unblockCode: isA.string().regex(BASE_36).length(unblockCodeLen).optional(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },
         response: {
@@ -389,7 +390,7 @@ module.exports = function (
         var emailRecord, sessions, sessionToken, keyFetchToken, mustVerifySession, doSigninConfirmation, emailSent, unblockCode, customsErr, allowSigninUnblock, didSigninUnblock
         var ip = request.app.clientAddress
 
-        metricsContext.validate(request)
+        request.validateMetricsContext()
 
         // Monitor for any clients still sending obsolete 'contentToken' param.
         if (request.payload.contentToken) {
@@ -639,7 +640,7 @@ module.exports = function (
             .then(
               function (result) {
                 sessionToken = result
-                return metricsContext.stash(sessionToken, form.metricsContext)
+                return request.stashMetricsContext(sessionToken)
               }
             )
             .then(
@@ -647,10 +648,10 @@ module.exports = function (
                 if (doSigninConfirmation) {
                   // There is no session token when we emit account.confirmed
                   // so stash the data against a synthesized "token" instead.
-                  return metricsContext.stash({
+                  return request.stashMetricsContext({
                     uid: emailRecord.uid,
                     id: tokenVerificationId.toString('hex')
-                  }, form.metricsContext)
+                  })
                 }
               }
             )
@@ -677,7 +678,7 @@ module.exports = function (
                   .then(
                     function (result) {
                       keyFetchToken = result
-                      return metricsContext.stash(keyFetchToken, form.metricsContext)
+                      return request.stashMetricsContext(keyFetchToken)
                     }
                   )
                 }
@@ -1457,22 +1458,6 @@ module.exports = function (
         var service = request.payload.service || request.query.service
         var reminder = request.payload.reminder || request.query.reminder
 
-        // Because we have no session token on this endpoint, metrics context
-        // metadata was stashed against a synthesized token for the benefit of
-        // the activity events. This fake request object allows the correct
-        // metadata to be gathered when we emit the events.
-        var fakeRequestObject = {
-          auth: {
-            credentials: {
-              uid: uid,
-              id: request.payload.code
-            }
-          },
-          headers: request.headers,
-          payload: request.payload,
-          query: request.query
-        }
-
         log.begin('Account.RecoveryEmailVerify', request)
         db.account(uid)
           .then(
@@ -1511,7 +1496,7 @@ module.exports = function (
                       uid: uidHex,
                       code: request.payload.code
                     })
-                    log.activityEvent('account.confirmed', fakeRequestObject, {
+                    log.activityEvent('account.confirmed', request, {
                       uid: uidHex
                     })
                     push.notifyUpdate(uid, 'accountConfirm')
@@ -1547,14 +1532,14 @@ module.exports = function (
                     .then(function () {
                       log.timing('account.verified', Date.now() - account.createdAt)
                       log.increment('account.verified')
-                      return log.notifyAttachedServices('verified', fakeRequestObject, {
+                      return log.notifyAttachedServices('verified', request, {
                         email: account.email,
                         uid: account.uid,
                         locale: account.locale
                       })
                     })
                     .then(function () {
-                      return log.activityEvent('account.verified', fakeRequestObject, {
+                      return log.activityEvent('account.verified', request, {
                         uid: uidHex
                       })
                     })
@@ -1630,7 +1615,7 @@ module.exports = function (
         validate: {
           payload: {
             email: validators.email().required(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         }
       },

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -18,8 +18,7 @@ module.exports = function (
   mailer,
   Password,
   config,
-  customs,
-  metricsContext
+  customs
   ) {
   var isPreVerified = require('../preverifier')(error, config)
   var defaults = require('./defaults')(log, P, db, error)
@@ -42,7 +41,6 @@ module.exports = function (
     isPreVerified,
     checkPassword,
     push,
-    metricsContext,
     devices
   )
   var password = require('./password')(
@@ -56,8 +54,7 @@ module.exports = function (
     config.verifierVersion,
     customs,
     checkPassword,
-    push,
-    metricsContext
+    push
   )
   var session = require('./session')(log, isA, error, db)
   var sign = require('./sign')(log, P, isA, error, signer, db, config.domain, devices)

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -10,6 +10,8 @@ var butil = require('../crypto/butil')
 var P = require('../promise')
 var requestHelper = require('../routes/utils/request_helper')
 
+const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema
+
 module.exports = function (
   log,
   isA,
@@ -21,8 +23,7 @@ module.exports = function (
   verifierVersion,
   customs,
   checkPassword,
-  push,
-  metricsContext
+  push
   ) {
 
   function failVerifyAttempt(passwordForgotToken) {
@@ -304,7 +305,7 @@ module.exports = function (
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: validators.redirectTo(redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },
         response: {
@@ -380,7 +381,7 @@ module.exports = function (
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: validators.redirectTo(redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },
         response: {
@@ -438,7 +439,7 @@ module.exports = function (
         validate: {
           payload: {
             code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
-            metricsContext: metricsContext.schema
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },
         response: {

--- a/lib/server.js
+++ b/lib/server.js
@@ -271,6 +271,12 @@ function create(log, error, config, routes, db) {
     }
   )
 
+  const metricsContext = require('./metrics/context')(log, config)
+
+  server.decorate('request', 'stashMetricsContext', metricsContext.stash)
+  server.decorate('request', 'gatherMetricsContext', metricsContext.gather)
+  server.decorate('request', 'validateMetricsContext', metricsContext.validate)
+
   server.stat = function() {
     return {
       stat: 'mem',

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -49,7 +49,6 @@ var makeRoutes = function (options, requireMocks) {
   }
   var checkPassword = options.checkPassword || require('../../lib/routes/utils/password_check')(log, config, Password, customs, db)
   var push = options.push || require('../../lib/push')(log, db, {})
-  var metricsContext = options.metricsContext || log.metricsContext || require('../../lib/metrics/context')(log, config)
   return proxyquire('../../lib/routes/account', requireMocks || {})(
     log,
     crypto,
@@ -65,7 +64,6 @@ var makeRoutes = function (options, requireMocks) {
     isPreVerified,
     checkPassword,
     push,
-    metricsContext,
     options.devices || require('../../lib/devices')(log, db, push)
   )
 }
@@ -566,7 +564,13 @@ test('/account/device/destroy', function (t) {
 })
 
 test('/account/create', function (t) {
+  var mockMetricsContext = mocks.mockMetricsContext({
+    gather: sinon.spy(function (data) {
+      return P.resolve(this.payload && this.payload.metricsContext)
+    })
+  })
   var mockRequest = mocks.mockRequest({
+    metricsContext: mockMetricsContext,
     payload: {
       email: TEST_EMAIL,
       authPW: crypto.randomBytes(32).toString('hex'),
@@ -609,12 +613,6 @@ test('/account/create', function (t) {
       write: sinon.spy()
     }
   })
-  var mockMetricsContext = mocks.mockMetricsContext({
-    gather: sinon.spy(function (data, request) {
-      return P.resolve(request.payload.metricsContext)
-    })
-  })
-  mockLog.setMetricsContext(mockMetricsContext)
   mockLog.activityEvent = sinon.spy(function () {
     return P.resolve()
   })
@@ -629,7 +627,6 @@ test('/account/create', function (t) {
     db: mockDB,
     log: mockLog,
     mailer: mockMailer,
-    metricsContext: mockMetricsContext,
     Password: function () {
       return {
         unwrap: function () {
@@ -662,29 +659,27 @@ test('/account/create', function (t) {
     t.deepEqual(args[2], { uid: uid.toString('hex') }, 'third argument contained uid')
 
     t.equal(mockMetricsContext.validate.callCount, 1, 'metricsContext.validate was called')
-    args = mockMetricsContext.validate.args[0]
-    t.equal(args.length, 1, 'validate was called with a single argument')
-    t.deepEqual(args[0], mockRequest, 'validate was called with the request')
+    t.equal(mockMetricsContext.validate.args[0].length, 0, 'validate was called without arguments')
 
     t.equal(mockMetricsContext.stash.callCount, 3, 'metricsContext.stash was called three times')
 
     args = mockMetricsContext.stash.args[0]
-    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments first time')
-    t.deepEqual(args[0].tokenId, sessionTokenId, 'first argument was session token')
+    t.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
+    t.deepEqual(args[0].tokenId, sessionTokenId, 'argument was session token')
     t.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
-    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+    t.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
 
     args = mockMetricsContext.stash.args[1]
-    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
-    t.equal(args[0].id, emailCode.toString('hex'), 'first argument was synthesized token')
+    t.equal(args.length, 1, 'metricsContext.stash was passed one argument second time')
+    t.equal(args[0].id, emailCode.toString('hex'), 'argument was synthesized token')
     t.deepEqual(args[0].uid, uid, 'token.uid was correct')
-    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+    t.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
     args = mockMetricsContext.stash.args[2]
-    t.equal(args.length, 2, 'metricsContext.stash was passed two arguments third time')
-    t.deepEqual(args[0].tokenId, keyFetchTokenId, 'first argument was key fetch token')
+    t.equal(args.length, 1, 'metricsContext.stash was passed one argument third time')
+    t.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
     t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
-    t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+    t.equal(mockMetricsContext.stash.thisValues[2], mockRequest, 'this was request')
 
     var securityEvent = mockDB.securityEvent
     t.equal(securityEvent.callCount, 1, 'db.securityEvent is called')
@@ -711,10 +706,13 @@ test('/account/login', function (t) {
       enabled: true
     }
   }
+  var mockMetricsContext = mocks.mockMetricsContext({
+    gather: sinon.spy(function (data) {
+      return P.resolve(this.payload && this.payload.metricsContext)
+    })
+  })
   var mockRequest = mocks.mockRequest({
-    query: {
-      keys: 'true'
-    },
+    metricsContext: mockMetricsContext,
     payload: {
       authPW: crypto.randomBytes(32).toString('hex'),
       email: TEST_EMAIL,
@@ -727,10 +725,13 @@ test('/account/login', function (t) {
         entrypoint: 'preferences',
         utmContent: 'some-content-string'
       }
+    },
+    query: {
+      keys: 'true'
     }
   })
   var mockRequestNoKeys = mocks.mockRequest({
-    query: {},
+    metricsContext: mockMetricsContext,
     payload: {
       authPW: crypto.randomBytes(32).toString('hex'),
       email: 'test@mozilla.com',
@@ -741,7 +742,8 @@ test('/account/login', function (t) {
         flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         service: 'dcdb5ae7add825d2'
       }
-    }
+    },
+    query: {}
   })
   var mockRequestWithUnblockCode = mocks.mockRequest({
     query: {},
@@ -779,12 +781,6 @@ test('/account/login', function (t) {
       write: sinon.spy()
     }
   })
-  var mockMetricsContext = mocks.mockMetricsContext({
-    gather: sinon.spy(function (data, request) {
-      return P.resolve(request.payload.metricsContext)
-    })
-  })
-  mockLog.setMetricsContext(mockMetricsContext)
   mockLog.activityEvent = sinon.spy(function () {
     return P.resolve()
   })
@@ -802,7 +798,6 @@ test('/account/login', function (t) {
     db: mockDB,
     log: mockLog,
     mailer: mockMailer,
-    metricsContext: mockMetricsContext,
     push: mockPush
   })
   var route = getRoute(accountRoutes, '/account/login')
@@ -833,23 +828,21 @@ test('/account/login', function (t) {
         t.deepEqual(args[2], {uid: uid.toString('hex')}, 'third argument contained uid')
 
         t.equal(mockMetricsContext.validate.callCount, 1, 'metricsContext.validate was called')
-        args = mockMetricsContext.validate.args[0]
-        t.equal(args.length, 1, 'validate was called with a single argument')
-        t.deepEqual(args[0], mockRequest, 'validate was called with the request')
+        t.equal(mockMetricsContext.validate.args[0].length, 0, 'validate was called without arguments')
 
         t.equal(mockMetricsContext.stash.callCount, 2, 'metricsContext.stash was called twice')
 
         args = mockMetricsContext.stash.args[0]
-        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments first time')
-        t.deepEqual(args[0].tokenId, sessionTokenId, 'first argument was session token')
+        t.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
+        t.deepEqual(args[0].tokenId, sessionTokenId, 'argument was session token')
         t.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
-        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+        t.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
 
         args = mockMetricsContext.stash.args[1]
-        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
-        t.deepEqual(args[0].tokenId, keyFetchTokenId, 'first argument was key fetch token')
+        t.equal(args.length, 1, 'metricsContext.stash was passed one argument second time')
+        t.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
         t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
-        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+        t.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
         t.equal(mockMailer.sendNewDeviceLoginNotification.getCall(0).args[1].location.city, 'Mountain View')
@@ -961,10 +954,10 @@ test('/account/login', function (t) {
 
         t.equal(mockMetricsContext.stash.callCount, 3, 'metricsContext.stash was called three times')
         var args = mockMetricsContext.stash.args[1]
-        t.equal(args.length, 2, 'metricsContext.stash was passed two arguments second time')
-        t.ok(/^[0-9a-f]{32}$/.test(args[0].id), 'first argument was synthesized token')
+        t.equal(args.length, 1, 'metricsContext.stash was passed one argument second time')
+        t.ok(/^[0-9a-f]{32}$/.test(args[0].id), 'argument was synthesized token')
         t.deepEqual(args[0].uid, uid, 'token.uid was correct')
-        t.equal(args[1], mockRequest.payload.metricsContext, 'second argument was metrics context')
+        t.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
         t.equal(mockMailer.sendVerifyLoginEmail.callCount, 1, 'mailer.sendVerifyLoginEmail was called')
         t.equal(mockMailer.sendVerifyLoginEmail.getCall(0).args[2].location.city, 'Mountain View')
@@ -1572,17 +1565,7 @@ test('/recovery_email/verify_code', function (t) {
         var args = mockLog.activityEvent.args[0]
         t.equal(args.length, 3, 'activityEvent was passed three arguments')
         t.equal(args[0], 'account.verified', 'first argument was event name')
-        t.deepEqual(args[1], {
-          auth: {
-            credentials: {
-              uid: Buffer(uid, 'hex'),
-              id: mockRequest.payload.code,
-            }
-          },
-          headers: mockRequest.headers,
-          payload: mockRequest.payload,
-          query: mockRequest.query
-        }, 'second argument was synthesized request object')
+        t.equal(args[1], mockRequest, 'second argument was request object')
         t.deepEqual(args[2], { uid: uid }, 'third argument contained uid')
 
         t.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate should have been called once')
@@ -1664,17 +1647,7 @@ test('/recovery_email/verify_code', function (t) {
         var args = mockLog.activityEvent.args[0]
         t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
         t.equal(args[0], 'account.confirmed', 'first argument was event name')
-        t.deepEqual(args[1], {
-          auth: {
-            credentials: {
-              uid: Buffer(uid, 'hex'),
-              id: mockRequest.payload.code,
-            }
-          },
-          headers: mockRequest.headers,
-          payload: mockRequest.payload,
-          query: mockRequest.query
-        }, 'second argument was synthesized request object')
+        t.equal(args[1], mockRequest, 'second argument was request object')
         t.deepEqual(args[2], { uid: uid }, 'third argument contained uid')
 
         t.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate should have been called once')

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -26,7 +26,6 @@ var makeRoutes = function (options) {
   var Password = require('../../lib/crypto/password')(log, config)
   var customs = options.customs || {}
   var checkPassword = require('../../lib/routes/utils/password_check')(log, config, Password, customs, db)
-  var metricsContext = options.metricsContext || log.metricsContext || require('../../lib/metrics/context')(log, config)
   return require('../../lib/routes/password')(
     log,
     isA,
@@ -38,8 +37,7 @@ var makeRoutes = function (options) {
     config.verifierVersion,
     options.customs || {},
     checkPassword,
-    options.push || {},
-    metricsContext
+    options.push || {}
   )
 }
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -267,6 +267,8 @@ function spyLog (methods) {
 }
 
 function mockRequest (data) {
+  const metricsContext = data.metricsContext || module.exports.mockMetricsContext()
+
   return {
     app: {
       acceptLanguage: 'en-US',
@@ -275,11 +277,14 @@ function mockRequest (data) {
     auth: {
       credentials: data.credentials
     },
+    gatherMetricsContext: metricsContext.gather,
     headers: {
       'user-agent': 'test user-agent'
     },
+    payload: data.payload,
     query: data.query,
-    payload: data.payload
+    stashMetricsContext: metricsContext.stash,
+    validateMetricsContext: metricsContext.validate
   }
 }
 


### PR DESCRIPTION
Part 2/3, related to #1284. Part 1 was #1500.

This PR addresses the meat of the linked issue, namely the awkwardness involved in passing the `metricsContext` object everywhere. It does so by leaning on Hapi's [`server.decorate`](http://hapijs.com/api#serverdecoratetype-property-method-options) extension point to expose the `metricsContext` methods (well, proxies for them) directly on the `request` object.

I also experimented with a slightly different approach, using [`server.method`](http://hapijs.com/api#servermethodname-method-options) instead. That ended up being a bit uglier though, you can see it in 66b27cb if you're interested. The advantage of that approach is that the extension methods are only attached once, on `request.server.methods`. Here the methods are decorated per-request, but I didn't find a measurable difference when I timed them.

The secondary benefit to this PR  came in ditching the `fakeRequestObject` guff that was polluting the `/recovery_email/verify_code` handler. The request object is not passed explicitly to `gather` any more, so some kind of change was needed. I opted to pull it into the `metricsContext` object as @vbudhram suggested I should in the original PR, iirc.

If you want to test the changes locally, just check the logs to make sure that flow events are still emitted as you expect, e.g.:

```
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476450520383,"flow_id":"0adb6e069da2696bbee7efbecec4f5c149b82e04e41bc177bec02b246599856c","flow_time":11093,"context":"web"}
flowEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476450528534,"flow_id":"0adb6e069da2696bbee7efbecec4f5c149b82e04e41bc177bec02b246599856c","flow_time":19244,"context":"web"}
```

@seanmonstar r?