### PR TITLE
fix(config): Update secondary email config to support softvision and restmail

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -753,7 +753,7 @@ var conf = convict({
     enabledEmailAddresses: {
       doc: 'Only enable for email addresses matching this regex.',
       format: RegExp,
-      default: /.+@mozilla\.com$/,
+      default: /.+@mozilla\.com$|.+@restmail\.net$|.+@softvision\..{2,3}$/,
       env: 'SECONDARY_EMAIL_ENABLE_REGEX'
     },
     minUnverifiedAccountTime: {

--- a/config/index.js
+++ b/config/index.js
@@ -753,7 +753,7 @@ var conf = convict({
     enabledEmailAddresses: {
       doc: 'Only enable for email addresses matching this regex.',
       format: RegExp,
-      default: /.+@mozilla\.com$|.+@restmail\.net$|.+@softvision\..{2,3}$/,
+      default: /.+@mozilla\.com$|.+@restmail\.net$|.+@softvisioninc\.eu$|.+@softvision\.(com|ro)$/,
       env: 'SECONDARY_EMAIL_ENABLE_REGEX'
     },
     minUnverifiedAccountTime: {


### PR DESCRIPTION
Found that softvision has `softvision.com`, `softvisioninc.eu`, `softvision.ro` emails. Updated regex to support this and `restmail.net`.

@vladikoff Does this match what you were expecting? . r?

Fixes #1891 