### PR TITLE
fix(config): Graduate security history and ip profiling features

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -527,17 +527,7 @@ var conf = convict({
     }
   },
   securityHistory: {
-    enabled: {
-      doc: 'enable security history',
-      default: true,
-      env: 'SECURITY_HISTORY_ENABLED'
-    },
     ipProfiling: {
-      enabled: {
-        doc: 'enable ip profiling, bypass sign-in confirmation if login is coming from a previously verified ip address.',
-        default: true,
-        env: 'IP_PROFILING_ENABLED'
-      },
       allowedRecency: {
         doc: 'Length of time since previously verified event to allow skipping confirmation',
         default: '72 hours',

--- a/lib/features.js
+++ b/lib/features.js
@@ -8,7 +8,6 @@ const crypto = require('crypto')
 
 module.exports = config => {
   const lastAccessTimeUpdates = config.lastAccessTimeUpdates
-  const securityHistory = config.securityHistory
 
   return {
     /**
@@ -23,31 +22,6 @@ module.exports = config => {
         isSampledUser(lastAccessTimeUpdates.sampleRate, uid, 'lastAccessTimeUpdates') ||
         lastAccessTimeUpdates.enabledEmailAddresses.test(email)
       )
-    },
-
-    /**
-     * Return whether tracking of security history events is enabled.
-     *
-     * @returns {boolean}
-     */
-    isSecurityHistoryTrackingEnabled() {
-      return securityHistory.enabled
-    },
-
-    /**
-     * Return whether or not we can bypass sign-in confirmation based
-     * on previously seen security event history.
-     *
-     * @returns {boolean}
-     */
-    isSecurityHistoryProfilingEnabled() {
-      if (! securityHistory.enabled) {
-        return false
-      }
-      if (! securityHistory.ipProfiling || ! securityHistory.ipProfiling.enabled) {
-        return false
-      }
-      return true
     },
 
     /**

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -57,7 +57,6 @@ module.exports = (
     supportedLanguages: config.i18n.supportedLanguages,
     defaultLanguage: config.i18n.defaultLanguage
   })
-  const features = require('../features')(config)
 
   const PUSH_SERVER_REGEX = config.push && config.push.allowedServerRegex
   const unblockCodeLifetime = config.signinUnblock && config.signinUnblock.codeLifetime || 0
@@ -352,15 +351,12 @@ module.exports = (
         }
 
         function recordSecurityEvent() {
-          if (features.isSecurityHistoryTrackingEnabled()) {
-            // don't block response recording db event
-            db.securityEvent({
-              name: 'account.create',
-              uid: account.uid,
-              ipAddr: request.app.clientAddress,
-              tokenId: sessionToken.tokenId
-            })
-          }
+          db.securityEvent({
+            name: 'account.create',
+            uid: account.uid,
+            ipAddr: request.app.clientAddress,
+            tokenId: sessionToken.tokenId
+          })
         }
 
         function createResponse () {
@@ -565,9 +561,6 @@ module.exports = (
         }
 
         function checkSecurityHistory () {
-          if (! features.isSecurityHistoryTrackingEnabled()) {
-            return
-          }
           return db.securityEvents({
             uid: emailRecord.uid,
             ipAddr: request.app.clientAddress
@@ -701,15 +694,13 @@ module.exports = (
           // If they're logging in from an IP address on which they recently did
           // another, successfully-verified login, then we can consider this one
           // verified as well without going through the loop again.
-          if (features.isSecurityHistoryProfilingEnabled()) {
-            const allowedRecency = config.securityHistory.ipProfiling.allowedRecency || 0
-            if (securityEventVerified && securityEventRecency < allowedRecency) {
-              log.info({
-                op: 'Account.ipprofiling.seenAddress',
-                uid: account.uid.toString('hex')
-              })
-              return true
-            }
+          const allowedRecency = config.securityHistory.ipProfiling.allowedRecency || 0
+          if (securityEventVerified && securityEventRecency < allowedRecency) {
+            log.info({
+              op: 'Account.ipprofiling.seenAddress',
+              uid: account.uid.toString('hex')
+            })
+            return true
           }
 
           // If the account was recently created, don't make the user
@@ -958,15 +949,12 @@ module.exports = (
         }
 
         function recordSecurityEvent() {
-          if (features.isSecurityHistoryTrackingEnabled()) {
-            // don't block response recording db event
-            db.securityEvent({
-              name: 'account.login',
-              uid: emailRecord.uid,
-              ipAddr: request.app.clientAddress,
-              tokenId: sessionToken && sessionToken.tokenId
-            })
-          }
+          db.securityEvent({
+            name: 'account.login',
+            uid: emailRecord.uid,
+            ipAddr: request.app.clientAddress,
+            tokenId: sessionToken && sessionToken.tokenId
+          })
         }
 
         function createResponse () {
@@ -2191,15 +2179,12 @@ module.exports = (
         }
 
         function recordSecurityEvent() {
-          if (features.isSecurityHistoryTrackingEnabled()) {
-             // don't block response recording db event
-            db.securityEvent({
-              name: 'account.reset',
-              uid: account.uid,
-              ipAddr: request.app.clientAddress,
-              tokenId: sessionToken && sessionToken.tokenId
-            })
-          }
+          db.securityEvent({
+            name: 'account.reset',
+            uid: account.uid,
+            ipAddr: request.app.clientAddress,
+            tokenId: sessionToken && sessionToken.tokenId
+          })
         }
 
         function createResponse () {

--- a/test/local/lib/features.js
+++ b/test/local/lib/features.js
@@ -33,11 +33,9 @@ describe('features', () => {
     'interface is correct',
     () => {
       assert.equal(typeof features, 'object', 'object type should be exported')
-      assert.equal(Object.keys(features).length, 4, 'object should have four properties')
+      assert.equal(Object.keys(features).length, 2, 'object should have four properties')
       assert.equal(typeof features.isSampledUser, 'function', 'isSampledUser should be function')
       assert.equal(typeof features.isLastAccessTimeEnabledForUser, 'function', 'isLastAccessTimeEnabledForUser should be function')
-      assert.equal(typeof features.isSecurityHistoryTrackingEnabled, 'function', 'isSecurityHistoryTrackingEnabled should be function')
-      assert.equal(typeof features.isSecurityHistoryProfilingEnabled, 'function', 'isSecurityHistoryProfilingEnabled should be function')
 
       assert.equal(crypto.createHash.callCount, 1, 'crypto.createHash should have been called once on require')
       let args = crypto.createHash.args[0]
@@ -178,40 +176,6 @@ describe('features', () => {
       config.lastAccessTimeUpdates.sampleRate = 0.03
       config.lastAccessTimeUpdates.enabledEmailAddresses = /.+@mozilla\.com$/
       assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when feature is disabled')
-    }
-  )
-
-  it(
-    'isSecurityHistoryTrackingEnabled',
-    () => {
-      config.securityHistory.enabled = true
-      assert.equal(features.isSecurityHistoryTrackingEnabled(), true, 'should return true when enabled in config')
-
-      config.securityHistory.enabled = false
-      assert.equal(features.isSecurityHistoryTrackingEnabled(), false, 'should return false when disabled in config')
-    }
-  )
-
-  it(
-    'isSecurityHistoryProfilingEnabled',
-    () => {
-      config.securityHistory.enabled = true
-      config.securityHistory.ipProfiling = {
-        enabled: true
-      }
-      assert.equal(features.isSecurityHistoryProfilingEnabled(), true, 'should return true when everything is enabled in config')
-
-      config.securityHistory.enabled = true
-      config.securityHistory.ipProfiling = {
-        enabled: false
-      }
-      assert.equal(features.isSecurityHistoryProfilingEnabled(), false, 'should return false when profiling is disabled in config')
-
-      config.securityHistory.enabled = false
-      config.securityHistory.ipProfiling = {
-        enabled: true
-      }
-      assert.equal(features.isSecurityHistoryProfilingEnabled(), false, 'should return false when tracking is disabled in config')
     }
   )
 })

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -355,7 +355,7 @@ describe('/account/login', function () {
   var config = {
     newLoginNotificationEnabled: true,
     securityHistory: {
-      enabled: true
+      ipProfiling: {}
     },
     signinConfirmation: {},
     signinUnblock: {

--- a/test/remote/account_reset_tests.js
+++ b/test/remote/account_reset_tests.js
@@ -82,7 +82,7 @@ describe('remote account reset', function() {
         .then(
           function () {
             // make sure we can still login after password reset
-            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            return client.login(email, newPassword, {keys:true})
           }
         )
         .then(
@@ -163,7 +163,7 @@ describe('remote account reset', function() {
         .then(
           function () {
             // make sure we can still login after password reset
-            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            return client.login(email, newPassword, {keys:true})
           }
         )
         .then(

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -24,8 +24,7 @@ describe('remote account signin verification', function() {
   this.timeout(30000)
   let server
   before(() => {
-    config.securityHistory.ipProfiling.enabled = false
-
+    config.securityHistory.ipProfiling.allowedRecency = 0
     return TestServer.start(config)
       .then(s => {
         server = s

--- a/test/remote/flow_tests.js
+++ b/test/remote/flow_tests.js
@@ -80,7 +80,7 @@ describe('remote flow', function() {
         'e': '65537'
       }
       var duration = 1000 * 60 * 60 * 24 // 24 hours
-      return Client.loginAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+      return Client.login(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -24,8 +24,7 @@ describe('remote password change', function() {
   this.timeout(15000)
   let server
   before(() => {
-    config.securityHistory.ipProfiling.enabled = false
-
+    config.securityHistory.ipProfiling.allowedRecency = 0
     return TestServer.start(config)
       .then(s => {
         server = s

--- a/test/remote/recovery_email_resend_code_tests.js
+++ b/test/remote/recovery_email_resend_code_tests.js
@@ -14,7 +14,7 @@ describe('remote recovery email resend code', function() {
   this.timeout(15000)
   let server
   before(() => {
-    config.securityHistory.ipProfiling.enabled = false
+    config.securityHistory.ipProfiling.allowedRecency = 0
 
     return TestServer.start(config)
       .then(s => {

--- a/test/remote/verifier_upgrade_tests.js
+++ b/test/remote/verifier_upgrade_tests.js
@@ -29,7 +29,7 @@ describe('remote verifier upgrade', function() {
 
   before(() => {
     config.verifierVersion = 0
-    config.securityHistory.ipProfiling.enabled = true
+    config.securityHistory.ipProfiling.allowedRecency = 0
   })
 
   it(
@@ -88,11 +88,6 @@ describe('remote verifier upgrade', function() {
               .then(
                 function (x) {
                   client = x
-                  return client.keys()
-                }
-              )
-              .then(
-                function () {
                   return client.changePassword(password)
                 }
               )


### PR DESCRIPTION
This PR graduates 🎓 the security history and ip profiling features. This removes the `enabled` config values for them and all the corresponding checks in code. There are some whitespace changes so it might be a little better to review with [?w=1](https://github.com/mozilla/fxa-auth-server/commit/3ff423d355511a9e85b4ce8b83f80f006a464d06?w=1).

Fixes https://github.com/mozilla/fxa-auth-server/issues/1695

@mozilla/fxa-devs r?