### PR TITLE
feat(sms): Mock out Nexmo for functional tests.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -623,6 +623,12 @@ var conf = convict({
       format: Boolean,
       env: 'SMS_ENABLED'
     },
+    useMock: {
+      doc: 'Use a mock SMS provider implementation, for functional testing',
+      default: false,
+      format: Boolean,
+      env: 'SMS_USE_MOCK'
+    },
     apiKey: {
       doc: 'API key for the SMS service',
       default: 'YOU MUST CHANGE ME',

--- a/lib/mock-nexmo.js
+++ b/lib/mock-nexmo.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+/**
+ * Mock out Nexmo for functional tests. `checkBalance` always
+ * returns `balanceThreshold`, and `sendSms` always pretends
+ * the message is sent successfully.
+ */
+
+function MockNexmo(log, balanceThreshold) {
+  return {
+    account: {
+      /**
+       * Always returns the `balanceThreshold`
+       */
+      checkBalance: function checkBalance (callback) {
+        log.info({ op: 'sms.balance.mock' })
+
+        callback(null, {
+          value: balanceThreshold
+        })
+      }
+    },
+    message: {
+      /**
+       * Drop message on the ground, call callback with `0` (send-OK) status.
+       */
+      sendSms: function sendSms (senderId, phoneNumber, message, options, callback) {
+        // this is the same as how the Nexmo version works.
+        if (! callback) {
+          callback = options
+          options = {}
+        }
+
+        log.info({ op: 'sms.send.mock' })
+
+        callback(null, {
+          messages: [{ status: '0' }]
+        })
+      }
+    }
+  }
+}
+
+module.exports = MockNexmo

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -5,6 +5,7 @@
 'use strict'
 
 var Nexmo = require('nexmo')
+var MockNexmo = require('../mock-nexmo')
 var P = require('bluebird')
 var error = require('../error')
 
@@ -13,10 +14,11 @@ var TEMPLATE_NAMES = new Map([
 ])
 
 module.exports = function (log, translator, templates, smsConfig) {
-  var nexmo = new Nexmo({
+  var nexmo = smsConfig.useMock ? new MockNexmo(log, smsConfig.balanceThreshold) : new Nexmo({
     apiKey: smsConfig.apiKey,
     apiSecret: smsConfig.apiSecret
   })
+
   var sendSms = promisify('sendSms', nexmo.message)
   var checkBalance = promisify('checkBalance', nexmo.account)
   var NEXMO_ERRORS = new Map([

--- a/test/local/lib/mock-nexmo.js
+++ b/test/local/lib/mock-nexmo.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const MockNexmo = require('../../../lib/mock-nexmo')
+const sinon = require('sinon')
+
+const BALANCE_THRESHOLD = 1.5
+
+describe('mock-nexmo', () => {
+  let log
+  let mockNexmo
+
+  before(() => {
+    log = {
+      info: sinon.spy()
+    }
+    mockNexmo = new MockNexmo(log, BALANCE_THRESHOLD)
+  })
+
+  afterEach(() => {
+    log.info.reset()
+  })
+
+  it('constructor creates an instance', () => {
+    assert.ok(mockNexmo)
+  })
+
+  describe('account.checkBalance', () => {
+    it('returns the balance threshold', (done) => {
+      mockNexmo.account.checkBalance((err, resp) => {
+        assert.equal(resp.value, BALANCE_THRESHOLD)
+        assert.equal(log.info.callCount, 1)
+
+        done()
+      })
+    })
+  })
+
+  describe('message.sendSms', () => {
+    it('returns status: 0 with options, callback', (done) => {
+      mockNexmo.message.sendSms('senderid', '+019999999999', 'message', {}, (err, resp) => {
+        assert.strictEqual(err, null)
+        assert.equal(resp.messages.length, 1)
+        assert.strictEqual(resp.messages[0].status, '0')
+        assert.equal(log.info.callCount, 1)
+
+        done()
+      })
+    })
+
+    it('returns status: 0 without options, only callback', (done) => {
+      mockNexmo.message.sendSms('senderid', '+019999999999', 'message', (err, resp) => {
+        assert.strictEqual(err, null)
+        assert.equal(resp.messages.length, 1)
+        assert.strictEqual(resp.messages[0].status, '0')
+        assert.equal(log.info.callCount, 1)
+
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
@philbooth - before I get too far down a rabbit hole, mind seeing what you think?

The goal is for functional tests to be able to run against fxa-ci w/o actually sending SMS messages and costing Mozilla money for every test, as well as to reduce the number of places where real Nexmo creds are needed.

If this were to land, I imagine a different config value name should be used, as well as extracting the MockNexmo into its own module.

