### PR TITLE
fix(script): fix broken write email to disk script

### DIFF
--- a/scripts/write-emails-to-disk.js
+++ b/scripts/write-emails-to-disk.js
@@ -62,7 +62,7 @@ require('../lib/senders/translator')(config.i18n.supportedLanguages, config.i18n
     return createSenders(log, config, error, db, translator, mailSender)
   })
   .then((senders) => {
-    const mailer = senders.email
+    const mailer = senders.email._ungatedMailer
     checkMessageType(mailer, messageToSend)
 
     ensureTargetDirectoryExists()


### PR DESCRIPTION
This PR fixes the write email to disk script. It uses the correct mailer `_ungatedMailer` to create emails.

@mozilla/fxa-devs r?