### PR TITLE
fix(bypass): Don't bypass sign-in confirmation for forced emails

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -465,7 +465,7 @@ var conf = convict({
       ],
       env: 'SIGNIN_CONFIRMATION_SUPPORTED_CLIENTS'
     },
-    enabledEmailAddresses: {
+    forcedEmailAddresses: {
       doc: 'If feature enabled, force sign-in confirmation for email addresses matching this regex.',
       format: RegExp,
       default: /.+@mozilla\.com$/,

--- a/lib/features.js
+++ b/lib/features.js
@@ -46,7 +46,7 @@ module.exports = config => {
       }
 
       // Or if the email address matches the regex.
-      if (signinConfirmation.enabledEmailAddresses.test(email)) {
+      if (signinConfirmation.forcedEmailAddresses.test(email)) {
         return true
       }
 
@@ -110,18 +110,17 @@ module.exports = config => {
      * @param recency
      * @returns {boolean}
      */
-    canBypassSiginConfirmation(verified, recency) {
-      let bypass = false
+    canBypassSiginConfirmation(email, verified, recency) {
+      // If sign-in confirmation is forced for an email, it can't be bypassed.
+      if (signinConfirmation.enabled && signinConfirmation.forcedEmailAddresses.test(email)) {
+        return false
+      }
 
-      // IP Profiling sets bypass to true if this user has verified a session
+      // IP Profiling returns true if this user has verified a session
       // within the past day from this ip address.
       let ipProfilingEnabled = securityHistory.enabled && securityHistory.ipProfiling &&
         securityHistory.ipProfiling.enabled
-      if (ipProfilingEnabled && verified && recency === 'day') {
-        bypass = true
-      }
-
-      return bypass
+      return ipProfilingEnabled && verified && recency === 'day'
     },
 
     /**

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -594,7 +594,7 @@ module.exports = function (
 
           // Check to see if this login can bypass sign-in confirmation. Current scenarios include
           //  * User has already logged in from this ip address and verified the sign-in
-          let bypassSiginConfirmation = features.canBypassSiginConfirmation(securityEventVerified, securityEventRecency)
+          let bypassSiginConfirmation = features.canBypassSiginConfirmation(emailRecord.email, securityEventVerified, securityEventRecency)
           if (bypassSiginConfirmation) {
             log.info({
               op: 'Account.ipprofiling.seenAddress',

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -1064,7 +1064,7 @@ describe('/account/login', function () {
     before(() => {
       config.signinConfirmation.enabled = true
       config.signinConfirmation.supportedClients = [ 'fx_desktop_v3' ]
-      config.signinConfirmation.enabledEmailAddresses = /.+@mozilla\.com$/
+      config.signinConfirmation.forcedEmailAddresses = /.+@mozilla\.com$/
 
       mockDB.emailRecord = function () {
         return P.resolve({


### PR DESCRIPTION
For consideration, this does not bypass sign-in confirmation when it is specified by a forced email.

- [x] Don't bypass sign-in confirmation
- [x] Rename `enabledEmailAddresses` to `forcedEmailAddresses`
- [ ] ~~Rename `canBypassSiginConfirmation` to `isIpProfilingEnabledForUser`~~

Fixes #1547 
