### PR TITLE
fix(server): disallow any query or payload params without validation

### DIFF
--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -18,7 +18,10 @@ const FLOW_ID_LENGTH = 64
 const SCHEMA = isA.object({
   flowId: isA.string().length(64).regex(HEX).optional(),
   flowBeginTime: isA.number().integer().positive().optional()
-}).and('flowId', 'flowBeginTime').optional()
+})
+  .unknown(false)
+  .and('flowId', 'flowBeginTime')
+  .optional()
 
 const NOP = function () {
   return P.resolve()

--- a/lib/routes/defaults.js
+++ b/lib/routes/defaults.js
@@ -87,6 +87,12 @@ module.exports = function (log, P, db, error) {
     {
       method: '*',
       path: '/v0/{p*}',
+      config: {
+        validate: {
+          query: true,
+          params: true
+        }
+      },
       handler: function v0(request, reply) {
         log.begin('Defaults.v0', request)
         reply(error.gone())

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -135,6 +135,9 @@ module.exports = function (
           strategy: 'passwordChangeToken'
         },
         validate: {
+          query: {
+            keys: isA.boolean().optional()
+          },
           payload: {
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             wrapKb: isA.string().min(64).max(64).regex(HEX_STRING).required(),
@@ -341,9 +344,13 @@ module.exports = function (
       path: '/password/forgot/send_code',
       config: {
         validate: {
+          query: {
+            service: validators.service,
+            keys: isA.boolean().optional()
+          },
           payload: {
             email: validators.email().required(),
-            service: isA.string().max(16).alphanum().optional(),
+            service: validators.service,
             redirectTo: validators.redirectTo(redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
             metricsContext: METRICS_CONTEXT_SCHEMA
@@ -447,9 +454,12 @@ module.exports = function (
           strategy: 'passwordForgotToken'
         },
         validate: {
+          query: {
+            service: validators.service
+          },
           payload: {
             email: validators.email().required(),
-            service: isA.string().max(16).alphanum().optional(),
+            service: validators.service,
             redirectTo: validators.redirectTo(redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
             metricsContext: METRICS_CONTEXT_SCHEMA

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
+const validators = require('./validators')
+
 module.exports = function (log, P, isA, error, signer, db, domain, devices) {
 
   const HOUR = 1000 * 60 * 60
@@ -16,6 +20,9 @@ module.exports = function (log, P, isA, error, signer, db, domain, devices) {
           payload: 'required'
         },
         validate: {
+          query: {
+            service: validators.service
+          },
           payload: {
             publicKey: isA.object({
               algorithm: isA.string().valid('RS', 'DS').required(),

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -9,7 +9,7 @@
  * @returns {boolean}
  */
 function wantsKeys (request) {
-  return !!(request.query && request.query.keys)
+  return !! (request.query && request.query.keys)
 }
 
 module.exports = {

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -9,7 +9,7 @@
  * @returns {boolean}
  */
 function wantsKeys (request) {
-  return request.query && request.query.keys === 'true'
+  return !!(request.query && request.query.keys)
 }
 
 module.exports = {

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -63,6 +63,8 @@ module.exports.email = function() {
   return email
 }
 
+module.exports.service = isA.string().max(16).regex(/^[a-zA-Z0-9\-]*$/g)
+
 
 // Function to validate an email address.
 // This is a transliteration of the HTML5 email-validation logic

--- a/lib/server.js
+++ b/lib/server.js
@@ -111,6 +111,11 @@ function create(log, error, config, routes, db) {
         },
         files: {
           relativeTo: path.dirname(__dirname)
+        },
+        validate: {
+          options: {
+            stripUnknown: true
+          }
         }
       },
       load: {

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -575,7 +575,7 @@ module.exports = config => {
   }
 
   function getQueryString (options) {
-    let qs = []
+    const qs = []
 
     if (options.keys) {
       qs.push('keys=true')

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 module.exports = config => {
   var EventEmitter = require('events').EventEmitter
   var util = require('util')
@@ -573,21 +575,25 @@ module.exports = config => {
   }
 
   function getQueryString (options) {
-    var qs = '?'
+    let qs = []
 
     if (options.keys) {
-      qs += 'keys=true&'
+      qs.push('keys=true')
     }
 
     if (options.serviceQuery) {
-      qs += 'service=' + options.serviceQuery + '&'
+      qs.push('service=' + options.serviceQuery)
     }
 
     if (options.createdAt) {
-      qs += '_createdAt=' + options.createdAt
+      qs.push('_createdAt=' + options.createdAt)
     }
 
-    return qs
+    if (qs) {
+      return '?' + qs.join('&')
+    } else {
+      return ''
+    }
   }
 
   return ClientApi

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -29,25 +29,27 @@ module.exports = config => {
   Client.Api = ClientApi
 
   Client.prototype.setupCredentials = function (email, password) {
-    this.email = email
-    return pbkdf2.derive(Buffer(password), hkdf.KWE('quickStretch', email), 1000, 32)
-      .then(
-        function (stretch) {
-          return hkdf(stretch, 'authPW', null, 32)
-            .then(
-              function (authPW) {
-                this.authPW = authPW
-                return hkdf(stretch, 'unwrapBKey', null, 32)
-              }.bind(this)
-            )
-        }.bind(this)
-      )
-      .then(
-        function (unwrapBKey) {
-          this.unwrapBKey = unwrapBKey
-          return this
-        }.bind(this)
-      )
+    return P.resolve().then(() => {
+      this.email = email
+      return pbkdf2.derive(Buffer(password), hkdf.KWE('quickStretch', email), 1000, 32)
+        .then(
+          function (stretch) {
+            return hkdf(stretch, 'authPW', null, 32)
+              .then(
+                function (authPW) {
+                  this.authPW = authPW
+                  return hkdf(stretch, 'unwrapBKey', null, 32)
+                }.bind(this)
+              )
+          }.bind(this)
+        )
+        .then(
+          function (unwrapBKey) {
+            this.unwrapBKey = unwrapBKey
+            return this
+          }.bind(this)
+        )
+    })
   }
 
   Client.create = function (origin, email, password, options) {

--- a/test/local/routes/request_helper.js
+++ b/test/local/routes/request_helper.js
@@ -22,8 +22,8 @@ describe('requestHelper', () => {
     () => {
       assert.equal(!! requestHelper.wantsKeys({}), false, 'should return falsey if request.query is not set')
       assert.equal(requestHelper.wantsKeys({ query: {} }), false, 'should return false if query.keys is not set')
-      assert.equal(requestHelper.wantsKeys({ query: { keys: 'wibble' } }), false, 'should return false if keys is not true')
-      assert.equal(requestHelper.wantsKeys({ query: { keys: 'true' } }), true, 'should return true if keys is true')
+      assert.equal(requestHelper.wantsKeys({ query: { keys: false } }), false, 'should return false if query.keys is false')
+      assert.equal(requestHelper.wantsKeys({ query: { keys: true } }), true, 'should return true if keys is true')
     }
   )
 })

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -421,32 +421,6 @@ describe('remote account create', function() {
   )
 
   it(
-    'account creation fails with old metricsContext fields',
-    () => {
-      var email = server.uniqueEmail()
-      return Client.create(config.publicUrl, email, 'foo', {
-        metricsContext: {
-          flowId: 'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
-          flowBeginTime: 1,
-          context: 'foo',
-          entrypoint: 'bar',
-          migration: 'baz',
-          service: 'qux',
-          utmCampaign: 'wibble',
-          utmContent: 'blurgh',
-          utmMedium: 'blee',
-          utmSource: 'fnarr',
-          utmTerm: 'frang'
-        }
-      }).then(function () {
-        assert(false, 'account creation should have failed')
-      }, function (err) {
-        assert.ok(err, 'account creation failed')
-      })
-    }
-  )
-
-  it(
     'account creation fails with invalid metricsContext flowId',
     () => {
       var email = server.uniqueEmail()

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -108,14 +108,6 @@ describe('remote certificate sign', function() {
           () => assert(false),
           function (err) {
             assert.equal(err.code, 400, 'empty object as publicKey')
-            // invalid publicKey argument
-            return client.sign({ algorithm: 'RS', n: 'x', e: 'y', invalid: true }, 1000)
-          }
-        )
-        .then(
-          () => assert(false),
-          function (err) {
-            assert.equal(err.code, 400, 'invalid publicKey argument')
             // undefined duration
             return client.sign({ algorithm: 'RS', n: 'x', e: 'y' }, undefined)
           }

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -376,34 +376,16 @@ describe('remote device', function() {
     () => {
       var email = server.uniqueEmail()
       var password = 'test password'
-      var deviceInfo = {
-        name: 'test device',
-        type: 'mobile'
-      }
       return Client.create(config.publicUrl, email, password, {
         createdAt: '-1'
       })
       .then(
-        function (client) {
-          return client.updateDevice(deviceInfo)
-            .then(
-              function () {
-                return client.devices()
-              }
-            )
-            .then(
-              function (devices) {
-                assert.equal(devices.length, 1, 'devices returned one item')
-                assert.ok(devices[0].lastAccessTime > 0, 'devices returned correct lastAccessTime')
-                assert.strictEqual(devices[0].lastAccessTimeFormatted, 'a few seconds ago',
-                  'devices returned correct lastAccessTimeFormatted')
-                assert.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
-                assert.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
-                return client.destroyDevice(devices[0].id)
-              }
-            )
+        () => assert(false),
+        err => {
+          assert.equal(err.code, 400)
         }
       )
+
     }
   )
 


### PR DESCRIPTION
This is a backport of a code that has been in production now for a few weeks, coming from the private repo. This strips from the query, payload, and parameters anything which the route doesn't explicitly list out validation for.

The second commit is to adjust the code to new lints that arrived in the public repo.

This must merge before tagging a new train.