### PR TITLE
feat(emails): Throw unique error if initiating password reset from secondary email

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -52,6 +52,7 @@ var ERRNO = {
   LOGIN_WITH_SECONDARY_EMAIL: 142,
   SECONDARY_EMAIL_UNKNOWN: 143,
   VERIFIED_SECONDARY_EMAIL_EXISTS: 144,
+  RESET_PASSWORD_WITH_SECONDARY_EMAIL: 145,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -646,6 +647,15 @@ AppError.unknownSecondaryEmail = () => {
     error: 'Bad Request',
     errno: ERRNO.SECONDARY_EMAIL_UNKNOWN,
     message: 'Unknown email'
+  })
+}
+
+AppError.cannotResetPasswordWithSecondaryEmail = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.RESET_PASSWORD_WITH_SECONDARY_EMAIL,
+    message: 'Reset password with this email type is not currently supported'
   })
 }
 

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -407,6 +407,25 @@ module.exports = function (
               // Clobber the timestamp to prevent prematurely expired tokens.
               emailRecord.createdAt = undefined
               return db.createPasswordForgotToken(emailRecord)
+            },
+            (err) => {
+              // If account was not found, ensure that this is not a secondary email and
+              // throw the correct error if it is.
+              if (features.isSecondaryEmailEnabled() && err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
+                return db.getSecondaryEmail(email)
+                  .then(() => {
+                    throw error.cannotResetPasswordWithSecondaryEmail()
+                  })
+                  .catch((emailErr) => {
+                    // If no secondary email exists, we want to throw the original account unknown
+                    // error because the user could potentially create this account.
+                    if (emailErr.errno === error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
+                      return err
+                    }
+                    throw emailErr
+                  })
+              }
+              throw err
             }
           )
           .then(

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -420,7 +420,7 @@ module.exports = function (
                     // If no secondary email exists, we want to throw the original account unknown
                     // error because the user could potentially create this account.
                     if (emailErr.errno === error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
-                      return err
+                      throw err
                     }
                     throw emailErr
                   })

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -662,7 +662,7 @@ describe('remote emails', function () {
     })
 
     it(
-      'fails to initiate account reset',
+      'fails to initiate account reset with known secondary email',
       () => {
         client.email = secondEmail
         return client.forgotPassword()
@@ -672,6 +672,21 @@ describe('remote emails', function () {
           .catch((err) => {
             assert.equal(err.code, 400, 'correct error code')
             assert.equal(err.errno, 145, 'correct errno code')
+          })
+      }
+    )
+
+    it(
+      'returns account unknown error when using unknown email',
+      () => {
+        client.email = 'unknown@email.com'
+        return client.forgotPassword()
+          .then(() => {
+            assert.fail(new Error('should not have been able to initiate reset password'))
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'correct error code')
+            assert.equal(err.errno, 102, 'correct errno code')
           })
       }
     )

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -645,6 +645,38 @@ describe('remote emails', function () {
     )
   })
 
+  describe('shouldn\'t be able to initiate account reset from secondary email', () => {
+    let secondEmail
+    beforeEach(() => {
+      secondEmail = server.uniqueEmail()
+      return client.createEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return server.mailbox.waitForEmail(secondEmail)
+        })
+        .then((emailData) => {
+          const emailCode = emailData['headers']['x-verify-code']
+          assert.ok(emailCode, 'emailCode set')
+          return client.verifySecondaryEmail(emailCode, secondEmail)
+        })
+    })
+
+    it(
+      'fails to initiate account reset',
+      () => {
+        client.email = secondEmail
+        return client.forgotPassword()
+          .then(() => {
+            assert.fail(new Error('should not have been able to initiate reset password'))
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'correct error code')
+            assert.equal(err.errno, 145, 'correct errno code')
+          })
+      }
+    )
+  })
+
   describe('shouldn\'t be able to login with secondary email', () => {
     let secondEmail
     beforeEach(() => {


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/fxa-content-server/pull/4996#issuecomment-298347100 by sending a unique error if a user is attempting to reset an account from a secondary email. This will cause the content server not to show the option of creating that account.

@vladikoff r?