### PR TITLE
feat(metrics): Log metrics event for sending a tab between devices.

### DIFF
--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -150,6 +150,7 @@ are emitted:
 |`device.created`|A device record has been created for a Sync account.|
 |`device.updated`|Device record is updated on a Sync account.|
 |`device.deleted`|Device record has been deleted from a Sync account.|
+|`sync.sentTabToDevice`|Device sent a push message for send-tab-to-device feature.|
 
 In redshift,
 these events are stored

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -18,7 +18,8 @@ const ACTIVITY_EVENTS = new Set([
   'account.verified',
   'device.created',
   'device.deleted',
-  'device.updated'
+  'device.updated',
+  'sync.sentTabToDevice'
 ])
 
 // We plan to emit a vast number of flow events to cover all
@@ -30,7 +31,8 @@ const NOT_FLOW_EVENTS = new Set([
   'account.deleted',
   'device.created',
   'device.deleted',
-  'device.updated'
+  'device.updated',
+  'sync.sentTabToDevice'
 ])
 
 // It's an error if a flow event doesn't have a flow_id

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1363,6 +1363,25 @@ module.exports = function (
                 .catch(catchPushError)
             }
           })
+          .then(function () {
+            // Emit a metrics event for when a user sends tabs between devices.
+            // In the future we will aim to get this event directly from sync telemetry,
+            // but we're doing it here for now as a quick way to get metrics on the feature.
+            if (payload.command === 'sync:collection_changed') {
+              // Note that payload schema validation ensures that these properties exist.
+              if (payload.data.collections.length === 1 && payload.data.collections[0] === 'clients') {
+                var deviceId = undefined
+                if  (sessionToken.deviceId) {
+                  deviceId = sessionToken.deviceId.toString('hex')
+                }
+                return request.emitMetricsEvent('sync.sentTabToDevice', {
+                  device_id: deviceId,
+                  service: 'sync',
+                  uid: stringUid
+                })
+              }
+            }
+          })
           .then(
             function () {
               reply({})


### PR DESCRIPTION
This is a WIP PR to emit a new metrics event, which we'll need for the metrics vendor evaluation that's going on right now.  It's a bit of a hack to detect when a user uses the "send tab to device" feature in sync.  In the real world, we'd aim to get this event out of sync telemetry data.  For initial proof-of-concept with metrics tooling, it suffices to cheat a little and log it from within FxA.

@mhammond @grigoryk could you please take a look at my inspection of the payload for 'sync:collection_changed' here, and confirm whether such a push message body does indicate an attempt to send a tab from one device to another?

This needs tests, but if it looks low-risk, I'd like to make a train-82 point release to get this out and logging in production as soon as possible.  The more historical data we manage to collect, the more useful it will be for the metrics tooling evaluation.