### PR TITLE
fix(logging): log errors when we encounter unexpected createdAt values

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -252,6 +252,18 @@ module.exports = function (
             tokenVerificationId = undefined
           }
 
+          if (query._createdAt) {
+            // We don't expect this to be set outside the tests so log an error
+            // if we do encounter it, to help debug what's going on.
+            log.error({
+              op: 'account.create.createSessionToken',
+              err: new Error('Unexpected _createdAt query parameter'),
+              _createdAt: query._createdAt,
+              userAgent: request.headers['user-agent'],
+              service
+            })
+          }
+
           return db.createSessionToken({
             uid: account.uid,
             email: account.email,

--- a/lib/tokens/token.js
+++ b/lib/tokens/token.js
@@ -59,6 +59,18 @@ module.exports = function (log, random, P, hkdf, Bundle, error) {
   // This uses randomly-generated seed data to derive the keys.
   //
   Token.createNewToken = function(TokenType, details) {
+    if (details.createdAt) {
+      // We don't expect this to be set outside the tests so log an error
+      // if we do encounter it, to help debug what's going on.
+      const err = new Error('Unexpected createdAt data')
+      log.error({
+        op: 'token.constructor',
+        TokenType: TokenType.name,
+        createdAt: details.createdAt,
+        err,
+        stack: err.stack
+      })
+    }
     return random(32)
       .then(bytes => Token.deriveTokenKeys(TokenType, bytes))
       .then(keys => new TokenType(keys, details || {}))

--- a/test/local/tokens/key_fetch_token.js
+++ b/test/local/tokens/key_fetch_token.js
@@ -6,7 +6,7 @@
 
 const assert = require('insist')
 const crypto = require('crypto')
-const log = { trace() {} }
+const log = { trace () {}, error () {} }
 
 const tokens = require('../../../lib/tokens/index')(log)
 const KeyFetchToken = tokens.KeyFetchToken

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -29,6 +29,7 @@ const DB_METHOD_NAMES = [
   'createPasswordForgotToken',
   'createSessionToken',
   'createUnblockCode',
+  'createVerificationReminder',
   'deleteAccount',
   'deleteDevice',
   'deleteKeyFetchToken',

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -8,7 +8,7 @@ const assert = require('insist')
 var uuid = require('uuid')
 var crypto = require('crypto')
 var base64url = require('base64url')
-var log = { trace() {}, info() {} }
+const log = { trace () {}, info () {}, error () {} }
 
 var config = require('../../config').getProperties()
 var P = require('../../lib/promise')

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -10,7 +10,7 @@ var uuid = require('uuid')
 var crypto = require('crypto')
 var base64url = require('base64url')
 var proxyquire = require('proxyquire')
-var log = { trace() {}, info() {} }
+const log = { trace () {}, info () {}, error () {} }
 
 var config = require('../../config').getProperties()
 var TestServer = require('../test_server')


### PR DESCRIPTION
This is my first stab at trying to find out what's going on with the recent `createdAt` weirdness that was spotted in production. Hopefully there's enough context in these log messages to try and pin down the context. It's meant to be complementary to "other changes" that have been made in "other repos" recently. *NUDGE, WINK*

If possible, I'd like to get it merged in time for train 80, so that we can (hopefully) debug it quicker.

@vladikoff, r?