### PR TITLE
fix(sms): propagate countryCode through our fxa-geodb wrapper

### DIFF
--- a/lib/geodb.js
+++ b/lib/geodb.js
@@ -46,6 +46,7 @@ module.exports = function (log) {
           location: {
             city: location.city,
             country: location.country,
+            countryCode: location.countryCode,
             state: location.state,
             stateCode: location.stateCode
           },

--- a/test/local/lib/geodb.js
+++ b/test/local/lib/geodb.js
@@ -31,6 +31,7 @@ describe('geodb', () => {
       .then(function (geoData) {
         assert.equal(geoData.location.city, 'Mountain View')
         assert.equal(geoData.location.country, 'United States')
+        assert.equal(geoData.location.countryCode, 'US')
         assert.equal(geoData.timeZone, 'America/Los_Angeles')
         assert.equal(geoData.location.state, 'California')
         assert.equal(geoData.location.stateCode, 'CA')


### PR DESCRIPTION
Absent-mindedly, I failed to return `countryCode` from `lib/geodb` and stupidly, I failed to spot the problem because there were no remote tests for the SMS endpoints.

This PR uplifts the `countryCode` change from #1766 to `train-83` because I suspect it is causing problems there. Specifically, I presume that [this check](https://github.com/mozilla/fxa-auth-server/blob/train-83/lib/routes/sms.js#L122) always fails for obvious reasons:

```js
return REGIONS.has(result.location.countryCode)
```

@shane-tomlinson, am I right in thinking this would mean we never actually enable SMS on the front end?

@mozilla/fxa-devs r?