### PR TITLE
fix(config): Correctly resolve if isSecondaryEmailEnabled is disabled

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -31,7 +31,7 @@ module.exports = config => {
      * @returns {boolean}
      */
     isSecondaryEmailEnabled() {
-      return !! secondaryEmail.enabled
+      return !! (secondaryEmail && secondaryEmail.enabled)
     },
 
     /**

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -514,7 +514,7 @@ module.exports = (
         function checkSecondaryEmail() {
           log.trace({op: 'Account.login.checkSecondaryEmail'})
           if (! features.isSecondaryEmailEnabled()) {
-            return
+            return P.resolve()
           }
 
           // Currently, we only allow emails on the account table to log a user in.
@@ -529,7 +529,7 @@ module.exports = (
               // No secondary email exists for this, continue with the regular login flow
               if (err.errno === error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
                 log.trace({op: 'Account.login.checkSecondaryEmail.noconflict'})
-                return
+                return P.resolve()
               }
               throw err
             })

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -20,7 +20,9 @@ describe('remote emails', function () {
 
   before(() => {
     config = require('../../config').getProperties()
-    config.secondaryEmail.enabled = true
+    config.secondaryEmail = {
+      enabled: true
+    }
     config.securityHistory.ipProfiling = {}
     return TestServer.start(config)
       .then(s => {


### PR DESCRIPTION
This correctly resolves `checkSecondaryEmail` if `isSecondaryEmailEnabled` is disabled. Also added some more guards if missing config for secondaryEmails.

Fixes #1871 

@jrgm r?