### PR TITLE
fix(server): propagate metrics context in /account/reset

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1806,7 +1806,8 @@ module.exports = function (
         validate: {
           payload: {
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
-            sessionToken: isA.boolean().optional()
+            sessionToken: isA.boolean().optional(),
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }
         }
       },
@@ -1897,6 +1898,14 @@ module.exports = function (
             .then(
               function (wrapKbData) {
                 wrapKb = wrapKbData
+
+                let flowCompleteSignal
+                if (requestHelper.wantsKeys(request)) {
+                  flowCompleteSignal = 'account.signed'
+                } else {
+                  flowCompleteSignal = 'account.login'
+                }
+                request.setMetricsFlowCompleteSignal(flowCompleteSignal)
               }
             )
         }
@@ -1917,6 +1926,7 @@ module.exports = function (
               .then(
                 function (result) {
                   sessionToken = result
+                  return request.stashMetricsContext(sessionToken)
                 }
               )
           }
@@ -1938,6 +1948,7 @@ module.exports = function (
             .then(
               function (result) {
                 keyFetchToken = result
+                return request.stashMetricsContext(keyFetchToken)
               }
             )
           }


### PR DESCRIPTION
Related to mozilla/fxa-content-server#4477.

We're not quite propagating the metrics context payload through to the end of the `/account/reset` flow, meaning our flow metrics aren't showing completed flows. This change fixes that.

When run against equivalent changes to `fxa-js-client` and `fxa-content-server`, the following flow events show up in the auth server log when you reset your password:

```
flowEvent {"event":"password.forgot.send_code.start","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511151787,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":7096,"service":"sync"}
flowEvent {"event":"password.forgot.send_code.completed","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511151808,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":7117,"service":"sync"}
flowEvent {"event":"password.forgot.verify_code.start","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511168533,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":23842}
flowEvent {"event":"password.forgot.verify_code.completed","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511168559,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":23868}
flowEvent {"event":"account.keyfetch","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511168677,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":23986,"flowCompleteSignal":"account.signed"}
flowEvent {"event":"account.signed","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511168707,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":24016,"flowCompleteSignal":"account.signed"}
flowEvent {"event":"flow.complete","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","time":1480511168707,"flow_id":"9d0437d21a3bdc251549f65814521325b8beee05326b7870723532a9a25444d0","flow_time":24016,"flowCompleteSignal":"account.signed"}
```

Without this change, those logs stop at `password.forgot.verify_code.completed`.

@seanmonstar r?