### PR TITLE
feat(logging): emit a flow.complete event

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -28,6 +28,7 @@ var ERRNO = {
   INVALID_VERIFICATION_CODE: 105,
   MISSING_CONTENT_LENGTH_HEADER: 112,
   MISSING_PARAMETER: 108,
+  MISSING_TOKEN: 128,
   REQUEST_TOO_LARGE: 113,
   REQUEST_BLOCKED: 125,
   SERVER_BUSY: 201,
@@ -469,6 +470,13 @@ AppError.invalidUnblockCode = function () {
     message: 'Invalid unblock code'
   })
 }
+
+AppError.missingToken = () => new AppError({
+  code: 400,
+  error: 'Bad Request',
+  errno: ERRNO.MISSING_TOKEN,
+  message: 'Missing token'
+})
 
 module.exports = AppError
 module.exports.ERRNO = ERRNO

--- a/lib/log.js
+++ b/lib/log.js
@@ -219,13 +219,18 @@ Lug.prototype.flowEvent = function (event, request) {
         optionallySetService(info, request)
 
         this.logger.info('flowEvent', info)
+
+        if (event === info.flowCompleteSignal) {
+          this.logger.info('flowEvent', Object.assign({}, info, {
+            event: 'flow.complete'
+          }))
+        }
       } else if (! OPTIONAL_FLOW_EVENTS[event]) {
         this.error({ op: 'log.flowEvent', event: event, missingFlowId: true })
       }
     }
   )
 }
-
 
 function optionallySetService (data, request) {
   // don't overwrite service if it is already set

--- a/lib/log.js
+++ b/lib/log.js
@@ -224,6 +224,7 @@ Lug.prototype.flowEvent = function (event, request) {
           this.logger.info('flowEvent', Object.assign({}, info, {
             event: 'flow.complete'
           }))
+          request.clearMetricsContext()
         }
       } else if (! OPTIONAL_FLOW_EVENTS[event]) {
         this.error({ op: 'log.flowEvent', event: event, missingFlowId: true })

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -4,12 +4,14 @@
 
 'use strict'
 
-const crypto = require('crypto')
-const isA = require('joi')
 const bufferEqualConstantTime = require('buffer-equal-constant-time')
+const crypto = require('crypto')
+const error = require('../error')
 const HEX = require('../routes/validators').HEX_STRING
-const P = require('../promise')
+const isA = require('joi')
 const Memcached = require('memcached')
+const P = require('../promise')
+
 P.promisifyAll(Memcached.prototype)
 
 const FLOW_ID_LENGTH = 64
@@ -155,7 +157,7 @@ module.exports = function (log, config) {
       }
     }
 
-    throw new Error('Invalid credentials')
+    throw error.missingToken()
   }
 
   /**
@@ -167,7 +169,14 @@ module.exports = function (log, config) {
   function clear () {
     return P.resolve()
       .then(() => getMemcached().delAsync(getKey(getToken(this))))
-      .catch(() => {})
+      .catch(err => {
+        // Swallow errors from getToken on this method because we expect
+        // them to occur when the flow complete signal is `account.login`
+        // or `account.created`.
+        if (err.errno !== error.ERRNO.MISSING_TOKEN) {
+          throw err
+        }
+      })
   }
 
   /**

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -44,6 +44,7 @@ module.exports = function (log, config) {
   return {
     stash: stash,
     gather: gather,
+    clear: clear,
     validate: validate,
     setFlowCompleteSignal: setFlowCompleteSignal
   }
@@ -155,6 +156,18 @@ module.exports = function (log, config) {
     }
 
     throw new Error('Invalid credentials')
+  }
+
+  /**
+   * Attempt to clear previously-stashed metrics context metadata.
+   *
+   * @name clearMetricsContext
+   * @this request
+   */
+  function clear () {
+    return P.resolve()
+      .then(() => getMemcached().delAsync(getKey(getToken(this))))
+      .catch(() => {})
   }
 
   /**

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -44,7 +44,8 @@ module.exports = function (log, config) {
   return {
     stash: stash,
     gather: gather,
-    validate: validate
+    validate: validate,
+    setFlowCompleteSignal: setFlowCompleteSignal
   }
 
   /**
@@ -122,6 +123,7 @@ module.exports = function (log, config) {
           data.time = Date.now()
           data.flow_id = metadata.flowId
           data.flow_time = calculateFlowTime(data.time, metadata.flowBeginTime)
+          data.flowCompleteSignal = metadata.flowCompleteSignal
           data.context = metadata.context
           data.entrypoint = metadata.entrypoint
           data.migration = metadata.migration
@@ -228,6 +230,19 @@ module.exports = function (log, config) {
       ].join('\n'))
       .digest()
       .slice(0, signatureLength)
+  }
+
+  /**
+   * Sets the event name that will signal completion of the current flow.
+   *
+   * @name setMetricsFlowCompleteSignal
+   * @this request
+   * @param {String} flowCompleteSignal
+   */
+  function setFlowCompleteSignal (flowCompleteSignal) {
+    if (this.payload && this.payload.metricsContext) {
+      this.payload.metricsContext.flowCompleteSignal = flowCompleteSignal
+    }
   }
 }
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -140,6 +140,16 @@ module.exports = function (
             .then(
               function (result) {
                 preVerified = result
+
+                let flowCompleteSignal
+                if (service === 'sync') {
+                  flowCompleteSignal = 'account.signed'
+                } else if (preVerified) {
+                  flowCompleteSignal = 'account.created'
+                } else {
+                  flowCompleteSignal = 'account.verified'
+                }
+                request.setMetricsFlowCompleteSignal(flowCompleteSignal)
               }
             )
         }
@@ -580,6 +590,16 @@ module.exports = function (
             mustVerifySession = requestHelper.wantsKeys(request)
             doSigninConfirmation = mustVerifySession && emailRecord.emailVerified
           }
+
+          let flowCompleteSignal
+          if (service === 'sync') {
+            flowCompleteSignal = 'account.signed'
+          } else if (doSigninConfirmation) {
+            flowCompleteSignal = 'account.confirmed'
+          } else {
+            flowCompleteSignal = 'account.login'
+          }
+          request.setMetricsFlowCompleteSignal(flowCompleteSignal)
 
           if(email !== emailRecord.email) {
             customs.flag(request.app.clientAddress, {

--- a/lib/server.js
+++ b/lib/server.js
@@ -300,6 +300,7 @@ function create(log, error, config, routes, db) {
   server.decorate('request', 'stashMetricsContext', metricsContext.stash)
   server.decorate('request', 'gatherMetricsContext', metricsContext.gather)
   server.decorate('request', 'validateMetricsContext', metricsContext.validate)
+  server.decorate('request', 'setMetricsFlowCompleteSignal', metricsContext.setFlowCompleteSignal)
 
   const metricsEvents = require('./metrics/events')(log)
   server.decorate('request', 'emitMetricsEvent', metricsEvents.emit)

--- a/lib/server.js
+++ b/lib/server.js
@@ -299,6 +299,7 @@ function create(log, error, config, routes, db) {
   const metricsContext = require('./metrics/context')(log, config)
   server.decorate('request', 'stashMetricsContext', metricsContext.stash)
   server.decorate('request', 'gatherMetricsContext', metricsContext.gather)
+  server.decorate('request', 'clearMetricsContext', metricsContext.clear)
   server.decorate('request', 'validateMetricsContext', metricsContext.validate)
   server.decorate('request', 'setMetricsFlowCompleteSignal', metricsContext.setFlowCompleteSignal)
 

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -684,6 +684,11 @@ test('/account/create', function (t) {
     t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
     t.equal(mockMetricsContext.stash.thisValues[2], mockRequest, 'this was request')
 
+    t.equal(mockMetricsContext.setFlowCompleteSignal.callCount, 1, 'metricsContext.setFlowCompleteSignal was called once')
+    args = mockMetricsContext.setFlowCompleteSignal.args[0]
+    t.equal(args.length, 1, 'metricsContext.setFlowCompleteSignal was passed one argument')
+    t.deepEqual(args[0], 'account.signed', 'argument was event name')
+
     var securityEvent = mockDB.securityEvent
     t.equal(securityEvent.callCount, 1, 'db.securityEvent is called')
     securityEvent = securityEvent.args[0][0]
@@ -859,6 +864,11 @@ test('/account/login', function (t) {
         t.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
         t.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
+        t.equal(mockMetricsContext.setFlowCompleteSignal.callCount, 1, 'metricsContext.setFlowCompleteSignal was called once')
+        args = mockMetricsContext.setFlowCompleteSignal.args[0]
+        t.equal(args.length, 1, 'metricsContext.setFlowCompleteSignal was passed one argument')
+        t.deepEqual(args[0], 'account.signed', 'argument was event name')
+
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
         t.equal(mockMailer.sendNewDeviceLoginNotification.getCall(0).args[1].location.city, 'Mountain View')
         t.equal(mockMailer.sendNewDeviceLoginNotification.getCall(0).args[1].location.country, 'United States')
@@ -873,6 +883,7 @@ test('/account/login', function (t) {
         mockMailer.sendNewDeviceLoginNotification.reset()
         mockDB.createSessionToken.reset()
         mockMetricsContext.stash.reset()
+        mockMetricsContext.setFlowCompleteSignal.reset()
       })
     })
 
@@ -1000,6 +1011,7 @@ test('/account/login', function (t) {
       }).then(function () {
         mockMailer.sendVerifyLoginEmail.reset()
         mockDB.createSessionToken.reset()
+        mockMetricsContext.setFlowCompleteSignal.reset()
       })
     })
 
@@ -1028,11 +1040,16 @@ test('/account/login', function (t) {
         // since it can't have been a new device connection.
         t.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 0, 'mailer.sendNewDeviceLoginNotification was not called')
         t.equal(mockMailer.sendVerifyLoginEmail.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
+
+        t.equal(mockMetricsContext.setFlowCompleteSignal.callCount, 1, 'metricsContext.setFlowCompleteSignal was called once')
+        t.deepEqual(mockMetricsContext.setFlowCompleteSignal.args[0][0], 'account.login', 'argument was event name')
+
         t.ok(response.verified, 'response indicates account is verified')
         t.notOk(response.verificationMethod, 'verificationMethod doesn\'t exist')
         t.notOk(response.verificationReason, 'verificationReason doesn\'t exist')
       }).then(function () {
         mockDB.createSessionToken.reset()
+        mockMetricsContext.setFlowCompleteSignal.reset()
       })
     })
 

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -24,6 +24,7 @@ var metricsContext = {
   gather: sinon.spy(function (data) {
     return P.resolve(this.payload && {
       flow_id: this.payload.metricsContext.flowId,
+      flowCompleteSignal: this.payload.metricsContext.flowCompleteSignal,
       service: this.payload.metricsContext.service
     })
   })
@@ -383,6 +384,79 @@ test(
       t.equal(args[1].event, 'account.signed', 'correct event name')
       t.equal(args[1].flow_id, 'bar', 'correct flow id')
       t.equal(args[1].service, 'baz', 'correct metrics data')
+
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+
+      metricsContext.gather.reset()
+      logger.info.reset()
+    })
+  }
+)
+
+test(
+  'log.flowEvent with matching flowCompleteSignal',
+  t => {
+    return log.flowEvent('account.login', {
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          service: 'baz',
+          flowCompleteSignal: 'account.login'
+        },
+        service: 'qux'
+      }
+    }).then(() => {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+      t.equal(logger.info.callCount, 2, 'logger.info was called twice')
+      let args = logger.info.args[0]
+      t.equal(args[0], 'flowEvent', 'correct event type first time')
+      t.equal(args[1].event, 'account.login', 'correct event name first time')
+      t.equal(args[1].flow_id, 'bar', 'correct flow id first time')
+      t.equal(args[1].service, 'baz', 'correct metrics data first time')
+      args = logger.info.args[1]
+      t.equal(args[0], 'flowEvent', 'correct event type second time')
+      t.equal(args[1].event, 'flow.complete', 'correct event name second time')
+      t.equal(args[1].flow_id, 'bar', 'correct flow id second time')
+      t.equal(args[1].service, 'baz', 'correct metrics data second time')
+
+      t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+      t.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+      t.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+      t.equal(logger.error.callCount, 0, 'logger.error was not called')
+
+      metricsContext.gather.reset()
+      logger.info.reset()
+    })
+  }
+)
+
+test(
+  'log.flowEvent with non-matching flowCompleteSignal',
+  t => {
+    return log.flowEvent('account.login', {
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          service: 'baz',
+          flowCompleteSignal: 'account.signed'
+        },
+        service: 'qux'
+      }
+    }).then(() => {
+      t.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+      t.equal(logger.info.callCount, 1, 'logger.info was called once')
 
       t.equal(logger.debug.callCount, 0, 'logger.debug was not called')
       t.equal(logger.critical.callCount, 0, 'logger.critical was not called')

--- a/test/local/metrics_context_tests.js
+++ b/test/local/metrics_context_tests.js
@@ -29,7 +29,7 @@ test(
 
     t.equal(typeof metricsContext, 'object', 'metricsContext is object')
     t.notEqual(metricsContext, null, 'metricsContext is not null')
-    t.equal(Object.keys(metricsContext).length, 3, 'metricsContext has 3 properties')
+    t.equal(Object.keys(metricsContext).length, 4, 'metricsContext has 4 properties')
 
     t.equal(typeof metricsContext.stash, 'function', 'metricsContext.stash is function')
     t.equal(metricsContext.stash.length, 1, 'metricsContext.stash expects 1 argument')
@@ -39,6 +39,9 @@ test(
 
     t.equal(typeof metricsContext.validate, 'function', 'metricsContext.validate is function')
     t.equal(metricsContext.validate.length, 0, 'metricsContext.validate expects no arguments')
+
+    t.equal(typeof metricsContext.setFlowCompleteSignal, 'function', 'metricsContext.setFlowCompleteSignal is function')
+    t.equal(metricsContext.setFlowCompleteSignal.length, 1, 'metricsContext.setFlowCompleteSignal expects 1 argument')
 
     t.end()
   }
@@ -181,6 +184,7 @@ test(
         metricsContext: {
           flowId: 'mock flow id',
           flowBeginTime: time,
+          flowCompleteSignal: 'mock flow complete signal',
           context: 'mock context',
           entrypoint: 'mock entry point',
           migration: 'mock migration',
@@ -196,11 +200,12 @@ test(
     }, {}).then(function (result) {
       t.equal(typeof result, 'object', 'result is object')
       t.notEqual(result, null, 'result is not null')
-      t.equal(Object.keys(result).length, 12, 'result has 12 properties')
+      t.equal(Object.keys(result).length, 13, 'result has 13 properties')
       t.ok(result.time > time, 'result.time seems correct')
       t.equal(result.flow_id, 'mock flow id', 'result.flow_id is correct')
       t.ok(result.flow_time > 0, 'result.flow_time is greater than zero')
       t.ok(result.flow_time < time, 'result.flow_time is less than the current time')
+      t.equal(result.flowCompleteSignal, 'mock flow complete signal', 'result.flowCompleteSignal is correct')
       t.equal(result.context, 'mock context', 'result.context is correct')
       t.equal(result.entrypoint, 'mock entry point', 'result.entrypoint is correct')
       t.equal(result.migration, 'mock migration', 'result.migration is correct')
@@ -254,6 +259,7 @@ test(
         metricsContext: {
           flowId: 'mock flow id',
           flowBeginTime: time,
+          flowCompleteSignal: 'mock flow complete signal',
           context: 'mock context',
           entrypoint: 'mock entry point',
           migration: 'mock migration',
@@ -267,7 +273,7 @@ test(
         }
       }
     }, {}).then(function (result) {
-      t.equal(Object.keys(result).length, 7, 'result has 7 properties')
+      t.equal(Object.keys(result).length, 8, 'result has 8 properties')
       t.equal(result.utm_campaign, undefined, 'result.utm_campaign is undefined')
       t.equal(result.utm_content, undefined, 'result.utm_content is undefined')
       t.equal(result.utm_medium, undefined, 'result.utm_medium is undefined')
@@ -294,6 +300,7 @@ test(
       return P.resolve({
         flowId: 'flowId',
         flowBeginTime: time,
+        flowCompleteSignal: 'flowCompleteSignal',
         context: 'context',
         entrypoint: 'entrypoint',
         migration: 'migration',
@@ -320,11 +327,12 @@ test(
 
       t.equal(typeof result, 'object', 'result is object')
       t.notEqual(result, null, 'result is not null')
-      t.equal(Object.keys(result).length, 12, 'result has 12 properties')
+      t.equal(Object.keys(result).length, 13, 'result has 13 properties')
       t.ok(result.time > time, 'result.time seems correct')
       t.equal(result.flow_id, 'flowId', 'result.flow_id is correct')
       t.ok(result.flow_time > 0, 'result.flow_time is greater than zero')
       t.ok(result.flow_time < time, 'result.flow_time is less than the current time')
+      t.equal(result.flowCompleteSignal, 'flowCompleteSignal', 'result.flowCompleteSignal is correct')
       t.equal(result.context, 'context', 'result.context is correct')
       t.equal(result.entrypoint, 'entrypoint', 'result.entry point is correct')
       t.equal(result.migration, 'migration', 'result.migration is correct')
@@ -371,7 +379,7 @@ test(
 
       t.equal(typeof result, 'object', 'result is object')
       t.notEqual(result, null, 'result is not null')
-      t.equal(Object.keys(result).length, 12, 'result has 12 properties')
+      t.equal(Object.keys(result).length, 13, 'result has 13 properties')
       t.ok(result.time > time, 'result.time seems correct')
       t.equal(result.flow_id, 'flowId', 'result.flow_id is correct')
       t.ok(result.flow_time > 0, 'result.flow_time is greater than zero')
@@ -921,3 +929,30 @@ test(
     t.end()
   }
 )
+
+test(
+  'setFlowCompleteSignal',
+  t => {
+    const request = {
+      payload: {
+        metricsContext: {}
+      }
+    }
+    metricsContext.setFlowCompleteSignal.call(request, 'wibble')
+    t.deepEqual(request.payload.metricsContext, { flowCompleteSignal: 'wibble' }, 'flowCompleteSignal was set correctly')
+    t.end()
+  }
+)
+
+test(
+  'setFlowCompleteSignal without metricsContext',
+  t => {
+    const request = {
+      payload: {}
+    }
+    metricsContext.setFlowCompleteSignal.call(request, 'wibble')
+    t.deepEqual(request.payload, {}, 'flowCompleteSignal was not set')
+    t.end()
+  }
+)
+

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -279,6 +279,7 @@ function mockRequest (data) {
     auth: {
       credentials: data.credentials
     },
+    clearMetricsContext: metricsContext.clear,
     emitMetricsEvent: events.emit,
     gatherMetricsContext: metricsContext.gather,
     headers: data.headers || {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -72,6 +72,7 @@ const MAILER_METHOD_NAMES = [
 
 const METRICS_CONTEXT_METHOD_NAMES = [
   'gather',
+  'setFlowCompleteSignal',
   'stash',
   'validate'
 ]
@@ -285,6 +286,7 @@ function mockRequest (data) {
     },
     payload: data.payload,
     query: data.query,
+    setMetricsFlowCompleteSignal: metricsContext.setFlowCompleteSignal,
     stashMetricsContext: metricsContext.stash,
     validateMetricsContext: metricsContext.validate
   }


### PR DESCRIPTION
Fixes #1480.

Because different flows have different completion signals, we need to emit an explicit `flow.complete` event for the benefit of the funnel queries.

There may be a more elegant way to achieve that than what I've done here, but I had half an eye on the clock in an effort to get this onto train 72. I took the approach of stashing an extra piece of data in memcached, calling it `flowCompleteSignal`.

While implementing it, I also noticed a separate issue that I introduced in #1500. Because the metrics context data is no longer cleared from memcached on read, and because Sync hits the `/certificate/sign` endpoint more than once, it was possible for multiple completion events to be emitted. I fixed this by adding a `request.clearMetricsContext` method and calling it after we emit `flow.complete`. There is a slightly clumsy aspect to this fix, which I'll call out in the inline comments.

Sample log output for a web session sign-up:

```
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476893208642,"flow_id":"e09ae158cc19fef799e2d846801e4d909b430f2a80bd0054df66f9212747c04b","flow_time":13337,"flowCompleteSignal":"account.verified","context":"web"}
flowEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476893215495,"flow_id":"e09ae158cc19fef799e2d846801e4d909b430f2a80bd0054df66f9212747c04b","flow_time":20190,"flowCompleteSignal":"account.verified","context":"web"}
flowEvent {"event":"flow.complete","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476893215495,"flow_id":"e09ae158cc19fef799e2d846801e4d909b430f2a80bd0054df66f9212747c04b","flow_time":20190,"flowCompleteSignal":"account.verified","context":"web"}
```

Sample log output for a web session sign-in:

```
flowEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476893264937,"flow_id":"085dbc8f18779c2352b9de480f768c9b8c3740f9652e09d22ca4504a07373b93","flow_time":50263,"flowCompleteSignal":"account.login","context":"web"}
flowEvent {"event":"flow.complete","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2881.0 Safari/537.36","time":1476893264937,"flow_id":"085dbc8f18779c2352b9de480f768c9b8c3740f9652e09d22ca4504a07373b93","flow_time":50263,"flowCompleteSignal":"account.login","context":"web"}
```

Sample log output for a Sync sign-in:

```
flowEvent {"event":"account.login","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476893309188,"flow_id":"af5e059e1ed96155c217fd10eef112669992faef84753651af02327ebe1e3083","flow_time":6779,"flowCompleteSignal":"account.signed","context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.confirmed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476893317259,"flow_id":"af5e059e1ed96155c217fd10eef112669992faef84753651af02327ebe1e3083","flow_time":14850,"flowCompleteSignal":"account.signed","context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476893324361,"flow_id":"af5e059e1ed96155c217fd10eef112669992faef84753651af02327ebe1e3083","flow_time":21952,"flowCompleteSignal":"account.signed","context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476893324433,"flow_id":"af5e059e1ed96155c217fd10eef112669992faef84753651af02327ebe1e3083","flow_time":22024,"flowCompleteSignal":"account.signed","context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"flow.complete","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1476893324433,"flow_id":"af5e059e1ed96155c217fd10eef112669992faef84753651af02327ebe1e3083","flow_time":22024,"flowCompleteSignal":"account.signed","context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

@seanmonstar r?

Btw, if what I've done here is too rushed then no worries, it's not the end of the world if it misses the train.