### PR TITLE
fix(docs): document recent fix that affects flow events

### DIFF
--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -194,6 +194,15 @@ in the preceding five days.
 
 ## Significant changes
 
+### Train 75
+
+* The correct `service` parameter
+  was passed to `/certificate/sign`
+  for OAuth reliers,
+  stopping those requests from
+  being identified as originating from
+  the content server.
+
 ### Train 74
 
 * Flow event data validation


### PR DESCRIPTION
I'm starting to think it was a mistake keeping this document in the repo, the continual PRs to update it are getting tiresome. Perhaps it will be okay when the flow event code settles down a bit more, or perhaps I should batch the updates to be less frequent (but I worry about forgetting them), or perhaps I the doc is in the wrong place.

Anyway, this documents mozilla/fxa-content-server#4419.

@vbudhram r?