### PR TITLE
chore(debug): Expose debug port for spawned process

### DIFF
--- a/test/test_server.js
+++ b/test/test_server.js
@@ -17,6 +17,13 @@ let currentServer
 function TestServer(config, printLogs) {
   currentServer = this
   if (printLogs === undefined) {
+
+    // Issue where debugger does not attach if
+    // child process output is not piped to console
+    if (isDebug()) {
+      process.env.REMOTE_TEST_LOGS = 'true'
+    }
+
     printLogs = (process.env.REMOTE_TEST_LOGS === 'true')
   }
   this.printLogs = printLogs

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -84,10 +84,21 @@ TestServer.start = function (config, printLogs) {
   return d.promise
 }
 
+function isDebug(){
+  return global.v8debug ? true : false
+}
+
 TestServer.prototype.start = function () {
+  var spawnOptions = ['./key_server_stub.js']
+
+  var nextDebugPort = process.debugPort + 2
+  if (isDebug()) {
+    spawnOptions.unshift('--debug-brk=' + nextDebugPort)
+  }
+
   this.server = cp.spawn(
     'node',
-    ['./key_server_stub.js'],
+    spawnOptions,
     {
       cwd: __dirname,
       stdio: this.printLogs ? 'pipe' : 'ignore'


### PR DESCRIPTION
Currently, the spawned test server process can not be debugged into. This PR increments the debug port the parent process is running and sets it in the child process.