### PR TITLE
chore(deps): update nexmo

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -65,7 +65,7 @@
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
@@ -269,7 +269,7 @@
     "fxa-auth-db-mysql": {
       "version": "1.86.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#8930d80112a93d757484fcf6ac07d585e23e0662",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#b74079397aab4bebdf031e95e138955e990afc53",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -1046,9 +1046,9 @@
                   "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
                 },
                 "stack-trace": {
-                  "version": "0.0.9",
+                  "version": "0.0.10",
                   "from": "stack-trace@>=0.0.9 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
                 },
                 "strftime": {
                   "version": "0.9.2",
@@ -1322,7 +1322,7 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "assert-plus@1.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
@@ -2119,13 +2119,13 @@
           }
         },
         "minimatch": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "from": "minimatch@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.7",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "brace-expansion@>=1.1.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "dependencies": {
                 "balanced-match": {
@@ -2211,13 +2211,13 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
-                  "version": "3.0.3",
+                  "version": "3.0.4",
                   "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dependencies": {
                         "balanced-match": {
@@ -2286,7 +2286,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2344,7 +2344,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2685,9 +2685,9 @@
                       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
                       "dependencies": {
                         "jsonparse": {
-                          "version": "1.3.0",
+                          "version": "1.3.1",
                           "from": "jsonparse@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
                         }
                       }
                     },
@@ -3386,7 +3386,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.8",
-                  "from": "normalize-package-data@>=2.3.5 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -3591,7 +3591,7 @@
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "process-nextick-args": {
@@ -3709,7 +3709,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -3864,9 +3864,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.15",
+                      "version": "0.10.18",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.18.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.1",
@@ -3901,9 +3901,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.15",
+                      "version": "0.10.18",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.18.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.1",
@@ -3937,9 +3937,9 @@
               }
             },
             "espree": {
-              "version": "3.4.2",
+              "version": "3.4.3",
               "from": "espree@>=3.4.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "5.0.3",
@@ -4107,13 +4107,13 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
-                  "version": "3.0.3",
+                  "version": "3.0.4",
                   "from": "minimatch@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dependencies": {
                         "balanced-match": {
@@ -4356,9 +4356,9 @@
               }
             },
             "js-yaml": {
-              "version": "3.8.3",
+              "version": "3.8.4",
               "from": "js-yaml@>=3.5.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.9",
@@ -4647,13 +4647,13 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
-                  "version": "3.0.3",
+                  "version": "3.0.4",
                   "from": "minimatch@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dependencies": {
                         "balanced-match": {
@@ -4705,12 +4705,12 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@1.1.3",
+              "from": "chalk@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
@@ -4720,7 +4720,7 @@
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -4947,9 +4947,9 @@
               "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
             },
             "chokidar": {
-              "version": "1.6.1",
+              "version": "1.7.0",
               "from": "chokidar@>=1.6.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
@@ -5209,13 +5209,13 @@
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                     },
                     "minimatch": {
-                      "version": "3.0.3",
+                      "version": "3.0.4",
                       "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "brace-expansion@>=1.1.7 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                           "dependencies": {
                             "balanced-match": {
@@ -5471,30 +5471,30 @@
                       "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
-                    "fstream": {
-                      "version": "1.0.10",
-                      "from": "fstream@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
-                    },
                     "fstream-ignore": {
                       "version": "1.0.5",
                       "from": "fstream-ignore@>=1.0.5 <1.1.0",
                       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.10",
+                      "from": "fstream@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
                     },
                     "gauge": {
                       "version": "2.7.3",
                       "from": "gauge@>=2.7.1 <2.8.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz"
                     },
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "glob": {
                       "version": "7.1.1",
@@ -5516,15 +5516,15 @@
                       "from": "har-validator@>=2.0.6 <2.1.0",
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                     },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
                     "has-unicode": {
                       "version": "2.0.1",
                       "from": "has-unicode@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
                     "hawk": {
                       "version": "3.1.3",
@@ -5566,15 +5566,15 @@
                       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
                     },
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    },
                     "is-typedarray": {
                       "version": "1.0.0",
                       "from": "is-typedarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -5850,18 +5850,6 @@
                         }
                       }
                     },
-                    "sshpk": {
-                      "version": "1.10.2",
-                      "from": "sshpk@>=1.7.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
                     "rc": {
                       "version": "1.1.7",
                       "from": "rc@>=1.1.6 <1.2.0",
@@ -5871,6 +5859,18 @@
                           "version": "1.2.0",
                           "from": "minimist@>=1.2.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.2",
+                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         }
                       }
                     },
@@ -6045,9 +6045,9 @@
           }
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.26",
           "from": "uglify-js@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.26.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -6231,9 +6231,9 @@
               "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
             },
             "joi": {
-              "version": "10.4.1",
+              "version": "10.4.2",
               "from": "joi@>=10.0.0 <11.0.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.2.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "2.2.1",
@@ -6272,9 +6272,9 @@
               "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
             },
             "joi": {
-              "version": "10.4.1",
+              "version": "10.4.2",
               "from": "joi@>=10.0.0 <11.0.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.2.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "2.2.1",
@@ -6318,9 +6318,9 @@
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.27.0",
+              "version": "1.28.0",
               "from": "mime-db@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.28.0.tgz"
             }
           }
         },
@@ -6335,9 +6335,9 @@
           "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.0.tgz",
           "dependencies": {
             "joi": {
-              "version": "10.4.1",
+              "version": "10.4.2",
               "from": "joi@>=10.0.0 <11.0.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.4.2.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "2.2.1",
@@ -6643,9 +6643,9 @@
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
                 },
                 "clean-css": {
-                  "version": "3.4.25",
+                  "version": "3.4.26",
                   "from": "clean-css@>=3.1.9 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.25.tgz",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.8.1",
@@ -6782,9 +6782,9 @@
                   }
                 },
                 "uglify-js": {
-                  "version": "2.8.22",
+                  "version": "2.8.26",
                   "from": "uglify-js@>=2.4.19 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.26.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.5.6",
@@ -7273,13 +7273,13 @@
                       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
-                          "version": "3.0.3",
+                          "version": "3.0.4",
                           "from": "minimatch@>=0.2.4",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.7",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "from": "brace-expansion@>=1.1.7 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                               "dependencies": {
                                 "balanced-match": {
@@ -7458,13 +7458,13 @@
               }
             },
             "minimatch": {
-              "version": "3.0.3",
-              "from": "minimatch@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "dependencies": {
                     "balanced-match": {
@@ -7558,9 +7558,9 @@
           }
         },
         "mime": {
-          "version": "1.3.4",
+          "version": "1.3.6",
           "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
         },
         "uue": {
           "version": "3.1.0",
@@ -7653,7 +7653,7 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "glob": {
@@ -7684,13 +7684,13 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
-              "version": "3.0.3",
+              "version": "3.0.4",
               "from": "minimatch@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "dependencies": {
                     "balanced-match": {
@@ -7830,7 +7830,7 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
@@ -7840,7 +7840,7 @@
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -7875,9 +7875,9 @@
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
-              "version": "0.0.9",
+              "version": "0.0.10",
               "from": "stack-trace@>=0.0.9 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
             },
             "strftime": {
               "version": "0.9.2",
@@ -8031,9 +8031,9 @@
       }
     },
     "nexmo": {
-      "version": "1.2.0",
-      "from": "nexmo@1.2.0",
-      "resolved": "https://registry.npmjs.org/nexmo/-/nexmo-1.2.0.tgz",
+      "version": "2.0.2",
+      "from": "nexmo@2.0.2",
+      "resolved": "https://registry.npmjs.org/nexmo/-/nexmo-2.0.2.tgz",
       "dependencies": {
         "jsonwebtoken": {
           "version": "7.4.0",
@@ -8773,15 +8773,15 @@
           "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
         "center-align": {
           "version": "0.1.3",
           "from": "center-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "code-point-at": {
           "version": "1.0.1",
@@ -8823,25 +8823,25 @@
           "from": "detect-indent@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-        },
         "error-ex": {
           "version": "1.3.0",
           "from": "error-ex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
         },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "esutils": {
           "version": "2.0.2",
           "from": "esutils@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "from": "expand-brackets@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
         },
         "expand-range": {
           "version": "1.8.2",
@@ -9118,15 +9118,15 @@
           "from": "object-assign@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         },
-        "object.omit": {
-          "version": "2.0.1",
-          "from": "object.omit@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
-        },
         "once": {
           "version": "1.4.0",
           "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "from": "object.omit@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
         },
         "optimist": {
           "version": "0.6.1",
@@ -9193,15 +9193,15 @@
           "from": "pkg-dir@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
         },
-        "preserve": {
-          "version": "0.2.0",
-          "from": "preserve@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-        },
         "pseudomap": {
           "version": "1.0.2",
           "from": "pseudomap@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "from": "preserve@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
         },
         "randomatic": {
           "version": "1.1.5",
@@ -9936,13 +9936,13 @@
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
-                          "version": "3.0.3",
+                          "version": "3.0.4",
                           "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.7",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "from": "brace-expansion@>=1.1.7 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                               "dependencies": {
                                 "balanced-match": {
@@ -10059,9 +10059,9 @@
           }
         },
         "mime": {
-          "version": "1.3.4",
+          "version": "1.3.6",
           "from": "mime@>=1.2.11 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
         },
         "negotiator": {
           "version": "0.6.1",
@@ -10171,7 +10171,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "moment-timezone": "0.5.11",
     "mozlog": "2.0.6",
     "newrelic": "1.30.1",
-    "nexmo": "1.2.0",
+    "nexmo": "2.0.2",
     "node-statsd": "0.1.1",
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
     "nodemailer": "2.7.2",

--- a/test/remote/sms_tests.js
+++ b/test/remote/sms_tests.js
@@ -10,44 +10,14 @@ const Client = require('../client')()
 const config = require('../../config').getProperties()
 const error = require('../../lib/error')
 
-describe('remote sms (live nexmo)', function() {
-  this.timeout(10000)
-  let server
-
-  before(() => {
-    config.sms.enabled = true
-    config.sms.isStatusGeoEnabled = true
-
-    return TestServer.start(config)
-      .then(result => {
-        server = result
-      })
-  })
-
-  it('GET /sms/status', () => {
-    return Client.create(config.publicUrl, server.uniqueEmail(), 'wibble')
-      .then(client => {
-        return client.smsStatus()
-          .then(status => {
-            assert.ok(status)
-            assert.equal(typeof status.ok, 'boolean')
-            assert.equal(status.country, 'US')
-          })
-      })
-  })
-
-  after(() => {
-    return TestServer.stop(server)
-  })
-})
-
 describe('remote sms (mocked nexmo)', function() {
   this.timeout(10000)
   let server
 
   before(() => {
     config.sms.enabled = true
-    // POST /sms spends actual money unless the SMS provider is mocked
+    config.sms.isStatusGeoEnabled = true
+    // /sms endpoints need creds and spend money unless the SMS provider is mocked
     config.sms.useMock = true
 
     return TestServer.start(config)
@@ -103,6 +73,18 @@ describe('remote sms (mocked nexmo)', function() {
             assert.equal(err.code, 400)
             assert.equal(err.errno, error.ERRNO.INVALID_MESSAGE_ID)
             assert.equal(err.message, 'Invalid message id')
+          })
+      })
+  })
+
+  it('GET /sms/status', () => {
+    return Client.create(config.publicUrl, server.uniqueEmail(), 'wibble')
+      .then(client => {
+        return client.smsStatus()
+          .then(status => {
+            assert.ok(status)
+            assert.equal(typeof status.ok, 'boolean')
+            assert.equal(status.country, 'US')
           })
       })
   })


### PR DESCRIPTION
Fixes #1821. Fixes #1877.

The secondary change of replacing the live nexmo test with a mocked one was made because that test was only passing by accident. From https://github.com/mozilla/fxa-auth-server/issues/1877#issuecomment-302025879:

> The actual response we're getting from Nexmo in this test is:
> 
> ```js
> {
>   'error-code': '401',
>   'error-code-label': 'authentication failed'
> }
> ```
> 
> Then our own code stupidly treats that like the balance is insufficient:
> 
> ```js
> var balance = result.value
> var isOk = balance >= smsConfig.balanceThreshold
> ```
> 
> In the latest version of the nexmo client, the error is properly returned down the error path and this test fails completely.

With that change made, we can safely update Nexmo and everyone's happy. I've tested the latest Nexmo with our current SMS flow and it works tremendously.

@mozilla/fxa-devs r?

/cc @vbudhram, I'm whacking a `shipit` on this because it would be great to get it in to train 87 if possible.