### PR TITLE
fix(logging): don't emit null or undefined uid on flow events

### DIFF
--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -153,10 +153,14 @@ module.exports = log => {
     return request.gatherMetricsContext({
       event: event,
       locale: marshallLocale(request),
-      uid: coalesceUid(optionalData, request),
       userAgent: request.headers['user-agent']
     }).then(data => {
       if (data.flow_id) {
+        const uid = coalesceUid(optionalData, request)
+        if (uid) {
+          data.uid = uid
+        }
+
         log.flowEvent(data)
 
         if (event === data.flowCompleteSignal) {
@@ -191,7 +195,7 @@ function marshallLocale (request) {
 
 function coalesceUid (data, request) {
   if (data && data.uid) {
-    return data.uid
+    return Buffer.isBuffer(data.uid) ? data.uid.toString('hex') : data.uid
   }
 
   return request.auth &&

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -220,6 +220,212 @@ describe('metrics/events', () => {
       })
   })
 
+  it('.emit with flow event and no session token', () => {
+    const time = Date.now()
+    sinon.stub(Date, 'now', () => time)
+    const metricsContext = mocks.mockMetricsContext()
+    const request = {
+      app: {
+        isLocaleAcceptable: false,
+        locale: 'en'
+      },
+      auth: null,
+      clearMetricsContext: metricsContext.clear,
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: time - 1000,
+          flowCompleteSignal: 'account.signed'
+        },
+        service: 'baz'
+      }
+    }
+    return events.emit.call(request, 'account.reminder')
+      .then(() => {
+        assert.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+        assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+        const args = log.flowEvent.args[0]
+        assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
+        assert.deepEqual(args[0], {
+          event: 'account.reminder',
+          flow_id: 'bar',
+          flow_time: 1000,
+          flowCompleteSignal: 'account.signed',
+          locale: 'en.default',
+          time,
+          userAgent: 'foo'
+        }, 'argument was event data')
+
+        assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      }).finally(() => {
+        metricsContext.gather.reset()
+        log.flowEvent.reset()
+        Date.now.restore()
+      })
+  })
+
+  it('.emit with flow event and string uid', () => {
+    const time = Date.now()
+    sinon.stub(Date, 'now', () => time)
+    const metricsContext = mocks.mockMetricsContext()
+    const request = {
+      app: {
+        isLocaleAcceptable: false,
+        locale: 'en'
+      },
+      auth: null,
+      clearMetricsContext: metricsContext.clear,
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: time - 1000,
+          flowCompleteSignal: 'account.signed'
+        },
+        service: 'baz'
+      }
+    }
+    return events.emit.call(request, 'account.reminder', { uid: 'deadbeef' })
+      .then(() => {
+        assert.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+        assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+        const args = log.flowEvent.args[0]
+        assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
+        assert.deepEqual(args[0], {
+          event: 'account.reminder',
+          flow_id: 'bar',
+          flow_time: 1000,
+          flowCompleteSignal: 'account.signed',
+          locale: 'en.default',
+          time,
+          uid: 'deadbeef',
+          userAgent: 'foo'
+        }, 'argument was event data')
+
+        assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      }).finally(() => {
+        metricsContext.gather.reset()
+        log.flowEvent.reset()
+        Date.now.restore()
+      })
+  })
+
+  it('.emit with flow event and buffer uid', () => {
+    const time = Date.now()
+    sinon.stub(Date, 'now', () => time)
+    const metricsContext = mocks.mockMetricsContext()
+    const request = {
+      app: {
+        isLocaleAcceptable: false,
+        locale: 'en'
+      },
+      auth: null,
+      clearMetricsContext: metricsContext.clear,
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: time - 1000,
+          flowCompleteSignal: 'account.signed'
+        },
+        service: 'baz'
+      }
+    }
+    return events.emit.call(request, 'account.reminder', { uid: Buffer.from('deadbeef', 'hex') })
+      .then(() => {
+        assert.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+        assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+        const args = log.flowEvent.args[0]
+        assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
+        assert.deepEqual(args[0], {
+          event: 'account.reminder',
+          flow_id: 'bar',
+          flow_time: 1000,
+          flowCompleteSignal: 'account.signed',
+          locale: 'en.default',
+          time,
+          uid: 'deadbeef',
+          userAgent: 'foo'
+        }, 'argument was event data')
+
+        assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      }).finally(() => {
+        metricsContext.gather.reset()
+        log.flowEvent.reset()
+        Date.now.restore()
+      })
+  })
+
+  it('.emit with flow event and null uid', () => {
+    const time = Date.now()
+    sinon.stub(Date, 'now', () => time)
+    const metricsContext = mocks.mockMetricsContext()
+    const request = {
+      app: {
+        isLocaleAcceptable: false,
+        locale: 'en'
+      },
+      auth: null,
+      clearMetricsContext: metricsContext.clear,
+      gatherMetricsContext: metricsContext.gather,
+      headers: {
+        'user-agent': 'foo'
+      },
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: time - 1000,
+          flowCompleteSignal: 'account.signed'
+        },
+        service: 'baz'
+      }
+    }
+    return events.emit.call(request, 'account.reminder', { uid: null })
+      .then(() => {
+        assert.equal(metricsContext.gather.callCount, 1, 'metricsContext.gather was called once')
+
+        assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
+        const args = log.flowEvent.args[0]
+        assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
+        assert.deepEqual(args[0], {
+          event: 'account.reminder',
+          flow_id: 'bar',
+          flow_time: 1000,
+          flowCompleteSignal: 'account.signed',
+          locale: 'en.default',
+          time,
+          userAgent: 'foo'
+        }, 'argument was event data')
+
+        assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
+        assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      }).finally(() => {
+        metricsContext.gather.reset()
+        log.flowEvent.reset()
+        Date.now.restore()
+      })
+  })
+
   it('.emit with flow event that matches complete signal', () => {
     const time = Date.now()
     sinon.stub(Date, 'now', () => time)
@@ -532,7 +738,6 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           locale: undefined,
           time,
-          uid: undefined,
           userAgent: 'foo'
         }, 'argument was event data')
 
@@ -576,7 +781,6 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           locale: undefined,
           time,
-          uid: undefined,
           userAgent: 'foo'
         }, 'argument was event data')
 
@@ -620,7 +824,6 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           locale: undefined,
           time,
-          uid: undefined,
           userAgent: 'foo'
         }, 'argument was event data')
 
@@ -664,7 +867,6 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           locale: undefined,
           time,
-          uid: undefined,
           userAgent: 'foo'
         }, 'argument was event data')
 

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -540,7 +540,6 @@ describe('/account/login', function () {
         flowCompleteSignal: 'account.signed',
         locale: 'en-US',
         time: now,
-        uid: undefined,
         userAgent: 'test user-agent'
       }, 'second flow event was correct')
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -325,7 +325,9 @@ function mockMetricsContext (methods) {
       if (this.payload && this.payload.metricsContext) {
         this.payload.metricsContext.flowCompleteSignal = flowCompleteSignal
       }
-    })
+    }),
+
+    validate: methods.validate || sinon.spy(() => true)
   })
 }
 
@@ -368,6 +370,7 @@ function mockRequest (data) {
     headers: data.headers || {
       'user-agent': 'test user-agent'
     },
+    path: data.path,
     payload: data.payload,
     query: data.query,
     setMetricsFlowCompleteSignal: metricsContext.setFlowCompleteSignal,


### PR DESCRIPTION
Fixes [bug 1349830](https://bugzilla.mozilla.org/show_bug.cgi?id=1349830).

On requests that don't have a session token, flow events were being emitted with `uid: null`. In the metrics pipeline, this gets hashed to a very high value. In the import scripts we use `MAX(uid)` when updating `flow_metadata`, which means only uids that hash to a value larger than hashed null show up in the data. Everything else appears to be associated with the hashed null "user".

This fixes that by ensuring we don't emit uids with falsey values. I also took the precaution of calling `toString` predicated on the result of `Buffer.isBuffer(data.uid)`. There wasn't any direct evidence that this is causing us a problem at the moment, but I thought it was worth tightening the function up while I was in there.

@mozilla/fxa-devs r?