### PR TITLE
Release 81.1 with createdAt fix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "dependencies": {
     "ajv": {
       "version": "4.1.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -293,7 +293,7 @@
     "fxa-auth-db-mysql": {
       "version": "0.76.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#44470ad7cbb598c07cb8850fe6ff959959f56b9d",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#95e64c2ae262a07f62ee09c16fcee3c7d94cb9ae",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"


### PR DESCRIPTION
Branches from release 81.0 and contains updated auth-mysql-db fix for https://github.com/mozilla/fxa-auth-db-mysql/pull/209.

@vladikoff Missing anything, r?