### PR TITLE
fix(server): recognise the new iOS client UA string

### DIFF
--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -501,7 +501,7 @@ describe('userAgent', () => {
   )
 
   it(
-    'recognises Firefox-iOS user agents',
+    'recognises old Firefox-iOS user agents',
     () => {
       parserResult = {
         ua: {
@@ -530,7 +530,7 @@ describe('userAgent', () => {
   )
 
   it(
-    'preserves device type on Firefox-iOS user agents',
+    'preserves device type on old Firefox-iOS user agents',
     () => {
       parserResult = {
         ua: {
@@ -551,6 +551,36 @@ describe('userAgent', () => {
       assert.equal(result.uaBrowserVersion, '6.0')
       assert.equal(result.uaOS, 'iOS')
       assert.equal(result.uaDeviceType, 'tablet')
+
+      assert.equal(log.info.callCount, 0)
+
+      uaParser.parse.reset()
+    }
+  )
+
+  it(
+    'recognises new Firefox-iOS user agents',
+    () => {
+      parserResult = {
+        ua: {
+          family: 'Other'
+        },
+        os: {
+          family: 'Other'
+        },
+        device: {
+          family: 'Other'
+        }
+      }
+      const context = {}
+      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Firefox)'
+      const result = userAgent.call(context, userAgentString, log)
+
+      assert.equal(result.uaBrowser, 'Firefox')
+      assert.equal(result.uaBrowserVersion, '6.0')
+      assert.equal(result.uaOS, 'iOS')
+      assert.equal(result.uaOSVersion, '10.3')
+      assert.equal(result.uaDeviceType, 'mobile')
 
       assert.equal(log.info.callCount, 0)
 


### PR DESCRIPTION
Related to #1781.

Updates our user-agent parser to properly handle the new iOS user-agent strings from mozilla-mobile/firefox-ios#2556 / [bug 1350146](https://bugzilla.mozilla.org/show_bug.cgi?id=1350146). Fwiw the old regex still matches them, but it lumps the build number together with the browser version and it doesn't look for the extra OS version info that was added.

This doesn't fix the issue for us, as we're still awaiting an equivalent change to the Android user-agent string and there are also changes to be made to the metric pipeline scripts in `puppet-config`.

@mozilla/fxa-devs r?

/cc @sleroux, this is intended to match the changes from your PR, if have a moment to check that the regex appears to be sane that would be much appreciated, thanks!