### PR TITLE
fix(sms): make the fallback error case work sanely

### DIFF
--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -76,15 +76,17 @@ module.exports = (log, isA, error, config, customs, sms) => {
         function sendMessage (senderId) {
           return sms.send(phoneNumber, senderId, messageId, acceptLanguage)
             .catch(err => {
-              if (err.status === 500) {
-                throw error.messageRejected(err.reason, err.reasonCode)
+              if (err) {
+                if (err.status === 500) {
+                  throw error.messageRejected(err.reason, err.reasonCode)
+                }
+
+                if (err.status === 400) {
+                  throw error.invalidMessageId()
+                }
               }
 
-              if (err.status === 400) {
-                throw error.invalidMessageId()
-              }
-
-              throw new error.unexpectedError()
+              throw error.unexpectedError()
             })
         }
 

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -303,6 +303,41 @@ describe('/sms', () => {
       assert.equal(err.message, 'Invalid message id')
     })
   })
+
+  describe('sms.send fails with unknown error', () => {
+    let err
+
+    beforeEach(() => {
+      sms.send = sinon.spy(() => P.reject())
+      request.payload.phoneNumber = '+18885083401'
+      return runTest(route, request)
+        .catch(e => {
+          err = e
+        })
+    })
+
+    it('called log.begin once', () => {
+      assert.equal(log.begin.callCount, 1)
+    })
+
+    it('called request.validateMetricsContext once', () => {
+      assert.equal(request.validateMetricsContext.callCount, 1)
+    })
+
+    it('called sms.send once', () => {
+      assert.equal(sms.send.callCount, 1)
+    })
+
+    it('did not call log.flowEvent', () => {
+      assert.equal(log.flowEvent.callCount, 0)
+    })
+
+    it('threw the correct error data', () => {
+      assert.ok(err instanceof AppError)
+      assert.equal(err.errno, AppError.ERRNO.UNEXPECTED_ERROR)
+      assert.equal(err.message, 'Unspecified error')
+    })
+  })
 })
 
 describe('/sms disabled', () => {


### PR DESCRIPTION
Oh man, I am not having a good day.

I was just giving the `/sms` endpoint a final once-over when I noticed a `new` in the fallback error case that should not be there. Surely that errant `new` would cause a `TypeError` at runtime? Why haven't the tests caught that?

Of course, it transpires that I didn't write tests for the fallback error case, so that code was not being tested. And, on writing the test, I realised a separate `TypeError` could occur in the same handler if `err` is undefined.

This change fixes both of those issues and adds a test that catches them.

@mozilla/fxa-devs r?