### PR TITLE
fix(devices): add special-case recognition of Firefox-iOS

### DIFF
--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -27,6 +27,8 @@ var MOBILE_OS_FAMILIES = {
 
 var ELLIPSIS = '\u2026'
 
+const SYNC_MOBILE_USER_AGENT = /^Firefox-(Android|iOS)-FxA(?:ccounts)?\/(\S+)/
+
 module.exports = function (userAgentString, log) {
   var userAgentData = ua.parse(userAgentString)
 
@@ -36,9 +38,19 @@ module.exports = function (userAgentString, log) {
   this.uaOSVersion = getVersion(userAgentData.os) || null
   this.uaDeviceType = getDeviceType(userAgentData) || null
 
-  if (! this.uaBrowser && ! this.uaOS) {
-    // In the worst case, fall back to a truncated user agent string
-    this.uaBrowser = truncate(userAgentString || '', log)
+  if (! this.uaBrowser) {
+    const matches = SYNC_MOBILE_USER_AGENT.exec(userAgentString)
+    if (matches && matches.length === 3) {
+      this.uaBrowser = 'Firefox'
+      this.uaBrowserVersion = matches[2]
+      this.uaOS = matches[1]
+      if (! this.uaDeviceType) {
+        this.uaDeviceType = 'mobile'
+      }
+    } else if (! this.uaOS) {
+      // In the worst case, fall back to a truncated user agent string
+      this.uaBrowser = truncate(userAgentString || '', log)
+    }
   }
 
   return this

--- a/test/local/user_agent_tests.js
+++ b/test/local/user_agent_tests.js
@@ -499,5 +499,92 @@ describe('userAgent', () => {
       log.info.reset()
     }
   )
+
+  it(
+    'recognises Firefox-iOS user agents',
+    () => {
+      parserResult = {
+        ua: {
+          family: 'Other'
+        },
+        os: {
+          family: 'iOS'
+        },
+        device: {
+          family: 'Other'
+        }
+      }
+      const context = {}
+      const userAgentString = 'Firefox-iOS-FxA/5.3 (Firefox)'
+      const result = userAgent.call(context, userAgentString, log)
+
+      assert.equal(result.uaBrowser, 'Firefox')
+      assert.equal(result.uaBrowserVersion, '5.3')
+      assert.equal(result.uaOS, 'iOS')
+      assert.equal(result.uaDeviceType, 'mobile')
+
+      assert.equal(log.info.callCount, 0)
+
+      uaParser.parse.reset()
+    }
+  )
+
+  it(
+    'preserves device type on Firefox-iOS user agents',
+    () => {
+      parserResult = {
+        ua: {
+          family: 'Other'
+        },
+        os: {
+          family: 'Other'
+        },
+        device: {
+          family: 'iPad'
+        }
+      }
+      const context = {}
+      const userAgentString = 'Firefox-iOS-FxA/6.0 (Firefox)'
+      const result = userAgent.call(context, userAgentString, log)
+
+      assert.equal(result.uaBrowser, 'Firefox')
+      assert.equal(result.uaBrowserVersion, '6.0')
+      assert.equal(result.uaOS, 'iOS')
+      assert.equal(result.uaDeviceType, 'tablet')
+
+      assert.equal(log.info.callCount, 0)
+
+      uaParser.parse.reset()
+    }
+  )
+
+  it(
+    'recognises Firefox-Android user agents',
+    () => {
+      parserResult = {
+        ua: {
+          family: 'Other'
+        },
+        os: {
+          family: 'Android'
+        },
+        device: {
+          family: 'Other'
+        }
+      }
+      const context = {}
+      const userAgentString = 'Firefox-Android-FxAccounts/49.0.2 (Firefox)'
+      const result = userAgent.call(context, userAgentString, log)
+
+      assert.equal(result.uaBrowser, 'Firefox')
+      assert.equal(result.uaBrowserVersion, '49.0.2')
+      assert.equal(result.uaOS, 'Android')
+      assert.equal(result.uaDeviceType, 'mobile')
+
+      assert.equal(log.info.callCount, 0)
+
+      uaParser.parse.reset()
+    }
+  )
 })
 


### PR DESCRIPTION
Fixes #1555.

Firefox-iOS is showing up with ugly user agent strings in the device view. This adds a test to recognise them and return appropriate parsed data instead.

I took the simplest approach of ignoring the Firefox version in the regex here. We could also add a match group to pull that out and return an appropriate `uaBrowserVersion` too if it's preferable. But I thought that was probably unnecessary in light of #1556, which suggests dropping the browser version. And the less specific regex may (or may not) be more robust?

@vladikoff r?