### PR TITLE
feat(mailer): disable X-Mailer header in emails

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -231,6 +231,7 @@ module.exports = function (log) {
       subject: localized.subject,
       text: localized.text,
       html: localized.html,
+      xMailer: false,
       headers: extend({
         'Content-Language': localized.language,
         'X-Template-Name': message.template

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -81,6 +81,7 @@ describe('remote account create', function() {
         )
         .then(
           function (emailData) {
+            assert.equal(emailData.headers['x-mailer'], undefined)
             assert.equal(emailData.headers['x-template-name'], 'verifySyncEmail')
             assert.equal(emailData.html.indexOf('IP address') > -1, true) // Ensure some location data is present
             return emailData.headers['x-verify-code']


### PR DESCRIPTION
When testing some emails, I noticed that we send an `X-Mailer: nodemailer blah blah` header, and many other automated emails from other companies does not include this header. It was noticeable in Gmail when viewing the original message, they highlighted `From accounts as firefox dot com Using nodemailer v2.7.2...`.

It's possible that a spam filter can inspect this header and determine that the mailer was an automated program and not a mail client, though it is easily forged. It's essentially the `User-Agent` header for email. Better to say nothing.

**tl;dr** - We don't need to send it, everyone else doesn't, let's stop.