### PR TITLE
fix(logging): remove raw token data from error log

### DIFF
--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -76,7 +76,13 @@ module.exports = function (log, config) {
 
     return P.resolve()
       .then(() => getMemcached().setAsync(getKey(token), metadata, config.memcached.lifetime))
-      .catch(err => log.error({ op: 'metricsContext.stash', err: err, token: token }))
+      .catch(err => log.error({
+        op: 'metricsContext.stash',
+        err: err,
+        hasToken: !! token,
+        hasId: !! (token && token.id),
+        hasUid: !! (token && token.uid)
+      }))
   }
 
   function getMemcached () {
@@ -149,7 +155,13 @@ module.exports = function (log, config) {
           }
         }
       })
-      .catch(err => log.error({ op: 'metricsContext.gather', err: err, token: token }))
+      .catch(err => log.error({
+        op: 'metricsContext.gather',
+        err: err,
+        hasToken: !! token,
+        hasId: !! (token && token.id),
+        hasUid: !! (token && token.uid)
+      }))
       .then(() => data)
   }
 

--- a/test/local/metrics_context_tests.js
+++ b/test/local/metrics_context_tests.js
@@ -108,6 +108,9 @@ describe('metricsConext', () => {
         assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
         assert.equal(log.error.args[0][0].op, 'metricsContext.stash', 'argument op property was correct')
         assert.equal(log.error.args[0][0].err, 'wibble', 'argument err property was correct')
+        assert.strictEqual(log.error.args[0][0].hasToken, true, 'hasToken property was correct')
+        assert.strictEqual(log.error.args[0][0].hasId, true, 'hasId property was correct')
+        assert.strictEqual(log.error.args[0][0].hasUid, true, 'hasUid property was correct')
 
         Memcached.prototype.setAsync.restore()
         log.error.reset()
@@ -135,7 +138,9 @@ describe('metricsConext', () => {
         assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
         assert.equal(log.error.args[0][0].op, 'metricsContext.stash', 'op property was correct')
         assert.equal(log.error.args[0][0].err.message, 'Invalid token', 'err.message property was correct')
-        assert.deepEqual(log.error.args[0][0].token, { id: 'foo' }, 'token property was correct')
+        assert.strictEqual(log.error.args[0][0].hasToken, true, 'hasToken property was correct')
+        assert.strictEqual(log.error.args[0][0].hasId, true, 'hasId property was correct')
+        assert.strictEqual(log.error.args[0][0].hasUid, false, 'hasUid property was correct')
 
         assert.equal(Memcached.prototype.setAsync.callCount, 0, 'memcached.setAsync was not called')
 
@@ -413,7 +418,9 @@ describe('metricsConext', () => {
         assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
         assert.equal(log.error.args[0][0].op, 'metricsContext.gather', 'op property was correct')
         assert.equal(log.error.args[0][0].err.message, 'Invalid token', 'err.message property was correct')
-        assert.deepEqual(log.error.args[0][0].token, { uid: Buffer.alloc(32, 'cd') }, 'token property was correct')
+        assert.strictEqual(log.error.args[0][0].hasToken, true, 'hasToken property was correct')
+        assert.strictEqual(log.error.args[0][0].hasId, false, 'hasId property was correct')
+        assert.strictEqual(log.error.args[0][0].hasUid, true, 'hasUid property was correct')
 
         Memcached.prototype.getAsync.restore()
         log.error.reset()


### PR DESCRIPTION
Fixes #1571.

`token` was added to these error logs so we could see why `getKey` fails. But dumping the whole token in the error message was wrong (and quite lazy) of me. Really all we're interested in is identifying which field was missing, so that is what this PR does.

@shane-tomlinson r?