### PR TITLE
feat(emails): Create account from unverified secondary email

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -780,6 +780,7 @@ conf.set('smtp.initiatePasswordResetUrl', conf.get('contentServer.url') + '/rese
 conf.set('smtp.initiatePasswordChangeUrl', conf.get('contentServer.url') + '/settings/change_password')
 conf.set('smtp.verifyLoginUrl', conf.get('contentServer.url') + '/complete_signin')
 conf.set('smtp.reportSignInUrl', conf.get('contentServer.url') + '/report_signin')
+conf.set('smtp.verifySecondaryEmailUrl', conf.get('contentServer.url') + '/verify_secondary_email')
 
 conf.set('isProduction', conf.get('env') === 'prod')
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -44,14 +44,15 @@ var ERRNO = {
   SESSION_UNVERIFIED: 138,
   USER_PRIMARY_EMAIL_EXISTS: 139,
   VERIFIED_PRIMARY_EMAIL_EXISTS: 140,
-  LOGIN_WITH_SECONDARY_EMAIL: 141,
-  SECONDARY_EMAIL_UNKNOWN: 142,
-
   // If there exists an account that was created under 24hrs and
   // has not verified their email address, this error is thrown
   // if another user attempts to add that email to their account
   // as a secondary email.
   UNVERIFIED_PRIMARY_EMAIL_NEWLY_CREATED: 141,
+  LOGIN_WITH_SECONDARY_EMAIL: 142,
+  SECONDARY_EMAIL_UNKNOWN: 143,
+  VERIFIED_SECONDARY_EMAIL_EXISTS: 144,
+
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
   UNEXPECTED_ERROR: 999
@@ -605,6 +606,15 @@ AppError.verifiedPrimaryEmailAlreadyExists = () => {
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.VERIFIED_PRIMARY_EMAIL_EXISTS,
+    message: 'Email already exists'
+  })
+}
+
+AppError.verifiedSecondaryEmailAlreadyExists = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.VERIFIED_SECONDARY_EMAIL_EXISTS,
     message: 'Email already exists'
   })
 }

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -128,6 +128,7 @@ module.exports = function (log) {
     this.translator = translator.getTranslator
     this.verificationUrl = config.verificationUrl
     this.verifyLoginUrl = config.verifyLoginUrl
+    this.verifySecondaryEmailUrl = config.verifySecondaryEmailUrl
   }
 
   Mailer.prototype.stop = function () {
@@ -457,14 +458,15 @@ module.exports = function (log) {
     var query = {
       code: message.code,
       uid: message.uid,
-      type: 'secondary'
+      type: 'secondary',
+      secondary_email_verified: message.email
     }
 
     if (message.service) { query.service = message.service }
     if (message.redirectTo) { query.redirectTo = message.redirectTo }
     if (message.resume) { query.resume = message.resume }
 
-    var links = this._generateLinks(this.verificationUrl, message.email, query, templateName)
+    var links = this._generateLinks(this.verifySecondaryEmailUrl, message.email, query, templateName)
 
     var headers = {
       'X-Link': links.link,

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1061,7 +1061,7 @@ describe('/account/login', function () {
     })
     return runTest(route, mockRequest).then(() => assert.ok(false), (err) => {
       assert.equal(mockDB.getSecondaryEmail.callCount, 1, 'db.getSecondaryEmail was called')
-      assert.equal(err.errno, 141, 'correct errno called')
+      assert.equal(err.errno, 142, 'correct errno called')
     })
   })
 })

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -129,6 +129,7 @@ describe(
           service: 'sync',
           uid: 'uid',
           unblockCode: 'AS6334PK',
+          type: 'secondary',
           flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
           flowBeginTime: Date.now()
         }
@@ -184,6 +185,20 @@ describe(
             mailer[type](message)
           }
         )
+
+        if (type === 'verifySecondaryEmail') {
+          it(
+            'contains correct type ' + type,
+            function () {
+              mailer.mailer.sendMail = function (emailConfig) {
+                assert.ok(includes(emailConfig.headers['X-Link'], 'type=secondary'))
+                assert.ok(includes(emailConfig.html, 'type=secondary'))
+                assert.ok(includes(emailConfig.text, 'type=secondary'))
+              }
+              mailer[type](message)
+            }
+          )
+        }
 
         it(
           'If sesConfigurationSet is not defined, then outgoing email does not contain X-SES* headers, for type ' + type,


### PR DESCRIPTION
This builds off of https://github.com/mozilla/fxa-auth-server/pull/1850. It allows a user to create an account from an unverified secondary email. It also returns a corresponding error if user attempts to create an account from a verified secondary email.