### PR TITLE
chore(tests): Make remote db tests independent

### DIFF
--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -63,12 +63,9 @@ describe('remote db', function() {
       })
       .then(x => {
         db = x
+        return db.createAccount(ACCOUNT)
       })
-  })
-
-  beforeEach(() => {
-    return db.createAccount(ACCOUNT)
-      .then(function(account) {
+      .then((account) => {
         assert.deepEqual(account.uid, ACCOUNT.uid, 'account.uid is the same as the input ACCOUNT.uid')
       })
   })
@@ -661,16 +658,6 @@ describe('remote db', function() {
         })
     }
   )
-
-  afterEach(() => {
-    return db.emailRecord(ACCOUNT.email)
-      .then(function (emailRecord) {
-        return db.deleteAccount(emailRecord)
-      })
-      .catch(function (err) {
-        //
-      })
-  })
 
   after(() => {
     return TestServer.stop(dbServer)

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -66,6 +66,13 @@ describe('remote db', function() {
       })
   })
 
+  beforeEach(() => {
+    return db.createAccount(ACCOUNT)
+      .then(function(account) {
+        assert.deepEqual(account.uid, ACCOUNT.uid, 'account.uid is the same as the input ACCOUNT.uid')
+      })
+  })
+
   it(
     'ping',
     () => {
@@ -76,13 +83,7 @@ describe('remote db', function() {
   it(
     'account creation',
     () => {
-      return db.createAccount(ACCOUNT)
-        .then(function(account) {
-          assert.deepEqual(account.uid, ACCOUNT.uid, 'account.uid is the same as the input ACCOUNT.uid')
-        })
-        .then(function() {
-          return db.accountExists(ACCOUNT.email)
-        })
+      return db.accountExists(ACCOUNT.email)
         .then(function(exists) {
           assert.ok(exists, 'account exists for this email address')
         })
@@ -660,6 +661,16 @@ describe('remote db', function() {
         })
     }
   )
+
+  afterEach(() => {
+    return db.emailRecord(ACCOUNT.email)
+      .then(function (emailRecord) {
+        return db.deleteAccount(emailRecord)
+      })
+      .catch(function (err) {
+        //
+      })
+  })
 
   after(() => {
     return TestServer.stop(dbServer)


### PR DESCRIPTION
Previously, each test relied on the account being created in the first `it` test case. This moves it to a `beforeEach` and then deletes the account in the `afterEach`. You can use a `it.only` to test a specific test case.