### PR TITLE
chore(tests): move test/local/lib/* up to test/local/

### DIFF
--- a/test/local/bounces.js
+++ b/test/local/bounces.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const ROOT_DIR = '../../..'
+const ROOT_DIR = '../..'
 
 const assert = require('insist')
 const config = require(`${ROOT_DIR}/config`).getProperties()

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const ROOT_DIR = '../..'
+
 const assert = require('insist')
 const log = {
   trace: () => {},
@@ -9,11 +11,11 @@ const log = {
   flowEvent: () => {},
   error() {}
 }
-const mocks = require('../../mocks')
-var error = require('../../../lib/error.js')
+const mocks = require('../mocks')
+const error = require(`${ROOT_DIR}/lib/error.js`)
 var nock = require('nock')
 
-var Customs = require('../../../lib/customs.js')(log, error)
+const Customs = require(`${ROOT_DIR}/lib/customs.js`)(log, error)
 
 var CUSTOMS_URL_REAL = 'http://localhost:7000'
 var CUSTOMS_URL_MISSING = 'http://localhost:7001'

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -7,9 +7,9 @@
 const assert = require('insist')
 var uuid = require('uuid')
 var crypto = require('crypto')
-var mocks = require('../../mocks')
+const mocks = require('../mocks')
 
-var modulePath = '../../../lib/devices'
+const modulePath = '../../lib/devices'
 
 describe('devices', () => {
   it('should be an exported function', () => {

--- a/test/local/error.js
+++ b/test/local/error.js
@@ -4,7 +4,7 @@
 
 const assert = require('insist')
 var messages = require('joi/lib/language')
-var AppError = require('../../../lib/error')
+const AppError = require('../../lib/error')
 
 describe('AppErrors', () => {
 

--- a/test/local/features.js
+++ b/test/local/features.js
@@ -24,7 +24,7 @@ const config = {
   securityHistory: {}
 }
 
-const features = proxyquire('../../../lib/features', {
+const features = proxyquire('../../lib/features', {
   crypto: crypto
 })(config)
 

--- a/test/local/geodb.js
+++ b/test/local/geodb.js
@@ -6,8 +6,8 @@
 
 const assert = require('insist')
 const proxyquire = require('proxyquire')
-const mockLog = require('../../mocks').mockLog
-const modulePath = '../../../lib/geodb'
+const mockLog = require('../mocks').mockLog
+const modulePath = '../../lib/geodb'
 
 describe('geodb', () => {
   it(

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -28,7 +28,7 @@ mocks.mozlog.config = sinon.spy()
 mocks['./metrics/statsd'] = function () {
   return statsd
 }
-var log = proxyquire('../../../lib/log', mocks)('foo', 'bar')
+const log = proxyquire('../../lib/log', mocks)('foo', 'bar')
 
 const emitRouteFlowEvent = sinon.spy()
 

--- a/test/local/mailer_locales.js
+++ b/test/local/mailer_locales.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const ROOT_DIR = '../../..'
+const ROOT_DIR = '../..'
 
 const assert = require('insist')
 const config = require(`${ROOT_DIR}/config/index`).getProperties()

--- a/test/local/mock-nexmo.js
+++ b/test/local/mock-nexmo.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const assert = require('insist')
-const MockNexmo = require('../../../lib/mock-nexmo')
+const MockNexmo = require('../../lib/mock-nexmo')
 const sinon = require('sinon')
 
 const BALANCE_THRESHOLD = 1.5

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -4,6 +4,8 @@
 
 'use strict'
 
+const ROOT_DIR = '../..'
+
 const assert = require('insist')
 var proxyquire = require('proxyquire')
 var sinon = require('sinon')
@@ -11,14 +13,14 @@ var ajv = require('ajv')()
 var fs = require('fs')
 var path = require('path')
 
-var P = require('../../../lib/promise')
-var mockLog = require('../../mocks').mockLog
+const P = require(`${ROOT_DIR}/lib/promise`)
+const mockLog = require('../mocks').mockLog
 var mockUid = Buffer.from('foo')
 var mockConfig = {}
 
-var PUSH_PAYLOADS_SCHEMA_PATH = '../../../docs/pushpayloads.schema.json'
+const PUSH_PAYLOADS_SCHEMA_PATH = `${ROOT_DIR}/docs/pushpayloads.schema.json`
 var TTL = '42'
-const pushModulePath = '../../../lib/push'
+const pushModulePath = `${ROOT_DIR}/lib/push`
 
 var mockDbEmpty = {
   devices: function () {
@@ -591,7 +593,7 @@ describe('push', () => {
 
       var mockConfig = {
         publicUrl: 'https://example.com',
-        vapidKeysFile: path.join(__dirname, '../../', 'config', 'mock-vapid-keys.json')
+        vapidKeysFile: path.join(__dirname, '../config/mock-vapid-keys.json')
       }
 
       var mocks = {

--- a/test/local/senders/db_connect.js
+++ b/test/local/senders/db_connect.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ROOT_DIR = '../../../..'
+const ROOT_DIR = '../../..'
 
 const assert = require('insist')
 var P = require('bluebird')

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const ROOT_DIR = '../../../..'
+const ROOT_DIR = '../../..'
 
 const assert = require('insist')
 var extend = require('util')._extend

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const ROOT_DIR = '../../../..'
+const ROOT_DIR = '../../..'
 
 const assert = require('insist')
 const config = require(`${ROOT_DIR}/config`).getProperties()

--- a/test/local/senders/legacy_log.js
+++ b/test/local/senders/legacy_log.js
@@ -4,7 +4,7 @@
 
 const assert = require('insist')
 var sinon = require('sinon')
-var legacyLog = require('../../../../lib/senders/legacy_log')
+const legacyLog = require('../../../lib/senders/legacy_log')
 
 var spyLog = {
   critical: sinon.spy(),

--- a/test/local/senders/pool.js
+++ b/test/local/senders/pool.js
@@ -239,7 +239,7 @@ it(
 
 function setup () {
   poolee = sinon.createStubInstance(require('poolee'))
-  Pool = proxyquire('../../../../lib/senders/pool', {
+  Pool = proxyquire('../../../lib/senders/pool', {
     poolee: function () {
       return poolee
     }

--- a/test/local/senders/reminder.js
+++ b/test/local/senders/reminder.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ROOT_DIR = '../../../../'
+const ROOT_DIR = '../../../'
 
 const assert = require('insist')
 var sinon = require('sinon')

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -4,6 +4,8 @@
 
 'use strict'
 
+const ROOT_DIR = '../../..'
+
 const assert = require('insist')
 const P = require('bluebird')
 const proxyquire = require('proxyquire')
@@ -54,10 +56,10 @@ describe('lib/senders/sms:', () => {
 
   before(() => {
     return P.all([
-      require('../../../../lib/senders/translator')(['en'], 'en'),
-      require('../../../../lib/senders/templates')()
+      require(`${ROOT_DIR}/lib/senders/translator`)(['en'], 'en'),
+      require(`${ROOT_DIR}/lib/senders/templates`)()
     ]).spread((translator, templates) => {
-      sms = proxyquire('../../../../lib/senders/sms', {
+      sms = proxyquire(`${ROOT_DIR}/lib/senders/sms`, {
         nexmo: Nexmo
       })(log, translator, templates, {
         apiKey: 'foo',
@@ -222,10 +224,10 @@ describe('lib/senders/sms:', () => {
 
   it('uses the NexmoMock constructor if `useMock: true`', () => {
     return P.all([
-      require('../../../../lib/senders/translator')(['en'], 'en'),
-      require('../../../../lib/senders/templates')()
+      require(`${ROOT_DIR}/lib/senders/translator`)(['en'], 'en'),
+      require(`${ROOT_DIR}/lib/senders/templates`)()
     ]).spread((translator, templates) => {
-      sms = proxyquire('../../../../lib/senders/sms', {
+      sms = proxyquire(`${ROOT_DIR}/lib/senders/sms`, {
         nexmo: Nexmo,
         '../mock-nexmo': MockNexmo
       })(log, translator, templates, {

--- a/test/local/senders/translator.js
+++ b/test/local/senders/translator.js
@@ -6,7 +6,7 @@
 
 const assert = require('insist')
 
-require('../../../../lib/senders/translator')(['en', 'pt_br', 'DE', 'ES_AR', 'ES_cl'], 'en')
+require('../../../lib/senders/translator')(['en', 'pt_br', 'DE', 'ES_AR', 'ES_cl'], 'en')
 .then(translator => {
   it('returns the correct interface', () => {
     assert.equal(typeof translator, 'object')

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -4,12 +4,14 @@
 
 'use strict'
 
+const ROOT_DIR = '../..'
+
 const assert = require('insist')
 const EndpointError = require('poolee/lib/error')(require('util').inherits)
-const error = require('../../../lib/error')
+const error = require(`${ROOT_DIR}/lib/error`)
 const hapi = require('hapi')
-const mocks = require('../../mocks')
-const server = require('../../../lib/server')
+const mocks = require('../mocks')
+const server = require(`${ROOT_DIR}/lib/server`)
 const sinon = require('sinon')
 
 describe('lib/server', () => {

--- a/test/local/verification_reminder.js
+++ b/test/local/verification_reminder.js
@@ -4,16 +4,18 @@
 
 'use strict'
 
+const ROOT_DIR = '../..'
+
 const assert = require('insist')
 var proxyquire = require('proxyquire')
 var uuid = require('uuid')
 
-var P = require('../../../lib/promise')
-var mockLog = require('../../mocks').mockLog
+const P = require(`${ROOT_DIR}/lib/promise`)
+const mockLog = require('../mocks').mockLog
 
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 
-const verificationModulePath = '../../../lib/verification-reminders'
+const verificationModulePath = `${ROOT_DIR}/lib/verification-reminders`
 
 var ACCOUNT = {
   uid: uuid.v4('binary'),


### PR DESCRIPTION
This has been getting on my wick for a while now. Some of the tests are in `test/local/` and some of the tests are in `test/local/lib/`.

There's no rhyme or reason to it. All of the source is under `lib/` so all of the tests should either be under `lib/` or not be under `lib/`, which means the existence of `test/local/lib/` is completely redundant. Let's just get rid of it and have all those tests in `test/local/`, or sub-directories thereof.

This PR does that.

@mozilla/fxa-devs r?