### PR TITLE
fix(circle): fix string comparison on docker push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ deployment:
       - "[ ! -z $DOCKERHUB_REPO ]"
       - docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
       - |
-          if [ $CIRCLE_BRANCH -eq "master" ]; then
+          if [ $CIRCLE_BRANCH = "master" ]; then
             CIRCLE_BRANCH=latest
           fi
           echo ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}


### PR DESCRIPTION
`=`, not `-eq`.

r? - @vladikoff 