### PR TITLE
Use updated verify email call

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -685,7 +685,7 @@ module.exports = function (
 
   DB.prototype.verifyEmail = function (account) {
     log.trace({ op: 'DB.verifyEmail', uid: account && account.uid })
-    return this.pool.post('/account/' + account.uid.toString('hex') + '/verifyEmail')
+    return this.pool.post('/account/' + account.uid.toString('hex') + '/verifyEmail/' + account.emailCode.toString('hex'))
   }
 
   DB.prototype.verifyTokens = function (tokenVerificationId, accountData) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -286,9 +286,9 @@
       "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#80252879f17a81af0d9a70c960963b6ab9c2b50b"
     },
     "fxa-auth-db-mysql": {
-      "version": "0.82.0",
+      "version": "0.83.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0f816cba9d10095bf4f63a66e46c81195cce43b5",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#2a7e4f14510601ae586598ff226069ac74733bae",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",


### PR DESCRIPTION
This PR passes the `emailCode` when using the updated [verifyEmail](https://github.com/mozilla/fxa-auth-db-mysql/blob/46e333b5bb38ceac6529c9355ae13fa99effc006/docs/API.md#verifyemailuid-emailcode).