### PR TITLE
feat(api): add a skeleton request handler for POST /sms

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -59,6 +59,7 @@ module.exports = function (
   )
   const session = require('./session')(log, isA, error, db)
   const sign = require('./sign')(log, P, isA, error, signer, db, config.domain, devices)
+  const sms = require('./sms')(log, isA)
   const util = require('./util')(
     log,
     random,
@@ -75,6 +76,7 @@ module.exports = function (
     password,
     session,
     sign,
+    sms,
     util
   )
   v1Routes.forEach(r => { r.path = basePath + '/v1' + r.path })

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const validators = require('./validators')
+
+const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema
+
+module.exports = (log, isA) => {
+  return [
+    {
+      method: 'POST',
+      path: '/sms',
+      config: {
+        auth: {
+          strategy: 'sessionToken'
+        },
+        validate: {
+          payload: {
+            phoneNumber: isA.string().regex(validators.NANP_NUMBER).required(),
+            messageId: isA.number().positive().required(),
+            metricsContext: METRICS_CONTEXT_SCHEMA
+          }
+        }
+      },
+      handler (request, reply) {
+        log.begin('sms.send', request)
+        request.validateMetricsContext()
+        reply()
+      }
+    }
+  ]
+}

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -16,6 +16,11 @@ module.exports.URLSAFEBASE64 = /^[a-zA-Z0-9-_]*$/
 
 module.exports.BASE_36 = /^[a-zA-Z0-9]*$/
 
+// North-American phone numbers, see http://nationalnanpa.com/.
+// When it gets more complicated than this, we can switch to a
+// 3rd-party package like `google-libphonenumber`.
+exports.NANP_NUMBER = /^1?([2-9][0-8][0-9])([2-9][0-9]{2})([0-9]{4})$/
+
 // Match display-safe unicode characters.
 // We're pretty liberal with what's allowed in a unicode string,
 // but we exclude the following classes of characters:

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const getRoute = require('../../routes_helpers').getRoute
+const isA = require('joi')
+const mocks = require('../../mocks')
+const P = require('../../../lib/promise')
+
+function makeRoutes (options) {
+  options = options || {}
+  const log = options.log || mocks.mockLog()
+  return require('../../../lib/routes/sms')(log, isA)
+}
+
+function runTest (route, request) {
+  return new P((resolve, reject) => {
+    route.handler(request, response => {
+      if (response instanceof Error) {
+        reject(response)
+      } else {
+        resolve(response)
+      }
+    })
+  })
+}
+
+describe('/sms', () => {
+  let log, request
+
+  beforeEach(() => {
+    log = mocks.spyLog()
+    request = mocks.mockRequest({
+      payload: {
+        phoneNumber: '12002000000',
+        messageId: 42,
+        metricsContext: {
+          flowBeginTime: Date.now(),
+          flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        }
+      }
+    })
+    const routes = makeRoutes({ log })
+    const route = getRoute(routes, '/sms')
+    return runTest(route, request)
+  })
+
+  it('called log.begin correctly', () => {
+    assert.equal(log.begin.callCount, 1)
+    const args = log.begin.args[0]
+    assert.equal(args.length, 2)
+    assert.equal(args[0], 'sms.send')
+    assert.equal(args[1], request)
+  })
+
+  it('called request.validateMetricsContext correctly', () => {
+    assert.equal(request.validateMetricsContext.callCount, 1)
+    const args = request.validateMetricsContext.args[0]
+    assert.equal(args.length, 0)
+  })
+})
+


### PR DESCRIPTION
Related to #1628.

@shane-tomlinson, not sure if there's any value in this for you, we can close it if not. But I figured it may make client-side work easier if a bare-bones, empty route for `/sms` landed ahead of the the finished implementation.

The only change from what we discussed last week is there's no `locale` in the payload. I realised we use the `Accept-Language` header for this everywhere else, right?

Anyway, let me know if you think this is worth merging on its own or not.