### PR TITLE
feat(email): record email bounces in database

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -838,6 +838,15 @@ module.exports = function (
       )
   }
 
+  DB.prototype.createEmailBounce = function (bounceData) {
+    log.trace({
+      op: 'DB.createEmailBounce',
+      bouceData: bounceData
+    })
+
+    return this.pool.post('/emailBounces', bounceData)
+  }
+
   function wrapTokenNotFoundError (err) {
     if (isNotFoundError(err)) {
       err = error.invalidToken('The authentication token could not be found')

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -293,7 +293,7 @@
     "fxa-auth-db-mysql": {
       "version": "0.76.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0e83db972cd970bacea28a7b3f4adb92f57cdcb3",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#dd249e5a2a75eca52f620fb8d2acc3e03e8393fd",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -24,6 +24,7 @@ const DB_METHOD_NAMES = [
   'consumeUnblockCode',
   'createAccount',
   'createDevice',
+  'createEmailBounce',
   'createKeyFetchToken',
   'createPasswordForgotToken',
   'createSessionToken',


### PR DESCRIPTION
Works just fine, but is missing updated shrinkwrap to use the newest auth-db, so remote tests will be failing until then.

Blocked by https://github.com/mozilla/fxa-auth-db-mysql/pull/199

Connects to #1565 