### PR TITLE
refactor(logging): Log emailEvent for bounces and deliveries

### DIFF
--- a/config/popular-email-domains.js
+++ b/config/popular-email-domains.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is a list of popular email domains based on FxA users
+// Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1337932
+const domains = new Set([
+  'gmail.com',
+  'hotmail.com',
+  'yahoo.com',
+  'mail.ru',
+  'outlook.com',
+  'aol.com',
+  'qq.com',
+  'web.de',
+  'yandex.ru',
+  'gmx.de',
+  'live.com',
+  'comcast.net',
+  't-online.de',
+  'hotmail.fr',
+  'msn.com',
+  'yahoo.fr',
+  'orange.fr',
+  '163.com',
+  'icloud.com',
+  'hotmail.co.uk'
+])
+
+module.exports = domains

--- a/lib/email/bounces.js
+++ b/lib/email/bounces.js
@@ -63,10 +63,12 @@ module.exports = function (log, error) {
 
       return P.each(recipients, function (recipient) {
         const email = eaddrs.parseOneAddress(recipient.emailAddress).address
+        const emailDomain = utils.getAnonymizedEmailDomain(email)
         const logData = {
           op: 'handleBounce',
           action: recipient.action,
           email: email,
+          domain: emailDomain,
           bounce: !! message.bounce,
           diagnosticCode: recipient.diagnosticCode,
           status: recipient.status
@@ -107,8 +109,9 @@ module.exports = function (log, error) {
           }
         }
 
-        // Log the bounced flowEvent metrics if available
+        // Log the bounced flowEvent and emailEvent metrics
         utils.logFlowEventFromMessage(log, message, 'bounced')
+        utils.logEmailEventFromMessage(log, message, 'bounced', emailDomain)
 
         log.info(logData)
         log.increment('account.email_bounced')

--- a/lib/email/delivery.js
+++ b/lib/email/delivery.js
@@ -25,9 +25,11 @@ module.exports = function (log) {
       return P.each(recipients, function (recipient) {
 
         var email = recipient
+        var emailDomain = utils.getAnonymizedEmailDomain(email)
         var logData = {
           op: 'handleDelivery',
           email: email,
+          domain: emailDomain,
           processingTimeMillis: message.delivery.processingTimeMillis
         }
 
@@ -36,8 +38,9 @@ module.exports = function (log) {
           logData.template = templateName
         }
 
-        // Log the delivery flowEvent metrics if available
+        // Log the delivery flowEvent and emailEvent metrics if available
         utils.logFlowEventFromMessage(log, message, 'delivered')
+        utils.logEmailEventFromMessage(log, message, 'delivered', emailDomain)
 
         log.info(logData)
         log.increment('account.email_delivered')

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const emailDomains = require('../../../config/popular-email-domains')
+
 function getHeaderValue(headerName, message){
   var value = ''
+  var headerNameNormalized = headerName.toLowerCase()
   if (message.mail && message.mail.headers) {
     message.mail.headers.some(function (header) {
-      if (header.name === headerName) {
+      if (header.name.toLowerCase() === headerNameNormalized) {
         value = header.value
         return true
       }
@@ -18,9 +21,55 @@ function getHeaderValue(headerName, message){
   return value
 }
 
+function logEmailEventSent(log, message) {
+  const emailDomain = getAnonymizedEmailDomain(message.email)
+  const emailEventInfo = {
+    domain: emailDomain,
+    template: message.template,
+    type: 'sent'
+  }
+
+  if (message.headers && message.headers['X-Flow-Id']) {
+    emailEventInfo['flow_id'] = message.headers['X-Flow-Id']
+  }
+  if (message.headers && message.headers['Content-Language']) {
+    emailEventInfo.locale = message.headers['Content-Language']
+  }
+
+
+  log.info('emailEvent', emailEventInfo)
+}
+
+function logEmailEventFromMessage(log, message, type, emailDomain) {
+  const templateName = getHeaderValue('X-Template-Name', message)
+  const flowId = getHeaderValue('X-Flow-Id', message)
+  const locale = getHeaderValue('Content-Language', message)
+
+  const emailEventInfo = {
+    domain: emailDomain,
+    locale: locale,
+    template: templateName,
+    type: type
+  }
+
+  if (flowId) {
+    emailEventInfo['flow_id'] = flowId
+  }
+
+  if (message.bounce) {
+    emailEventInfo.bounced = true
+  }
+
+  if (message.complaint) {
+    emailEventInfo.complaint = true
+  }
+
+  log.info('emailEvent', emailEventInfo)
+}
+
 function logFlowEventFromMessage(log, message, type) {
   const currentTime = Date.now()
-  var templateName = getHeaderValue('X-Template-Name', message)
+  const templateName = getHeaderValue('X-Template-Name', message)
 
   // Log flow metrics if `flowId` and `flowBeginTime` specified in headers
   const flowId = getHeaderValue('X-Flow-Id', message)
@@ -45,7 +94,24 @@ function logFlowEventFromMessage(log, message, type) {
   }
 }
 
+function getAnonymizedEmailDomain(email) {
+  // This function returns an email domain if it is considered a popular domain,
+  // which means it is in `./config/popular-email-domains.js`. Otherwise, it
+  // return `other` as domain.
+  const tokens = email.split('@')
+  const emailDomain = tokens[1]
+  var anonymizedEmailDomain = 'other'
+  if (emailDomain && emailDomains.has(emailDomain)) {
+    anonymizedEmailDomain = emailDomain
+  }
+
+  return anonymizedEmailDomain
+}
+
 module.exports = {
+  logEmailEventSent: logEmailEventSent,
+  logEmailEventFromMessage: logEmailEventFromMessage,
   logFlowEventFromMessage: logFlowEventFromMessage,
-  getHeaderValue: getHeaderValue
+  getHeaderValue: getHeaderValue,
+  getAnonymizedEmailDomain: getAnonymizedEmailDomain
 }

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -7,6 +7,7 @@ var url = require('url')
 var P = require('bluebird')
 var nodemailer = require('nodemailer')
 var moment = require('moment-timezone')
+var emailUtils = require('./../email/utils/helpers')
 
 var DEFAULT_LOCALE = 'en'
 var DEFAULT_TIMEZONE = 'Etc/UTC'
@@ -264,6 +265,9 @@ module.exports = function (log) {
             id: status && status.messageId
           }
         )
+
+        emailUtils.logEmailEventSent(log, message)
+
         return d.resolve(status)
       }
     )

--- a/test/local/email/bounce.js
+++ b/test/local/email/bounce.js
@@ -72,12 +72,12 @@ describe('bounce messages', () => {
         assert.equal(mockDB.deleteAccount.callCount, 2)
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
-        assert.equal(mockLog.messages.length, 8, 'messages logged')
-        assert.equal(mockLog.messages[2].level, 'increment')
-        assert.equal(mockLog.messages[2].args[0], 'account.email_bounced')
-        assert.equal(mockLog.messages[7].level, 'info')
-        assert.equal(mockLog.messages[7].args[0].op, 'accountDeleted')
-        assert.equal(mockLog.messages[7].args[0].email, 'foobar@example.com')
+        assert.equal(mockLog.messages.length, 10, 'messages logged')
+        assert.equal(mockLog.messages[3].level, 'increment')
+        assert.equal(mockLog.messages[3].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages[9].level, 'info')
+        assert.equal(mockLog.messages[9].args[0].op, 'accountDeleted')
+        assert.equal(mockLog.messages[9].args[0].email, 'foobar@example.com')
         assert.equal(mockMsg.del.callCount, 1)
       })
     }
@@ -119,10 +119,14 @@ describe('bounce messages', () => {
         assert.equal(mockDB.deleteAccount.callCount, 2)
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
-        assert.equal(mockLog.messages.length, 8, 'messages logged')
-        assert.equal(mockLog.messages[1].args[0].complaintFeedbackType, complaintType)
-        assert.equal(mockLog.messages[1].args[0].complaint, true)
-        assert.equal(mockLog.messages[1].args[0].complaintUserAgent, 'AnyCompany Feedback Loop (V0.01)')
+        assert.equal(mockLog.messages.length, 10, 'messages logged')
+        assert.equal(mockLog.messages[1].args[0], 'emailEvent')
+        assert.equal(mockLog.messages[1].args[1].domain, 'other')
+        assert.equal(mockLog.messages[1].args[1].type, 'bounced')
+        assert.equal(mockLog.messages[1].args[1].complaint, true)
+        assert.equal(mockLog.messages[2].args[0].complaintFeedbackType, complaintType)
+        assert.equal(mockLog.messages[2].args[0].complaint, true)
+        assert.equal(mockLog.messages[2].args[0].complaintUserAgent, 'AnyCompany Feedback Loop (V0.01)')
       })
     }
   )
@@ -159,22 +163,23 @@ describe('bounce messages', () => {
         assert.equal(mockDB.emailRecord.args[1][0], 'verified@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(mockLog.messages.length, 8)
-        assert.equal(mockLog.messages[1].args[0].op, 'handleBounce')
-        assert.equal(mockLog.messages[1].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[1].args[0].status, '5.0.0')
-        assert.equal(mockLog.messages[1].args[0].action, 'failed')
-        assert.equal(mockLog.messages[1].args[0].diagnosticCode, 'smtp; 550 user unknown')
-        assert.equal(mockLog.messages[2].args[0], 'account.email_bounced')
-        assert.equal(mockLog.messages[3].args[0].op, 'accountDeleted')
-        assert.equal(mockLog.messages[3].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[5].args[0].op, 'handleBounce')
-        assert.equal(mockLog.messages[5].args[0].email, 'verified@example.com')
-        assert.equal(mockLog.messages[5].args[0].status, '4.0.0')
+        assert.equal(mockLog.messages.length, 10)
+        assert.equal(mockLog.messages[2].args[0].op, 'handleBounce')
+        assert.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[2].args[0].domain, 'other')
+        assert.equal(mockLog.messages[2].args[0].status, '5.0.0')
+        assert.equal(mockLog.messages[2].args[0].action, 'failed')
+        assert.equal(mockLog.messages[2].args[0].diagnosticCode, 'smtp; 550 user unknown')
+        assert.equal(mockLog.messages[3].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages[4].args[0].op, 'accountDeleted')
+        assert.equal(mockLog.messages[4].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[7].args[0].op, 'handleBounce')
+        assert.equal(mockLog.messages[7].args[0].email, 'verified@example.com')
+        assert.equal(mockLog.messages[7].args[0].status, '4.0.0')
         assert(! mockLog.messages[3].args[0].diagnosticCode)
-        assert.equal(mockLog.messages[6].args[0], 'account.email_bounced')
-        assert.equal(mockLog.messages[7].level, 'increment')
-        assert.equal(mockLog.messages[7].args[0], 'account.email_bounced.already_verified')
+        assert.equal(mockLog.messages[8].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages[9].level, 'increment')
+        assert.equal(mockLog.messages[9].args[0], 'account.email_bounced.already_verified')
       })
     }
   )
@@ -200,12 +205,12 @@ describe('bounce messages', () => {
       return mockedBounces(mockLog, mockDB).handleBounce(mockMsg).then(function () {
         assert.equal(mockDB.emailRecord.callCount, 1)
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
-        assert.equal(mockLog.messages.length, 4)
-        assert.equal(mockLog.messages[1].args[0].op, 'handleBounce')
-        assert.equal(mockLog.messages[1].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[2].args[0], 'account.email_bounced')
-        assert.equal(mockLog.messages[3].args[0].op, 'databaseError')
-        assert.equal(mockLog.messages[3].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages.length, 5)
+        assert.equal(mockLog.messages[2].args[0].op, 'handleBounce')
+        assert.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[3].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages[4].args[0].op, 'databaseError')
+        assert.equal(mockLog.messages[4].args[0].email, 'test@example.com')
         assert.equal(mockMsg.del.callCount, 1)
       })
     }
@@ -241,13 +246,13 @@ describe('bounce messages', () => {
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(mockLog.messages.length, 4)
-        assert.equal(mockLog.messages[1].args[0].op, 'handleBounce')
-        assert.equal(mockLog.messages[1].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[2].args[0], 'account.email_bounced')
-        assert.equal(mockLog.messages[3].args[0].op, 'databaseError')
-        assert.equal(mockLog.messages[3].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[3].args[0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
+        assert.equal(mockLog.messages.length, 5)
+        assert.equal(mockLog.messages[2].args[0].op, 'handleBounce')
+        assert.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[3].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages[4].args[0].op, 'databaseError')
+        assert.equal(mockLog.messages[4].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[4].args[0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
         assert.equal(mockMsg.del.callCount, 1)
       })
     }
@@ -338,14 +343,14 @@ describe('bounce messages', () => {
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(mockLog.messages.length, 4)
-        assert.equal(mockLog.messages[1].args[0].op, 'handleBounce')
-        assert.equal(mockLog.messages[1].args[0].email, 'test@example.com')
-        assert.equal(mockLog.messages[1].args[0].template, 'verifyLoginEmail')
-        assert.equal(mockLog.messages[1].args[0].bounceType, 'Permanent')
-        assert.equal(mockLog.messages[1].args[0].bounceSubType, 'General')
-        assert.equal(mockLog.messages[1].args[0].lang, 'db-LB')
-        assert.equal(mockLog.messages[2].args[0], 'account.email_bounced')
+        assert.equal(mockLog.messages.length, 5)
+        assert.equal(mockLog.messages[2].args[0].op, 'handleBounce')
+        assert.equal(mockLog.messages[2].args[0].email, 'test@example.com')
+        assert.equal(mockLog.messages[2].args[0].template, 'verifyLoginEmail')
+        assert.equal(mockLog.messages[2].args[0].bounceType, 'Permanent')
+        assert.equal(mockLog.messages[2].args[0].bounceSubType, 'General')
+        assert.equal(mockLog.messages[2].args[0].lang, 'db-LB')
+        assert.equal(mockLog.messages[3].args[0], 'account.email_bounced')
       })
     }
   )
@@ -388,6 +393,10 @@ describe('bounce messages', () => {
             {
               name: 'X-Flow-Begin-Time',
               value: '1234'
+            },
+            {
+              name: 'Content-Language',
+              value: 'en'
             }
           ]
         }
@@ -398,11 +407,82 @@ describe('bounce messages', () => {
         assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(mockLog.messages.length, 4)
+        assert.equal(mockLog.messages.length, 5)
         assert.equal(mockLog.messages[0].args[0]['event'], 'email.verifyLoginEmail.bounced')
         assert.equal(mockLog.messages[0].args[0]['flow_id'], 'someFlowId')
         assert.equal(mockLog.messages[0].args[0]['flow_time'] > 0, true)
         assert.equal(mockLog.messages[0].args[0]['time'] > 0, true)
+        assert.equal(mockLog.messages[1].args[0], 'emailEvent')
+        assert.equal(mockLog.messages[1].args[1].domain, 'other')
+        assert.equal(mockLog.messages[1].args[1].type, 'bounced')
+        assert.equal(mockLog.messages[1].args[1].template, 'verifyLoginEmail')
+        assert.equal(mockLog.messages[1].args[1]['flow_id'], 'someFlowId')
+      })
+    }
+  )
+
+  it(
+    'should log email domain if popular one',
+    () => {
+      var mockLog = spyLog()
+      var mockDB = {
+        createEmailBounce: sinon.spy(() => P.resolve({})),
+        emailRecord: sinon.spy(function (email) {
+          return P.resolve({
+            uid: '123456',
+            email: email,
+            emailVerified: false
+          })
+        }),
+        deleteAccount: sinon.spy(function () {
+          return P.resolve({ })
+        })
+      }
+      var mockMsg = mockMessage({
+        bounce: {
+          bounceType: 'Permanent',
+          bounceSubType: 'General',
+          bouncedRecipients: [
+            {emailAddress: 'test@aol.com'}
+          ]
+        },
+        mail: {
+          headers: [
+            {
+              name: 'X-Template-Name',
+              value: 'verifyLoginEmail'
+            },
+            {
+              name: 'X-Flow-Id',
+              value: 'someFlowId'
+            },
+            {
+              name: 'X-Flow-Begin-Time',
+              value: '1234'
+            },
+            {
+              name: 'Content-Language',
+              value: 'en'
+            }
+          ]
+        }
+      })
+
+      return mockedBounces(mockLog, mockDB).handleBounce(mockMsg).then(function () {
+        assert.equal(mockLog.messages.length, 5)
+        assert.equal(mockLog.messages[0].args[0]['event'], 'email.verifyLoginEmail.bounced')
+        assert.equal(mockLog.messages[0].args[0]['flow_id'], 'someFlowId')
+        assert.equal(mockLog.messages[0].args[0]['flow_time'] > 0, true)
+        assert.equal(mockLog.messages[0].args[0]['time'] > 0, true)
+        assert.equal(mockLog.messages[1].args[0], 'emailEvent')
+        assert.equal(mockLog.messages[1].args[1].domain, 'aol.com')
+        assert.equal(mockLog.messages[1].args[1].type, 'bounced')
+        assert.equal(mockLog.messages[1].args[1].template, 'verifyLoginEmail')
+        assert.equal(mockLog.messages[1].args[1].bounced, true)
+        assert.equal(mockLog.messages[1].args[1].locale, 'en')
+        assert.equal(mockLog.messages[1].args[1]['flow_id'], 'someFlowId')
+        assert.equal(mockLog.messages[2].args[0]['email'], 'test@aol.com')
+        assert.equal(mockLog.messages[2].args[0]['domain'], 'aol.com')
       })
     }
   )


### PR DESCRIPTION
This PR will log the email domain if it is one of the popular domains, otherwise it logs `other`. The goal for this is to help us identify popular email services that have high bounce rates.

@rfk @seanmonstar r?

Fixes #1689