### PR TITLE
fix(starup): handle promise rejected on bind failure

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -174,6 +174,7 @@ function main() {
       })
     }
   })
+  .catch(process.exit.bind(null, 8))
 }
 
 if (require.main === module) {


### PR DESCRIPTION
From latest.dev
`
{"Timestamp":1492530683953000000,"Logger":"fxa-auth-server","Type":"server.start.1","Severity":2,"Pid":28079,"EnvVersion":"2.0","Fields":{"op":"server.start.1","msg":"failed startup with error","err":"{\"message\":\"listen EADDRINUSE 127.0.0.1:9000\"}"}}
{"Timestamp":1492530683956000000,"Logger":"fxa-auth-server","Type":"promise.unhandledRejection","Severity":0,"Pid":28079,"EnvVersion":"2.0","Fields":{"op":"promise.unhandledRejection","error":"Error: listen EADDRINUSE 127.0.0.1:9000"}}
`

After that, the daemon continues to run, but will accept no connections.

r? - @vladikoff 