### PR TITLE
style(lib): update `let` to `const` when possible

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -461,7 +461,7 @@ module.exports = function (
         function checkIsBlockForced () {
           // For testing purposes, some email addresses are forced
           // to go through signin unblock on every login attempt.
-          let forced = config.signinUnblock && config.signinUnblock.enabled && config.signinUnblock.forcedEmailAddresses
+          const forced = config.signinUnblock && config.signinUnblock.enabled && config.signinUnblock.forcedEmailAddresses
 
           if (forced && forced.test(email)) {
             return P.reject(error.requestBlocked(true))
@@ -764,7 +764,7 @@ module.exports = function (
               }
             })
             .then(() => {
-              let sessionTokenOptions = {
+              const sessionTokenOptions = {
                 uid: emailRecord.uid,
                 email: emailRecord.email,
                 emailCode: emailRecord.emailCode,
@@ -1671,7 +1671,7 @@ module.exports = function (
           )
           .then(
             (account) => {
-              let isAccountVerification = butil.buffersAreEqual(code, account.emailCode)
+              const isAccountVerification = butil.buffersAreEqual(code, account.emailCode)
 
               /**
                * Logic for account and token verification

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -277,7 +277,7 @@ module.exports = function (
             })
             .then(maybeToken => {
               // Create a sessionToken with the verification status of the current session
-              let sessionTokenOptions = {
+              const sessionTokenOptions = {
                 uid: account.uid,
                 email: account.email,
                 emailCode: account.emailCode,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -288,7 +288,7 @@
     "eslint-plugin-fxa": {
       "version": "1.0.0",
       "from": "git+https://github.com/mozilla/eslint-plugin-fxa.git#master",
-      "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#84d614b1e137cd9f2441cf56118dafa2c8454124"
+      "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#80252879f17a81af0d9a70c960963b6ab9c2b50b"
     },
     "fxa-auth-db-mysql": {
       "version": "0.76.0",

--- a/test/local/lib/log.js
+++ b/test/local/lib/log.js
@@ -111,7 +111,7 @@ describe('log', () => {
       log.activityEvent()
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.activityEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -137,7 +137,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.activityEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -165,7 +165,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.activityEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -222,7 +222,7 @@ describe('log', () => {
       log.flowEvent()
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -250,7 +250,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -282,7 +282,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -314,7 +314,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
       assert.deepEqual(args[1], {
@@ -346,7 +346,7 @@ describe('log', () => {
       })
 
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
-      let args = logger.error.args[0]
+      const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
       assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
       assert.deepEqual(args[1], {

--- a/test/local/lib/server.js
+++ b/test/local/lib/server.js
@@ -15,9 +15,9 @@ describe('lib/server', () => {
   })
 
   describe('logEndpointErrors', () => {
-    let msg = 'Timeout'
-    let reason = 'Socket fail'
-    let response = {
+    const msg = 'Timeout'
+    const reason = 'Socket fail'
+    const response = {
       __proto__: {
         name: 'EndpointError'
       },

--- a/test/local/pool.js
+++ b/test/local/pool.js
@@ -77,7 +77,7 @@ describe('Pool', () => {
     'pool.request callback with error',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -96,7 +96,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP error response',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -116,7 +116,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP error response and JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -137,7 +137,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and empty body',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function (result) {
           assert.equal(result, undefined, 'result is undefined')
         })
@@ -153,7 +153,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and valid JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function (result) {
           assert.equal(typeof result, 'object', 'result is object')
           assert.equal(Object.keys(result).length, 1, 'result has 1 property')
@@ -171,7 +171,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and invalid JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      let p = pool.request()
+      const p = pool.request()
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -160,7 +160,7 @@ TestServer.prototype.stop = function () {
   currentServer = undefined
   try { this.db.close() } catch (e) {}
   if (this.server) {
-    let doomed = [
+    const doomed = [
       processKill(this.server, 'server', 'SIGINT'),
       processKill(this.mail, 'mail')
     ]


### PR DESCRIPTION
From mozilla/eslint-plugin-fxa#5

Surprisingly, it doesn't lint about all the `var`s. Probably need to tweak the rule some more.