### PR TITLE
refactor(bounces): Move email bounce to its own module

### DIFF
--- a/lib/bounces.js
+++ b/lib/bounces.js
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict'
+
+const P = require('./promise')
+
+module.exports = function (log, config, error, db) {
+
+  const configBounces = config.smtp && config.smtp.bounces || {}
+  const BOUNCES_ENABLED = !! configBounces.enabled
+  const MAX_HARD = configBounces.hard && configBounces.hard.max || 0
+  const MAX_SOFT = configBounces.soft && configBounces.soft.max || 0
+  const MAX_COMPLAINT = configBounces.complaint && configBounces.complaint.max || 0
+  const DURATION_HARD = configBounces.hard && configBounces.hard.duration || Infinity
+  const DURATION_SOFT = configBounces.soft && configBounces.soft.duration || Infinity
+  const DURATION_COMPLAINT = configBounces.complaint && configBounces.complaint.duration || Infinity
+  const BOUNCE_TYPE_HARD = 1
+  const BOUNCE_TYPE_SOFT = 2
+  const BOUNCE_TYPE_COMPLAINT = 3
+
+  const BOUNCE_RULES = {
+    BOUNCE_TYPE_HARD: {
+      duration: DURATION_HARD,
+      error: error.emailBouncedHard,
+      max: MAX_HARD
+    },
+    BOUNCE_TYPE_COMPLAINT: {
+      duration: DURATION_COMPLAINT,
+      error: error.emailComplaint,
+      max: MAX_COMPLAINT
+    },
+    BOUNCE_TYPE_SOFT: {
+      duration: DURATION_SOFT,
+      error: error.emailBouncedSoft,
+      max: MAX_SOFT
+    }
+  }
+
+  return {
+    hasEmailBounced: function (email) {
+      if (! BOUNCES_ENABLED) {
+        return P.resolve()
+      }
+
+      return db.emailBounces(email)
+        .then(function (bounces) {
+          const counts = {}
+          counts[BOUNCE_TYPE_HARD] = 0
+          counts[BOUNCE_TYPE_COMPLAINT] = 0
+          counts[BOUNCE_TYPE_SOFT] = 0
+          const now = Date.now()
+          bounces.forEach(function (bounce) {
+            const type = bounce.bounceType
+            const ruleSet = BOUNCE_RULES[type]
+            if (ruleSet) {
+              if (bounce.createdAt > now - ruleSet.duration) {
+                counts[type]++
+                if (counts[type] > ruleSet.max) {
+                  throw ruleSet.error()
+                }
+              }
+            }
+          })
+
+          return P.resolve()
+        })
+    }
+  }
+}

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -12,6 +12,7 @@ var createSenders = require('./legacy_index')
 var P = require('../promise')
 
 module.exports = function (log, config, error, db, translator, sender) {
+  var bounces = require('../bounces')(log, config, error, db)
   var defaultLanguage = config.i18n.defaultLanguage
 
   return createSenders(
@@ -27,58 +28,10 @@ module.exports = function (log, config, error, db, translator, sender) {
     var ungatedMailer = senders.email
     var configBounces = config.smtp && config.smtp.bounces || {}
     var BOUNCES_ENABLED = !! configBounces.enabled
-    var MAX_HARD = configBounces.hard && configBounces.hard.max || 0
-    var MAX_SOFT = configBounces.soft && configBounces.soft.max || 0
-    var MAX_COMPLAINT = configBounces.complaint && configBounces.complaint.max || 0
-    var DURATION_HARD = configBounces.hard && configBounces.hard.duration || Infinity
-    var DURATION_SOFT = configBounces.soft && configBounces.soft.duration || Infinity
-    var DURATION_COMPLAINT = configBounces.complaint && configBounces.complaint.duration || Infinity
-    var BOUNCE_TYPE_HARD = 1
-    var BOUNCE_TYPE_SOFT = 2
-    var BOUNCE_TYPE_COMPLAINT = 3
-
-    // I really wanted to use Computer property names here, but thats
-    // an ES2015 feature, and this directory (senders) is stuck in
-    // ES5-land.
-    var freeze = Object.freeze
-    var BOUNCE_RULES = {}
-    BOUNCE_RULES[BOUNCE_TYPE_HARD] = freeze({
-      duration: DURATION_HARD,
-      error: error.emailBouncedHard,
-      max: MAX_HARD
-    })
-    BOUNCE_RULES[BOUNCE_TYPE_COMPLAINT] = freeze({
-      duration: DURATION_COMPLAINT,
-      error: error.emailComplaint,
-      max: MAX_COMPLAINT
-    })
-    BOUNCE_RULES[BOUNCE_TYPE_SOFT] = freeze({
-      duration: DURATION_SOFT,
-      error: error.emailBouncedSoft,
-      max: MAX_SOFT
-    })
-    BOUNCE_RULES = freeze(BOUNCE_RULES)
 
     function bounceGatedMailer(email) {
-      return db.emailBounces(email)
-        .then(function (bounces) {
-          var counts = {}
-          counts[BOUNCE_TYPE_HARD] = 0
-          counts[BOUNCE_TYPE_COMPLAINT] = 0
-          counts[BOUNCE_TYPE_SOFT] = 0
-          var now = Date.now()
-          bounces.forEach(function (bounce) {
-            var type = bounce.bounceType
-            var ruleSet = BOUNCE_RULES[type]
-            if (ruleSet) {
-              if (bounce.createdAt > now - ruleSet.duration) {
-                counts[type]++
-                if (counts[type] > ruleSet.max) {
-                  throw ruleSet.error()
-                }
-              }
-            }
-          })
+      return bounces.hasEmailBounced(email)
+        .then(function () {
           return ungatedMailer
         })
         .catch(function (err) {


### PR DESCRIPTION
This PR moves email bounce checking to its own module for reuse in https://github.com/mozilla/fxa-auth-server/pull/1729.

@seanmonstar r?