### PR TITLE
refactor(sms): swap out ad hoc error structures for lib/error

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -604,6 +604,12 @@ var conf = convict({
       default: 'https://mzl.la/1HOd4ec',
       format: 'url',
       env: 'SMS_INSTALL_FIREFOX_LINK'
+    },
+    throttleWaitTime: {
+      doc: 'The number of seconds to wait if throttled by the SMS service provider',
+      default: 2,
+      format: Number,
+      env: 'SMS_THROTTLE_WAIT_TIME'
     }
   }
 })

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -79,19 +79,6 @@ module.exports = (log, isA, error, config, customs, sms) => {
 
         function sendMessage (senderId) {
           return sms.send(phoneNumber, senderId, messageId, acceptLanguage)
-            .catch(err => {
-              if (err) {
-                if (err.status === 500) {
-                  throw error.messageRejected(err.reason, err.reasonCode)
-                }
-
-                if (err.status === 400) {
-                  throw error.invalidMessageId()
-                }
-              }
-
-              throw error.unexpectedError()
-            })
         }
 
         function logSuccess () {

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -229,15 +229,11 @@ describe('/sms', () => {
     })
   })
 
-  describe('sms.send fails with 500 error', () => {
+  describe('sms.send fails', () => {
     let err
 
     beforeEach(() => {
-      sms.send = sinon.spy(() => P.reject({
-        status: 500,
-        reason: 'wibble',
-        reasonCode: 7
-      }))
+      sms.send = sinon.spy(() => P.reject(AppError.messageRejected('wibble', 7)))
       request.payload.phoneNumber = '+18885083401'
       return runTest(route, request)
         .catch(e => {
@@ -267,78 +263,6 @@ describe('/sms', () => {
       assert.equal(err.message, 'Message rejected')
       assert.equal(err.output.payload.reason, 'wibble')
       assert.equal(err.output.payload.reasonCode, 7)
-    })
-  })
-
-  describe('sms.send fails with 400 error', () => {
-    let err
-
-    beforeEach(() => {
-      sms.send = sinon.spy(() => P.reject({
-        status: 400
-      }))
-      request.payload.phoneNumber = '+18885083401'
-      return runTest(route, request)
-        .catch(e => {
-          err = e
-        })
-    })
-
-    it('called log.begin once', () => {
-      assert.equal(log.begin.callCount, 1)
-    })
-
-    it('called request.validateMetricsContext once', () => {
-      assert.equal(request.validateMetricsContext.callCount, 1)
-    })
-
-    it('called sms.send once', () => {
-      assert.equal(sms.send.callCount, 1)
-    })
-
-    it('did not call log.flowEvent', () => {
-      assert.equal(log.flowEvent.callCount, 0)
-    })
-
-    it('threw the correct error data', () => {
-      assert.ok(err instanceof AppError)
-      assert.equal(err.errno, AppError.ERRNO.INVALID_MESSAGE_ID)
-      assert.equal(err.message, 'Invalid message id')
-    })
-  })
-
-  describe('sms.send fails with unknown error', () => {
-    let err
-
-    beforeEach(() => {
-      sms.send = sinon.spy(() => P.reject())
-      request.payload.phoneNumber = '+18885083401'
-      return runTest(route, request)
-        .catch(e => {
-          err = e
-        })
-    })
-
-    it('called log.begin once', () => {
-      assert.equal(log.begin.callCount, 1)
-    })
-
-    it('called request.validateMetricsContext once', () => {
-      assert.equal(request.validateMetricsContext.callCount, 1)
-    })
-
-    it('called sms.send once', () => {
-      assert.equal(sms.send.callCount, 1)
-    })
-
-    it('did not call log.flowEvent', () => {
-      assert.equal(log.flowEvent.callCount, 0)
-    })
-
-    it('threw the correct error data', () => {
-      assert.ok(err instanceof AppError)
-      assert.equal(err.errno, AppError.ERRNO.UNEXPECTED_ERROR)
-      assert.equal(err.message, 'Unspecified error')
     })
   })
 })


### PR DESCRIPTION
Now that the mailer is inside the auth server repo, there's no need for the `sms` module to return its own ad hoc error structures. Instead it can call `lib/error.js` directly.

At the same time, I also opted to return a proper error for the case where Nexmo throttles us, which fixes #1693.

@mozilla/fxa-devs r?