### PR TITLE
fix(tests): Add timeout for sms

### DIFF
--- a/test/remote/sms_tests.js
+++ b/test/remote/sms_tests.js
@@ -41,7 +41,7 @@ describe('remote sms (live nexmo)', function() {
   })
 })
 
-describe('remote sms (mocked nexmo)', function(){
+describe('remote sms (mocked nexmo)', function() {
   this.timeout(10000)
   let server
 

--- a/test/remote/sms_tests.js
+++ b/test/remote/sms_tests.js
@@ -10,7 +10,8 @@ const Client = require('../client')()
 const config = require('../../config').getProperties()
 const error = require('../../lib/error')
 
-describe('remote sms (live nexmo)', () => {
+describe('remote sms (live nexmo)', function() {
+  this.timeout(10000)
   let server
 
   before(() => {
@@ -40,7 +41,8 @@ describe('remote sms (live nexmo)', () => {
   })
 })
 
-describe('remote sms (mocked nexmo)', () => {
+describe('remote sms (mocked nexmo)', function(){
+  this.timeout(10000)
   let server
 
   before(() => {


### PR DESCRIPTION
Found this testing docker locally and with logging on.

```
  remote sms (live nexmo)
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
mail_helper started...
fxa-auth-server.INFO: geodb.accuracy {"op":"geodb.accuracy","accuracy":50}
fxa-auth-server.INFO: geodb.accuracy_confidence {"op":"geodb.accuracy_confidence","accuracy_confidence":"fxa.location.accuracy.uncertain"}
fxa-auth-server.INFO: geodb.check {"op":"geodb.check","result":{"location":{"city":"Mountain View","country":"United States","countryCode":"US","state":"California","stateCode":"CA"},"timeZone":"America/Los_Angeles"}}
    1) "before all" hook

  remote sms (mocked nexmo)
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
fxa-auth-server.INFO: server.start.1 {"op":"server.start.1","msg":"running on http://127.0.0.1:9000"}
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
fxa-auth-server.INFO: geodb.start {"op":"geodb.start","enabled":true,"dbPath":"/app/node_modules/fxa-geodb/db/cities-db.mmdb"}
mail_helper started...
{ [Error: listen EADDRINUSE 127.0.0.1:9010]
  code: 'EADDRINUSE',
  errno: 'EADDRINUSE',
  syscall: 'listen',
  address: '127.0.0.1',
  port: 9010 }
    2) "before all" hook
fxa-auth-server.INFO: geodb.accuracy {"op":"geodb.accuracy","accuracy":50}
fxa-auth-server.INFO: geodb.accuracy {"op":"geodb.accuracy","accuracy":50}
fxa-auth-server.INFO: geodb.accuracy_confidence {"op":"geodb.accuracy_confidence","accuracy_confidence":"fxa.location.accuracy.uncertain"}
fxa-auth-server.INFO: geodb.accuracy_confidence {"op":"geodb.accuracy_confidence","accuracy_confidence":"fxa.location.accuracy.uncertain"}
fxa-auth-server.INFO: geodb.check {"op":"geodb.check","result":{"location":{"city":"Mountain View","country":"United States","countryCode":"US","state":"California","stateCode":"CA"},"timeZone":"America/Los_Angeles"}}
fxa-auth-server.INFO: geodb.check {"op":"geodb.check","result":{"location":{"city":"Mountain View","country":"United States","countryCode":"US","state":"California","stateCode":"CA"},"timeZone":"America/Los_Angeles"}}


  0 passing (3s)
  2 failing

  1) remote sms (live nexmo) "before all" hook:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
  

  2) remote sms (mocked nexmo) "before all" hook:
     Error: listen EADDRINUSE 127.0.0.1:9010
      at Object.exports._errnoException (util.js:907:11)
      at exports._exceptionWithHostPort (util.js:930:20)
      at Server._listen2 (net.js:1253:14)
      at listen (net.js:1289:10)
      at net.js:1398:9
      at GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:64:16)
      at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:83:10)

```
My interpreation was that the live sms test was hanging when starting the mailer causing the mock test to timeout. Adding a small timeout ~10s unflakes this.

Fixes #1842 