### PR TITLE
fix(emails): Can create secondary email if it is unverified in another account

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -863,6 +863,9 @@ module.exports = (
     })
 
     return this.pool.get('/email/' + Buffer(email, 'utf8').toString('hex'))
+      .then((body) => {
+        return bufferize(body)
+      })
       .catch((err) => {
         if (isNotFoundError(err)) {
           throw error.unknownSecondaryEmail()

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2132,7 +2132,8 @@ module.exports = (
         }
 
         customs.check(request, primaryEmail, 'createEmail')
-          .then(checkEmail)
+          .then(deleteAccountIfUnverified)
+          .then(deleteSecondaryEmailIfUnverified)
           .then(generateRandomValues)
           .then(createEmail)
           .then(sendEmailVerification)
@@ -2143,7 +2144,7 @@ module.exports = (
             reply
           )
 
-        function checkEmail() {
+        function deleteAccountIfUnverified() {
           return db.emailRecord(email)
             .then((emailRecord) => {
               if (emailRecord.emailVerified) {
@@ -2164,6 +2165,22 @@ module.exports = (
             .catch((err) => {
               // Email does not exist in primary account table, carry on
               if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
+                throw err
+              }
+            })
+        }
+
+        function deleteSecondaryEmailIfUnverified() {
+          return db.getSecondaryEmail(email)
+            .then((secondaryEmailRecord) => {
+              // Only delete secondary email if it is unverified and does not belong
+              // to the current user.
+              if (! secondaryEmailRecord.isVerified && secondaryEmailRecord.uid !== uid.toString('hex')) {
+                return db.deleteEmail(Buffer(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
+              }
+            })
+            .catch((err) => {
+              if (err.errno !== error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
                 throw err
               }
             })

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2175,8 +2175,7 @@ module.exports = (
             .then((secondaryEmailRecord) => {
               // Only delete secondary email if it is unverified and does not belong
               // to the current user.
-              if (! secondaryEmailRecord.isVerified &&
-                secondaryEmailRecord.uid.toString('hex') !== uid.toString('hex')) {
+              if (! secondaryEmailRecord.isVerified && ! butil.buffersAreEqual(secondaryEmailRecord.uid, uid)) {
                 return db.deleteEmail(Buffer.from(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
               }
             })

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -158,7 +158,7 @@ module.exports = (
                 throw error.verifiedSecondaryEmailAlreadyExists()
               }
 
-              return db.deleteEmail(Buffer(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
+              return db.deleteEmail(Buffer.from(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
             })
             .catch((err) => {
               if (err.errno !== error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
@@ -2176,7 +2176,7 @@ module.exports = (
               // Only delete secondary email if it is unverified and does not belong
               // to the current user.
               if (! secondaryEmailRecord.isVerified && secondaryEmailRecord.uid !== uid.toString('hex')) {
-                return db.deleteEmail(Buffer(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
+                return db.deleteEmail(Buffer.from(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
               }
             })
             .catch((err) => {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2175,7 +2175,8 @@ module.exports = (
             .then((secondaryEmailRecord) => {
               // Only delete secondary email if it is unverified and does not belong
               // to the current user.
-              if (! secondaryEmailRecord.isVerified && secondaryEmailRecord.uid !== uid.toString('hex')) {
+              if (! secondaryEmailRecord.isVerified &&
+                secondaryEmailRecord.uid.toString('hex') !== uid.toString('hex')) {
                 return db.deleteEmail(Buffer.from(secondaryEmailRecord.uid, 'hex'), secondaryEmailRecord.email)
               }
             })


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/275. If a secondary email is unverified in an account A, if another account B attempts to add it, it will add to the account B and deleted it from account A.

@mozilla/fxa-devs r?