### PR TITLE
fix(logging): emit flow events for sign-in unblock, not activity events

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -25,8 +25,6 @@ var ACTIVITY_FLOW_EVENTS = Object.keys(ALWAYS_ACTIVITY_FLOW_EVENTS)
   }, {
     // These activity events are flow events when there is a flowId
     'account.keyfetch': true,
-    'account.login.sentUnblockCode': true,
-    'account.login.confirmedUnblockCode': true,
     'account.signed': true
   })
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -461,9 +461,7 @@ module.exports = function (
                           throw error.invalidUnblockCode()
                         }
                         didSigninUnblock = true
-                        return log.activityEvent('account.login.confirmedUnblockCode', request, {
-                          uid: emailRecord.uid.toString('hex')
-                        })
+                        return log.flowEvent('account.login.confirmedUnblockCode', request)
                       }
                     )
                     .catch(
@@ -1627,9 +1625,7 @@ module.exports = function (
           .then(lookupAccount)
           .then(createUnblockCode)
           .then(mailUnblockCode)
-          .then(() => log.activityEvent('account.login.sentUnblockCode', request, {
-            uid: emailRecord.uid.toString('hex')
-          }))
+          .then(() => log.flowEvent('account.login.sentUnblockCode', request))
           .done(() => {
             reply({})
           }, reply)


### PR DESCRIPTION
I don't think the events added for sign-in unblock should be activity events.

In my internal model at least, activity events are reserved for concrete state changes to the account. Flow events, on the other hand, are for tracking different steps of the sign-in funnel and these seem more like flow events than activity events to me.

I realise I've done a poor job at explaining this distinction and [my documentation PR](https://github.com/mozilla/fxa-auth-server/pull/1447) hasn't landed yet because the flow events are still in flux, sorry. But fwiw I'm also working on a refactoring that should make things much easier, to the point where the decision of what is and isn't a flow event or an activity event will mostly be made automagically.

In the meantime, I figured it was worth fixing this separately to raise awareness as much as anything.

@seanmonstar r?