### PR TITLE
fix(server): make account.reset a flow event

### DIFF
--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -60,6 +60,7 @@ in a sign-in or sign-up flow:
 |`account.verified`|A new account has been verified via email.|
 |`account.keyfetch`|Sync encryption keys have been fetched.|
 |`account.signed`|A certificate has been signed.|
+|`account.reset`|An account has been reset.|
 |`account.login.confirmedUnblockCode`|A user has successfully unblocked their account.|
 |`account.login.sentUnblockCode`|A sign-in unblock email has been sent to the user.|
 |`password.forgot.send_code.start`|A user has initiated the password reset flow.|
@@ -202,6 +203,10 @@ in the preceding five days.
 * [Duplicate flow events
   were fixed in the content server]
   (https://github.com/mozilla/fxa-content-server/pull/4478).
+
+* [The `account.reset` event
+  was made a flow event]
+  (https://github.com/mozilla/fxa-auth-server/pull/1584).
 
 ### Train 75
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -17,6 +17,7 @@ var StatsDCollector = require('./metrics/statsd')
 // Don't log the error for those events.
 const OPTIONAL_FLOW_EVENTS = {
   'account.keyfetch': true,
+  'account.reset': true,
   'account.signed': true
 }
 

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -28,7 +28,6 @@ const ACTIVITY_EVENTS = new Set([
 const NOT_FLOW_EVENTS = new Set([
   'account.changedPassword',
   'account.deleted',
-  'account.reset',
   'device.created',
   'device.deleted',
   'device.updated'

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1808,6 +1808,16 @@ module.exports = function (
         var account, sessionToken, keyFetchToken, verifyHash, wrapKb, devicesToNotify
         var hasSessionToken = request.payload.sessionToken
 
+        request.validateMetricsContext()
+
+        let flowCompleteSignal
+        if (requestHelper.wantsKeys(request)) {
+          flowCompleteSignal = 'account.signed'
+        } else {
+          flowCompleteSignal = 'account.reset'
+        }
+        request.setMetricsFlowCompleteSignal(flowCompleteSignal)
+
         return fetchDevicesToNotify()
           .then(resetAccountData)
           .then(createSessionToken)
@@ -1888,14 +1898,6 @@ module.exports = function (
             .then(
               function (wrapKbData) {
                 wrapKb = wrapKbData
-
-                let flowCompleteSignal
-                if (requestHelper.wantsKeys(request)) {
-                  flowCompleteSignal = 'account.signed'
-                } else {
-                  flowCompleteSignal = 'account.login'
-                }
-                request.setMetricsFlowCompleteSignal(flowCompleteSignal)
               }
             )
         }

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -365,6 +365,9 @@ describe('/account/reset', function () {
       assert.equal(securityEvent.ipAddr, clientAddress)
       assert.equal(securityEvent.name, 'account.reset')
 
+      assert.equal(mockMetricsContext.validate.callCount, 1, 'metricsContext.validate was called')
+      assert.equal(mockMetricsContext.validate.args[0].length, 0, 'validate was called without arguments')
+
       assert.equal(mockMetricsContext.setFlowCompleteSignal.callCount, 1, 'metricsContext.setFlowCompleteSignal was called once')
       args = mockMetricsContext.setFlowCompleteSignal.args[0]
       assert.equal(args.length, 1, 'metricsContext.setFlowCompleteSignal was passed one argument')


### PR DESCRIPTION
I should have done the following two things as part of #1578:

1. Call `request.validateMetricsContext()` at the start of the `/account/reset` route handler.

2. Promote the `account.reset` activity event to a flow event.

This change does that.

