### PR TITLE
chore(login): Remove the legacy `contentToken` parameter from login.

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -370,8 +370,6 @@ module.exports = function (
           payload: {
             email: validators.email().required(),
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
-            // Obsolete contentToken param, here for backwards compat.
-            contentToken: isA.string().optional(),
             service: isA.string().max(16).alphanum().optional(),
             redirectTo: isA.string().uri().optional(),
             resume: isA.string().optional(),
@@ -410,14 +408,6 @@ module.exports = function (
         let securityEventRecency, securityEventVerified = false
 
         request.validateMetricsContext()
-
-        // Monitor for any clients still sending obsolete 'contentToken' param.
-        if (request.payload.contentToken) {
-          log.info({
-            op: 'Account.login.contentToken',
-            agent: request.headers['user-agent']
-          })
-        }
 
         checkIsBlockForced()
           .then(() => customs.check(request, email, 'accountLogin'))


### PR DESCRIPTION
We don't have any instances of this showing up in Kibana, so I think we can safely remove it.