### PR TITLE
fix(emails): Fix issue where change password link was undefined

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -498,6 +498,8 @@ module.exports = function (log) {
         link: links.link,
         location: this._constructLocationString(message),
         oneClickLink: links.oneClickLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        passwordChangeLink: links.passwordChangeLink,
         privacyUrl: links.privacyUrl,
         reportSignInLink: links.reportSignInLink,
         reportSignInLinkAttributes: links.reportSignInLinkAttributes,

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -54,7 +54,8 @@ var typesContainPasswordResetLinks = [
 
 var typesContainPasswordChangeLinks = [
   'newDeviceLoginEmail',
-  'verifyLoginEmail'
+  'verifyLoginEmail',
+  'verifySecondaryEmail'
 ]
 
 var typesContainUnblockCode = [


### PR DESCRIPTION
Fixes an issue where verify secondary email, change password link at the bottom was undefined from html and text emails.

Ref: https://github.com/mozilla/fxa-content-server/pull/4996#issue-224176438