### PR TITLE
fix(config): Pref off signin unblock by default.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -512,7 +512,10 @@ var conf = convict({
       env: 'SIGNIN_UNBLOCK_CODE_LIFETIME'
     },
     enabled: {
-      default: true
+      doc: 'Is signin unblock enabled?',
+      format: Boolean,
+      default: false,
+      env: 'SIGNIN_UNBLOCK_ENABLED'
     },
     allowedEmailAddresses: {
       doc: 'If feature enabled, allow sign-in unblock for email addresses matching this regex.',


### PR DESCRIPTION
@rfk suggested we pref off signin unblock by default. Here is the PR to do so. If we merge, we'll have to enable signin unblock on latest and any boxes where this is being tested (including locally in fxa-local-dev).

@seanmonstar, @jrgm - r?