### PR TITLE
fix(docs): document the /sms endpoint

### DIFF
--- a/docs/endpoint_data.md
+++ b/docs/endpoint_data.md
@@ -469,3 +469,9 @@
   * Devices
   * SessionTokens
 
+## /sms
+
+* input
+  * phoneNumber
+  * messageId
+


### PR DESCRIPTION
I forgot to write docs for the new `/sms` endpoint! Then I saw @vbudhram's comment about docs in another PR and realised what I'd done! This is my attempt to right that wrong!

@mozilla/fxa-devs r?

