### PR TITLE
fix(emails): Only send email notifications to verified secondary emails

### DIFF
--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -37,22 +37,14 @@ module.exports = function (log, config, error, bounces, translator, sender) {
         })
     }
 
-    function getVerifiedSecondaryEmails(emais) {
-      return emais.reduce(function(list, email) {
-        if (! email.isPrimary && email.isVerified) {
-          list.push(email.email)
-        }
-        return list
-      }, [])
-    }
-
-    function getSecondaryEmails(emails) {
-      return emails.reduce(function(list, email) {
-        if (! email.isPrimary) {
-          list.push(email.email)
-        }
-        return list
-      }, [])
+    // Returns an array of only emails that are verified.
+    // This returns only the email and not the email object.
+    function getVerifiedSecondaryEmails(emails) {
+      return emails.filter(function (email) {
+        return ! email.isPrimary && email.isVerified
+      }).map(function (email) {
+        return email.email
+      })
     }
 
     senders.email = {
@@ -160,7 +152,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
       },
       sendPasswordChangedNotification: function (emails, account, opts) {
         var primaryEmail = account.email
-        var ccEmails = getSecondaryEmails(emails)
+        var ccEmails = getVerifiedSecondaryEmails(emails)
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
@@ -179,7 +171,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
       },
       sendPasswordResetNotification: function (emails, account, opts) {
         var primaryEmail = account.email
-        var ccEmails = getSecondaryEmails(emails)
+        var ccEmails = getVerifiedSecondaryEmails(emails)
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
@@ -194,7 +186,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
       },
       sendNewDeviceLoginNotification: function (emails, account, opts) {
         var primaryEmail = account.email
-        var ccEmails = getSecondaryEmails(emails)
+        var ccEmails = getVerifiedSecondaryEmails(emails)
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -145,10 +145,8 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.passwordChangedEmail.getCall(0).args
             assert.equal(args[0].email, EMAIL, 'email correctly set')
-            assert.equal(args[0].ccEmails.length, 2, 'email correctly set')
+            assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(args[0].ccEmails[1], EMAILS[2].email, 'cc email correctly set')
-
             assert.equal(bounces.check.callCount, 1)
           })
       })
@@ -168,10 +166,8 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.passwordResetEmail.getCall(0).args
             assert.equal(args[0].email, EMAIL, 'email correctly set')
-            assert.equal(args[0].ccEmails.length, 2, 'email correctly set')
+            assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(args[0].ccEmails[1], EMAILS[2].email, 'cc email correctly set')
-
             assert.equal(bounces.check.callCount, 1)
           })
       })
@@ -191,10 +187,8 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.newDeviceLoginEmail.getCall(0).args
             assert.equal(args[0].email, EMAIL, 'email correctly set')
-            assert.equal(args[0].ccEmails.length, 2, 'email correctly set')
+            assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(args[0].ccEmails[1], EMAILS[2].email, 'cc email correctly set')
-
             assert.equal(bounces.check.callCount, 1)
           })
       })
@@ -215,7 +209,6 @@ describe('lib/senders/index', () => {
             const args = email._ungatedMailer.postVerifyEmail.getCall(0).args
             assert.equal(args[0].email, EMAIL, 'email correctly set')
             assert.equal(args[0].ccEmails, undefined, 'no cc emails set')
-
             assert.equal(bounces.check.callCount, 1)
           })
       })

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -379,7 +379,7 @@ describe('remote emails', function () {
     )
   })
 
-  describe('should receive email confirmations on verified secondary emails', () => {
+  describe('should receive emails on verified secondary emails', () => {
     let secondEmail
     let thirdEmail
     beforeEach(() => {
@@ -498,46 +498,6 @@ describe('remote emails', function () {
           })
       }
     )
-  })
-
-  describe('should receive email notifications on all secondary emails', () => {
-    let secondEmail
-    let thirdEmail
-    beforeEach(() => {
-      secondEmail = server.uniqueEmail()
-      thirdEmail = server.uniqueEmail()
-      return client.createEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response')
-          return server.mailbox.waitForEmail(secondEmail)
-        })
-        .then((emailData) => {
-          const templateName = emailData['headers']['x-template-name']
-          const emailCode = emailData['headers']['x-verify-code']
-          assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
-          assert.ok(emailCode, 'emailCode set')
-          return client.verifySecondaryEmail(emailCode, secondEmail)
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response')
-          return client.accountEmails()
-        })
-        .then((res) => {
-          assert.equal(res.length, 2, 'returns number of emails')
-          assert.equal(res[1].email, secondEmail, 'returns correct email')
-          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
-          assert.equal(res[1].verified, true, 'returns correct verified')
-          return server.mailbox.waitForEmail(email)
-        })
-        .then((emailData) => {
-          const templateName = emailData['headers']['x-template-name']
-          assert.equal(templateName, 'postVerifySecondaryEmail', 'email template name set')
-
-          // Create a third email that is unverified. User should receive notifications
-          // on this email, even thought it is not been verified
-          return client.createEmail(thirdEmail)
-        })
-    })
 
     it(
       'receives change password notification',
@@ -550,9 +510,8 @@ describe('remote emails', function () {
           .then((emailData) => {
             const templateName = emailData['headers']['x-template-name']
             assert.equal(templateName, 'passwordChangedEmail', 'email template name set')
-            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc.length, 1)
             assert.equal(emailData.cc[0].address, secondEmail)
-            assert.equal(emailData.cc[1].address, thirdEmail)
           })
       }
     )
@@ -577,9 +536,8 @@ describe('remote emails', function () {
           .then((emailData) => {
             const templateName = emailData['headers']['x-template-name']
             assert.equal(templateName, 'passwordResetEmail', 'email template name set')
-            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc.length, 1)
             assert.equal(emailData.cc[0].address, secondEmail)
-            assert.equal(emailData.cc[1].address, thirdEmail)
             return client.login({keys: true})
           })
           .then((x) => {
@@ -638,9 +596,8 @@ describe('remote emails', function () {
           .then((emailData) => {
             const templateName = emailData['headers']['x-template-name']
             assert.equal(templateName, 'newDeviceLoginEmail', 'email template name set')
-            assert.equal(emailData.cc.length, 2)
+            assert.equal(emailData.cc.length, 1)
             assert.equal(emailData.cc[0].address, secondEmail)
-            assert.equal(emailData.cc[1].address, thirdEmail)
           })
       }
     )


### PR DESCRIPTION
This PR updates how we handle sending email notifications to secondary email. Previously, we were sending all to emails, verified nor not. With this change we only send to verified emails.

Fixes #1887 

@rfk r? / @mozilla/fxa-devs 