### PR TITLE
fix(config): set default BOUNCES_SOFT_MAX to 10

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -304,7 +304,7 @@ var conf = convict({
         },
         max: {
           doc: 'Maximum number of soft bounces before blocking emails',
-          default: 0,
+          default: 10,
           env: 'BOUNCES_SOFT_MAX'
         }
       }


### PR DESCRIPTION
This aligns this to the production setting, which will allow that override to be removed
https://github.com/mozilla-services/puppet-config/blob/master/fxa/modules/fxa/templates/data/fxa-auth-server/config/default.json.erb#L43-L48

r? - @seanmonstar 