### PR TITLE
feat(metrics): Add password reset flow metrics

### DIFF
--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -324,10 +324,13 @@ module.exports = function (
 
         request.validateMetricsContext()
 
-        customs.check(
-          request,
-          email,
-          'passwordForgotSendCode')
+        request.emitMetricsEvent('password.forgot.send_code.start')
+          .then(
+            customs.check.bind(
+              request,
+              email,
+              'passwordForgotSendCode')
+          )
           .then(db.emailRecord.bind(db, email))
           .then(
             function (emailRecord) {
@@ -351,7 +354,7 @@ module.exports = function (
               )
               .then(
                 function() {
-                  return request.emitMetricsEvent('password.forgot.send_code')
+                  return request.emitMetricsEvent('password.forgot.send_code.completed')
                 }
               )
               .then(
@@ -408,10 +411,13 @@ module.exports = function (
 
         request.validateMetricsContext()
 
-        customs.check(
-          request,
-          passwordForgotToken.email,
-          'passwordForgotResendCode')
+        request.emitMetricsEvent('password.forgot.resend_code.start')
+          .then(
+            customs.check.bind(
+              request,
+              passwordForgotToken.email,
+              'passwordForgotResendCode')
+          )
           .then(
             mailer.sendRecoveryCode.bind(
               mailer,
@@ -427,12 +433,11 @@ module.exports = function (
           )
           .then(
             function(){
-              request.emitMetricsEvent('password.forgot.resend_code')
+              request.emitMetricsEvent('password.forgot.resend_code.completed')
             }
           )
           .done(
             function () {
-
               reply(
                 {
                   passwordForgotToken: passwordForgotToken.data.toString('hex'),
@@ -472,10 +477,13 @@ module.exports = function (
 
         request.validateMetricsContext()
 
-        customs.check(
-          request,
-          passwordForgotToken.email,
-          'passwordForgotVerifyCode')
+        request.emitMetricsEvent('password.forgot.verify_code.start')
+          .then(
+            customs.check.bind(
+              request,
+              passwordForgotToken.email,
+              'passwordForgotVerifyCode')
+          )
           .then(
             function () {
               if (butil.buffersAreEqual(passwordForgotToken.passCode, code) &&
@@ -491,7 +499,7 @@ module.exports = function (
                       )
                       .then(
                         function () {
-                          request.emitMetricsEvent('password.forgot.verify_code')
+                          request.emitMetricsEvent('password.forgot.verify_code.completed')
                         }
                       )
                       .then(

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -327,6 +327,7 @@ module.exports = function (
         request.emitMetricsEvent('password.forgot.send_code.start')
           .then(
             customs.check.bind(
+              customs,
               request,
               email,
               'passwordForgotSendCode')
@@ -414,6 +415,7 @@ module.exports = function (
         request.emitMetricsEvent('password.forgot.resend_code.start')
           .then(
             customs.check.bind(
+              customs,
               request,
               passwordForgotToken.email,
               'passwordForgotResendCode')
@@ -433,7 +435,7 @@ module.exports = function (
           )
           .then(
             function(){
-              request.emitMetricsEvent('password.forgot.resend_code.completed')
+              return request.emitMetricsEvent('password.forgot.resend_code.completed')
             }
           )
           .done(
@@ -480,6 +482,7 @@ module.exports = function (
         request.emitMetricsEvent('password.forgot.verify_code.start')
           .then(
             customs.check.bind(
+              customs,
               request,
               passwordForgotToken.email,
               'passwordForgotVerifyCode')

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -321,6 +321,9 @@ module.exports = function (
         log.begin('Password.forgotSend', request)
         var email = request.payload.email
         var service = request.payload.service || request.query.service
+
+        request.validateMetricsContext()
+
         customs.check(
           request,
           email,
@@ -344,6 +347,11 @@ module.exports = function (
                   redirectTo: request.payload.redirectTo,
                   resume: request.payload.resume,
                   acceptLanguage: request.app.acceptLanguage
+                }
+              )
+              .then(
+                function() {
+                  return request.emitMetricsEvent('password.forgot.send_code')
                 }
               )
               .then(
@@ -397,6 +405,9 @@ module.exports = function (
         log.begin('Password.forgotResend', request)
         var passwordForgotToken = request.auth.credentials
         var service = request.payload.service || request.query.service
+
+        request.validateMetricsContext()
+
         customs.check(
           request,
           passwordForgotToken.email,
@@ -414,8 +425,14 @@ module.exports = function (
               }
             )
           )
+          .then(
+            function(){
+              request.emitMetricsEvent('password.forgot.resend_code')
+            }
+          )
           .done(
             function () {
+
               reply(
                 {
                   passwordForgotToken: passwordForgotToken.data.toString('hex'),
@@ -452,6 +469,9 @@ module.exports = function (
         log.begin('Password.forgotVerify', request)
         var passwordForgotToken = request.auth.credentials
         var code = Buffer(request.payload.code, 'hex')
+
+        request.validateMetricsContext()
+
         customs.check(
           request,
           passwordForgotToken.email,
@@ -471,6 +491,11 @@ module.exports = function (
                       )
                       .then(
                         function () {
+                          request.emitMetricsEvent('password.forgot.verify_code')
+                        }
+                      )
+                      .then(
+                        function () {
                           return accountResetToken
                         }
                       )
@@ -478,6 +503,7 @@ module.exports = function (
                   )
                   .done(
                     function (accountResetToken) {
+
                       reply(
                         {
                           accountResetToken: accountResetToken.data.toString('hex')

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -11,6 +11,8 @@ var uuid = require('uuid')
 var crypto = require('crypto')
 var isA = require('joi')
 var error = require('../../lib/error')
+const sinon = require('sinon')
+const log = require('../../lib/log')
 
 var TEST_EMAIL = 'foo@gmail.com'
 
@@ -52,16 +54,36 @@ test(
       passwordForgotTokenId: crypto.randomBytes(16),
       uid: uid
     })
+    var mockMailer = mocks.mockMailer()
+    var mockMetricsContext = mocks.mockMetricsContext()
+    var mockLog = log('ERROR', 'test', {
+      stdout: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      },
+      stderr: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      }
+    })
+    mockLog.flowEvent = sinon.spy(() => {
+      return P.resolve()
+    })
     var passwordRoutes = makeRoutes({
       customs: mockCustoms,
-      db: mockDB
+      db: mockDB,
+      mailer : mockMailer,
+      metricsContext: mockMetricsContext,
+      log: mockLog
     })
 
     var mockRequest = mocks.mockRequest({
+      log: mockLog,
       payload: {
         email: TEST_EMAIL
       },
-      query: {}
+      query: {},
+      metricsContext: mockMetricsContext
     })
     return new P(function(resolve) {
       getRoute(passwordRoutes, '/password/forgot/send_code')
@@ -75,7 +97,69 @@ test(
       t.equal(args.length, 1, 'db.createPasswordForgotToken was passed one argument')
       t.deepEqual(args[0].uid, uid, 'db.createPasswordForgotToken was passed the correct uid')
       t.equal(args[0].createdAt, undefined, 'db.createPasswordForgotToken was not passed a createdAt timestamp')
+
+      t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
+      t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
+      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.send_code', 'password.forgot.send_code event was logged')
     })
+  }
+)
+
+test(
+  '/password/forgot/resend_code',
+  function (t) {
+    var mockCustoms = mocks.mockCustoms()
+    var uid = uuid.v4('binary')
+    var mockDB = mocks.mockDB()
+    var mockMailer = mocks.mockMailer()
+    var mockMetricsContext = mocks.mockMetricsContext()
+    var mockLog = log('ERROR', 'test', {
+      stdout: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      },
+      stderr: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      }
+    })
+    mockLog.flowEvent = sinon.spy(() => {
+      return P.resolve()
+    })
+    var passwordRoutes = makeRoutes({
+      customs: mockCustoms,
+      db: mockDB,
+      mailer : mockMailer,
+      metricsContext: mockMetricsContext,
+      log: mockLog
+    })
+
+    var mockRequest = mocks.mockRequest({
+      credentials: {
+        data: crypto.randomBytes(16),
+        email: TEST_EMAIL,
+        passCode: Buffer('abcdef', 'hex'),
+        ttl: function () { return 17 },
+        uid: uid
+      },
+      log: mockLog,
+      payload: {
+        email: TEST_EMAIL
+      },
+      query: {},
+      metricsContext: mockMetricsContext
+    })
+    return new P(function(resolve) {
+      getRoute(passwordRoutes, '/password/forgot/resend_code')
+        .handler(mockRequest, resolve)
+    })
+      .then(function(response) {
+        t.equal(mockMailer.sendRecoveryCode.callCount, 1, 'mailer.sendRecoveryCode was called once')
+
+        t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
+        t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
+        t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.resend_code', 'password.forgot.resend_code event was logged')
+      })
   }
 )
 
@@ -95,13 +179,29 @@ test(
       uid: uid
     })
     var mockMailer = mocks.mockMailer()
+    var mockMetricsContext = mocks.mockMetricsContext()
+    var mockLog = log('ERROR', 'test', {
+      stdout: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      },
+      stderr: {
+        on: sinon.spy(),
+        write: sinon.spy()
+      }
+    })
+    mockLog.flowEvent = sinon.spy(() => {
+      return P.resolve()
+    })
     var passwordRoutes = makeRoutes({
       customs: mockCustoms,
       db: mockDB,
-      mailer: mockMailer
+      mailer: mockMailer,
+      metricsContext: mockMetricsContext
     })
 
     var mockRequest = mocks.mockRequest({
+      log: mockLog,
       credentials: {
         email: TEST_EMAIL,
         passCode: Buffer('abcdef', 'hex'),
@@ -127,6 +227,10 @@ test(
       var args = mockDB.forgotPasswordVerified.args[0]
       t.equal(args.length, 1, 'db.passwordForgotVerified was passed one argument')
       t.deepEqual(args[0].uid, uid, 'db.forgotPasswordVerified was passed the correct token')
+
+      t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
+      t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
+      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.verify_code', 'password.forgot.verify_code event was logged')
     })
   }
 )

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -99,8 +99,9 @@ test(
       t.equal(args[0].createdAt, undefined, 'db.createPasswordForgotToken was not passed a createdAt timestamp')
 
       t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
-      t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
-      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.send_code', 'password.forgot.send_code event was logged')
+      t.equal(mockLog.flowEvent.callCount, 2, 'log.flowEvent was called twice')
+      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.send_code.start', 'password.forgot.send_code.start event was logged')
+      t.equal(mockLog.flowEvent.args[1][0], 'password.forgot.send_code.completed', 'password.forgot.send_code.completed event was logged')
     })
   }
 )
@@ -157,8 +158,9 @@ test(
         t.equal(mockMailer.sendRecoveryCode.callCount, 1, 'mailer.sendRecoveryCode was called once')
 
         t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
-        t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
-        t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.resend_code', 'password.forgot.resend_code event was logged')
+        t.equal(mockLog.flowEvent.callCount, 2, 'log.flowEvent was called twice')
+        t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.resend_code.start', 'password.forgot.resend_code.start event was logged')
+        t.equal(mockLog.flowEvent.args[1][0], 'password.forgot.resend_code.completed', 'password.forgot.resend_code.completed event was logged')
       })
   }
 )
@@ -229,8 +231,9 @@ test(
       t.deepEqual(args[0].uid, uid, 'db.forgotPasswordVerified was passed the correct token')
 
       t.equal(mockRequest.validateMetricsContext.callCount, 1, 'validateMetricsContext was called')
-      t.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent was called once')
-      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.verify_code', 'password.forgot.verify_code event was logged')
+      t.equal(mockLog.flowEvent.callCount, 2, 'log.flowEvent was called twice')
+      t.equal(mockLog.flowEvent.args[0][0], 'password.forgot.verify_code.start', 'password.forgot.verify_code.start event was logged')
+      t.equal(mockLog.flowEvent.args[1][0], 'password.forgot.verify_code.completed', 'password.forgot.verify_code.completed event was logged')
     })
   }
 )

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -67,7 +67,8 @@ const MAILER_METHOD_NAMES = [
   'sendPostVerifyEmail',
   'sendUnblockCode',
   'sendVerifyCode',
-  'sendVerifyLoginEmail'
+  'sendVerifyLoginEmail',
+  'sendRecoveryCode'
 ]
 
 const METRICS_CONTEXT_METHOD_NAMES = [
@@ -143,7 +144,10 @@ function mockDB (data, errors) {
         data: crypto.randomBytes(32),
         passCode: data.passCode,
         tokenId: data.passwordForgotTokenId,
-        uid: data.uid
+        uid: data.uid,
+        ttl: function () {
+          return data.passwordForgotTokenTTL || 100
+        }
       })
     }),
     createSessionToken: sinon.spy(() => {


### PR DESCRIPTION
This PR emits the needed flow events to track password reset. To test, connect with https://github.com/mozilla/fxa-content-server/pull/4297 and js client https://github.com/mozilla/fxa-js-client/pull/214.

Sample output
```
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084450050,"flow_id":"00998b433c6bc2cbbe618e009188ac7047495ff3bdffd50b5dfabd0e2eb4b679","flow_time":942771,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.verified","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084476101,"flow_id":"00998b433c6bc2cbbe618e009188ac7047495ff3bdffd50b5dfabd0e2eb4b679","flow_time":968822,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.reminder","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084476102,"flow_id":"00998b433c6bc2cbbe618e009188ac7047495ff3bdffd50b5dfabd0e2eb4b679","flow_time":968823,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.keyfetch","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084478068,"flow_id":"00998b433c6bc2cbbe618e009188ac7047495ff3bdffd50b5dfabd0e2eb4b679","flow_time":970789,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084478098,"flow_id":"00998b433c6bc2cbbe618e009188ac7047495ff3bdffd50b5dfabd0e2eb4b679","flow_time":970819,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"password.forgot.send_code","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084505518,"flow_id":"b36be862985e672ca56e30199b0178186aa82304bd2253915f6155d54d035150","flow_time":12231,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"password.forgot.resend_code","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084510098,"flow_id":"b36be862985e672ca56e30199b0178186aa82304bd2253915f6155d54d035150","flow_time":16811,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
flowEvent {"event":"password.forgot.verify_code","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0","time":1477084528888,"flow_id":"bd4ccb954519a1bec8fa34bc4cb7a733058eb0167e1550b43617c0224c1d9781","flow_time":9391,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync","utm_campaign":"fx-forgot-password","utm_content":"fx-reset-password","utm_medium":"email","utm_source":"email"}

```