### PR TITLE
feat(db): make database fault tolerant of db server

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -29,22 +29,7 @@ module.exports = function (
   }
 
   DB.connect = function (options) {
-    var db = new DB(options)
-
-    return db.pool.get('/')
-    .then(
-      function (api) {
-        // TODO: transition to api version
-        // patchLevel is mysql specific
-        if (
-          api.patchLevel < options.patchLevel ||
-          api.patchLevel > options.patchLevel + 1
-        ) {
-          throw error.dbIncorrectPatchLevel(api.patchLevel, options.patchLevel)
-        }
-        return db
-      }
-    )
+    return P.resolve(new DB(options))
   }
 
   DB.prototype.close = function () {


### PR DESCRIPTION
This is support of our docker-dev work in https://github.com/vladikoff/fxa-docker-dev/pull/7. And it's currently WIP.

----

The idea here is that the auth-server should be able to stand up even if the db-server is currently on fire. We don't actually need to start listening for requests. If an incoming request needs access to the database, we will already correctly send back a 500 if the db connection fails.