### PR TITLE
refactor(signin): Use new verify account sync template and add location data to others

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -27,7 +27,13 @@ module.exports = function (config, log) {
             service: opts.service,
             redirectTo: opts.redirectTo,
             resume: opts.resume,
-            acceptLanguage: opts.acceptLanguage || defaultLanguage
+            acceptLanguage: opts.acceptLanguage || defaultLanguage,
+            ip: opts.ip,
+            location: opts.location,
+            uaBrowser: opts.uaBrowser,
+            uaBrowserVersion: opts.uaBrowserVersion,
+            uaOS: opts.uaOS,
+            uaOSVersion: opts.uaOSVersion
           }
         ))
       }
@@ -60,7 +66,14 @@ module.exports = function (config, log) {
             service: opts.service,
             redirectTo: opts.redirectTo,
             resume: opts.resume,
-            acceptLanguage: opts.acceptLanguage || defaultLanguage
+            acceptLanguage: opts.acceptLanguage || defaultLanguage,
+            ip: opts.ip,
+            location: opts.location,
+            timeZone: opts.timeZone,
+            uaBrowser: opts.uaBrowser,
+            uaBrowserVersion: opts.uaBrowserVersion,
+            uaOS: opts.uaOS,
+            uaOSVersion: opts.uaOSVersion
           }
         ))
       }
@@ -68,7 +81,13 @@ module.exports = function (config, log) {
         return P.resolve(mailer.passwordChangedEmail(
           {
             email: email,
-            acceptLanguage: opts.acceptLanguage || defaultLanguage
+            acceptLanguage: opts.acceptLanguage || defaultLanguage,
+            ip: opts.ip,
+            location: opts.location,
+            uaBrowser: opts.uaBrowser,
+            uaBrowserVersion: opts.uaBrowserVersion,
+            uaOS: opts.uaOS,
+            uaOSVersion: opts.uaOSVersion
           }
         ))
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -895,7 +895,7 @@
     "fxa-auth-mailer": {
       "version": "1.76.0",
       "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#3114e1608a363f3ab0cd016c14732e859c0cf0bc",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#f430684f3f5ad50d0523d6f821384f1f9430b2b0",
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -895,7 +895,7 @@
     "fxa-auth-mailer": {
       "version": "1.76.0",
       "from": "git+https://github.com/mozilla/fxa-auth-mailer.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#ebce13a050bfa935bd9bdbbf663bbc5cbce463d2",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-mailer.git#3114e1608a363f3ab0cd016c14732e859c0cf0bc",
       "dependencies": {
         "bluebird": {
           "version": "2.9.34",

--- a/test/local/account_routes.js
+++ b/test/local/account_routes.js
@@ -825,6 +825,10 @@ describe('/account/create', function () {
       assert.equal(securityEvent.name, 'account.create')
       assert.equal(securityEvent.uid, uid)
       assert.equal(securityEvent.ipAddr, clientAddress)
+
+      assert.equal(mockMailer.sendVerifyCode.callCount, 1, 'mailer.sendVerifyCode was called')
+      assert.equal(mockMailer.sendVerifyCode.getCall(0).args[2].location.city, 'Mountain View')
+      assert.equal(mockMailer.sendVerifyCode.getCall(0).args[2].location.country, 'United States')
     })
   })
 })

--- a/test/local/password_routes.js
+++ b/test/local/password_routes.js
@@ -105,6 +105,11 @@ describe('/password', () => {
         assert.equal(mockLog.flowEvent.callCount, 2, 'log.flowEvent was called twice')
         assert.equal(mockLog.flowEvent.args[0][0], 'password.forgot.send_code.start', 'password.forgot.send_code.start event was logged')
         assert.equal(mockLog.flowEvent.args[1][0], 'password.forgot.send_code.completed', 'password.forgot.send_code.completed event was logged')
+
+        assert.equal(mockMailer.sendRecoveryCode.callCount, 1, 'mailer.sendRecoveryCode was called once')
+        assert.equal(mockMailer.sendRecoveryCode.getCall(0).args[2].location.city, 'Mountain View')
+        assert.equal(mockMailer.sendRecoveryCode.getCall(0).args[2].location.country, 'United States')
+        assert.equal(mockMailer.sendRecoveryCode.getCall(0).args[2].timeZone, 'America/Los_Angeles')
       })
     }
   )
@@ -289,6 +294,9 @@ describe('/password', () => {
         assert.equal(mockDB.account.callCount, 1)
         assert.equal(mockMailer.sendPasswordChangedNotification.callCount, 1)
         assert.equal(mockMailer.sendPasswordChangedNotification.firstCall.args[0], TEST_EMAIL)
+        assert.equal(mockMailer.sendPasswordChangedNotification.getCall(0).args[1].location.city, 'Mountain View')
+        assert.equal(mockMailer.sendPasswordChangedNotification.getCall(0).args[1].location.country, 'United States')
+        assert.equal(mockMailer.sendPasswordChangedNotification.getCall(0).args[1].timeZone, 'America/Los_Angeles')
 
         assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
         var args = mockLog.activityEvent.args[0]

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -539,7 +539,7 @@ describe('remote account create', function() {
   )
 
   it(
-    'create account for non-sync service does not get post-verify email',
+    'create account for non-sync service, gets generic sign-up email and does not get post-verify email',
     () => {
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
@@ -553,7 +553,13 @@ describe('remote account create', function() {
         )
         .then(
           function () {
-            return server.mailbox.waitForCode(email)
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            assert.equal(emailData.headers['x-template-name'], 'verifyEmail')
+            return emailData.headers['x-verify-code']
           }
         )
         .then(

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -53,12 +53,12 @@ describe('remote account create', function() {
   )
 
   it(
-    'create and verify account',
+    'create and verify sync account',
     () => {
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
       var client = null
-      return Client.create(config.publicUrl, email, password)
+      return Client.create(config.publicUrl, email, password, {service: 'sync'})
         .then(
           function (x) {
             client = x
@@ -77,7 +77,14 @@ describe('remote account create', function() {
         )
         .then(
           function () {
-            return server.mailbox.waitForCode(email)
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            assert.equal(emailData.headers['x-template-name'], 'verifySyncEmail')
+            assert.equal(emailData.html.indexOf('IP address') > -1, true) // Ensure some location data is present
+            return emailData.headers['x-verify-code']
           }
         )
         .then(
@@ -586,7 +593,7 @@ describe('remote account create', function() {
   )
 
   it(
-    'create account for unspecified service does not get post-verify email',
+    'create account for unspecified service does not get create sync email and no post-verify email',
     () => {
       var email = server.uniqueEmail()
       var password = 'allyourbasearebelongtous'
@@ -600,7 +607,14 @@ describe('remote account create', function() {
         )
         .then(
           function () {
-            return server.mailbox.waitForCode(email)
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            assert.equal(emailData.headers['x-template-name'], 'verifyEmail')
+            assert.equal(emailData.html.indexOf('IP address') === -1, true) // Does not contain location data
+            return emailData.headers['x-verify-code']
           }
         )
         .then(

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -222,6 +222,7 @@ describe('remote password change', function() {
             var link = emailData.headers['x-link']
             var query = url.parse(link, true).query
             assert.ok(query.email, 'email is in the link')
+            assert.equal(emailData.html.indexOf('IP address') > -1, true, 'contains ip location data')
           }
         )
         .then(

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -48,7 +48,13 @@ describe('remote password forgot', function() {
         )
         .then(
           function () {
-            return server.mailbox.waitForCode(email)
+            return server.mailbox.waitForEmail(email)
+          }
+        )
+        .then(
+          function (emailData) {
+            assert.equal(emailData.html.indexOf('IP address') > -1, true, 'contains ip location data')
+            return emailData.headers['x-recovery-code']
           }
         )
         .then(


### PR DESCRIPTION
This PR uses the new verify account sync template and adds location data to password change completed and password change requested. It requires 

- [x] Update shrinkwrap when https://github.com/mozilla/fxa-auth-mailer/pull/243 merges

Connects with https://github.com/mozilla/fxa-auth-mailer/issues/189