### PR TITLE
fix(notifier): don't sns publish 'config' events

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -30,6 +30,14 @@ if (notifierSnsTopicArn !== 'disabled') {
 module.exports = function notifierLog(log) {
   return {
     send: (event, callback) => {
+      // Don't broadcast our config events
+      if (event.event === 'config') {
+        if (typeof callback === 'function') {
+          return callback(null, {})
+        }
+        return
+      }
+
       const msg = event.data || {}
       msg.event = event.event
 


### PR DESCRIPTION
I was looking at profiler logs on an fxa-dev, and was suprised to see a log line with auth-server information. Oops.

The previous notifier process did not forward the config event to SNS, and we should keep that behaviour.

I changed the tests to pass in event structures more like what `log.notifyAttachedServices` sends, and added a test with `event: "config"`. But I have little confidence that I'm using the spies, etc. correctly, so look closely ;-)

Finally after writing this patch, it occurred to me "why are we sending 'config' events at all?". They were previously used as a way to pass the snsTopicArn value between processes. 

r? - @vladikoff 