### PR TITLE
fix(logging): add /v1 prefix to flow event route definitions

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -261,8 +261,10 @@ const FLOW_EVENT_ROUTES = new Set([
   '/recovery_email/verify_code'
 ])
 
+const PATH_PREFIX = /^\/v1/
+
 function logRouteFlowEvent(log, request, response) {
-  const path = request.path
+  const path = request.path.replace(PATH_PREFIX, '')
   if (!FLOW_EVENT_ROUTES.has(path)) {
     return
   }

--- a/test/local/log_tests.js
+++ b/test/local/log_tests.js
@@ -586,7 +586,7 @@ describe('log', () => {
         info: {
           received: Date.now()
         },
-        path: '/account/login',
+        path: '/v1/account/login',
         payload: {
           metricsContext: {
             flowId: 'bar',


### PR DESCRIPTION
As per [rfk's comment](https://github.com/mozilla/fxa-auth-server/pull/1576#issuecomment-270045182), the new route-summary flow events aren't working. It turns out they were missing the `/v1` path prefix.

Sample flow event captured with this fix added:

```
flowEvent {"event":"account.created","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1483434604591,"flow_id":"994908ff1db04960cf8d3dab7f369064cb422d6cd8e3e632bde3d5737f2314de","flow_time":8674,"flowCompleteSignal":"account.verified"}
flowEvent {"event":"route./v1/account/create.200","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1483434604648,"flow_id":"994908ff1db04960cf8d3dab7f369064cb422d6cd8e3e632bde3d5737f2314de","flow_time":8731,"flowCompleteSignal":"account.verified"}
```

@mozilla/fxa-devs r?