### PR TITLE
feat(metrics): Emit an `account.changedPassword` activity event.

### DIFF
--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -7,6 +7,7 @@
 const P = require('../promise')
 
 const ACTIVITY_EVENTS = new Set([
+  'account.changedPassword',
   'account.confirmed',
   'account.created',
   'account.deleted',
@@ -25,6 +26,7 @@ const ACTIVITY_EVENTS = new Set([
 // It's far easier to define the events that *aren't* a flow
 // event than it is to define those that are.
 const NOT_FLOW_EVENTS = new Set([
+  'account.changedPassword',
   'account.deleted',
   'account.reset',
   'device.created',

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -219,6 +219,18 @@ module.exports = function (
                 )
               }
             )
+            .then(
+              function (result) {
+                return request.emitMetricsEvent('account.changedPassword', {
+                  uid: passwordChangeToken.uid.toString('hex')
+                })
+                .then(
+                  function () {
+                    return result
+                  }
+                )
+              }
+            )
         }
 
         function notifyAccount() {


### PR DESCRIPTION
To complete the conversation in https://github.com/mozilla/fxa-auth-server/issues/1452; @seanmonstar r?