### PR TITLE
fix(sms): short-circuit the geodb lookup if calling from localhost

### DIFF
--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -106,8 +106,19 @@ module.exports = (log, isA, error, config, customs, sms) => {
           .then(reply, reply)
 
         function getLocation () {
+          if (request.app.clientAddress === '127.0.0.1') {
+            return true
+          }
+
           return getGeoData(request.app.clientAddress)
-            .then(result => REGIONS.has(result.location.countryCode))
+            .then(result => {
+              if (! result.location) {
+                log.error({ op: 'sms.getGeoData', err: 'missing location data in result' })
+                return false
+              }
+
+              return REGIONS.has(result.location.countryCode)
+            })
             .catch(err => {
               log.error({ op: 'sms.getGeoData', err: err })
               throw error.unexpectedError()


### PR DESCRIPTION
Fixes #1747. Replaces #1748.

This eliminates a nonsensical geo-lookup when we're testing on localhost, which was the indirect cause of an undefined dereference because the geo-lookup obviously can't return any data. If the geo-lookup doesn't return location data for some other reason, treat it as if the region is unsupported.

@mozilla/fxa-devs r?

/cc @shane-tomlinson