### PR TITLE
fix(errors): fix misleading error string for featureNotEnabled

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -415,7 +415,7 @@ AppError.featureNotEnabled = function (retryAfter) {
       code: 503,
       error: 'Feature not enabled',
       errno: ERRNO.FEATURE_NOT_ENABLED,
-      message: 'Service unavailable'
+      message: 'Feature not enabled'
     },
     {
       retryAfter: retryAfter


### PR DESCRIPTION
The auto-generated API docs claim their first victim!

I was just reviewing the output from the script I'm working on and noticed that one of the error strings was duplicated. Just a little copy/paste error, nothing too major, but it's nice to have some early validation that the automation is doing its job.

@mozilla/fxa-devs r?