### PR TITLE
feat(metrics): log flowEvents of all requests

### DIFF
--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -68,6 +68,7 @@ in a sign-in or sign-up flow:
 |`password.forgot.resend_code.completed`|A password reset email has been re-sent to the user.|
 |`password.forgot.verify_code.start`|A user has clicked on the link in a password reset email.|
 |`password.forgot.verify_code.completed`|A password reset has been successfully completed on the server.|
+|`route.${path}.200`| A route responded with a 200 status code. Example: `route./account/login.200`|
 |`flow.complete`|A user has successfully completed a sign-in or sign-up flow.|
 
 The following flow events
@@ -78,6 +79,7 @@ to a flow:
 |Name|Description|
 |----|-----------|
 |`customs.blocked`|A request was blocked by the customs server.|
+|`route.${path}.${statusCode}.${errno}`| A route responded with a >=400 status code. Includes `errno`. Example: `route./account/login.400.103`|
 
 In redshift,
 these events are stored
@@ -212,6 +214,8 @@ in the preceding five days.
 
 * Duplicate flow events
   were fixed in the content server.
+
+* The `route.*` events were implemented.
 
 ### Train 74
 

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -55,7 +55,7 @@ function waitLoop(testServer, url, cb) {
         }
         return setTimeout(waitLoop.bind(null, testServer, url, cb), 100)
       } else if (res.statusCode !== 200) {
-        cb(body)
+        cb(new Error(body))
       }
       cb()
     }


### PR DESCRIPTION
This logs responses as flow events for routes we've determined are definitely part of a user flow. The format is `route.${path}.${status}`, such as `route./account/login.200` or `route./account/login.400.103`. Includes documentation.

cc @philbooth 
Closes #1526 