### PR TITLE
feat(server): auto-unbuffer binary data when crossing API boundaries

### DIFF
--- a/lib/crypto/butil.js
+++ b/lib/crypto/butil.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var HEX = /^(?:[a-fA-F0-9]{2})+$/
+'use strict'
+
+const HEX = /^(?:[a-fA-F0-9]{2})+$/
 
 module.exports.ONES = Buffer('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
 
@@ -32,14 +34,26 @@ module.exports.xorBuffers = function xorBuffers(buffer1, buffer2) {
   return result
 }
 
-module.exports.unbuffer = function unbuffer(object, inplace) {
-  var keys = Object.keys(object)
-  var copy = inplace ? object : {}
-  for (var i = 0; i < keys.length; i++) {
-    var x = object[keys[i]]
-    copy[keys[i]] = Buffer.isBuffer(x) ? x.toString('hex') : x
+module.exports.unbuffer = (object, inplace) => {
+  return Object.keys(object).reduce((unbuffered, key) => {
+    unbuffered[key] = unbufferDatum.call(object, key, object[key])
+    return unbuffered
+  }, inplace ? object : {})
+}
+
+module.exports.unbufferDatum = unbufferDatum
+
+// Invoked as the `replacer` in calls to JSON.stringify.
+// If you're going to call it elsewhere, `this` must be
+// set as it would be then.
+function unbufferDatum (key, value) {
+  const unstringifiedValue = this[key]
+
+  if (Buffer.isBuffer(unstringifiedValue)) {
+    return unstringifiedValue.toString('hex')
   }
-  return copy
+
+  return value
 }
 
 module.exports.bufferize = function bufferize(object, options) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -4,23 +4,13 @@
 
 'use strict'
 
-var EventEmitter = require('events').EventEmitter
-var util = require('util')
-var mozlog = require('mozlog')
-var config = require('../config')
-var logConfig = config.get('log')
-var StatsDCollector = require('./metrics/statsd')
-
-function unbuffer(object) {
-  var keys = Object.keys(object)
-  for (var i = 0; i < keys.length; i++) {
-    var x = object[keys[i]]
-    if (Buffer.isBuffer(x)) {
-      object[keys[i]] = x.toString('hex')
-    }
-  }
-  return object
-}
+const EventEmitter = require('events').EventEmitter
+const util = require('util')
+const mozlog = require('mozlog')
+const config = require('../config')
+const logConfig = config.get('log')
+const StatsDCollector = require('./metrics/statsd')
+const unbuffer = require('./crypto/butil').unbuffer
 
 function Lug(options) {
   EventEmitter.call(this)
@@ -139,10 +129,10 @@ Lug.prototype.summary = function (request, response) {
   if (line.code >= 500) {
     line.trace = request.app.traced
     line.stack = response.stack
-    this.error(unbuffer(line), response.message)
+    this.error(unbuffer(line, true), response.message)
   }
   else {
-    this.info(unbuffer(line))
+    this.info(unbuffer(line, true))
   }
 }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -16,6 +16,14 @@ function parseUrl(url) {
   throw new Error('url is invalid: ' + url)
 }
 
+function unbuffer (key, value) {
+  if (Buffer.isBuffer(this[key])) {
+    return this[key].toString('hex')
+  }
+
+  return value
+}
+
 function Pool(url, options) {
   options = options || {}
   var parsedUrl = parseUrl(url)
@@ -40,7 +48,7 @@ Pool.prototype.request = function (method, path, data) {
       headers: {
         'Content-Type': 'application/json'
       },
-      data: data ? JSON.stringify(data) : undefined
+      data: data ? JSON.stringify(data, unbuffer) : undefined
     },
     handleResponse
   )

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var P = require('./promise')
-var Poolee = require('poolee')
+'use strict'
+
+const P = require('./promise')
+const Poolee = require('poolee')
+const unbufferDatum = require('./crypto/butil').unbufferDatum
 
 function parseUrl(url) {
   var match = /([a-zA-Z]+):\/\/(\S+)/.exec(url)
@@ -14,14 +17,6 @@ function parseUrl(url) {
     }
   }
   throw new Error('url is invalid: ' + url)
-}
-
-function unbuffer (key, value) {
-  if (Buffer.isBuffer(this[key])) {
-    return this[key].toString('hex')
-  }
-
-  return value
 }
 
 function Pool(url, options) {
@@ -48,7 +43,7 @@ Pool.prototype.request = function (method, path, data) {
       headers: {
         'Content-Type': 'application/json'
       },
-      data: data ? JSON.stringify(data, unbuffer) : undefined
+      data: data ? JSON.stringify(data, unbufferDatum) : undefined
     },
     handleResponse
   )


### PR DESCRIPTION
Fixes #1465.

Friday is Experiment Day. And in addition to experimenting with code, this Friday I am also experimenting with the PR format.

To wit:

## What's this?

This change shifts the burden for unbuffering binary data, from multiple places where we call `pool.put`, `pool.post` or `pool.del` to a single place, inside `pool.request`.

## Why is that a good thing?

Because sometimes people forget to call `unbuffer` and the effect of doing that may not be immediately obvious. For instance, it was exactly this kind of issue that @shane-tomlinson fixed in #1469.

The default stringification of buffers looks like this:

```js
{ "type": "Buffer", "data": [...] }
```

Our database never expects to receive binary data in that form. Instead it expects binary data as hex strings and reconstructs the buffer from those. Calling `unbuffer` ensures we transmit the data in the expected format.

Rather than hope people always remember to call `unbuffer` manually, we can do it automatically and eliminate the possibility of issues like the one Shane fixed.

## Is it safe?

I think so.

The automatic unbuffering only kicks in if `Buffer.isBuffer` returns `true`. All other values are left unsullied.

The only callers to `lib/pool` are `lib/db` and `lib/customs`. The respective repos for those two both expect string representations of binary data (`uid` in the customs server's case, loads of stuff in the db).

## Are there any other benefits?

This way is (a little bit) more efficient.

By moving the unbuffering to the point at which stringification occurs, we avoid having to iterate through every key ourselves. Instead, we can lean on the `replacer` argument to `JSON.stringify` and let *it* call *us* as it traverses the object.

@mozilla/fxa-devs r?
