### PR TITLE
refactor(server): extract memcached usage to a dedicated module

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const crypto = require('crypto')
+const Memcached = require('memcached')
+const P = require('./promise')
+
+P.promisifyAll(Memcached.prototype)
+
+const NOP = () => P.resolve()
+const NULL_CACHE = {
+  delAsync: NOP,
+  getAsync: NOP,
+  setAsync: NOP
+}
+
+module.exports = (log, config, namespace) => {
+  let _cache
+
+  const CACHE_ADDRESS = config.memcached.address
+  const CACHE_IDLE = config.memcached.idle
+  const CACHE_LIFETIME = config.memcached.lifetime
+
+  return {
+    /**
+     * Delete data from the cache, keyed by a hash of
+     * `token.uid` and `token.id`. Fails silently if
+     * the cache is not enabled.
+     *
+     * @param token
+     */
+    del (token) {
+      return getCache()
+        .then(cache => cache.delAsync(getKey(token)))
+    },
+
+    /**
+     * Fetch data from the cache, keyed by a hash of
+     * `token.uid` and `token.id`. Fails silently if
+     * the cache is not enabled.
+     *
+     * @param token
+     */
+    get (token) {
+      return getCache()
+        .then(cache => cache.getAsync(getKey(token)))
+    },
+
+    /**
+     * Fetch data from the cache, keyed by a hash of
+     * `token.uid` and `token.id`. Fails silently if
+     * the cache is not enabled.
+     *
+     * @param token
+     * @param data
+     */
+    set (token, data) {
+      return getCache()
+        .then(cache => cache.setAsync(getKey(token), data, CACHE_LIFETIME))
+    }
+  }
+
+  function getCache () {
+    return P.resolve()
+      .then(() => {
+        if (_cache) {
+          return _cache
+        }
+
+        if (CACHE_ADDRESS === 'none') {
+          _cache = NULL_CACHE
+        } else {
+          _cache = new Memcached(CACHE_ADDRESS, {
+            timeout: 500,
+            retries: 1,
+            retry: 1000,
+            reconnect: 1000,
+            idle: CACHE_IDLE,
+            namespace
+          })
+        }
+
+        return _cache
+      })
+      .catch(err => {
+        log.error({ op: 'cache.getCache', err: err })
+        return NULL_CACHE
+      })
+  }
+}
+
+function getKey (token) {
+  if (! token || ! token.uid || ! token.id) {
+    const err = new Error('Invalid token')
+    throw err
+  }
+
+  const hash = crypto.createHash('sha256')
+  hash.update(token.uid)
+  hash.update(token.id)
+
+  return hash.digest('base64')
+}
+

--- a/test/local/cache.js
+++ b/test/local/cache.js
@@ -1,0 +1,276 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const ROOT_DIR = '../..'
+
+const assert = require('insist')
+const crypto = require('crypto')
+const Memcached = require('memcached')
+const mocks = require('../mocks')
+const P = require(`${ROOT_DIR}/lib/promise`)
+const sinon = require('sinon')
+
+const modulePath = `${ROOT_DIR}/lib/cache`
+
+describe('cache:', () => {
+  let sandbox, log, cache, token, digest
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    log = mocks.spyLog()
+    cache = require(modulePath)(log, {
+      memcached: {
+        address: '127.0.0.1:1121',
+        idle: 500,
+        lifetime: 30
+      }
+    }, 'wibble')
+    token = {
+      uid: Buffer.alloc(32, 'cd'),
+      id: 'deadbeef'
+    }
+    const hash = crypto.createHash('sha256')
+    hash.update(token.uid)
+    hash.update(token.id)
+    digest = hash.digest('base64')
+  })
+
+  afterEach(() => sandbox.restore())
+
+  it('exports the correct interface', () => {
+    assert.ok(cache)
+    assert.equal(typeof cache, 'object')
+    assert.equal(Object.keys(cache).length, 3)
+    assert.equal(typeof cache.del, 'function')
+    assert.equal(cache.del.length, 1)
+    assert.equal(typeof cache.get, 'function')
+    assert.equal(cache.get.length, 1)
+    assert.equal(typeof cache.set, 'function')
+    assert.equal(cache.set.length, 2)
+  })
+
+  describe('memcached resolves:', () => {
+    beforeEach(() => {
+      sandbox.stub(Memcached.prototype, 'delAsync', () => P.resolve())
+      sandbox.stub(Memcached.prototype, 'getAsync', () => P.resolve('mock get result'))
+      sandbox.stub(Memcached.prototype, 'setAsync', () => P.resolve())
+    })
+
+    describe('del:', () => {
+      beforeEach(() => {
+        return cache.del(token)
+      })
+
+      it('calls memcached.delAsync correctly', () => {
+        assert.equal(Memcached.prototype.delAsync.callCount, 1)
+        const args = Memcached.prototype.delAsync.args[0]
+        assert.equal(args.length, 1)
+        assert.equal(args[0], digest)
+
+        assert.equal(Memcached.prototype.getAsync.callCount, 0)
+        assert.equal(Memcached.prototype.setAsync.callCount, 0)
+        assert.equal(log.error.callCount, 0)
+      })
+    })
+
+    describe('del with bad token:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.del({ id: token.id })
+          .catch(e => error = e)
+      })
+
+      it('rejects correctly', () => {
+        assert.equal(error.message, 'Invalid token')
+      })
+
+      it('does not call memcached.delAsync', () => {
+        assert.equal(Memcached.prototype.delAsync.callCount, 0)
+      })
+    })
+
+    describe('get:', () => {
+      let result
+
+      beforeEach(() => {
+        return cache.get(token)
+          .then(r => result = r)
+      })
+
+      it('returns the correct result', () => {
+        assert.equal(result, 'mock get result')
+      })
+
+      it('calls memcached.getAsync correctly', () => {
+        assert.equal(Memcached.prototype.getAsync.callCount, 1)
+        const args = Memcached.prototype.getAsync.args[0]
+        assert.equal(args.length, 1)
+        assert.equal(args[0], digest)
+
+        assert.equal(Memcached.prototype.delAsync.callCount, 0)
+        assert.equal(Memcached.prototype.setAsync.callCount, 0)
+        assert.equal(log.error.callCount, 0)
+      })
+    })
+
+    describe('get with bad token:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.get({ uid: token.uid })
+          .catch(e => error = e)
+      })
+
+      it('rejects correctly', () => {
+        assert.equal(error.message, 'Invalid token')
+      })
+
+      it('does not call memcached.getAsync', () => {
+        assert.equal(Memcached.prototype.getAsync.callCount, 0)
+      })
+    })
+
+    describe('set:', () => {
+      beforeEach(() => {
+        return cache.set(token, 'wibble')
+      })
+
+      it('calls memcached.setAsync correctly', () => {
+        assert.equal(Memcached.prototype.setAsync.callCount, 1)
+        const args = Memcached.prototype.setAsync.args[0]
+        assert.equal(args.length, 3)
+        assert.equal(args[0], digest)
+        assert.equal(args[1], 'wibble')
+        assert.equal(args[2], 30)
+
+        assert.equal(Memcached.prototype.delAsync.callCount, 0)
+        assert.equal(Memcached.prototype.getAsync.callCount, 0)
+        assert.equal(log.error.callCount, 0)
+      })
+    })
+
+    describe('set with bad token:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.set({ id: token.id }, {})
+          .catch(e => error = e)
+      })
+
+      it('rejects correctly', () => {
+        assert.equal(error.message, 'Invalid token')
+      })
+
+      it('does not call memcached.setAsync', () => {
+        assert.equal(Memcached.prototype.setAsync.callCount, 0)
+      })
+    })
+  })
+
+  describe('memcached rejects:', () => {
+    beforeEach(() => {
+      sandbox.stub(Memcached.prototype, 'delAsync', () => P.reject('foo'))
+      sandbox.stub(Memcached.prototype, 'getAsync', () => P.reject('bar'))
+      sandbox.stub(Memcached.prototype, 'setAsync', () => P.reject('baz'))
+    })
+
+    describe('del:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.del(token)
+          .catch(e => error = e)
+      })
+
+      it('propagates the error', () => {
+        assert.equal(error, 'foo')
+      })
+    })
+
+    describe('get:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.get(token)
+          .catch(e => error = e)
+      })
+
+      it('propagates the error', () => {
+        assert.equal(error, 'bar')
+      })
+    })
+
+    describe('set:', () => {
+      let error
+
+      beforeEach(() => {
+        return cache.set(token, 'wibble')
+          .catch(e => error = e)
+      })
+
+      it('propagates the error', () => {
+        assert.equal(error, 'baz')
+      })
+    })
+  })
+})
+
+describe('null cache:', () => {
+  let sandbox, log, cache, token
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    log = mocks.spyLog()
+    cache = require(modulePath)(log, {
+      memcached: {
+        address: 'none',
+        idle: 500,
+        lifetime: 30
+      }
+    }, 'wibble')
+    token = {
+      uid: Buffer.alloc(32, 'cd'),
+      id: 'deadbeef'
+    }
+    sandbox.stub(Memcached.prototype, 'delAsync', () => P.resolve())
+    sandbox.stub(Memcached.prototype, 'getAsync', () => P.resolve())
+    sandbox.stub(Memcached.prototype, 'setAsync', () => P.resolve())
+  })
+
+  afterEach(() => sandbox.restore())
+
+  describe('del:', () => {
+    beforeEach(() => {
+      return cache.del(token)
+    })
+
+    it('did not call memcached.delAsync', () => {
+      assert.equal(Memcached.prototype.delAsync.callCount, 0)
+    })
+  })
+
+  describe('get:', () => {
+    beforeEach(() => {
+      return cache.get(token)
+    })
+
+    it('did not call memcached.getAsync', () => {
+      assert.equal(Memcached.prototype.getAsync.callCount, 0)
+    })
+  })
+
+  describe('set:', () => {
+    beforeEach(() => {
+      return cache.set(token, {})
+    })
+
+    it('did not call memcached.setAsync', () => {
+      assert.equal(Memcached.prototype.setAsync.callCount, 0)
+    })
+  })
+})
+


### PR DESCRIPTION
This change came out of my playing about with memcached for #1044. It seemed like it might be worthy of consideration in its own right, decoupling memcached from `lib/metrics/context.js` and providing an abstraction that may be useful if we ever decide to ditch memcached for redis (or whatever).

No functionality has changed, it's just moved around a bit. For instance, here's some sample log data showing memcached-stored metrics context data is still present on flow events:

```
flowEvent {"event":"account.created","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495313907,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":28560,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
flowEvent {"event":"route./account/create.200","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495314002,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":28655,"flowCompleteSignal":"account.signed"}
flowEvent {"event":"email.verify_code.clicked","locale":"en","userAgent":"got/6.6.3 (https://github.com/sindresorhus/got)","time":1491495321466,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":36119,"flowCompleteSignal":"account.signed"}
flowEvent {"event":"account.verified","locale":"en","userAgent":"got/6.6.3 (https://github.com/sindresorhus/got)","time":1491495321484,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":36137,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
flowEvent {"event":"route./recovery_email/verify_code.200","locale":"en","userAgent":"got/6.6.3 (https://github.com/sindresorhus/got)","time":1491495321545,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":36198,"flowCompleteSignal":"account.signed"}
flowEvent {"event":"account.keyfetch","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495322425,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":37078,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
flowEvent {"event":"route./account/keys.200","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495322430,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":37083,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
flowEvent {"event":"account.signed","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495322504,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":37157,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
flowEvent {"event":"flow.complete","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:54.0) Gecko/20100101 Firefox/54.0","time":1491495322504,"flow_id":"613f90c2cebef952fb352cd7b088b84f4bc95e60dc5237c123131d29903914bb","flow_time":37157,"flowCompleteSignal":"account.signed","uid":"ed4b83a1e5824b4abbd03492419a8d77"}
```

@mozilla/fxa-devs r?