### PR TITLE
fix(signup): Return canonical email address in 'account exists' error.

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -105,7 +105,7 @@ module.exports = function (
 
         customs.check(request, email, 'accountCreate')
           .then(db.emailRecord.bind(db, email))
-          .then(deleteAccount, ignoreUnknownAccountError)
+          .then(deleteAccountIfUnverified, ignoreUnknownAccountError)
           .then(checkPreVerified)
           .then(generateRandomValues)
           .then(createPassword)
@@ -117,9 +117,9 @@ module.exports = function (
           .then(createResponse)
           .done(reply, reply)
 
-        function deleteAccount (emailRecord) {
+        function deleteAccountIfUnverified (emailRecord) {
           if (emailRecord.emailVerified) {
-            throw error.accountExists(email)
+            throw error.accountExists(emailRecord.email)
           }
 
           request.app.accountRecreated = true

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -289,6 +289,7 @@ describe('remote account create', function() {
           function (err) {
             assert.equal(err.code, 400)
             assert.equal(err.errno, 101, 'Account already exists')
+            assert.equal(err.email, email, 'The existing email address is returned')
           }
         )
     }


### PR DESCRIPTION
Fixes #1583 (and also renames the containing function so it's more clear what it does and doesn't do)

@vbudhram r? for inclusion in train-76, so we can get it into prod ahead of a corresponding content-server change.