### PR TITLE
feat(metrics): emit a flow event for the sms region

### DIFF
--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -61,6 +61,7 @@ in a sign-in or sign-up flow:
 |`email.verification.resent`|A sign-up verification email has been re-sent to a user.|
 |`email.verify_code.clicked`|A user has clicked on the link in a confirmation/verification email.|
 |`email.${templateName}.delivered`|An email was delivered to a user.|
+|`sms.region.${region}`|A user has tried to send SMS to `region`.|
 |`sms.${templateName}.sent`|An SMS message has been sent to a user's phone.|
 |`account.confirmed`|Sign-in to an existing account has been confirmed via email.|
 |`account.reminder`|A new account has been verified via a reminder email.|
@@ -211,6 +212,11 @@ on a different device
 in the preceding five days.
 
 ## Significant changes
+
+### Train 84
+
+* [The `sms.region.${region}` event
+  was implemented](https://github.com/mozilla/fxa-auth-server/pull/1783).
 
 ### Train 83
 

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -71,6 +71,8 @@ module.exports = (log, isA, error, config, customs, sms) => {
           const region = phoneNumberUtil.getRegionCodeForNumber(parsedPhoneNumber)
           const senderId = SENDER_IDS[region]
 
+          request.emitMetricsEvent(`sms.region.${region}`)
+
           if (! senderId) {
             throw error.invalidRegion(region)
           }

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -104,9 +104,14 @@ describe('/sms', () => {
       })
 
       it('called log.flowEvent correctly', () => {
-        assert.equal(log.flowEvent.callCount, 1)
+        assert.equal(log.flowEvent.callCount, 2)
 
-        const args = log.flowEvent.args[0]
+        let args = log.flowEvent.args[0]
+        assert.equal(args.length, 1)
+        assert.equal(args[0].event, 'sms.region.US')
+        assert.equal(args[0].flow_id, request.payload.metricsContext.flowId)
+
+        args = log.flowEvent.args[1]
         assert.equal(args.length, 1)
         assert.equal(args[0].event, 'sms.42.sent')
         assert.equal(args[0].flow_id, request.payload.metricsContext.flowId)
@@ -134,8 +139,9 @@ describe('/sms', () => {
         assert.equal(args[1], '16474909977')
       })
 
-      it('called log.flowEvent once', () => {
-        assert.equal(log.flowEvent.callCount, 1)
+      it('called log.flowEvent correctly', () => {
+        assert.equal(log.flowEvent.callCount, 2)
+        assert.equal(log.flowEvent.args[0][0].event, 'sms.region.CA')
       })
     })
 
@@ -160,8 +166,9 @@ describe('/sms', () => {
         assert.equal(args[1], 'Firefox')
       })
 
-      it('called log.flowEvent once', () => {
-        assert.equal(log.flowEvent.callCount, 1)
+      it('called log.flowEvent correctly', () => {
+        assert.equal(log.flowEvent.callCount, 2)
+        assert.equal(log.flowEvent.args[0][0].event, 'sms.region.GB')
       })
     })
 
@@ -222,8 +229,9 @@ describe('/sms', () => {
         assert.equal(sms.send.callCount, 0)
       })
 
-      it('did not call log.flowEvent', () => {
-        assert.equal(log.flowEvent.callCount, 0)
+      it('called log.flowEvent correctly', () => {
+        assert.equal(log.flowEvent.callCount, 1)
+        assert.equal(log.flowEvent.args[0][0].event, 'sms.region.TW')
       })
 
       it('threw the correct error data', () => {
@@ -259,8 +267,8 @@ describe('/sms', () => {
       assert.equal(sms.send.callCount, 1)
     })
 
-    it('did not call log.flowEvent', () => {
-      assert.equal(log.flowEvent.callCount, 0)
+    it('called log.flowEvent once', () => {
+      assert.equal(log.flowEvent.callCount, 1)
     })
 
     it('threw the correct error data', () => {


### PR DESCRIPTION
This occurred to me as something we probably want to keep track of. Which regions are we sending SMS to?

@mozilla/fxa-devs r?