### PR TITLE
chore(cleanup): Remove signer-stub.js

### DIFF
--- a/test/signer-stub.js
+++ b/test/signer-stub.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-require('../bin/signer.js')


### PR DESCRIPTION
The referenced `../bin/signer.js` is not actually in bin folder. I also could not find references to it.