### PR TITLE
fix(config): Add config for unverified account to exist before secondary can replace it

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -27,5 +27,8 @@
     "ipProfiling": {
       "allowedRecency": 0
     }
+  },
+  "secondaryEmail": {
+    "enabled": true
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -755,6 +755,12 @@ var conf = convict({
       default: false,
       format: Boolean,
       env: 'SECONDARY_EMAIL_ENABLED'
+    },
+    minUnverifiedAccountTime: {
+      doc: 'The minimum amount of time an account can be unverified before another account can use it for secondary email',
+      default: '1 day',
+      format: 'duration',
+      env: 'SECONDARY_EMAIL_MIN_UNVERIFIED_ACCOUNT_TIME'
     }
   }
 })

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2092,8 +2092,9 @@ module.exports = (
               // a day, if so, delete account so another user can add it as a
               // secondary email
               const msSinceCreated = Date.now() - emailRecord.createdAt
-              if (msSinceCreated >= MS_ONE_DAY) {
-                return db.deleteAccount(emailRecord.uid)
+              const minUnverifiedAccountTime = config.secondaryEmail.minUnverifiedAccountTime
+              if (msSinceCreated >= minUnverifiedAccountTime) {
+                return db.deleteAccount(emailRecord)
               } else {
                 throw error.unverifiedPrimaryEmailNewlyCreated()
               }

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -615,7 +615,8 @@ describe('/recovery_email', () => {
       },
       config: {
         secondaryEmail: {
-          enabled: true
+          enabled: true,
+          minUnverifiedAccountTime: MS_IN_DAY
         }
       },
       customs: mockCustoms,


### PR DESCRIPTION
The PR exposes a config value for the time X needed for criteria

`When I attempt to add a secondary email that is the unverified primary email on an existing account, and the existing account is more than X old, then the existing account is deleted and my request succeeds.`

Also bounty if someone can figure out a more readable config value for this.

@mozilla/fxa-devs r?