### PR TITLE
fix(push): notify a device connected only when account verified

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -680,6 +680,27 @@ module.exports = function (
     )
   }
 
+  DB.prototype.deviceFromTokenVerificationId = function (uid, tokenVerificationId) {
+    log.trace(
+      {
+        op: 'DB.deviceFromTokenVerificationId',
+        uid: uid,
+        tokenVerificationId: tokenVerificationId
+      }
+    )
+    return this.pool.get(
+      '/account/' + uid.toString('hex') + '/tokens/' + tokenVerificationId.toString('hex') + '/device'
+    )
+    .catch(
+      function (err) {
+        if (isNotFoundError(err)) {
+          throw error.unknownDevice()
+        }
+        throw err
+      }
+    )
+  }
+
   // BATCH
 
   DB.prototype.resetAccount = function (accountResetToken, data) {

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -38,7 +38,9 @@ module.exports = function (log, db, push) {
           if (! deviceName) {
             deviceName = synthesizeName(deviceInfo)
           }
-          push.notifyDeviceConnected(sessionToken.uid, deviceName, result.id.toString('hex'))
+          if (sessionToken.tokenVerified) {
+            push.notifyDeviceConnected(sessionToken.uid, deviceName, result.id.toString('hex'))
+          }
           if (isPlaceholderDevice) {
             log.info({
               op: 'device:createPlaceholder',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -293,7 +293,7 @@
     "fxa-auth-db-mysql": {
       "version": "0.76.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#dd249e5a2a75eca52f620fb8d2acc3e03e8393fd",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#7f45075a57ce3f4ae2ed6e9635d4d9bf24b0ea40",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",

--- a/test/local/lib/devices.js
+++ b/test/local/lib/devices.js
@@ -61,7 +61,8 @@ describe('devices', () => {
         })
         sessionToken = {
           tokenId: crypto.randomBytes(16),
-          uid: uuid.v4('binary')
+          uid: uuid.v4('binary'),
+          tokenVerified: true
         }
       })
 
@@ -117,6 +118,16 @@ describe('devices', () => {
             assert.equal(args[0], sessionToken.uid, 'first argument was uid')
             assert.equal(args[1], device.name, 'second arguent was device name')
             assert.equal(args[2], deviceId.toString('hex'), 'third argument was device id')
+          })
+      })
+
+      it('should not call notifyDeviceConnected with unverified token', () => {
+        sessionToken.tokenVerified = false
+        device.name = 'device with an unverified sessionToken'
+        return devices.upsert(request, sessionToken, device)
+          .then(function () {
+            assert.equal(push.notifyDeviceConnected.callCount, 0, 'push.notifyDeviceConnected was not called')
+            sessionToken.tokenVerified = true
           })
       })
 

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -444,6 +444,28 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(mockLog.notifyAttachedServices.callCount, 0, 'does not call log.notifyAttachedServices')
         assert.equal(mockLog.activityEvent.callCount, 0, 'log.activityEvent was not called')
         assert.equal(mockPush.notifyUpdate.callCount, 0, 'mockPush.notifyUpdate should not have been called')
+        assert.equal(mockPush.notifyDeviceConnected.callCount, 0, 'mockPush.notifyDeviceConnected should not have been called (no devices)')
+      })
+        .then(function () {
+          mockDB.verifyTokens.reset()
+        })
+    })
+
+    it('email verification with associated device', function () {
+      mockDB.deviceFromTokenVerificationId = function (uid, tokenVerificationId) {
+        return P.resolve({
+          name: 'my device',
+          id: '123456789',
+          type: 'desktop'
+        })
+      }
+      return runTest(route, mockRequest, function (response) {
+        assert.equal(mockDB.verifyTokens.callCount, 1, 'call db.verifyTokens')
+        assert.equal(mockDB.verifyEmail.callCount, 0, 'does not call db.verifyEmail')
+        assert.equal(mockLog.notifyAttachedServices.callCount, 0, 'does not call log.notifyAttachedServices')
+        assert.equal(mockLog.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(mockPush.notifyUpdate.callCount, 0, 'mockPush.notifyUpdate should not have been called')
+        assert.equal(mockPush.notifyDeviceConnected.callCount, 1, 'mockPush.notifyDeviceConnected should have been called')
       })
         .then(function () {
           mockDB.verifyTokens.reset()

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -34,6 +34,7 @@ const DB_METHOD_NAMES = [
   'deleteKeyFetchToken',
   'deletePasswordChangeToken',
   'deleteVerificationReminder',
+  'deviceFromTokenVerificationId',
   'devices',
   'emailRecord',
   'forgotPasswordVerified',


### PR DESCRIPTION
Fixes #1651
(Should probably be reviewed with w=1 at the end of the github url because there were indentation changes in account.js)