### PR TITLE
Send push notification on account destroy

### DIFF
--- a/docs/pushpayloads.schema.json
+++ b/docs/pushpayloads.schema.json
@@ -9,7 +9,8 @@
     { "$ref":"#/definitions/profileUpdated" },
     { "$ref":"#/definitions/collectionsChanged" },
     { "$ref":"#/definitions/passwordChanged" },
-    { "$ref":"#/definitions/passwordReset" }
+    { "$ref":"#/definitions/passwordReset" },
+    { "$ref":"#/definitions/accountDestroyed" }
   ],
   "definitions":{
     "deviceConnected":{
@@ -166,6 +167,38 @@
           "enum":[
             "fxaccounts:password_reset"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "accountDestroyed":{
+      "required":[
+        "version",
+        "command",
+        "data"
+      ],
+      "properties":{
+        "version":{
+          "type":"integer"
+        },
+        "command":{
+          "type":"string",
+          "enum":[
+            "fxaccounts:account_destroyed"
+          ]
+        },
+        "data":{
+          "type":"object",
+          "required":[
+            "uid"
+          ],
+          "properties":{
+            "uid":{
+              "type":"string",
+              "description":"The UID of the account which was destroyed"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/lib/push.js
+++ b/lib/push.js
@@ -95,6 +95,12 @@ var reasonToEvents = {
   }
 }
 
+/**
+ * A device object returned by the db,
+ * typically obtained by calling db.devices(uid).
+ * @typedef {Object} Device
+ */
+
 module.exports = function (log, db, config) {
   var vapid
   if (config.vapidKeysFile) {
@@ -109,15 +115,14 @@ module.exports = function (log, db, config) {
   /**
    * Reports push errors to logs
    *
-   * @param err
-   * Error object
-   * @param deviceId
-   * The device id
+   * @param {Error} err
+   * @param {Buffer} uid
+   * @param {String} deviceId
    */
   function reportPushError(err, uid, deviceId) {
     log.error({
       op: LOG_OP_PUSH_TO_DEVICES,
-      uid: uid,
+      uid: uid.toString('hex'),
       deviceId: deviceId,
       err: err
     })
@@ -126,8 +131,7 @@ module.exports = function (log, db, config) {
   /**
    * Reports push increment actions to logs
    *
-   * @param name
-   * Name of the push action
+   * @param {String} name
    */
   function incrementPushAction(name) {
     if (name) {
@@ -143,7 +147,7 @@ module.exports = function (log, db, config) {
    * Copy sendPush authorized options from an existing options object
    * to a new one
    *
-   * @param options
+   * @param {Object} options
    */
   function filterOptions(options) {
     var allowedProps = ['TTL', 'data']
@@ -159,8 +163,8 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices that there was an update to the account
      *
-     * @param uid
-     * @param reason
+     * @param {Buffer} uid
+     * @param {String} reason
      * @promise
      */
     notifyUpdate: function notifyUpdate(uid, reason) {
@@ -171,9 +175,9 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices (except the one who joined) that a new device joined the account
      *
-     * @param uid
-     * @param deviceName
-     * @param currentDeviceId
+     * @param {Buffer} uid
+     * @param {String} deviceName
+     * @param {String} currentDeviceId
      * @promise
      */
     notifyDeviceConnected: function notifyDeviceConnected(uid, deviceName, currentDeviceId) {
@@ -191,8 +195,8 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a device that it is now disconnected from the account
      *
-     * @param uid
-     * @param idToDisconnect
+     * @param {Buffer} uid
+     * @param {String} idToDisconnect
      * @promise
      */
     notifyDeviceDisconnected: function notifyDeviceDisconnected(uid, idToDisconnect) {
@@ -210,7 +214,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices that a the profile attached to the account was updated
      *
-     * @param uid
+     * @param {Buffer} uid
      * @promise
      */
     notifyProfileUpdated: function notifyProfileUpdated(uid) {
@@ -225,8 +229,8 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a set of devices that the password was changed
      *
-     * @param uid
-     * @param {Object[]} devices (complete devices objects)
+     * @param {Buffer} uid
+     * @param {Device[]} devices
      * @promise
      */
     notifyPasswordChanged: function notifyPasswordChanged(uid, devices) {
@@ -241,8 +245,8 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a set of devices that the password was reset
      *
-     * @param uid
-     * @param {Object[]} devices (complete devices objects)
+     * @param {Buffer} uid
+     * @param {Device[]} devices
      * @promise
      */
     notifyPasswordReset: function notifyPasswordReset(uid, devices) {
@@ -257,8 +261,8 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to all the devices in the account (except the ones in the excludedDeviceIds)
      *
-     * @param uid
-     * @param reason
+     * @param {Buffer} uid
+     * @param {String} reason
      * @param {Object} options
      * @param {String} options.excludedDeviceIds
      * @param {String} options.data
@@ -283,9 +287,9 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to a set of devices in the account
      *
-     * @param uid
-     * @param {Array} ids
-     * @param reason
+     * @param {Buffer} uid
+     * @param {String[]} ids
+     * @param {String} reason
      * @param {Object} options
      * @param {String} options.data
      * @param {String} options.TTL (in seconds)
@@ -309,9 +313,9 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to one device in the account
      *
-     * @param uid
-     * @param id
-     * @param reason
+     * @param {Buffer} uid
+     * @param {String} id
+     * @param {String} reason
      * @param {Object} options
      * @param {String} options.data
      * @param {String} options.TTL (in seconds)
@@ -324,9 +328,9 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to a list of devices
      *
-     * @param uid
-     * @param devices
-     * @param reason
+     * @param {Buffer} uid
+     * @param {Device[]} devices
+     * @param {String} reason
      * @param {Object} options
      * @param {String} options.data
      * @param {String} options.TTL (in seconds)

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2589,6 +2589,7 @@ module.exports = (
         var form = request.payload
         var authPW = Buffer(form.authPW, 'hex')
         var uid
+        var devicesToNotify
         customs.check(
           request,
           form.email,
@@ -2596,7 +2597,7 @@ module.exports = (
           .then(db.emailRecord.bind(db, form.email))
           .then(
             function (emailRecord) {
-              uid = emailRecord.uid.toString('hex')
+              uid = emailRecord.uid
 
               return checkPassword(emailRecord, authPW, request.app.clientAddress)
                 .then(
@@ -2604,20 +2605,29 @@ module.exports = (
                     if (! match) {
                       throw error.incorrectPassword(emailRecord.email, form.email)
                     }
+                    // We fetch the devices to notify before deleteAccount()
+                    // because obviously we can't retrieve the devices list after!
+                    return db.devices(uid)
+                  }
+                )
+                .then(
+                  function (devices) {
+                    devicesToNotify = devices
                     return db.deleteAccount(emailRecord)
                   }
                 )
                 .then(
                   function () {
+                    push.notifyAccountDestroyed(uid, devicesToNotify).catch(function () {})
                     return log.notifyAttachedServices('delete', request, {
-                      uid: uid + '@' + config.domain
+                      uid: uid.toString('hex') + '@' + config.domain
                     })
                   }
                 )
                 .then(
                   function () {
                     return request.emitMetricsEvent('account.deleted', {
-                      uid: uid
+                      uid: uid.toString('hex')
                     })
                   }
                 )

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1962,7 +1962,7 @@ module.exports = (
                     })
                     .then(function () {
                       if (device) {
-                        push.notifyDeviceConnected(uidHex, device.name, device.id.toString('hex'))
+                        push.notifyDeviceConnected(uid, device.name, device.id.toString('hex'))
                       }
                     })
                     .then(function () {

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -85,7 +85,7 @@ describe('/account/reset', function () {
     const mockMetricsContext = mocks.mockMetricsContext()
     const mockRequest = mocks.mockRequest({
       credentials: {
-        uid: uid.toString('hex')
+        uid: uid
       },
       log: mockLog,
       metricsContext: mockMetricsContext,
@@ -130,7 +130,7 @@ describe('/account/reset', function () {
       assert.equal(mockDB.resetAccount.callCount, 1)
 
       assert.equal(mockPush.notifyPasswordReset.callCount, 1)
-      assert.equal(mockPush.notifyPasswordReset.firstCall.args[0], uid.toString('hex'))
+      assert.deepEqual(mockPush.notifyPasswordReset.firstCall.args[0], uid)
 
       assert.equal(mockDB.account.callCount, 1)
       assert.equal(mockCustoms.reset.callCount, 1)

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1144,6 +1144,7 @@ describe('/account/destroy', function () {
         authPW: new Array(65).join('f')
       }
     })
+    const mockPush = mocks.mockPush()
     var accountRoutes = makeRoutes({
       checkPassword: function () {
         return P.resolve(true)
@@ -1152,7 +1153,8 @@ describe('/account/destroy', function () {
         domain: 'wibble'
       },
       db: mockDB,
-      log: mockLog
+      log: mockLog,
+      push: mockPush
     })
     var route = getRoute(accountRoutes, '/account/destroy')
 
@@ -1168,6 +1170,9 @@ describe('/account/destroy', function () {
       assert.equal(args.length, 1, 'db.deleteAccount was passed one argument')
       assert.equal(args[0].email, email, 'db.deleteAccount was passed email record')
       assert.deepEqual(args[0].uid, uid, 'email record had correct uid')
+
+      assert.equal(mockPush.notifyAccountDestroyed.callCount, 1)
+      assert.equal(mockPush.notifyAccountDestroyed.firstCall.args[0], uid)
 
       assert.equal(mockLog.notifyAttachedServices.callCount, 1, 'log.notifyAttachedServices was called once')
       args = mockLog.notifyAttachedServices.args[0]

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -274,7 +274,7 @@ describe('/password', () => {
         var mockLog = mocks.spyLog()
         var mockRequest = mocks.mockRequest({
           credentials: {
-            uid: uid.toString('hex')
+            uid: uid
           },
           payload: {
             authPW: crypto.randomBytes(32).toString('hex'),
@@ -299,7 +299,7 @@ describe('/password', () => {
           assert.equal(mockDB.resetAccount.callCount, 1)
 
           assert.equal(mockPush.notifyPasswordChanged.callCount, 1)
-          assert.equal(mockPush.notifyPasswordChanged.firstCall.args[0], uid.toString('hex'))
+          assert.deepEqual(mockPush.notifyPasswordChanged.firstCall.args[0], uid)
 
           assert.equal(mockDB.account.callCount, 1)
           assert.equal(mockMailer.sendPasswordChangedNotification.callCount, 1)
@@ -338,7 +338,7 @@ describe('/password', () => {
         var mockLog = mocks.spyLog()
         var mockRequest = mocks.mockRequest({
           credentials: {
-            uid: uid.toString('hex')
+            uid: uid
           },
           payload: {
             authPW: crypto.randomBytes(32).toString('hex'),
@@ -363,7 +363,7 @@ describe('/password', () => {
           assert.equal(mockDB.resetAccount.callCount, 1)
 
           assert.equal(mockPush.notifyPasswordChanged.callCount, 1)
-          assert.equal(mockPush.notifyPasswordChanged.firstCall.args[0], uid.toString('hex'))
+          assert.deepEqual(mockPush.notifyPasswordChanged.firstCall.args[0], uid)
 
           assert.equal(mockDB.account.callCount, 1)
           assert.equal(mockMailer.sendPasswordChangedNotification.callCount, 1)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -105,6 +105,7 @@ const PUSH_METHOD_NAMES = [
   'notifyDeviceDisconnected',
   'notifyPasswordChanged',
   'notifyPasswordReset',
+  'notifyAccountDestroyed',
   'notifyUpdate',
   'pushToAllDevices',
   'pushToDevices'

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -120,7 +120,7 @@ module.exports = {
   spyLog: spyLog,
   mockMailer: mockObject(MAILER_METHOD_NAMES),
   mockMetricsContext: mockMetricsContext,
-  mockPush: mockObject(PUSH_METHOD_NAMES),
+  mockPush: mockPush,
   mockRequest: mockRequest
 }
 
@@ -278,6 +278,22 @@ function mockObject (methodNames) {
       return object
     }, {})
   }
+}
+
+function mockPush (methods) {
+  const push = extend({}, methods)
+  // So far every push method has a uid for first argument, let's keep it simple.
+  PUSH_METHOD_NAMES.forEach((name) => {
+    if (! push[name]) {
+      push[name] = sinon.spy(uid => {
+        if (! (uid instanceof Uint8Array)) {
+          throw new Error('The first param –uid– of ' + name + ' must be a Buffer!')
+        }
+        return P.resolve()
+      })
+    }
+  })
+  return push
 }
 
 function mockDevices (data) {


### PR DESCRIPTION
This connects to [Bugzilla #1365375](https://bugzilla.mozilla.org/show_bug.cgi?id=1365375).

I also noticed that we sometimes use a Buffer, sometimes an hex String for the `uid` param when we call the push library methods. I hardened the tests using the mock push and made the documentation crystal-clear on what we expect the parameters types to be in these push methods.  
These are the times when you miss strong typing :(