### PR TITLE
fix(tests): add missing tests for log.begin and log.summary calls

### DIFF
--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -672,4 +672,30 @@ describe('metrics/events', () => {
         Date.now.restore()
       })
   })
+
+  it('.emitRouteFlowEvent with non-matching route', () => {
+    const metricsContext = mocks.mockMetricsContext()
+    const request = {
+      clearMetricsContext: metricsContext.clear,
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      path: '/v1/account/devices',
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: Date.now() - 1000
+        }
+      }
+    }
+    return events.emitRouteFlowEvent.call(request, { statusCode: 200 })
+      .then(() => {
+        assert.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
+        assert.equal(log.flowEvent.callCount, 0, 'log.flowEvent was not called')
+        assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      })
+  })
 })

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -21,6 +21,7 @@ const CUSTOMS_METHOD_NAMES = [
 
 const DB_METHOD_NAMES = [
   'account',
+  'accountResetToken',
   'consumeUnblockCode',
   'createAccount',
   'createDevice',
@@ -39,11 +40,17 @@ const DB_METHOD_NAMES = [
   'devices',
   'emailRecord',
   'forgotPasswordVerified',
+  'keyFetchToken',
+  'keyFetchTokenWithVerificationStatus',
+  'passwordChangeToken',
+  'passwordForgotToken',
   'resetAccount',
   'securityEvent',
   'securityEvents',
   'sessions',
+  'sessionToken',
   'sessionTokenWithVerificationStatus',
+  'sessionWithDevice',
   'updateDevice',
   'updateLocale',
   'updateSessionToken',
@@ -60,6 +67,7 @@ const LOG_METHOD_NAMES = [
   'info',
   'notifyAttachedServices',
   'warn',
+  'summary',
   'timing',
   'trace'
 ]


### PR DESCRIPTION
Fixes #1610.

## What's this?

Some tests that I ~~was too lazy to~~ didn't have time to write when I landed #1606. They assert that the server calls `log.summary` correctly and that `request.emitRouteFlowEvent` calls `log.flowEvent` correctly. I also chucked some tests for `log.begin` and `log.error` in there for good measure.

## Isn't some of that stuff already tested?

It covers some of the same ground as the tests for `_logEndpointErrors`, yes. I confess that I'm not a massive fan of those tests because they focus on an internal implementation detail rather than the broader, end-to-end behaviour that we're really interested in. In the future, if we're happy with the broader tests, I may come back and rip those narrower ones out.

## Why did you add the test for `emitRouteFlowEvent`?

It covers a case that we weren't explicitly testing before: that `log.flowEvent` is not invoked for non-flow routes. Combined with the existing tests from that module and the new tests for the server code, we can be reasonably confident going forward that the route flow events haven't been broken by something we're working on.

@mozilla/fxa-devs r?