### PR TITLE
fix(tests): add remote tests for POST /sms

### DIFF
--- a/test/client/api.js
+++ b/test/client/api.js
@@ -591,6 +591,16 @@ module.exports = config => {
       )
   }
 
+  ClientApi.prototype.smsSend = function (sessionTokenHex, phoneNumber, messageId) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(token => this.doRequest(
+        'POST',
+        `${this.baseURL}/sms`,
+        token,
+        { phoneNumber, messageId }
+      ))
+  }
+
   ClientApi.prototype.smsStatus = function (sessionTokenHex, country, clientIpAddress) {
     return tokens.SessionToken.fromHex(sessionTokenHex)
       .then(token => this.doRequest(

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -442,6 +442,10 @@ module.exports = config => {
       )
   }
 
+  Client.prototype.smsSend = function (phoneNumber, messageId) {
+    return this.api.smsSend(this.sessionToken, phoneNumber, messageId)
+  }
+
   Client.prototype.smsStatus = function (country, clientIpAddress) {
     return this.api.smsStatus(this.sessionToken, country, clientIpAddress)
   }


### PR DESCRIPTION
Fixes #1774, adding remote tests of the `POST /sms` endpoint. It uses Shane's `useMock` flag because I figure we don't want to spend cash every time we run the tests.

@mozilla/fxa-devs r?