### PR TITLE
fix(logging): silence spurious "missing token" error noise

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -31,7 +31,7 @@ var ERRNO = {
   REQUEST_BLOCKED: 125,
   ACCOUNT_RESET: 126,
   INVALID_UNBLOCK_CODE: 127,
-  MISSING_TOKEN: 128,
+  // MISSING_TOKEN: 128,
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
   UNEXPECTED_ERROR: 999
@@ -475,13 +475,6 @@ AppError.invalidUnblockCode = function () {
     message: 'Invalid unblock code'
   })
 }
-
-AppError.missingToken = () => new AppError({
-  code: 400,
-  error: 'Bad Request',
-  errno: ERRNO.MISSING_TOKEN,
-  message: 'Missing token'
-})
 
 module.exports = AppError
 module.exports.ERRNO = ERRNO

--- a/test/local/metrics_context_tests.js
+++ b/test/local/metrics_context_tests.js
@@ -378,11 +378,7 @@ describe('metricsConext', () => {
         assert.notEqual(result, null, 'result is not null')
         assert.equal(Object.keys(result).length, 0, 'result is empty')
 
-        assert.equal(log.error.callCount, 1, 'log.error was called once')
-        assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
-        assert.equal(log.error.args[0][0].op, 'metricsContext.gather', 'op property was correct')
-        assert.equal(log.error.args[0][0].err.message, 'Missing token', 'err.message property was correct')
-        assert.equal(log.error.args[0][0].token, undefined, 'token property was correct')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
 
         Memcached.prototype.getAsync.restore()
         log.error.reset()
@@ -578,6 +574,7 @@ describe('metricsConext', () => {
       sinon.stub(Memcached.prototype, 'delAsync', () => P.resolve())
       return metricsContext.clear.call({}).then(() => {
         assert.equal(Memcached.prototype.delAsync.callCount, 0, 'memcached.delAsync was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
 
         Memcached.prototype.delAsync.restore()
       }).catch(err => assert.fail(err))


### PR DESCRIPTION
Fixes #1595.

The "missing token" error generates a lot of log noise because it occurs in legitimate scenarios when trying to gather metrics context data speculatively, from `log.notifyAttachedServices` and `log.flowEvent`.

We were already silencing it in `metricsContext.clear` and actually, due to the above, I think we should silence it in `gather` too. Doing this means `getToken` no longer needs to `throw`, which pleases me because it was only throwing for flow control anyway (my fault).

I also think our logging elsewhere is sufficient to cover any genuine issues relating to missing token data.

@vbudhram r?