### PR TITLE
feat(emails): Add custom error for users logging in with secondary email

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -856,6 +856,21 @@ module.exports = (
     return this.pool.get('/account/' + uid.toString('hex') + '/emails')
   }
 
+  DB.prototype.getSecondaryEmail = function (email) {
+    log.trace({
+      op: 'DB.getSecondaryEmail',
+      email: email
+    })
+
+    return this.pool.get('/email/' + Buffer(email, 'utf8').toString('hex'))
+      .catch((err) => {
+        if(isNotFoundError(err)){
+          throw error.unknownSecondaryEmail()
+        }
+        throw err
+      })
+  }
+
   DB.prototype.createEmail = function (uid, emailData) {
     log.trace({
       email: emailData.email,

--- a/lib/db.js
+++ b/lib/db.js
@@ -864,7 +864,7 @@ module.exports = (
 
     return this.pool.get('/email/' + Buffer(email, 'utf8').toString('hex'))
       .catch((err) => {
-        if(isNotFoundError(err)){
+        if (isNotFoundError(err)) {
           throw error.unknownSecondaryEmail()
         }
         throw err

--- a/lib/error.js
+++ b/lib/error.js
@@ -44,6 +44,8 @@ var ERRNO = {
   SESSION_UNVERIFIED: 138,
   USER_PRIMARY_EMAIL_EXISTS: 139,
   VERIFIED_PRIMARY_EMAIL_EXISTS: 140,
+  LOGIN_WITH_SECONDARY_EMAIL: 141,
+  SECONDARY_EMAIL_UNKNOWN: 142,
 
   // If there exists an account that was created under 24hrs and
   // has not verified their email address, this error is thrown
@@ -616,6 +618,24 @@ AppError.unverifiedPrimaryEmailNewlyCreated = () => {
     error: 'Bad Request',
     errno: ERRNO.UNVERIFIED_PRIMARY_EMAIL_NEWLY_CREATED,
     message: 'Email already exists'
+  })
+}
+
+AppError.cannotLoginWithSecondaryEmail = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.LOGIN_WITH_SECONDARY_EMAIL,
+    message: 'Logging in with this email type is not currently supported'
+  })
+}
+
+AppError.unknownSecondaryEmail = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.SECONDARY_EMAIL_UNKNOWN,
+    message: 'Unknown email'
   })
 }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -626,7 +626,7 @@ AppError.cannotLoginWithSecondaryEmail = () => {
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.LOGIN_WITH_SECONDARY_EMAIL,
-    message: 'Logging in with this email type is not currently supported'
+    message: 'Sign in with this email type is not currently supported'
   })
 }
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -489,6 +489,28 @@ module.exports = (
           throw e
         }
 
+        function checkSecondaryEmail() {
+          if (! features.isSecondaryEmailEnabled()) {
+            return
+          }
+
+          // Currently, we only allow emails on the account table to log a user in.
+          // If the email being used is a secondary email, fail fast and let the user
+          // know that this can not be used to login.
+          return db.getSecondaryEmail(email)
+            .then((email) => {
+              if (email) {
+                throw error.cannotLoginWithSecondaryEmail()
+              }
+            }, (err) => {
+              // No secondary email exists for this, continue with the regular login flow
+              if (err.errno === error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
+                return
+              }
+              throw err
+            })
+        }
+
         function readEmailRecord () {
           return db.emailRecord(email)
             .then(
@@ -505,19 +527,28 @@ module.exports = (
               },
               function (err) {
                 if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
-                  customs.flag(request.app.clientAddress, {
-                    email: email,
-                    errno: err.errno
-                  })
-                  // We rate-limit attempts to check whether an account exists, so
-                  // we have to be careful to re-throw any customs-server errors here.
-                  // We also have to be careful not to leak info about whether the account
-                  // existed, for example by saying sign-in unblock is unavailable on
-                  // accounts that don't exist. We pass a fake uid into the feature-flag
-                  // test to mask whether the account existed.
-                  if (customsErr) {
-                    throw customsErr
-                  }
+
+                  // Check to see if this email exists on the emails table. `checkSecondaryEmail` throws
+                  // a custom error if user is attempting to login with a secondary email, otherwise we
+                  // flag the request and throw account unknown error.
+                  return checkSecondaryEmail()
+                    .then(() => {
+                      customs.flag(request.app.clientAddress, {
+                        email: email,
+                        errno: err.errno
+                      })
+                      // We rate-limit attempts to check whether an account exists, so
+                      // we have to be careful to re-throw any customs-server errors here.
+                      // We also have to be careful not to leak info about whether the account
+                      // existed, for example by saying sign-in unblock is unavailable on
+                      // accounts that don't exist. We pass a fake uid into the feature-flag
+                      // test to mask whether the account existed.
+                      if (customsErr) {
+                        throw customsErr
+                      }
+
+                      throw err
+                    })
                 }
                 throw err
               }

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -490,6 +490,8 @@ module.exports = (
         }
 
         function checkSecondaryEmail() {
+          log.trace({op: 'Account.login.checkSecondaryEmail'})
+
           if (! features.isSecondaryEmailEnabled()) {
             return
           }
@@ -505,6 +507,8 @@ module.exports = (
             }, (err) => {
               // No secondary email exists for this, continue with the regular login flow
               if (err.errno === error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
+                log.trace({op: 'Account.login.checkSecondaryEmail.noconflict'})
+
                 return
               }
               throw err

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -269,7 +269,7 @@
     "fxa-auth-db-mysql": {
       "version": "1.85.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#3f5f27fe1c6aa0e03f1f6dbacabad7117dc861cd",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#8f5653cfb4aa9c75da124f678d4313e006f99684",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -11,6 +11,7 @@ const extend = require('util')._extend
 const P = require('../lib/promise')
 const crypto = require('crypto')
 const config = require('../config').getProperties()
+const error = require('../lib/error')
 
 const CUSTOMS_METHOD_NAMES = [
   'check',
@@ -45,6 +46,7 @@ const DB_METHOD_NAMES = [
   'emailBounces',
   'emailRecord',
   'forgotPasswordVerified',
+  'getSecondaryEmail',
   'keyFetchToken',
   'keyFetchTokenWithVerificationStatus',
   'passwordChangeToken',
@@ -237,6 +239,9 @@ function mockDB (data, errors) {
     }),
     forgotPasswordVerified: sinon.spy(() => {
       return P.resolve(data.accountResetToken)
+    }),
+    getSecondaryEmail: sinon.spy(() => {
+      return P.reject(error.unknownSecondaryEmail())
     }),
     securityEvents: sinon.spy(() => {
       return P.resolve([])


### PR DESCRIPTION
This PR allows `/account/login` to return a custom error when a user attempts to login with a secondary email. Previously if a user attempted to login with a secondary email, it would return `Account not found error`, which would cause the content-server to prompt to create account 👎 .

Connects with https://github.com/mozilla/fxa-auth-db-mysql/pull/227, which should be merged before this.