### PR TITLE
fix(config): Add email regex feature flag for secondary email

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -750,6 +750,12 @@ var conf = convict({
       format: Boolean,
       env: 'SECONDARY_EMAIL_ENABLED'
     },
+    enabledEmailAddresses: {
+      doc: 'Only enable for email addresses matching this regex.',
+      format: RegExp,
+      default: /.+@mozilla\.com$/,
+      env: 'SECONDARY_EMAIL_ENABLE_REGEX'
+    },
     minUnverifiedAccountTime: {
       doc: 'The minimum amount of time an account can be unverified before another account can use it for secondary email',
       default: '1 day',

--- a/lib/features.js
+++ b/lib/features.js
@@ -30,8 +30,12 @@ module.exports = config => {
      *
      * @returns {boolean}
      */
-    isSecondaryEmailEnabled() {
-      return !! (secondaryEmail && secondaryEmail.enabled)
+    isSecondaryEmailEnabled(email) {
+      if (secondaryEmail && secondaryEmail.enabled && secondaryEmail.enabledEmailAddresses) {
+        return secondaryEmail.enabledEmailAddresses.test(email)
+      }
+
+      return false
     },
 
     /**

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -513,7 +513,7 @@ module.exports = (
 
         function checkSecondaryEmail() {
           log.trace({op: 'Account.login.checkSecondaryEmail'})
-          if (! features.isSecondaryEmailEnabled()) {
+          if (! features.isSecondaryEmailEnabled(email)) {
             return P.resolve()
           }
 
@@ -929,7 +929,7 @@ module.exports = (
             && ! doSigninConfirmation
             && emailRecord.emailVerified
           if (shouldSendNewDeviceLoginEmail) {
-            const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(sessionToken.uid) : P.resolve([])
+            const secondaryEmails = features.isSecondaryEmailEnabled(emailRecord.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
             return P.all([getGeoData(ip), secondaryEmails])
               .spread((geoData, emails) => {
                 // New device notifications are always sent to the primary account email (emailRecord.email)
@@ -971,7 +971,7 @@ module.exports = (
               tokenVerificationId: tokenVerificationId
             })
 
-            const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(sessionToken.uid) : P.resolve([])
+            const secondaryEmails = features.isSecondaryEmailEnabled(emailRecord.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
             return P.all([getGeoData(ip), secondaryEmails])
               .spread((geoData, emails) => {
                 return mailer.sendVerifyLoginEmail(
@@ -1754,7 +1754,7 @@ module.exports = (
           )
 
         function setVerifyCode() {
-          const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(sessionToken.uid) : P.resolve([])
+          const secondaryEmails = features.isSecondaryEmailEnabled(sessionToken.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
           return secondaryEmails
             .then((emailData) => {
               if (email) {
@@ -1855,7 +1855,7 @@ module.exports = (
           .then((account) => {
             // Check if param `type` is specified and equal to `secondary`
             // If so, verify the secondary email and respond
-            if (type && type === 'secondary' && features.isSecondaryEmailEnabled()) {
+            if (type && type === 'secondary' && features.isSecondaryEmailEnabled(account.email)) {
               let matchedEmail
               return db.accountEmails(account.uid)
                 .then((emails) => {
@@ -2066,7 +2066,7 @@ module.exports = (
 
         log.begin('Account.RecoveryEmailEmails', request)
 
-        if (! features.isSecondaryEmailEnabled()) {
+        if (! features.isSecondaryEmailEnabled(sessionToken.email)) {
           return reply(error.featureNotEnabled())
         }
 
@@ -2115,7 +2115,7 @@ module.exports = (
 
         log.begin('Account.RecoveryEmailCreate', request)
 
-        if (! features.isSecondaryEmailEnabled()) {
+        if (! features.isSecondaryEmailEnabled(primaryEmail)) {
           return reply(error.featureNotEnabled())
         }
 
@@ -2222,7 +2222,7 @@ module.exports = (
 
         log.begin('Account.RecoveryEmailDestroy', request)
 
-        if (! features.isSecondaryEmailEnabled()) {
+        if (! features.isSecondaryEmailEnabled(primaryEmail)) {
           return reply(error.featureNotEnabled())
         }
 

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -251,7 +251,7 @@ module.exports = function (
             .then(
               function (accountData) {
                 account = accountData
-                return features.isSecondaryEmailEnabled() ? db.accountEmails(passwordChangeToken.uid) : P.resolve([])
+                return features.isSecondaryEmailEnabled(account.email) ? db.accountEmails(passwordChangeToken.uid) : P.resolve([])
               }
             )
             .then(
@@ -411,7 +411,7 @@ module.exports = function (
             (err) => {
               // If account was not found, ensure that this is not a secondary email and
               // throw the correct error if it is.
-              if (features.isSecondaryEmailEnabled() && err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
+              if (features.isSecondaryEmailEnabled(email) && err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
                 return db.getSecondaryEmail(email)
                   .then(() => {
                     throw error.cannotResetPasswordWithSecondaryEmail()
@@ -430,7 +430,7 @@ module.exports = function (
           )
           .then(
             function (passwordForgotToken) {
-              const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
+              const secondaryEmails = features.isSecondaryEmailEnabled(email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
               return P.all([getGeoData(ip), secondaryEmails])
                 .spread((geoData, emails) => {
                   return mailer.sendRecoveryCode(
@@ -531,7 +531,7 @@ module.exports = function (
           )
           .then(
             function () {
-              const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
+              const secondaryEmails = features.isSecondaryEmailEnabled(passwordForgotToken.email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
               return P.all([getGeoData(ip), secondaryEmails])
                 .spread((geoData, emails) => {
                   return mailer.sendRecoveryCode(
@@ -622,7 +622,7 @@ module.exports = function (
                 db.forgotPasswordVerified(passwordForgotToken)
                   .then(
                     function (accountResetToken) {
-                      const secondaryEmails = features.isSecondaryEmailEnabled() ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
+                      const secondaryEmails = features.isSecondaryEmailEnabled(passwordForgotToken.email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
                       return secondaryEmails
                         .then((emails) => {
                           return mailer.sendPasswordResetNotification(

--- a/test/local/features.js
+++ b/test/local/features.js
@@ -185,7 +185,11 @@ describe('features', () => {
     'isSecondaryEmailEnabled',
     () => {
       config.secondaryEmail.enabled = true
-      assert.equal(features.isSecondaryEmailEnabled(), true, 'should return true when everything is enabled in config')
+      assert.equal(features.isSecondaryEmailEnabled('asdf@mozilla.com'), false, 'should return false if no enabled regex address specified')
+
+      config.secondaryEmail.enabledEmailAddresses = /.+@mozilla\.com$/
+      assert.equal(features.isSecondaryEmailEnabled('asdf@mozilla.com'), true, 'should return true when email matches regex')
+      assert.equal(features.isSecondaryEmailEnabled('asdf@notmozilla.com'), false, 'should return false when email does not match regex')
 
       config.secondaryEmail.enabled = false
       assert.equal(features.isSecondaryEmailEnabled(), false, 'should return false when secondary email is disabled in config')

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1051,6 +1051,7 @@ describe('/account/login', function () {
 
   it('fails login with secondary email', function () {
     config.secondaryEmail.enabled = true
+    config.secondaryEmail.enabledEmailAddresses = /\w/
     mockDB.emailRecord = sinon.spy(function () {
       return P.reject(error.unknownAccount())
     })

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -83,7 +83,8 @@ function runTest (route, request, assertions) {
 describe('/recovery_email/status', function () {
   var config = {
     secondaryEmail: {
-      enabled: true
+      enabled: true,
+      enabledEmailAddresses: /\w/
     }
   }
   var mockDB = mocks.mockDB()
@@ -221,7 +222,8 @@ describe('/recovery_email/status', function () {
 describe('/recovery_email/resend_code', () => {
   const config = {
     secondaryEmail: {
-      enabled: true
+      enabled: true,
+      enabledEmailAddresses: /\w/
     }
   }
   const secondEmailCode = crypto.randomBytes(16)
@@ -398,7 +400,8 @@ describe('/recovery_email/verify_code', function () {
     },
     config: {
       secondaryEmail: {
-        enabled: true
+        enabled: true,
+        enabledEmailAddresses: /\w/
       }
     },
     customs: mockCustoms,
@@ -616,6 +619,7 @@ describe('/recovery_email', () => {
       config: {
         secondaryEmail: {
           enabled: true,
+          enabledEmailAddresses: /\w/,
           minUnverifiedAccountTime: MS_IN_DAY
         }
       },
@@ -755,7 +759,8 @@ describe('/recovery_email', () => {
         },
         config: {
           secondaryEmail: {
-            enabled: false
+            enabled: false,
+            enabledEmailAddresses: /\w/
           }
         },
         customs: mockCustoms,

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -21,7 +21,8 @@ describe('remote emails', function () {
   before(() => {
     config = require('../../config').getProperties()
     config.secondaryEmail = {
-      enabled: true
+      enabled: true,
+      enabledEmailAddresses: /\w/
     }
     config.securityHistory.ipProfiling = {}
     return TestServer.start(config)


### PR DESCRIPTION
From mtg: we wanted the ability to turn secondary emails on/off based on email address regex.

@seanmonstar / @mozilla/fxa-devs r?