### PR TITLE
fix(scripts): mend the broken write-emails-to-disk script

### DIFF
--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -12,7 +12,7 @@ var P = require('../promise')
 // up when you do that, they expect config and log in a different order.
 var createSenders = require('./legacy_index')
 
-module.exports = function (config, log) {
+module.exports = function (config, log, sender) {
   var defaultLanguage = config.i18n.defaultLanguage
 
   return createSenders(
@@ -22,7 +22,8 @@ module.exports = function (config, log) {
       defaultLanguage: defaultLanguage,
       mail: config.smtp,
       sms: config.sms
-    }
+    },
+    sender
   )
   .then(
     function (senders) {

--- a/scripts/write-emails-to-disk.js
+++ b/scripts/write-emails-to-disk.js
@@ -124,7 +124,10 @@ function getMailerMessageTypes(mailer) {
   var messageTypes = []
 
   for (var key in mailer) {
-    if (typeof mailer[key] === 'function' && ! /^_/.test(key) && /Email$/.test(key)) {
+    if (
+      typeof mailer[key] === 'function' &&
+      ! /^_/.test(key) && ! /^send/.test(key) && /Email$/.test(key)
+    ) {
       messageTypes.push(key)
     }
   }


### PR DESCRIPTION
Evidently I broke this script in d09759c. Yet I was positive I'd tested it after making that change to be sure nothing was broken. But I can't have, because it doesn't work at the moment.

Instead, it fails because the mock sender is not passed through from `lib/senders/index` to `lib/senders/legacy_index`. So instead of writing the emails to disk, it tries to send them out via SMTP.

This change fixes that, and it also fixes a secondary error I introduced, where the script tries to call every mailer method that ends with `...Email`. That pattern was correct in the old set-up, but since the merge it includes a method that the script doesn't want to call. Said method bails because it doesn't receive the correct args, killing the process.

@vladikoff, really sorry about these, care to r?