### PR TITLE
fix(sms): short-circuit the geodb lookup if calling from localhost

### DIFF
--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -106,6 +106,10 @@ module.exports = (log, isA, error, config, customs, sms) => {
           .then(reply, reply)
 
         function getLocation () {
+          if (request.app.clientAddress === '127.0.0.1') {
+            return true
+          }
+
           return getGeoData(request.app.clientAddress)
             .then(result => REGIONS.has(result.location.countryCode))
             .catch(err => {

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -317,7 +317,7 @@ describe('/sms/status', () => {
     let response
 
     beforeEach(() => {
-      geodbResult = Promise.resolve({ location: { countryCode: 'US' } })
+      geodbResult = P.resolve({ location: { countryCode: 'US' } })
       sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .then(r => response = r)
@@ -356,7 +356,7 @@ describe('/sms/status', () => {
     let response
 
     beforeEach(() => {
-      geodbResult = Promise.resolve({ location: { countryCode: 'US' } })
+      geodbResult = P.resolve({ location: { countryCode: 'US' } })
       sms.balance = sinon.spy(() => P.resolve({ isOk: false }))
       return runTest(route, request)
         .then(r => response = r)
@@ -387,7 +387,7 @@ describe('/sms/status', () => {
     let response
 
     beforeEach(() => {
-      geodbResult = Promise.resolve({ location: { countryCode: 'CA' } })
+      geodbResult = P.resolve({ location: { countryCode: 'CA' } })
       sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .then(r => response = r)
@@ -418,7 +418,7 @@ describe('/sms/status', () => {
     let err
 
     beforeEach(() => {
-      geodbResult = Promise.resolve({ location: { countryCode: 'US' } })
+      geodbResult = P.resolve({ location: { countryCode: 'US' } })
       sms.balance = sinon.spy(() => P.reject(new Error('foo')))
       return runTest(route, request)
         .catch(e => err = e)
@@ -456,7 +456,7 @@ describe('/sms/status', () => {
     let err
 
     beforeEach(() => {
-      geodbResult = Promise.reject(new Error('bar'))
+      geodbResult = P.reject(new Error('bar'))
       sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .catch(e => err = e)
@@ -488,6 +488,53 @@ describe('/sms/status', () => {
       assert.ok(args[0].err instanceof Error)
       assert.equal(args[0].err.message, 'bar')
     })
+  })
+})
+
+describe('/sms/status from localhost', () => {
+  let log, config, geodb, routes, route, request, response
+
+  beforeEach(() => {
+    log = mocks.spyLog()
+    config = {
+      sms: {
+        enabled: true,
+        regions: [ 'US' ]
+      }
+    }
+    geodb = sinon.spy(() => P.resolve())
+    routes = makeRoutes({ log, config }, { '../geodb': () => geodb })
+    route = getRoute(routes, '/sms/status')
+    request = mocks.mockRequest({
+      clientAddress: '127.0.0.1',
+      credentials: {
+        email: 'foo@example.org'
+      },
+      log: log
+    })
+    sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
+    return runTest(route, request)
+      .then(r => response = r)
+  })
+
+  it('returned the correct response', () => {
+    assert.deepEqual(response, { ok: true })
+  })
+
+  it('called log.begin once', () => {
+    assert.equal(log.begin.callCount, 1)
+  })
+
+  it('did not call geodb', () => {
+    assert.equal(geodb.callCount, 0)
+  })
+
+  it('called sms.balance once', () => {
+    assert.equal(sms.balance.callCount, 1)
+  })
+
+  it('did not call log.error', () => {
+    assert.equal(log.error.callCount, 0)
   })
 })
 


### PR DESCRIPTION
Fixes #1747.

This eliminates a nonsensical geo-lookup when we're testing on localhost, which was the indirect cause of an `undefined` dereference because the geo-lookup obviously can't return any data. If the geo-lookup doesn't return location data for some other reason, failure is still the right thing to do.

@mozilla/fxa-devs r?

/cc @shane-tomlinson 