### PR TITLE
feat(emails): Add secondary email remote tests and documentation Part 3

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -95,6 +95,12 @@ The currently-defined error responses are:
 * status code 400, errno 133:  email sent complaint
 * status code 400, errno 134:  email hard bounced
 * status code 400, errno 135:  email soft bounced
+* status code 400, errno 136:  email already exists
+* status code 400, errno 137:  can not delete primary email
+* status code 400, errno 138:  can not add email with unverified session
+* status code 400, errno 139:  can not add email that is the same as your primary email
+* status code 400, errno 140:  verified primary email already exists
+* status code 400, errno 141:  newly created unverified primary email exists
 * status code 503, errno 201:  service temporarily unavailable to due high load (see [backoff protocol](#backoff-protocol))
 * status code 503, errno 202:  feature has been disabled for operational reasons
 * any status code, errno 999:  unknown error
@@ -144,6 +150,9 @@ Since this is a HTTP-based protocol, clients should be prepared to gracefully ha
     * [GET  /v1/recovery_email/status (:lock: sessionToken)](#get-v1recovery_emailstatus)
     * [POST /v1/recovery_email/resend_code (:lock: sessionToken)](#post-v1recovery_emailresend_code)
     * [POST /v1/recovery_email/verify_code](#post-v1recovery_emailverify_code)
+    * [GET  /v1/recovery_emails](#post-v1recovery_emails)
+    * [POST /v1/recovery_email](#post-v1recovery_email)
+    * [POST /v1/recovery_email/destroy](#post-v1recovery_emaildestroy)
 
 * Certificate Signing
     * [POST /v1/certificate/sign (:lock: sessionToken) (verf-required)](#post-v1certificatesign)
@@ -855,7 +864,7 @@ Failing requests may be due to the following errors:
 
 Not HAWK-authenticated.
 
-This is an endpoint that is used to verify tokens and recovery emails for an account. If a valid token code is detected, the account email and tokens will be set to verified. If a valid email code is detected, the email will be marked as verified.
+This is an endpoint that is used to verify tokens and additional emails for an account. If a valid token code is detected, the account email and tokens will be set to verified. If a valid email code is detected, the email will be marked as verified.
 
 The verification code will be a random token, delivered in the fragment portion of a URL sent to the user's email address. The URL will lead to a page that extracts the code from the URL fragment, and performs a POST to `/recovery_email/verify_code`. The link can be clicked from any browser, not just the one being attached to the Firefox account.
 
@@ -896,6 +905,120 @@ Failing requests may be due to the following errors:
 * status code 411, errno 112:  content-length header was not provided
 * status code 413, errno 113:  request body too large
 
+## GET /v1/recovery_emails
+
+This endpoint is used to get all the emails associated with the logged in user. The primary email address, currently, will always be the email address on the accounts table.
+
+### Request
+
+```sh
+curl -v \
+-X GET \
+-H "Host: api-accounts.dev.lcip.org" \
+-H "Content-Type: application/json" \
+https://api-accounts.dev.lcip.org/v1/recovery_emails \
+```
+
+### Response
+
+Successful requests will produce a "200 OK" response with JSON body:
+
+```json
+[
+   {
+      "isPrimary":true,
+      "verified":true,
+      "email":"primary@email.com"
+   },
+   {
+      "isPrimary":false,
+      "verified":false,
+      "email":"anotherone@email.com"
+   }
+]
+```
+
+## POST /v1/recovery_email
+
+This endpoint is used add a secondary email address to the logged in user account. The address is created `unverified` and marked as not the primary address.
+
+### Request
+
+___Parameters___
+
+* email - email address to add to account
+
+```sh
+curl -v \
+-X POST \
+-H "Host: api-accounts.dev.lcip.org" \
+-H "Content-Type: application/json" \
+https://api-accounts.dev.lcip.org/v1/recovery_email \
+-d '{
+  "email": "another@email.com"
+}'
+```
+
+### Response
+
+Successful requests will produce a "200 OK" response with an empty JSON body:
+
+```json
+{}
+```
+
+Failing requests may be due to the following errors:
+
+* status code 400, errno 102:  attempt to access an account that does not exist
+* status code 400, errno 105:  invalid verification code
+* status code 400, errno 106:  request body was not valid json
+* status code 400, errno 107:  request body contains invalid parameters
+* status code 400, errno 108:  request body missing required parameters
+* status code 411, errno 112:  content-length header was not provided
+* status code 413, errno 113:  request body too large
+* status code 400, errno 138:  session is not verified
+* status code 400, errno 139:  cannot add your primary email address
+* status code 400, errno 140:  verified primary email address exist
+* status code 400, errno 141:  newly unverified primary account email exist
+
+## POST /v1/recovery_email/destroy
+
+This endpoint is used to delete an email address from the logged in user.
+
+### Request
+
+___Parameters___
+
+* email - email address to add to account
+
+```sh
+curl -v \
+-X POST \
+-H "Host: api-accounts.dev.lcip.org" \
+-H "Content-Type: application/json" \
+https://api-accounts.dev.lcip.org/v1/recovery_email/destroy \
+-d '{
+  "email": "another@email.com"
+}'
+```
+
+### Response
+
+Successful requests will produce a "200 OK" response with an empty JSON body:
+
+```json
+{}
+```
+
+Failing requests may be due to the following errors:
+
+* status code 400, errno 102:  attempt to access an account that does not exist
+* status code 400, errno 105:  invalid verification code
+* status code 400, errno 106:  request body was not valid json
+* status code 400, errno 107:  request body contains invalid parameters
+* status code 400, errno 108:  request body missing required parameters
+* status code 411, errno 112:  content-length header was not provided
+* status code 413, errno 113:  request body too large
 
 ## POST /v1/certificate/sign
 

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -1,0 +1,644 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const TestServer = require('../test_server')
+const Client = require('../client')()
+
+let config, server, client, email
+const password = 'allyourbasearebelongtous'
+
+describe('remote emails', function () {
+  this.timeout(30000)
+
+  before(() => {
+    config = require('../../config').getProperties()
+    return TestServer.start(config)
+      .then(s => {
+        server = s
+      })
+  })
+
+  beforeEach(() => {
+    email = server.uniqueEmail()
+    return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+      .then(function (x) {
+        client = x
+        assert.ok(client.authAt, 'authAt was set')
+      })
+      .then(function () {
+        return client.emailStatus()
+      })
+      .then(function (status) {
+        assert.equal(status.verified, true, 'account is verified')
+      })
+  })
+
+  describe('should create and get additional email', () => {
+    it(
+      'can create',
+      () => {
+        const secondEmail = server.uniqueEmail()
+        const thirdEmail = server.uniqueEmail()
+        return client.accountEmails()
+          .then((res) => {
+            assert.equal(res.length, 1, 'returns number of emails')
+            assert.equal(res[0].email, email, 'returns correct email')
+            assert.equal(res[0].isPrimary, true, 'returns correct isPrimary')
+            assert.equal(res[0].verified, true, 'returns correct verified')
+            return client.createEmail(secondEmail)
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 2, 'returns number of emails')
+            assert.equal(res[1].email, secondEmail, 'returns correct email')
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[1].verified, false, 'returns correct verified')
+            return client.createEmail(thirdEmail)
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 3, 'returns number of emails')
+            assert.equal(res[2].email, thirdEmail, 'returns correct email')
+            assert.equal(res[2].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[2].verified, false, 'returns correct verified')
+          })
+          .catch((err) => {
+            assert.fail(err)
+          })
+      }
+    )
+
+    it(
+      'fails create when email is user primary email',
+      () => {
+        return client.createEmail(email)
+          .then(assert.fail)
+          .catch((err) => {
+            assert.equal(err.errno, 139, 'email already exists errno')
+            assert.equal(err.code, 400, 'email already exists code')
+            assert.equal(err.message, 'Can not add secondary email that is same as your primary', 'correct error message')
+          })
+      }
+    )
+
+    it(
+      'fails create when email exists in user emails',
+      () => {
+        const secondEmail = server.uniqueEmail()
+        return client.createEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.createEmail(secondEmail)
+          })
+          .then(assert.fail)
+          .catch((err) => {
+            assert.equal(err.errno, 136, 'email already exists errno')
+            assert.equal(err.code, 400, 'email already exists code')
+            assert.equal(err.message, 'Email already exists', 'correct error message')
+          })
+      }
+    )
+
+    it(
+      'fails create when email exists in other user account',
+      () => {
+        const anotherUserEmail = server.uniqueEmail()
+        const anotherUserSecondEmail = server.uniqueEmail()
+        let anotherClient
+        return Client.createAndVerify(config.publicUrl, anotherUserEmail, password, server.mailbox)
+          .then((x) => {
+            anotherClient = x
+            assert.ok(client.authAt, 'authAt was set')
+            return anotherClient.createEmail(anotherUserSecondEmail)
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.createEmail(anotherUserSecondEmail)
+              .then(assert.fail)
+          })
+          .catch((err) => {
+            assert.equal(err.errno, 136, 'email already exists errno')
+            assert.equal(err.code, 400, 'email already exists code')
+            assert.equal(err.message, 'Email already exists', 'correct error message')
+          })
+      }
+    )
+
+    it(
+      'fails for unverified session',
+      () => {
+        const secondEmail = server.uniqueEmail()
+        return client.login()
+          .then(() => {
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 1, 'returns number of emails')
+            assert.equal(res[0].email, email, 'returns correct email')
+            assert.equal(res[0].isPrimary, true, 'returns correct isPrimary')
+            assert.equal(res[0].verified, true, 'returns correct verified')
+            return client.createEmail(secondEmail)
+              .then(() => {
+                assert.fail(new Error('Should not have created email'))
+              })
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'correct error code')
+            assert.equal(err.errno, 138, 'correct error errno unverified session')
+          })
+      }
+    )
+
+    it(
+      'fails create when email is another users verified primary',
+      () => {
+        const anotherUserEmail = server.uniqueEmail()
+        return Client.createAndVerify(config.publicUrl, anotherUserEmail, password, server.mailbox)
+          .then(() => {
+            return client.createEmail(anotherUserEmail)
+          })
+          .then(assert.fail)
+          .catch((err) => {
+            assert.equal(err.errno, 140, 'email already exists errno')
+            assert.equal(err.code, 400, 'email already exists code')
+            assert.equal(err.message, 'Email already exists', 'correct error message')
+          })
+      }
+    )
+  })
+
+  describe('should verify additional email', () => {
+    let secondEmail
+    beforeEach(() => {
+      secondEmail = server.uniqueEmail()
+      return client.createEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return client.accountEmails()
+        })
+        .then((res) => {
+          assert.equal(res.length, 2, 'returns number of emails')
+          assert.equal(res[1].email, secondEmail, 'returns correct email')
+          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+          assert.equal(res[1].verified, false, 'returns correct verified')
+        })
+    })
+
+    it(
+      'can verify',
+      () => {
+        return server.mailbox.waitForEmail(secondEmail)
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            const emailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+            assert.ok(emailCode, 'emailCode set')
+            return client.verifyEmail(emailCode)
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 2, 'returns number of emails')
+            assert.equal(res[1].email, secondEmail, 'returns correct email')
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[1].verified, true, 'returns correct verified')
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            assert.equal(templateName, 'postVerifySecondaryEmail', 'email template name set')
+          })
+      }
+    )
+
+    it(
+      'does not verify on random email code',
+      () => {
+        return server.mailbox.waitForEmail(secondEmail)
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            const emailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+            assert.ok(emailCode, 'emailCode set')
+            return client.verifyEmail('d092f3155ec8d534a7ee7f53b68e9e8b')
+          })
+          .then(assert.fail)
+          .catch((err) => {
+            assert.equal(err.errno, 105, 'correct error errno')
+            assert.equal(err.code, 400, 'correct error code')
+          })
+      }
+    )
+
+    it(
+      'can resend verify email code for added address',
+      () => {
+        var emailCode
+        return server.mailbox.waitForEmail(secondEmail)
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            emailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+            assert.ok(emailCode, 'emailCode set')
+            client.options.email = secondEmail
+            return client.requestVerifyEmail()
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return server.mailbox.waitForEmail(secondEmail)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            const resendEmailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+            assert.equal(resendEmailCode, emailCode, 'emailCode matches')
+            return client.verifyEmail(emailCode)
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 2, 'returns number of emails')
+            assert.equal(res[1].email, secondEmail, 'returns correct email')
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[1].verified, true, 'returns correct verified')
+          })
+
+      }
+    )
+  })
+
+  describe('should delete additional email', () => {
+    let secondEmail
+    beforeEach(() => {
+      secondEmail = server.uniqueEmail()
+      return client.createEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return client.accountEmails()
+        })
+        .then((res) => {
+          assert.equal(res.length, 2, 'returns number of emails')
+          assert.equal(res[1].email, secondEmail, 'returns correct email')
+          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+          assert.equal(res[1].verified, false, 'returns correct verified')
+        })
+    })
+
+    it(
+      'can delete',
+      () => {
+        return client.deleteEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response')
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 1, 'returns number of emails')
+            assert.equal(res[0].email, email, 'returns correct email')
+            assert.equal(res[0].isPrimary, true, 'returns correct isPrimary')
+            assert.equal(res[0].verified, true, 'returns correct verified')
+          })
+      }
+    )
+
+    it(
+      'silient fail on delete non-existent email',
+      () => {
+        return client.deleteEmail('fill@yourboots.com')
+          .then((res) => {
+            // User is attempting to delete an email that doesn't exist, make sure nothing blew up
+            assert.ok(res, 'ok response')
+          })
+      }
+    )
+
+    it(
+      'fails on delete primary account email',
+      () => {
+        return client.deleteEmail(email)
+          .then(assert.fail)
+          .catch((err) => {
+            assert.equal(err.errno, 137, 'correct error errno')
+            assert.equal(err.code, 400, 'correct error code')
+            assert.equal(err.message, 'Can not delete primary email', 'correct error message')
+          })
+      }
+    )
+
+    it(
+      'fails for unverified session',
+      () => {
+        return client.login()
+          .then(() => {
+            return client.accountEmails()
+          })
+          .then((res) => {
+            assert.equal(res.length, 2, 'returns number of emails')
+            assert.equal(res[1].email, secondEmail, 'returns correct email')
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[1].verified, false, 'returns correct verified')
+            return client.deleteEmail(secondEmail)
+              .then(() => {
+                assert.fail(new Error('Should not have deleted email'))
+              })
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'correct error code')
+            assert.equal(err.errno, 138, 'correct error errno unverified session')
+          })
+      }
+    )
+  })
+
+  describe('should receive email confirmations on verified secondary emails', () => {
+    let secondEmail
+    let thirdEmail
+    beforeEach(() => {
+      secondEmail = server.uniqueEmail()
+      thirdEmail = server.uniqueEmail()
+      return client.createEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return server.mailbox.waitForEmail(secondEmail)
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name']
+          const emailCode = emailData['headers']['x-verify-code']
+          assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+          assert.ok(emailCode, 'emailCode set')
+          return client.verifyEmail(emailCode)
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return client.accountEmails()
+        })
+        .then((res) => {
+          assert.equal(res.length, 2, 'returns number of emails')
+          assert.equal(res[1].email, secondEmail, 'returns correct email')
+          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+          assert.equal(res[1].verified, true, 'returns correct verified')
+          return server.mailbox.waitForEmail(email)
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name']
+          assert.equal(templateName, 'postVerifySecondaryEmail', 'email template name set')
+
+          // Create a third email but don't verify it. This should not appear in the cc-list
+          return client.createEmail(thirdEmail)
+        })
+    })
+
+    it(
+      'receives sign-in confirmation email',
+      () => {
+        let emailCode
+        return client.login({keys: true})
+          .then((res) => {
+            assert.ok(res)
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            emailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifyLoginEmail', 'email template name set')
+            assert.ok(emailCode, 'emailCode set')
+            assert.equal(emailData.cc.length, 1)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            return client.requestVerifyEmail()
+          })
+          .then((res) => {
+            assert.ok(res)
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            const anotherEmailCode = emailData['headers']['x-verify-code']
+            assert.equal(templateName, 'verifyLoginEmail', 'email template name set')
+            assert.equal(emailCode, anotherEmailCode, 'emailCodes match')
+            assert.equal(emailData.cc.length, 1)
+            assert.equal(emailData.cc[0].address, secondEmail)
+          })
+      }
+    )
+
+    it(
+      'receives sign-in unblock email',
+      () => {
+        let unblockCode
+        return client.sendUnblockCode(email)
+          .then(() => {
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            unblockCode = emailData['headers']['x-unblock-code']
+            assert.equal(templateName, 'unblockCodeEmail', 'email template name set')
+            assert.ok(unblockCode, 'code set')
+            assert.equal(emailData.cc.length, 1)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            return client.sendUnblockCode(email)
+          })
+          .then((res) => {
+            assert.ok(res)
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            const anotherUnblockCode = emailData['headers']['x-unblock-code']
+            assert.equal(templateName, 'unblockCodeEmail', 'email template name set')
+            assert.ok(unblockCode, anotherUnblockCode, 'unblock codes match set')
+            assert.equal(emailData.cc.length, 1)
+            assert.equal(emailData.cc[0].address, secondEmail)
+          })
+      }
+    )
+
+    it(
+      'receives password reset email',
+      () => {
+        return client.forgotPassword()
+          .then(() => {
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            assert.equal(templateName, 'recoveryEmail', 'email template name set')
+            assert.equal(emailData.cc.length, 1)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            return emailData.headers['x-recovery-code']
+          })
+      }
+    )
+  })
+
+  describe('should receive email notifications on all secondary emails', () => {
+    let secondEmail
+    let thirdEmail
+    beforeEach(() => {
+      secondEmail = server.uniqueEmail()
+      thirdEmail = server.uniqueEmail()
+      return client.createEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return server.mailbox.waitForEmail(secondEmail)
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name']
+          const emailCode = emailData['headers']['x-verify-code']
+          assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+          assert.ok(emailCode, 'emailCode set')
+          return client.verifyEmail(emailCode)
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return client.accountEmails()
+        })
+        .then((res) => {
+          assert.equal(res.length, 2, 'returns number of emails')
+          assert.equal(res[1].email, secondEmail, 'returns correct email')
+          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+          assert.equal(res[1].verified, true, 'returns correct verified')
+          return server.mailbox.waitForEmail(email)
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name']
+          assert.equal(templateName, 'postVerifySecondaryEmail', 'email template name set')
+
+          // Create a third email that is unverified. User should receive notifications
+          // on this email, even thought it is not been verified
+          return client.createEmail(thirdEmail)
+        })
+    })
+
+    it(
+      'receives change password notification',
+      () => {
+        return client.changePassword('password1', undefined)
+          .then((res) => {
+            assert.ok(res)
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            assert.equal(templateName, 'passwordChangedEmail', 'email template name set')
+            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            assert.equal(emailData.cc[1].address, thirdEmail)
+          })
+      }
+    )
+
+    it(
+      'receives password reset notification',
+      () => {
+        return client.forgotPassword()
+          .then(() => {
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            return emailData.headers['x-recovery-code']
+          })
+          .then((code) => {
+            return resetPassword(client, code, 'password1', undefined, undefined)
+          })
+          .then((res) => {
+            assert.ok(res)
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            assert.equal(templateName, 'passwordResetEmail', 'email template name set')
+            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            assert.equal(emailData.cc[1].address, thirdEmail)
+            return client.login({keys: true})
+          })
+          .then((x) => {
+            client = x
+            return client.accountEmails()
+          })
+          .then((res) => {
+            // Emails maintain there verification status through the password reset
+            assert.equal(res.length, 3, 'returns number of emails')
+            assert.equal(res[1].email, secondEmail, 'returns correct email')
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[1].verified, true, 'returns correct verified')
+            assert.equal(res[2].email, thirdEmail, 'returns correct email')
+            assert.equal(res[2].isPrimary, false, 'returns correct isPrimary')
+            assert.equal(res[2].verified, false, 'returns correct verified')
+          })
+      }
+    )
+
+    it(
+      'receives new device sign-in email',
+      () => {
+        config.signinConfirmation.skipForNewAccounts.enabled = true
+        return TestServer.start(config)
+          .then(s => {
+            server = s
+            email = server.uniqueEmail()
+            secondEmail = server.uniqueEmail()
+            thirdEmail = server.uniqueEmail()
+            return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+          })
+          .then((x) => {
+            client = x
+            return client.createEmail(secondEmail)
+          })
+          .then(() => {
+            return server.mailbox.waitForCode(secondEmail)
+          })
+          .then((code) => {
+            return client.verifyEmail(code)
+              .then(() => {
+                // Clear add secondary email notification
+                return server.mailbox.waitForEmail(email)
+              })
+          })
+          .then(() => {
+            // Create unverified email
+            return client.createEmail(thirdEmail)
+          })
+          .then(() => {
+            return client.login({keys: true})
+          })
+          .then(() => {
+            return server.mailbox.waitForEmail(email)
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name']
+            assert.equal(templateName, 'newDeviceLoginEmail', 'email template name set')
+            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc[0].address, secondEmail)
+            assert.equal(emailData.cc[1].address, thirdEmail)
+          })
+      }
+    )
+  })
+
+  after(() => {
+    return TestServer.stop(server)
+  })
+
+  function resetPassword(client, code, newPassword, headers, options) {
+    return client.verifyPasswordResetCode(code, headers, options)
+      .then(function () {
+        return client.resetPassword(newPassword, {}, options)
+      })
+  }
+})


### PR DESCRIPTION
This PR adds documentation and remote tests for additional emails per https://github.com/mozilla/fxa-auth-server/pull/1729#issuecomment-289026998, connects with https://github.com/mozilla/fxa-auth-server/issues/1672.

Please review [part 2](https://github.com/mozilla/fxa-auth-server/pull/1768) before this one.

@mozilla/fxa-devs r?