### PR TITLE
fix(notifications): Make data fields consistent across all notifyAttachedServices calls.

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2489,7 +2489,8 @@ module.exports = (
             .then(
               function () {
                 return log.notifyAttachedServices('reset', request, {
-                  uid: account.uid.toString('hex') + '@' + config.domain,
+                  uid: account.uid,
+                  iss: config.domain,
                   generation: account.verifierSetAt
                 })
               }
@@ -2634,7 +2635,8 @@ module.exports = (
                   function () {
                     push.notifyAccountDestroyed(uid, devicesToNotify).catch(function () {})
                     return log.notifyAttachedServices('delete', request, {
-                      uid: uid.toString('hex') + '@' + config.domain
+                      uid: uid,
+                      iss: config.domain
                     })
                   }
                 )

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1179,7 +1179,8 @@ describe('/account/destroy', function () {
       assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments')
       assert.equal(args[0], 'delete', 'first argument was event name')
       assert.equal(args[1], mockRequest, 'second argument was request object')
-      assert.equal(args[2].uid, uid.toString('hex') + '@wibble', 'third argument was event data')
+      assert.equal(args[2].uid, uid, 'third argument was event data with a uid')
+      assert.equal(args[2].iss, 'wibble', 'third argument was event data with an issuer field')
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
       args = mockLog.activityEvent.args[0]


### PR DESCRIPTION
Previously, some of them sent a plain "uid" and some of them sent the "uid" field as "uid@domain" for historical reasons.  This PR makes them all send a plain "uid" field, and include a new "iss" field so that existing applications can continue to piece together the old "uid@domain" form if they need to.

This will need to wait for https://github.com/mozilla-services/tokenserver/pull/107 to hit production before we can ship it.