### PR TITLE
feat(logs): disable statsd reporting in config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -405,7 +405,7 @@ var conf = convict({
   statsd: {
     enabled: {
       doc: 'enable UDP based statsd reporting',
-      default: true,
+      default: false,
       env: 'STATSD_ENABLE'
     },
     host: {


### PR DESCRIPTION
This is related to https://github.com/mozilla/fxa-auth-server/issues/1611 

We are doing other refactoring right now , so for now we can just flip the switch to turn off this datadog logging and remove the code later...

@mozilla/fxa-devs r?