### PR TITLE
fix(scripts): fix the broken sms scripts

### DIFF
--- a/scripts/sms/balance.js
+++ b/scripts/sms/balance.js
@@ -17,7 +17,7 @@ const log = require('../../lib/log')(config.log.level, 'sms-balance')
 
 require('../../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
   .then(translator => {
-    return require('../../lib/senders')(log, config, translator)
+    return require('../../lib/senders')(log, config, {}, null, translator)
   })
   .then(senders => {
     return senders.sms.balance()

--- a/scripts/sms/send.js
+++ b/scripts/sms/send.js
@@ -18,7 +18,7 @@ const log = require('../../lib/log')(config.log.level, 'send-sms')
 
 require('../../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n.defaultLanguage)
   .then(translator => {
-    return require('../../lib/senders')(log, config, translator)
+    return require('../../lib/senders')(log, config, {}, null, translator)
   })
   .then(senders => {
     return senders.sms.send.apply(null, args)


### PR DESCRIPTION
The interface for `lib/senders` changed in 8ea58bf / #1684 but these scripts weren't updated to match. This fixes them.

@mozilla/fxa-devs r?