### PR TITLE
fix(config): Use a more generic server url pattern for push registrations

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -572,7 +572,7 @@ var conf = convict({
     allowedServerRegex: {
       doc: 'RegExp that validates the URI format of the Push Server',
       format: RegExp,
-      default: /^https:\/\/updates\.push\.services\.mozilla\.com(\/.*)?$/
+      default: /^https:\/\/[a-zA-Z0-9._-]+\.services\.mozilla\.com(\/.*)?$/
     }
   },
   sms: {


### PR DESCRIPTION
Per suggestion in https://bugzilla.mozilla.org/show_bug.cgi?id=1341160#c14; @vladikoff r?