### PR TITLE
fix(metrics): log locale instead of accept languages on flow events

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 // Only `require()` the newrelic module if explicity enabled.
 // If required, modules will be instrumented.
 require('../lib/newrelic')()
@@ -74,7 +76,12 @@ function main() {
     log.stat(Password.stat())
   }
 
-  require('../lib/senders')(config, log)
+  let translator
+  require('../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
+    .then(result => {
+      translator = result
+      return require('../lib/senders')(log, config, translator)
+    })
     .then(
       function(result) {
         senders = result
@@ -108,7 +115,7 @@ function main() {
                 config,
                 customs
               )
-              server = Server.create(log, error, config, routes, db)
+              server = Server.create(log, error, config, routes, db, translator)
 
               server.start(
                 function (err) {

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -144,7 +144,7 @@ module.exports = log => {
 
     return request.gatherMetricsContext({
       event: event,
-      locale: request.app && request.app.locale,
+      locale: marshallLocale(request),
       uid: coalesceUid(optionalData, request),
       userAgent: request.headers['user-agent']
     }).then(data => {
@@ -173,6 +173,12 @@ function optionallySetService (data, request) {
   data.service =
     (request.payload && request.payload.service) ||
     (request.query && request.query.service)
+}
+
+function marshallLocale (request) {
+  if (request.app && request.app.locale) {
+    return `${request.app.locale}${request.app.isLocaleAcceptable ? '' : '.default'}`
+  }
 }
 
 function coalesceUid (data, request) {

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -144,7 +144,7 @@ module.exports = log => {
 
     return request.gatherMetricsContext({
       event: event,
-      locale: coalesceLocale(optionalData, request),
+      locale: request.app && request.app.locale,
       uid: coalesceUid(optionalData, request),
       userAgent: request.headers['user-agent']
     }).then(data => {
@@ -173,14 +173,6 @@ function optionallySetService (data, request) {
   data.service =
     (request.payload && request.payload.service) ||
     (request.query && request.query.service)
-}
-
-function coalesceLocale (data, request) {
-  if (data && data.locale) {
-    return data.locale
-  }
-
-  return request.app && request.app.acceptLanguage
 }
 
 function coalesceUid (data, request) {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -221,8 +221,7 @@ module.exports = function (
               account = result
 
               return request.emitMetricsEvent('account.created', {
-                uid: account.uid.toString('hex'),
-                locale: account.locale
+                uid: account.uid.toString('hex')
               })
             }
           )

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -118,7 +118,7 @@ module.exports = function (log) {
     this.supportUrl = config.supportUrl
     this.syncUrl = config.syncUrl
     this.templates = templates
-    this.translator = translator
+    this.translator = translator.getTranslator
     this.verificationUrl = config.verificationUrl
     this.verifyLoginUrl = config.verifyLoginUrl
   }

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -8,21 +8,19 @@ var P = require('../promise')
 // This indirection exists to accommodate different config properties
 // in the old auth mailer. If/when the two config files are merged and
 // there's nothing left that imports mailer/config, it is safe to merge
-// legacy_index.js and this file into one. Be careful not to mix the args
-// up when you do that, they expect config and log in a different order.
+// legacy_index.js and this file into one.
 var createSenders = require('./legacy_index')
 
-module.exports = function (config, log, sender) {
+module.exports = function (log, config, translator, sender) {
   var defaultLanguage = config.i18n.defaultLanguage
 
   return createSenders(
     log,
     {
-      locales: config.i18n.supportedLanguages,
-      defaultLanguage: defaultLanguage,
       mail: config.smtp,
       sms: config.sms
     },
+    translator,
     sender
   )
   .then(

--- a/lib/senders/legacy_index.js
+++ b/lib/senders/legacy_index.js
@@ -6,27 +6,17 @@
 // Those files should import this module rather than its sibling index.js.
 // If/when we eliminate the old mailer config and everything is importing
 // index.js, we can merge this into there and get rid of the indirection.
-// Be careful when doing that btw, they expect the log and config arguments
-// in a different order.
 
-var P = require('../promise')
 var createMailer = require('./email')
 var createSms = require('./sms')
 
-module.exports = function (log, config, sender) {
+module.exports = function (log, config, translator, sender) {
   var Mailer = createMailer(log)
-  return P.all(
-    [
-      require('./translator')(config.locales, config.defaultLanguage),
-      require('./templates')()
-    ]
-  )
-  .spread(
-    function (translator, templates) {
+  return require('./templates')()
+    .then(function (templates) {
       return {
         email: new Mailer(translator, templates, config.mail, sender),
         sms: createSms(log, translator, templates, config.sms)
       }
-    }
-  )
+    })
 }

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -97,7 +97,7 @@ module.exports = function (log, translator, templates, smsConfig) {
 
     return template({
       link: smsConfig[templateName + 'Link'],
-      translator: translator(acceptLanguage)
+      translator: translator.getTranslator(acceptLanguage)
     }).text
   }
 }

--- a/lib/senders/translator.js
+++ b/lib/senders/translator.js
@@ -43,11 +43,18 @@ module.exports = function (locales, defaultLanguage) {
         languageTranslations[language] = translator
       }
 
-      return function translator(acceptLanguage) {
-        var languages = i18n.parseAcceptLanguage(acceptLanguage)
-        var best = i18n.normalizeLanguage(i18n.bestLanguage(languages, supportedLanguages, defaultLanguage))
+      return {
+        getTranslator: function (acceptLanguage) {
+          return languageTranslations[getLocale(acceptLanguage)]
+        },
 
-        return languageTranslations[best]
+        getLocale: getLocale
+      }
+
+      function getLocale (acceptLanguage) {
+        var languages = i18n.parseAcceptLanguage(acceptLanguage)
+        var bestLanguage = i18n.bestLanguage(languages, supportedLanguages, defaultLanguage)
+        return i18n.normalizeLanguage(bestLanguage)
       }
     }
   )

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ function logEndpointErrors(response, log) {
   }
 }
 
-function create(log, error, config, routes, db) {
+function create(log, error, config, routes, db, translator) {
 
   // Hawk needs to calculate request signatures based on public URL,
   // not the local URL to which it is bound.
@@ -285,6 +285,7 @@ function create(log, error, config, routes, db) {
       request.app.clientAddress = xff[clientAddressIndex]
 
       request.app.acceptLanguage = trimLocale(request.headers['accept-language'])
+      request.app.locale = translator.getLocale(request.app.acceptLanguage)
 
       if (request.headers.authorization) {
         // Log some helpful details for debugging authentication problems.

--- a/lib/server.js
+++ b/lib/server.js
@@ -284,8 +284,11 @@ function create(log, error, config, routes, db, translator) {
       request.app.remoteAddressChain = xff
       request.app.clientAddress = xff[clientAddressIndex]
 
-      request.app.acceptLanguage = trimLocale(request.headers['accept-language'])
-      request.app.locale = translator.getLocale(request.app.acceptLanguage)
+      const acceptLanguage = trimLocale(request.headers['accept-language'])
+      request.app.acceptLanguage = acceptLanguage
+      const locale = translator.getLocale(acceptLanguage)
+      request.app.locale = locale
+      request.app.isLocaleAcceptable = isLocaleAcceptable(locale, acceptLanguage)
 
       if (request.headers.authorization) {
         // Log some helpful details for debugging authentication problems.
@@ -340,6 +343,10 @@ function create(log, error, config, routes, db, translator) {
   }
 
   return server
+}
+
+function isLocaleAcceptable (locale, acceptLanguage) {
+  return RegExp(`^(?:.+, *)*${locale}(?:[,-].+)*$`, 'i').test(acceptLanguage)
 }
 
 module.exports = {

--- a/scripts/sms/balance.js
+++ b/scripts/sms/balance.js
@@ -15,7 +15,10 @@ if (config.sms.apiKey === NOT_SET || config.sms.apiSecret === NOT_SET) {
 
 const log = require('../../lib/log')(config.log.level, 'sms-balance')
 
-require('../../lib/senders')(config, log)
+require('../../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
+  .then(translator => {
+    return require('../../lib/senders')(log, config, translator)
+  })
   .then(senders => {
     return senders.sms.balance()
   })

--- a/scripts/sms/send.js
+++ b/scripts/sms/send.js
@@ -16,7 +16,10 @@ if (config.sms.apiKey === NOT_SET || config.sms.apiSecret === NOT_SET) {
 const args = parseArgs()
 const log = require('../../lib/log')(config.log.level, 'send-sms')
 
-require('../../lib/senders')(config, log)
+require('../../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
+  .then(translator => {
+    return require('../../lib/senders')(log, config, translator)
+  })
   .then(senders => {
     return senders.sms.send.apply(null, args)
   })

--- a/scripts/write-emails-to-disk.js
+++ b/scripts/write-emails-to-disk.js
@@ -27,7 +27,7 @@
  */
 
 var P = require('bluebird')
-var config = require('../config')
+const config = require('../config').getProperties()
 const createSenders = require('../lib/senders')
 var fs = require('fs')
 const log = require('../lib/senders/legacy_log')(require('../lib/senders/log')('server'))
@@ -52,8 +52,10 @@ var mailSender = {
   close: function () {}
 }
 
-
-createSenders(config.getProperties(), log, mailSender)
+require('../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
+  .then(translator => {
+    return createSenders(log, config, translator, mailSender)
+  })
   .then((senders) => {
     const mailer = senders.email
     checkMessageType(mailer, messageToSend)

--- a/test/local/lib/mailer_locales.js
+++ b/test/local/lib/mailer_locales.js
@@ -4,15 +4,20 @@
 
 'use strict'
 
+const ROOT_DIR = '../../..'
+
 const assert = require('insist')
-var config = require('../../../config/index').getProperties()
-var log = {}
+const config = require(`${ROOT_DIR}/config/index`).getProperties()
+const log = {}
 
 describe('mailer locales', () => {
 
   let mailer
   before(() => {
-    return require('../../../lib/senders')(config, log)
+    return require(`${ROOT_DIR}/lib/senders/translator`)(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
+      .then(translator => {
+        return require(`${ROOT_DIR}/lib/senders`)(log, config, translator)
+      })
       .then(result => {
         mailer = result.email
       })

--- a/test/local/lib/senders/translator.js
+++ b/test/local/lib/senders/translator.js
@@ -2,25 +2,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 
 require('../../../../lib/senders/translator')(['en', 'pt_br', 'DE', 'ES_AR', 'ES_cl'], 'en')
-.then(
-  function (translator) {
-    it(
-      'translator works with upper and lowercase languages',
-      function (t) {
-        var x = translator('PT-br,DE')
-        assert.equal(x.language, 'pt-BR')
-        x = translator('bu-ll,es-ar')
-        assert.equal(x.language, 'es-AR')
-        x = translator('es-CL')
-        assert.equal(x.language, 'es-CL')
-        x = translator('en-US')
-        assert.equal(x.language, 'en')
-        x = translator('db-LB') // a locale that does not exist
-        assert.equal(x.language, 'en')
-      }
-    )
-  }
-)
+.then(translator => {
+  it('returns the correct interface', () => {
+    assert.equal(typeof translator, 'object')
+    assert.equal(Object.keys(translator).length, 2)
+    assert.equal(typeof translator.getTranslator, 'function')
+    assert.equal(typeof translator.getLocale, 'function')
+  })
+
+  it('getTranslator works with upper and lowercase languages', () => {
+    let x = translator.getTranslator('PT-br,DE')
+    assert.equal(x.language, 'pt-BR')
+    x = translator.getTranslator('bu-ll,es-ar')
+    assert.equal(x.language, 'es-AR')
+    x = translator.getTranslator('es-CL')
+    assert.equal(x.language, 'es-CL')
+    x = translator.getTranslator('en-US')
+    assert.equal(x.language, 'en')
+    x = translator.getTranslator('db-LB') // a locale that does not exist
+    assert.equal(x.language, 'en')
+  })
+
+  it('getLocale works with upper and lowercase languages', () => {
+    assert.equal(translator.getLocale('PT-br,DE'), 'pt-BR')
+    assert.equal(translator.getLocale('bu-ll,es-ar'), 'es-AR')
+    assert.equal(translator.getLocale('es-CL'), 'es-CL')
+    assert.equal(translator.getLocale('en-US'), 'en')
+    assert.equal(translator.getLocale('db-LB'), 'en')
+  })
+})

--- a/test/local/lib/server.js
+++ b/test/local/lib/server.js
@@ -10,6 +10,7 @@ const error = require('../../../lib/error')
 const hapi = require('hapi')
 const mocks = require('../../mocks')
 const server = require('../../../lib/server')
+const sinon = require('sinon')
 
 describe('lib/server', () => {
   describe('trimLocale', () => {
@@ -60,14 +61,18 @@ describe('lib/server', () => {
   })
 
   describe('create:', () => {
-    let log, config, routes, db, instance, response
+    let log, config, routes, db, instance, response, translator
 
     beforeEach(() => {
       log = mocks.spyLog()
       config = getConfig()
       routes = getRoutes()
       db = mocks.mockDB()
-      instance = server.create(log, error, config, routes, db)
+      translator = {
+        getTranslator: sinon.spy(() => ({ en: { format: () => {}, language: 'en' } })),
+        getLocale: sinon.spy(() => 'en')
+      }
+      instance = server.create(log, error, config, routes, db, translator)
     })
 
     it('returned a hapi Server instance', () => {
@@ -103,6 +108,7 @@ describe('lib/server', () => {
           assert.equal(args[0], 'server.onRequest')
           assert.ok(args[1])
           assert.equal(args[1].path, '/account/create')
+          assert.equal(args[1].app.locale, 'en')
         })
 
         it('called log.summary correctly', () => {

--- a/test/local/lib/server.js
+++ b/test/local/lib/server.js
@@ -91,10 +91,13 @@ describe('lib/server', () => {
         assert.equal(log.summary.callCount, 0)
       })
 
-      describe('successful request:', () => {
+      describe('successful request, acceptable locale:', () => {
         beforeEach(() => {
           response = 'ok'
           return instance.inject({
+            headers: {
+              'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5'
+            },
             method: 'POST',
             url: '/account/create',
             payload: {}
@@ -109,6 +112,7 @@ describe('lib/server', () => {
           assert.ok(args[1])
           assert.equal(args[1].path, '/account/create')
           assert.equal(args[1].app.locale, 'en')
+          assert.equal(args[1].app.isLocaleAcceptable, true)
         })
 
         it('called log.summary correctly', () => {
@@ -122,6 +126,35 @@ describe('lib/server', () => {
           assert.equal(args[1].errno, undefined)
           assert.equal(args[1].statusCode, 200)
           assert.equal(args[1].source, 'ok')
+        })
+
+        it('did not call log.error', () => {
+          assert.equal(log.error.callCount, 0)
+        })
+      })
+
+      describe('successful request, unacceptable locale:', () => {
+        beforeEach(() => {
+          response = 'ok'
+          return instance.inject({
+            headers: {
+              'accept-language': 'fr-CH, fr;q=0.9'
+            },
+            method: 'POST',
+            url: '/account/create',
+            payload: {}
+          })
+        })
+
+        it('called log.begin correctly', () => {
+          assert.equal(log.begin.callCount, 1)
+          const args = log.begin.args[0]
+          assert.equal(args[1].app.locale, 'en')
+          assert.equal(args[1].app.isLocaleAcceptable, false)
+        })
+
+        it('called log.summary once', () => {
+          assert.equal(log.summary.callCount, 1)
         })
 
         it('did not call log.error', () => {

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -170,6 +170,7 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = {
       app: {
+        isLocaleAcceptable: false,
         locale: 'en'
       },
       auth: {
@@ -203,7 +204,7 @@ describe('metrics/events', () => {
           flow_id: 'bar',
           flow_time: 1000,
           flowCompleteSignal: 'account.signed',
-          locale: 'en',
+          locale: 'en.default',
           time,
           uid: 'deadbeef',
           userAgent: 'foo'
@@ -225,6 +226,7 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = {
       app: {
+        isLocaleAcceptable: true,
         locale: 'fr'
       },
       clearMetricsContext: metricsContext.clear,

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -170,7 +170,7 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = {
       app: {
-        acceptLanguage: 'en'
+        locale: 'en'
       },
       auth: {
         credentials: {
@@ -224,6 +224,9 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = {
+      app: {
+        locale: 'fr'
+      },
       clearMetricsContext: metricsContext.clear,
       gatherMetricsContext: metricsContext.gather,
       headers: {
@@ -247,7 +250,7 @@ describe('metrics/events', () => {
           flow_id: 'bar',
           flow_time: 2000,
           flowCompleteSignal: 'account.reminder',
-          locale: 'baz',
+          locale: 'fr',
           time,
           uid: 'qux',
           userAgent: 'foo'
@@ -257,7 +260,7 @@ describe('metrics/events', () => {
           flow_id: 'bar',
           flow_time: 2000,
           flowCompleteSignal: 'account.reminder',
-          locale: 'baz',
+          locale: 'fr',
           time,
           uid: 'qux',
           userAgent: 'foo'

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -204,6 +204,7 @@ describe('/account/create', () => {
     mockLog.error = sinon.spy()
     const mockMetricsContext = mocks.mockMetricsContext()
     const mockRequest = mocks.mockRequest({
+      locale: 'en-GB',
       log: mockLog,
       metricsContext: mockMetricsContext,
       payload: {
@@ -288,7 +289,6 @@ describe('/account/create', () => {
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
         event: 'account.created',
-        locale: 'en',
         service: 'sync',
         userAgent: 'test user-agent',
         uid: uid.toString('hex')
@@ -302,7 +302,7 @@ describe('/account/create', () => {
         flowCompleteSignal: 'account.signed',
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
         flow_id: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
-        locale: 'en',
+        locale: 'en-GB',
         time: now,
         uid: uid.toString('hex'),
         userAgent: 'test user-agent'

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -353,8 +353,9 @@ function mockRequest (data) {
   return {
     app: {
       acceptLanguage: 'en-US',
-      locale: data.locale || 'en-US',
-      clientAddress: data.clientAddress || '63.245.221.32' // MTV
+      clientAddress: data.clientAddress || '63.245.221.32',
+      isLocaleAcceptable: true,
+      locale: data.locale || 'en-US'
     },
     auth: {
       credentials: data.credentials

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -353,6 +353,7 @@ function mockRequest (data) {
   return {
     app: {
       acceptLanguage: 'en-US',
+      locale: data.locale || 'en-US',
       clientAddress: data.clientAddress || '63.245.221.32' // MTV
     },
     auth: {


### PR DESCRIPTION
Fixes [bug 1345006](https://bugzilla.mozilla.org/show_bug.cgi?id=1345006), emitting just the resolved locale on flow events rather than the entire list of acceptable languages.

Doing this necessitated a bit of refactoring:

* `lib/senders/translator` is changed to export a `getLocale` method in addition to the existing function that returns the translator object.

* `lib/senders/translator` is now created at the top level and passed in to the sender modules, so that `getLocale` can be called from `lib/server` to decorate the `request` object with.

With this change in place, the flow events now look like this:

```
flowEvent {"event":"flow.complete","locale":"en","uid":"b639696295e244b6b985d0c12dd9f7af","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1488903497759,"flow_id":"dc73205d686084a21372da6bf5461637fd3768c0494b45f1b98623daea3522d2","flow_time":23039,"flowCompleteSignal":"account.signed"}
```

Before the change, they looked like this:

```
flowEvent {"event":"flow.complete","locale":"en-US,en;q=0.5","uid":"74b4de3eb29e4739b1467d2298ad398d","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:53.0) Gecko/20100101 Firefox/53.0","time":1486649552905,"flow_id":"5977024c73cb0361d9e7f7ceb818f1bff2fe9a49a3eaf0ca413417848bbcd891","flow_time":492398,"flowCompleteSignal":"account.verified"}
```

@mozilla/fxa-devs r?