### PR TITLE
refactor(logging): move activity/flow event decision out of log object

### DIFF
--- a/lib/customs.js
+++ b/lib/customs.js
@@ -53,7 +53,7 @@ module.exports = function (log, error) {
       function (result) {
         if (result.block) {
           // log a flow event that user got blocked.
-          log.flowEvent('customs.blocked', request)
+          request.emitMetricsEvent('customs.blocked')
 
           var unblock = !!result.unblock
           if (result.retryAfter) {

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -24,7 +24,7 @@ module.exports = function (log, db, push) {
     return db[operation](sessionToken.uid, sessionToken.tokenId, deviceInfo)
       .then(function (device) {
         result = device
-        return log.activityEvent(event, request, {
+        return request.emitMetricsEvent(event, {
           uid: sessionToken.uid.toString('hex'),
           device_id: result.id.toString('hex'),
           is_placeholder: isPlaceholderDevice

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const P = require('../promise')
+
+const ACTIVITY_EVENTS = new Set([
+  'account.confirmed',
+  'account.created',
+  'account.deleted',
+  'account.keyfetch',
+  'account.login',
+  'account.reset',
+  'account.signed',
+  'account.verified',
+  'device.created',
+  'device.deleted',
+  'device.updated'
+])
+
+// We plan to emit a vast number of flow events to cover all
+// kinds of success and error steps of the sign-in/up journey.
+// It's far easier to define the events that *aren't* a flow
+// event than it is to define those that are.
+const NOT_FLOW_EVENTS = new Set([
+  'account.deleted',
+  'account.reset',
+  'device.created',
+  'device.deleted',
+  'device.updated'
+])
+
+const IGNORE_FLOW_EVENTS_FROM_SERVICES = {
+  'account.signed': 'content-server'
+}
+
+module.exports = log => {
+  return {
+    /**
+     * Emit a flow event and/or an activity event.
+     *
+     * @name emitMetricsEvent
+     * @this request
+     * @param {String} event
+     * @param {Object} [data]
+     */
+    emit (event, data) {
+      const request = this
+
+      return P.resolve().then(() => {
+        if (ACTIVITY_EVENTS.has(event)) {
+          return log.activityEvent(event, request, data)
+        }
+      })
+      .then(() => {
+        if (NOT_FLOW_EVENTS.has(event)) {
+          return
+        }
+
+        const service = request.query && request.query.service
+        if (service && IGNORE_FLOW_EVENTS_FROM_SERVICES[event] === service) {
+          return
+        }
+
+        return log.flowEvent(event, request)
+      })
+    }
+  }
+}
+

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -186,7 +186,7 @@ module.exports = function (
             function (result) {
               account = result
 
-              return log.activityEvent('account.created', request, {
+              return request.emitMetricsEvent('account.created', {
                 uid: account.uid.toString('hex')
               })
             }
@@ -461,7 +461,7 @@ module.exports = function (
                           throw error.invalidUnblockCode()
                         }
                         didSigninUnblock = true
-                        return log.flowEvent('account.login.confirmedUnblockCode', request)
+                        return request.emitMetricsEvent('account.login.confirmedUnblockCode')
                       }
                     )
                     .catch(
@@ -596,7 +596,7 @@ module.exports = function (
                   throw error.incorrectPassword(emailRecord.email, email)
                 }
 
-                return log.activityEvent('account.login', request, {
+                return request.emitMetricsEvent('account.login', {
                   uid: emailRecord.uid.toString('hex')
                 })
               }
@@ -984,7 +984,7 @@ module.exports = function (
         db.deleteKeyFetchToken(keyFetchToken)
           .then(
             function () {
-              return log.activityEvent('account.keyfetch', request, {
+              return request.emitMetricsEvent('account.keyfetch', {
                 uid: keyFetchToken.uid.toString('hex')
               })
             }
@@ -1264,7 +1264,7 @@ module.exports = function (
           .then(
             function (res) {
               result = res
-              return log.activityEvent('device.deleted', request, {
+              return request.emitMetricsEvent('device.deleted', {
                 uid: uid.toString('hex'),
                 device_id: id
               })
@@ -1491,7 +1491,7 @@ module.exports = function (
                       uid: uidHex,
                       code: request.payload.code
                     })
-                    log.activityEvent('account.confirmed', request, {
+                    request.emitMetricsEvent('account.confirmed', {
                       uid: uidHex
                     })
                     push.notifyUpdate(uid, 'accountConfirm')
@@ -1534,7 +1534,7 @@ module.exports = function (
                       })
                     })
                     .then(function () {
-                      return log.activityEvent('account.verified', request, {
+                      return request.emitMetricsEvent('account.verified', {
                         uid: uidHex
                       })
                     })
@@ -1549,7 +1549,7 @@ module.exports = function (
                           op: 'mailer.send',
                           name: reminderOp
                         })
-                        return log.activityEvent('account.reminder', request, {
+                        return request.emitMetricsEvent('account.reminder', {
                           uid: uidHex
                         })
                       }
@@ -1625,7 +1625,7 @@ module.exports = function (
           .then(lookupAccount)
           .then(createUnblockCode)
           .then(mailUnblockCode)
-          .then(() => log.flowEvent('account.login.sentUnblockCode', request))
+          .then(() => request.emitMetricsEvent('account.login.sentUnblockCode'))
           .done(() => {
             reply({})
           }, reply)
@@ -1760,7 +1760,7 @@ module.exports = function (
             .then(
               function (accountData) {
                 account = accountData
-                return log.activityEvent('account.reset', request, {
+                return request.emitMetricsEvent('account.reset', {
                   uid: account.uid.toString('hex')
                 })
               }
@@ -1910,7 +1910,7 @@ module.exports = function (
                 )
                 .then(
                   function () {
-                    return log.activityEvent('account.deleted', request, {
+                    return request.emitMetricsEvent('account.deleted', {
                       uid: uid
                     })
                   }

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -127,15 +127,11 @@ module.exports = function (log, P, isA, error, signer, db, domain, devices) {
           .then(
             function(result) {
               certResult = result
-              return log.activityEvent(
-                'account.signed',
-                request,
-                {
-                  uid: uid,
-                  account_created_at: sessionToken.accountCreatedAt,
-                  device_id: deviceId
-                }
-              )
+              return request.emitMetricsEvent('account.signed', {
+                uid: uid,
+                account_created_at: sessionToken.accountCreatedAt,
+                device_id: deviceId
+              })
             }
           )
           .then(

--- a/lib/server.js
+++ b/lib/server.js
@@ -297,10 +297,12 @@ function create(log, error, config, routes, db) {
   )
 
   const metricsContext = require('./metrics/context')(log, config)
-
   server.decorate('request', 'stashMetricsContext', metricsContext.stash)
   server.decorate('request', 'gatherMetricsContext', metricsContext.gather)
   server.decorate('request', 'validateMetricsContext', metricsContext.validate)
+
+  const metricsEvents = require('./metrics/events')(log)
+  server.decorate('request', 'emitMetricsEvent', metricsEvents.emit)
 
   server.stat = function() {
     return {

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var test = require('../ptaptest')
-var log = {
-  trace: function () {},
-  flowEvent: function () {},
+const log = {
+  trace: () => {},
+  activityEvent: () => {},
+  flowEvent: () => {},
   error: console.error, // eslint-disable-line no-console
 }
+const mocks = require('../mocks')
 var error = require('../../lib/error.js')
 var nock = require('nock')
 
@@ -468,14 +470,12 @@ function newIp() {
 }
 
 function newRequest() {
-  return {
-    app: {
-      clientAddress: newIp()
-    },
+  return mocks.mockRequest({
+    clientAddress: newIp(),
     headers: {},
     query: {},
     payload: {}
-  }
+  })
 }
 
 

--- a/test/local/devices_tests.js
+++ b/test/local/devices_tests.js
@@ -44,7 +44,9 @@ test('require', function (t) {
 
     t.test('devices.upsert', function (t) {
       t.plan(3)
-      var request = {}
+      const request = mocks.mockRequest({
+        log: log
+      })
       var sessionToken = {
         tokenId: crypto.randomBytes(16),
         uid: uuid.v4('binary')

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var test = require('../ptaptest')
 var sinon = require('sinon')
 var proxyquire = require('proxyquire')
@@ -92,198 +94,42 @@ test(
         metricsContext: {}
       }
     }
-    return log.activityEvent('bar', request, {
+    log.activityEvent('bar', request, {
       uid: 'baz'
-    }).then(function () {
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      var args = logger.info.args[0]
-      t.equal(args.length, 2, 'logger.info was passed two arguments')
-      t.equal(args[0], 'activityEvent', 'first argument was correct')
-      t.equal(typeof args[1], 'object', 'second argument was object')
-      t.notEqual(args[1], null, 'second argument was not null')
-      t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
-      t.equal(args[1].uid, 'baz', 'uid property was correct')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-      args = statsd.write.args[0]
-      t.equal(args.length, 1, 'statsd.write was passed one argument')
-      t.equal(args[0], logger.info.args[0][1], 'statsd.write argument was correct')
-
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      logger.info.reset()
-      statsd.write.reset()
     })
-  }
-)
 
-test(
-  'log.activityEvent with flow event',
-  function (t) {
-    var request = {
-      gatherMetricsContext: metricsContext.gather,
-      headers: {
-        'user-agent': 'foo'
-      },
-      payload: {
-        metricsContext: {
-          flowId: 'bar'
-        }
-      }
-    }
-    return log.activityEvent('account.created', request, {
-      uid: 'baz'
-    }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-      var args = metricsContext.gather.args[0]
-      t.equal(args.length, 1, 'metricsContext.gather was passed one argument')
-      t.equal(typeof args[0], 'object', 'argument was object')
-      t.notEqual(args[0], null, 'argument was not null')
-      t.equal(Object.keys(args[0]).length, 2, 'argument had two properties')
-      t.equal(args[0].event, 'account.created', 'event property was correct')
-      t.equal(args[0].userAgent, 'foo', 'userAgent property was correct')
-      t.equal(metricsContext.gather.thisValues[0], request, 'this was request object')
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
 
-      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
-      t.equal(logger.info.args[0][0], 'activityEvent', 'first call was activityEvent')
-      t.equal(logger.info.args[1][0], 'flowEvent', 'second call was flowEvent')
-      t.equal(logger.info.args[1][1].event, 'account.created', 'flowEvent had correct event name')
+    t.equal(logger.info.callCount, 1, 'logger.info was called once')
+    let args = logger.info.args[0]
+    t.equal(args.length, 2, 'logger.info was passed two arguments')
+    t.equal(args[0], 'activityEvent', 'first argument was correct')
+    t.equal(typeof args[1], 'object', 'second argument was object')
+    t.notEqual(args[1], null, 'second argument was not null')
+    t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
+    t.equal(args[1].uid, 'baz', 'uid property was correct')
 
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+    t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+    args = statsd.write.args[0]
+    t.equal(args.length, 1, 'statsd.write was passed one argument')
+    t.equal(args[0], logger.info.args[0][1], 'statsd.write argument was correct')
 
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.error.callCount, 0, 'logger.error was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
 
-      metricsContext.gather.reset()
-      logger.info.reset()
-      statsd.write.reset()
-    })
-  }
-)
+    logger.info.reset()
+    statsd.write.reset()
 
-test(
-  'device.created is not treated as a flow event',
-  function (t) {
-    var request = {
-      gatherMetricsContext: metricsContext.gather,
-      headers: {
-        'user-agent': 'foo'
-      },
-      payload: {
-        metricsContext: {
-          flowId: 'bar'
-        }
-      }
-    }
-    return log.activityEvent('device.created', request, {
-      uid: 'baz'
-    }).then(function () {
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      logger.info.reset()
-      statsd.write.reset()
-    })
-  }
-)
-
-test(
-  'log.activityEvent with flow event and missing flowId',
-  function (t) {
-    var request = {
-      gatherMetricsContext: metricsContext.gather,
-      headers: {
-        'user-agent': 'foo'
-      },
-      payload: {
-        metricsContext: {}
-      }
-    }
-    return log.activityEvent('account.created', request, {
-      uid: 'bar'
-    }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      t.equal(logger.info.args[0][0], 'activityEvent', 'call was activityEvent')
-
-      t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
-      t.equal(args.length, 2, 'logger.error was passed two arguments')
-      t.equal(args[0], 'log.flowEvent')
-      t.deepEqual(args[1], {
-        op: 'log.flowEvent',
-        event: 'account.created',
-        missingFlowId: true
-      }, 'error data was correct')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      metricsContext.gather.reset()
-      logger.info.reset()
-      logger.error.reset()
-      statsd.write.reset()
-    })
-  }
-)
-
-test(
-  'log.activityEvent with optional flow event and missing flowId',
-  function (t) {
-    var request = {
-      gatherMetricsContext: metricsContext.gather,
-      headers: {
-        'user-agent': 'foo'
-      },
-      payload: {
-        metricsContext: {}
-      }
-    }
-    return log.activityEvent('account.signed', request, {
-      uid: 'bar'
-    }).then(function () {
-      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
-
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      t.equal(logger.info.args[0][0], 'activityEvent', 'call was activityEvent')
-
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      metricsContext.gather.reset()
-      logger.info.reset()
-      statsd.write.reset()
-    })
+    t.end()
   }
 )
 
 test(
   'log.activityEvent with service payload parameter',
   function (t) {
-    return log.activityEvent('wibble', {
+    log.activityEvent('wibble', {
       gatherMetricsContext: metricsContext.gather,
       headers: {},
       payload: {
@@ -292,33 +138,35 @@ test(
       }
     }, {
       uid: 'ugg'
-    }).then(function () {
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      var args = logger.info.args[0]
-      t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
-      t.equal(args[1].service, 'blee', 'service property was correct')
-      t.equal(args[1].uid, 'ugg', 'service property was correct')
-      t.equal(args[1].event, 'wibble', 'service property was correct')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-      t.equal(statsd.write.args[0][0], args[1], 'statsd.write argument was correct')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      logger.info.reset()
-      statsd.write.reset()
     })
+
+    t.equal(logger.info.callCount, 1, 'logger.info was called once')
+    const args = logger.info.args[0]
+    t.equal(Object.keys(args[1]).length, 3, 'second argument had three properties')
+    t.equal(args[1].service, 'blee', 'service property was correct')
+    t.equal(args[1].uid, 'ugg', 'service property was correct')
+    t.equal(args[1].event, 'wibble', 'service property was correct')
+
+    t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+    t.equal(statsd.write.args[0][0], args[1], 'statsd.write argument was correct')
+
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.error.callCount, 0, 'logger.error was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.info.reset()
+    statsd.write.reset()
+
+    t.end()
   }
 )
 
 test(
   'log.activityEvent with service query parameter',
   function (t) {
-    return log.activityEvent('foo', {
+    log.activityEvent('foo', {
       gatherMetricsContext: metricsContext.gather,
       headers: {},
       payload: {
@@ -329,29 +177,31 @@ test(
       }
     }, {
       uid: 'baz'
-    }).then(function () {
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      t.equal(logger.info.args[0][1].service, 'bar', 'service property was correct')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-      t.equal(statsd.write.args[0][0], logger.info.args[0][1], 'statsd.write argument was correct')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      logger.info.reset()
-      statsd.write.reset()
     })
+
+    t.equal(logger.info.callCount, 1, 'logger.info was called once')
+    t.equal(logger.info.args[0][1].service, 'bar', 'service property was correct')
+
+    t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+    t.equal(statsd.write.args[0][0], logger.info.args[0][1], 'statsd.write argument was correct')
+
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.error.callCount, 0, 'logger.error was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.info.reset()
+    statsd.write.reset()
+
+    t.end()
   }
 )
 
 test(
   'log.activityEvent with extra data',
   function (t) {
-    return log.activityEvent('foo', {
+    log.activityEvent('foo', {
       gatherMetricsContext: metricsContext.gather,
       headers: {
         'user-agent': 'bar'
@@ -363,61 +213,65 @@ test(
       baz: 'qux',
       uid: 42,
       wibble: 'blee'
-    }).then(function () {
-      t.equal(logger.info.callCount, 1, 'logger.info was called once')
-      var args = logger.info.args[0]
-      t.equal(Object.keys(args[1]).length, 5, 'second argument had 5 properties')
-      t.equal(args[1].baz, 'qux', 'first extra data property was correct')
-      t.equal(args[1].wibble, 'blee', 'second extra data property was correct')
-
-      t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
-      t.equal(statsd.write.args[0][0], args[1], 'statsd.write argument was correct')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-
-      logger.info.reset()
-      statsd.write.reset()
     })
+
+    t.equal(logger.info.callCount, 1, 'logger.info was called once')
+    const args = logger.info.args[0]
+    t.equal(Object.keys(args[1]).length, 5, 'second argument had 5 properties')
+    t.equal(args[1].baz, 'qux', 'first extra data property was correct')
+    t.equal(args[1].wibble, 'blee', 'second extra data property was correct')
+
+    t.equal(statsd.write.callCount, 1, 'statsd.write was called once')
+    t.equal(statsd.write.args[0][0], args[1], 'statsd.write argument was correct')
+
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.error.callCount, 0, 'logger.error was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.info.reset()
+    statsd.write.reset()
+
+    t.end()
   }
 )
 
 test(
   'log.activityEvent with no data',
   function (t) {
-    return log.activityEvent('foo', {
+    log.activityEvent('foo', {
       gatherMetricsContext: metricsContext.gather,
       headers: {},
       payload: {
         metricsContext: {}
       }
-    }).then(function () {
-      t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
-      t.equal(args.length, 2, 'logger.error was passed two arguments')
-      t.equal(args[0], 'log.activityEvent', 'first argument was correct')
-      t.equal(Object.keys(args[1]).length, 2, 'second argument had two properties')
-      t.equal(args[1].data, undefined, 'data property was undefined')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(statsd.write.callCount, 0, 'statsd.write was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-      t.equal(logger.info.callCount, 0, 'logger.info was not called')
-
-      logger.error.reset()
     })
+
+    t.equal(logger.error.callCount, 1, 'logger.error was called once')
+    const args = logger.error.args[0]
+    t.equal(args.length, 2, 'logger.error was passed two arguments')
+    t.equal(args[0], 'log.activityEvent', 'first argument was correct')
+    t.equal(Object.keys(args[1]).length, 2, 'second argument had two properties')
+    t.equal(args[1].data, undefined, 'data property was undefined')
+
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    t.equal(statsd.write.callCount, 0, 'statsd.write was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+    t.equal(logger.info.callCount, 0, 'logger.info was not called')
+
+    logger.error.reset()
+
+    t.end()
   }
 )
 
 test(
   'log.activityEvent with no uid',
   function (t) {
-    return log.activityEvent('foo', {
+    log.activityEvent('foo', {
       gatherMetricsContext: metricsContext.gather,
       headers: {},
       payload: {
@@ -425,21 +279,23 @@ test(
       }
     }, {
       foo: 'bar'
-    }).then(function () {
-      t.equal(logger.error.callCount, 1, 'logger.error was called once')
-      var args = logger.error.args[0]
-      t.equal(Object.keys(args[1].data).length, 1, 'data property had one property')
-      t.equal(args[1].data.foo, 'bar', 'data property had correct property')
-
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
-      t.equal(statsd.write.callCount, 0, 'statsd.write was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-      t.equal(logger.info.callCount, 0, 'logger.info was not called')
-
-      logger.error.reset()
     })
+
+    t.equal(logger.error.callCount, 1, 'logger.error was called once')
+    const args = logger.error.args[0]
+    t.equal(Object.keys(args[1].data).length, 1, 'data property had one property')
+    t.equal(args[1].data.foo, 'bar', 'data property had correct property')
+
+    t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+    t.equal(statsd.write.callCount, 0, 'statsd.write was not called')
+    t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+    t.equal(logger.info.callCount, 0, 'logger.info was not called')
+
+    logger.error.reset()
+
+    t.end()
   }
 )
 
@@ -499,35 +355,6 @@ test(
       t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
 
       logger.error.reset()
-    })
-  }
-)
-
-test(
-  'log.flowEvent with content server account.signed event',
-  t => {
-    return log.flowEvent('account.signed', {
-      gatherMetricsContext: metricsContext.gather,
-      headers: {
-        'user-agent': 'foo'
-      },
-      payload: {
-        metricsContext: {
-          flowId: 'bar',
-          service: 'baz'
-        },
-        service: 'qux'
-      },
-      query: {
-        service: 'content-server'
-      }
-    }).then(() => {
-      t.equal(logger.error.callCount, 0, 'logger.error was not called')
-      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
-      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
-      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
-      t.equal(logger.info.callCount, 0, 'logger.info was not called')
-      t.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
     })
   }
 )

--- a/test/local/metrics_events_tests.js
+++ b/test/local/metrics_events_tests.js
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const sinon = require('sinon')
+const test = require('../ptaptest')
+const P = require('../../lib/promise')
+const log = {
+  activityEvent: sinon.spy(() => {
+    return P.resolve()
+  }),
+  flowEvent: sinon.spy(() => {
+    return P.resolve()
+  })
+}
+const events = require('../../lib/metrics/events')(log)
+
+test('events interface is correct', t => {
+  t.equal(typeof events, 'object', 'events is object')
+  t.notEqual(events, null, 'events is not null')
+  t.equal(Object.keys(events).length, 1, 'events has 1 property')
+
+  t.equal(typeof events.emit, 'function', 'events.emit is function')
+  t.equal(events.emit.length, 2, 'events.emit expects 2 arguments')
+
+  t.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+  t.equal(log.flowEvent.callCount, 0, 'log.flowEvent was not called')
+
+  t.end()
+})
+
+test('events.emit with activity event', t => {
+  const request = {}
+  const data = {}
+  return events.emit.call(request, 'device.created', data)
+    .then(() => {
+      t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+      const args = log.activityEvent.args[0]
+      t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
+      t.equal(args[0], 'device.created', 'first argument was event name')
+      t.equal(args[1], request, 'second argument was request object')
+      t.equal(args[2], data, 'third argument was event data')
+
+      t.equal(log.flowEvent.callCount, 0, 'log.flowEvent was not called')
+
+      log.activityEvent.reset()
+    })
+})
+
+test('events.emit with flow event', t => {
+  const request = {}
+  const data = {}
+  return events.emit.call(request, 'account.reminder', data)
+    .then(() => {
+      t.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+      const args = log.flowEvent.args[0]
+      t.equal(args.length, 2, 'log.flowEvent was passed two arguments')
+      t.equal(args[0], 'account.reminder', 'first argument was event name')
+      t.equal(args[1], request, 'second argument was request object')
+
+      t.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+
+      log.flowEvent.reset()
+    })
+})
+
+test('events.emit with hybrid activity/flow event', t => {
+  const request = {}
+  const data = {}
+  return events.emit.call(request, 'account.created', data)
+    .then(() => {
+      t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+      let args = log.activityEvent.args[0]
+      t.equal(args.length, 3, 'log.activityEvent was passed three arguments')
+      t.equal(args[0], 'account.created', 'first argument was event name')
+      t.equal(args[1], request, 'second argument was request object')
+      t.equal(args[2], data, 'third argument was event data')
+
+      t.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+      args = log.flowEvent.args[0]
+      t.equal(args.length, 2, 'log.flowEvent was passed two arguments')
+      t.equal(args[0], 'account.created', 'first argument was event name')
+      t.equal(args[1], request, 'second argument was request object')
+
+      log.activityEvent.reset()
+      log.flowEvent.reset()
+    })
+})
+
+test('events.emit with content server account.signed event', t => {
+  const request = {
+    query: {
+      service: 'content-server'
+    }
+  }
+  const data = {}
+  return events.emit.call(request, 'account.signed', data)
+    .then(() => {
+      t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+      t.equal(log.flowEvent.callCount, 0, 'log.flowEvent was not called')
+
+      log.activityEvent.reset()
+    })
+})
+
+test('events.emit with sync account.signed event', t => {
+  const request = {
+    query: {
+      service: 'sync'
+    }
+  }
+  const data = {}
+  return events.emit.call(request, 'account.signed', data)
+    .then(() => {
+      t.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
+      t.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+
+      log.activityEvent.reset()
+      log.flowEvent.reset()
+    })
+})
+

--- a/test/local/sign_routes.js
+++ b/test/local/sign_routes.js
@@ -19,8 +19,8 @@ test(
     var mockDevices = mocks.mockDevices({
       deviceId: deviceId
     })
-    var mockLog = mocks.spyLog()
-    var mockRequest = mocks.mockRequest({
+    const mockLog = mocks.spyLog()
+    const mockRequest = mocks.mockRequest({
       credentials: {
         accountCreatedAt: Date.now(),
         emailVerified: true,
@@ -31,6 +31,7 @@ test(
         tokenId: crypto.randomBytes(16),
         uid: uuid.v4('binary')
       },
+      log: mockLog,
       payload: {
         duration: 0,
         publicKey: {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -267,18 +267,20 @@ function spyLog (methods) {
 }
 
 function mockRequest (data) {
+  const events = require('../lib/metrics/events')(data.log || module.exports.mockLog())
   const metricsContext = data.metricsContext || module.exports.mockMetricsContext()
 
   return {
     app: {
       acceptLanguage: 'en-US',
-      clientAddress: '63.245.221.32' // MTV
+      clientAddress: data.clientAddress || '63.245.221.32' // MTV
     },
     auth: {
       credentials: data.credentials
     },
+    emitMetricsEvent: events.emit,
     gatherMetricsContext: metricsContext.gather,
-    headers: {
+    headers: data.headers || {
       'user-agent': 'test user-agent'
     },
     payload: data.payload,


### PR DESCRIPTION
Part 3/3, fixes #1284. Part 1 was #1500 and part 2 was #1503.

Hopefully this change resolves the recent confusion around what is an activity event and what is a flow event. From now on, we need only make calls to `request.emitEvent` for both event types. All of the decision making for which `log` method to call is contained therein.

This also makes `lib/log.js` a little bit cleaner because it enabled me to move the decision-making into a dedicated module, `lib/events.js`. So `log.activityEvent` no longer includes a conditional call to `log.flowEvent`, those two methods are properly separated.

The new module takes the approach of defining all of the events that *aren't* a flow event. This is easier than defining the flow events directly because of how many there will be when we're finished. The body of the new method just checks the event name against these definitions before calling out to `log.activityEvent` and/or `log.flowEvent`.

Here are the salient log lines from a sample Sync sign-in:

```
activityEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","service":"sync","uid":"d761ffbe7e134eecba53037f101ffa3d"}
flowEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476796184340,"flow_id":"7deab7154fd0c5b0d81ab2256f7c0fdca5b51b3bc93c2532dc083a3880594d3a","flow_time":8139,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","service":"sync","uid":"d761ffbe7e134eecba53037f101ffa3d"}
flowEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476796222371,"flow_id":"7deab7154fd0c5b0d81ab2256f7c0fdca5b51b3bc93c2532dc083a3880594d3a","flow_time":46170,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","uid":"d761ffbe7e134eecba53037f101ffa3d"}
flowEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476796229593,"flow_id":"7deab7154fd0c5b0d81ab2256f7c0fdca5b51b3bc93c2532dc083a3880594d3a","flow_time":53392,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
activityEvent {"event":"device.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","uid":"d761ffbe7e134eecba53037f101ffa3d","device_id":"3c1a0a03e87e64c02c73f20552349ed2","is_placeholder":true}
activityEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","uid":"d761ffbe7e134eecba53037f101ffa3d","account_created_at":1476796184346,"device_id":"3c1a0a03e87e64c02c73f20552349ed2"}
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476796229632,"flow_id":"7deab7154fd0c5b0d81ab2256f7c0fdca5b51b3bc93c2532dc083a3880594d3a","flow_time":53431,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

@vbudhram r?