### PR TITLE
fix(customs): Sanitize 'oldAuthPW' field when sending to customs.

### DIFF
--- a/lib/customs.js
+++ b/lib/customs.js
@@ -20,6 +20,9 @@ module.exports = function (log, error) {
     if (clonePayload.authPW) {
       delete clonePayload.authPW
     }
+    if (clonePayload.oldAuthPW) {
+      delete clonePayload.oldAuthPW
+    }
 
     return clonePayload
   }

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -366,6 +366,8 @@ describe('Customs', () => {
 
       var request = newRequest()
       request.payload.authPW = 'asdfasdfadsf'
+      request.payload.oldAuthPW = '012301230123'
+      request.payload.notThePW = 'plaintext'
       var ip = request.app.clientAddress
       var email = newEmail()
       var action = newAction()
@@ -377,8 +379,10 @@ describe('Customs', () => {
           action: action,
           headers: request.headers,
           query: request.query,
-          payload: {}
-        }, 'should not have authPW in payload')
+          payload: {
+            notThePW: 'plaintext'
+          }
+        }, 'should not have password fields in payload')
         return true
       }).reply(200, {
         block: false,


### PR DESCRIPTION
There's one API endpoint that takes the authPW input in a non-standard param, we should sanitize it before sending to customs.  @mozilla/fxa-devs r?