### PR TITLE
feat(server): add endpoint for consuming signinCodes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,8 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [GET /session/status (:lock: sessionToken)](#get-sessionstatus)
   * [Sign](#sign)
     * [POST /certificate/sign (:lock: sessionToken)](#post-certificatesign)
+  * [Signin codes](#signin-codes)
+    * [POST /signinCodes/consume](#post-signincodesconsume)
   * [Sms](#sms)
     * [POST /sms (:lock: sessionToken)](#post-sms)
     * [GET /sms/status (:lock: sessionToken)](#get-smsstatus)
@@ -238,6 +240,8 @@ for `code` and `errno` are:
   Email already exists
 * `code: 400, errno: 145`:
   Reset password with this email type is not currently supported
+* `code: 400, errno: 146`:
+  Invalid signin code
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -295,17 +299,20 @@ those common validations are defined here.
 * `HEX_STRING`: `/^(?:[a-fA-F0-9]{2})+$/`
 * `URLSAFEBASE64`: `/^[a-zA-Z0-9-_]*$/`
 * `BASE_36`: `/^[a-zA-Z0-9]*$/`
+* `URL_SAFE_BASE_64`: `/^[A-Za-z0-9_-]*$/`
 * `DISPLAY_SAFE_UNICODE`: `/^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uD800-\uDFFF\uE000-\uF8FF\uFFF9-\uFFFF])*$/`
 * `service`: `string, max(16), regex(/^[a-zA-Z0-9\-]*$/g)`
 * `E164_NUMBER`: `/^\+[1-9]\d{1,14}$/`
 
 #### lib/metrics/context
 
-* `schema`: object({
+* `SCHEMA`: object({
     * `flowId`: string, length(64), regex(HEX_STRING), optional
     * `flowBeginTime`: number, integer, positive, optional
 
-  }), unknown(false), and('flowId', 'flowBeginTime'), optional
+  }), unknown(false), and('flowId', 'flowBeginTime')
+* `schema`: SCHEMA.optional
+* `requiredSchema`: SCHEMA.required
 
 #### lib/features
 
@@ -2034,6 +2041,37 @@ by the following errors
 
 * `code: 400, errno: 108`:
   Missing parameter in request body
+
+
+### Signin codes
+
+#### POST /signinCodes/consume
+<!--begin-route-post-signincodesconsume-->
+Exchange a single-use signin code
+for an email address.
+<!--end-route-post-signincodesconsume-->
+
+##### Request body
+
+* `code`: *string, regex(validators.URL_SAFE_BASE_64), length(CODE_LENGTH), required*
+
+  <!--begin-request-body-post-signincodesconsume-code-->
+  The signin code.
+  <!--end-request-body-post-signincodesconsume-code-->
+
+* `metricsContext`: *metricsContext.requiredSchema*
+
+  <!--begin-request-body-post-signincodesconsume-metricsContext-->
+  Metrics context data for the new flow.
+  <!--end-request-body-post-signincodesconsume-metricsContext-->
+
+##### Response body
+
+* `email`: *validators.email.required*
+
+  <!--begin-response-body-post-signincodesconsume-email-->
+  The email address associated with the signin code.
+  <!--end-response-body-post-signincodesconsume-email-->
 
 
 ### Sms

--- a/docs/metrics-events.md
+++ b/docs/metrics-events.md
@@ -149,6 +149,7 @@ in a sign-in or sign-up flow:
 |`email.${templateName}.delivered`|An email was delivered to a user.|
 |`sms.region.${region}`|A user has tried to send SMS to `region`.|
 |`sms.${templateName}.sent`|An SMS message has been sent to a user's phone.|
+|`signinCode.consumed`|A sign-in code has been consumed on the server.|
 |`account.confirmed`|Sign-in to an existing account has been confirmed via email.|
 |`account.reminder`|A new account has been verified via a reminder email.|
 |`account.verified`|A new account has been verified via email.|

--- a/lib/customs.js
+++ b/lib/customs.js
@@ -53,27 +53,8 @@ module.exports = function (log, error) {
       }
     )
     .then(
-      function (result) {
-        if (result.suspect) {
-          request.app.isSuspiciousRequest = true
-        }
-        if (result.block) {
-          // log a flow event that user got blocked.
-          request.emitMetricsEvent('customs.blocked')
-
-          var unblock = !! result.unblock
-          if (result.retryAfter) {
-            // create a localized retryAfterLocalized value from retryAfter, for example '713' becomes '12 minutes'.
-            var retryAfterLocalized = localizeTimestamp.format(Date.now() + (result.retryAfter * 1000),
-                request.headers['accept-language'])
-
-            throw error.tooManyRequests(result.retryAfter, retryAfterLocalized, unblock)
-          } else {
-            throw error.requestBlocked(unblock)
-          }
-        }
-      },
-      function (err) {
+      handleCustomsResult.bind(request),
+      err => {
         log.error({ op: 'customs.check.1', email: email, action: action, err: err })
         // If this happens, either:
         // - (1) the url in config doesn't point to a real customs server
@@ -81,6 +62,34 @@ module.exports = function (log, error) {
         // Either way, allow the request through so we fail open.
       }
     )
+  }
+
+  function handleCustomsResult (result) {
+    const request = this
+
+    if (result.suspect) {
+      request.app.isSuspiciousRequest = true
+    }
+
+    if (result.block) {
+      // Log a flow event that user got blocked.
+      request.emitMetricsEvent('customs.blocked')
+
+      const unblock = !! result.unblock
+
+      if (result.retryAfter) {
+        // Create a localized retryAfterLocalized value from retryAfter.
+        // For example '713' becomes '12 minutes' in English.
+        const retryAfterLocalized = localizeTimestamp.format(
+          Date.now() + result.retryAfter * 1000,
+          request.headers['accept-language']
+        )
+
+        throw error.tooManyRequests(result.retryAfter, retryAfterLocalized, unblock)
+      }
+
+      throw error.requestBlocked(unblock)
+    }
   }
 
   Customs.prototype.checkAuthenticated = function (action, ip, uid) {
@@ -105,6 +114,24 @@ module.exports = function (log, error) {
       },
       function (err) {
         log.error({ op: 'customs.checkAuthenticated', uid: uid, action: action, err: err })
+        // If this happens, either:
+        // - (1) the url in config doesn't point to a real customs server
+        // - (2) the customs server returned an internal server error
+        // Either way, allow the request through so we fail open.
+      }
+    )
+  }
+
+  Customs.prototype.checkIpOnly = function (request, email, action) {
+    log.trace({ op: 'customs.checkIpOnly', action: action })
+    return this.pool.post('/checkIpOnly', {
+      ip: request.app.clientAddress,
+      action: action
+    })
+    .then(
+      handleCustomsResult.bind(request),
+      err => {
+        log.error({ op: 'customs.checkIpOnly.1', email: email, action: action, err: err })
         // If this happens, either:
         // - (1) the url in config doesn't point to a real customs server
         // - (2) the customs server returned an internal server error

--- a/lib/customs.js
+++ b/lib/customs.js
@@ -122,7 +122,7 @@ module.exports = function (log, error) {
     )
   }
 
-  Customs.prototype.checkIpOnly = function (request, email, action) {
+  Customs.prototype.checkIpOnly = function (request, action) {
     log.trace({ op: 'customs.checkIpOnly', action: action })
     return this.pool.post('/checkIpOnly', {
       ip: request.app.clientAddress,
@@ -131,7 +131,7 @@ module.exports = function (log, error) {
     .then(
       handleCustomsResult.bind(request),
       err => {
-        log.error({ op: 'customs.checkIpOnly.1', email: email, action: action, err: err })
+        log.error({ op: 'customs.checkIpOnly.1', action: action, err: err })
         // If this happens, either:
         // - (1) the url in config doesn't point to a real customs server
         // - (2) the customs server returned an internal server error

--- a/lib/db.js
+++ b/lib/db.js
@@ -927,6 +927,19 @@ module.exports = (
       })
   }
 
+  DB.prototype.consumeSigninCode = function (code) {
+    log.trace({ op: 'DB.consumeSigninCode', code })
+
+    return this.pool.post(`/signinCodes/${code.toString('hex')}/consume`)
+      .catch(err => {
+        if (isNotFoundError(err)) {
+          throw error.invalidSigninCode()
+        }
+
+        throw err
+      })
+  }
+
   function wrapTokenNotFoundError (err) {
     if (isNotFoundError(err)) {
       err = error.invalidToken('The authentication token could not be found')

--- a/lib/error.js
+++ b/lib/error.js
@@ -53,6 +53,7 @@ var ERRNO = {
   SECONDARY_EMAIL_UNKNOWN: 143,
   VERIFIED_SECONDARY_EMAIL_EXISTS: 144,
   RESET_PASSWORD_WITH_SECONDARY_EMAIL: 145,
+  INVALID_SIGNIN_CODE: 146,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -656,6 +657,15 @@ AppError.cannotResetPasswordWithSecondaryEmail = () => {
     error: 'Bad Request',
     errno: ERRNO.RESET_PASSWORD_WITH_SECONDARY_EMAIL,
     message: 'Reset password with this email type is not currently supported'
+  })
+}
+
+AppError.invalidSigninCode = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.INVALID_SIGNIN_CODE,
+    message: 'Invalid signin code'
   })
 }
 

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -18,7 +18,6 @@ const SCHEMA = isA.object({
 })
   .unknown(false)
   .and('flowId', 'flowBeginTime')
-  .optional()
 
 module.exports = function (log, config) {
   const cache = require('../cache')(log, config, 'fxa-metrics~')
@@ -236,4 +235,8 @@ function calculateFlowTime (time, flowBeginTime) {
   return time - flowBeginTime
 }
 
-module.exports.schema = SCHEMA
+// HACK: Force the API docs to expand SCHEMA inline
+module.exports.SCHEMA = SCHEMA
+module.exports.schema = SCHEMA.optional()
+module.exports.requiredSchema = SCHEMA.required()
+

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -49,6 +49,7 @@ module.exports = function (
   )
   const session = require('./session')(log, db)
   const sign = require('./sign')(log, signer, db, config.domain, devices)
+  const signinCodes = require('./signin-codes')(log, db, config, customs)
   const smsRoute = require('./sms')(log, db, config, customs, smsImpl)
   const util = require('./util')(
     log,
@@ -63,6 +64,7 @@ module.exports = function (
     account,
     password,
     session,
+    signinCodes,
     sign,
     smsRoute,
     util

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -49,7 +49,7 @@ module.exports = function (
   )
   const session = require('./session')(log, db)
   const sign = require('./sign')(log, signer, db, config.domain, devices)
-  const signinCodes = require('./signin-codes')(log, db, config, customs)
+  const signinCodes = require('./signin-codes')(log, db, customs)
   const smsRoute = require('./sms')(log, db, config, customs, smsImpl)
   const util = require('./util')(
     log,

--- a/lib/routes/signin-codes.js
+++ b/lib/routes/signin-codes.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const isA = require('joi')
+const validators = require('./validators')
+
+const METRICS_CONTEXT_SCHEMA = require('../metrics/context').requiredSchema
+
+module.exports = (log, db, config, customs) => {
+  const CODE_LENGTH = Math.ceil(4 * (config.signinCodeSize / 3))
+
+  return [
+    {
+      method: 'POST',
+      path: '/signinCodes/consume',
+      config: {
+        validate: {
+          payload: {
+            code: isA.string().regex(validators.URL_SAFE_BASE_64).length(CODE_LENGTH).required(),
+            metricsContext: METRICS_CONTEXT_SCHEMA
+          }
+        },
+        response: {
+          schema: {
+            email: validators.email().required()
+          }
+        }
+      },
+      handler (request, reply) {
+        log.begin('signinCodes.consume', request)
+        request.validateMetricsContext()
+
+        customs.checkIpOnly(request, 'consumeSigninCode')
+          .then(bufferizeSigninCode)
+          .then(consumeSigninCode)
+          .then(reply, reply)
+
+        function bufferizeSigninCode () {
+          let base64 = request.payload.code.replace(/-/g, '+').replace(/_/g, '/')
+
+          const padCount = base64.length % 4
+          for (let i = 0; i < padCount; ++i) {
+            base64 += '='
+          }
+
+          return Buffer.from(base64, 'base64')
+        }
+
+        function consumeSigninCode (code) {
+          return db.consumeSigninCode(code)
+            .then(result => {
+              return request.emitMetricsEvent('signinCode.consumed')
+                .then(() => result)
+            })
+        }
+      }
+    }
+  ]
+}
+

--- a/lib/routes/signin-codes.js
+++ b/lib/routes/signin-codes.js
@@ -9,9 +9,7 @@ const validators = require('./validators')
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').requiredSchema
 
-module.exports = (log, db, config, customs) => {
-  const CODE_LENGTH = Math.ceil(4 * (config.signinCodeSize / 3))
-
+module.exports = (log, db, customs) => {
   return [
     {
       method: 'POST',
@@ -19,7 +17,7 @@ module.exports = (log, db, config, customs) => {
       config: {
         validate: {
           payload: {
-            code: isA.string().regex(validators.URL_SAFE_BASE_64).length(CODE_LENGTH).required(),
+            code: isA.string().regex(validators.URL_SAFE_BASE_64).required(),
             metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -13,6 +13,9 @@ module.exports.URLSAFEBASE64 = /^[a-zA-Z0-9-_]*$/
 
 module.exports.BASE_36 = /^[a-zA-Z0-9]*$/
 
+// RFC 4648, section 5
+module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]*$/
+
 // Crude phone number validation. The handler code does it more thoroughly.
 exports.E164_NUMBER = /^\+[1-9]\d{1,14}$/
 

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -14,7 +14,7 @@ module.exports.URLSAFEBASE64 = /^[a-zA-Z0-9-_]*$/
 module.exports.BASE_36 = /^[a-zA-Z0-9]*$/
 
 // RFC 4648, section 5
-module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]*$/
+module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]+$/
 
 // Crude phone number validation. The handler code does it more thoroughly.
 exports.E164_NUMBER = /^\+[1-9]\d{1,14}$/

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -16,7 +16,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
       .then(function (templates) {
         return {
           email: new Mailer(translator, templates, config.smtp, sender),
-          sms: createSms(log, translator, templates, config.sms)
+          sms: createSms(log, translator, templates, config)
         }
       })
   }

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -9,8 +9,9 @@ var MockNexmo = require('../mock-nexmo')
 var P = require('bluebird')
 var error = require('../error')
 
-module.exports = function (log, translator, templates, smsConfig) {
-  var nexmo = smsConfig.useMock ? new MockNexmo(log, smsConfig.balanceThreshold) : new Nexmo({
+module.exports = function (log, translator, templates, config) {
+  var smsConfig = config.sms
+  var nexmo = smsConfig.useMock ? new MockNexmo(log, config) : new Nexmo({
     apiKey: smsConfig.apiKey,
     apiSecret: smsConfig.apiSecret
   })

--- a/scripts/write-api-docs.js
+++ b/scripts/write-api-docs.js
@@ -211,7 +211,9 @@ function marshallRouteData (docs, errors, files) {
 }
 
 function getModuleName (filePath) {
-  return path.basename(filePath, '.js').replace(/^[a-z]/, character => character.toUpperCase())
+  return path.basename(filePath, '.js')
+    .replace(/^[a-z]/, character => character.toUpperCase())
+    .replace(/-/g, ' ')
 }
 
 function parseVariables (node) {

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -671,6 +671,18 @@ module.exports = config => {
     )
   }
 
+  ClientApi.prototype.consumeSigninCode = function (code, metricsContext) {
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/signinCodes/consume`,
+      null,
+      {
+        code: code.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''),
+        metricsContext
+      }
+    )
+  }
+
   ClientApi.heartbeat = function (origin) {
     return (new ClientApi(origin)).doRequest('GET', origin + '/__heartbeat__')
   }

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -676,10 +676,7 @@ module.exports = config => {
       'POST',
       `${this.baseURL}/signinCodes/consume`,
       null,
-      {
-        code: code.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ''),
-        metricsContext
-      }
+      { code, metricsContext }
     )
   }
 

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -474,5 +474,9 @@ module.exports = config => {
     return this.api.smsStatus(this.sessionToken, country, clientIpAddress)
   }
 
+  Client.prototype.consumeSigninCode = function (code, metricsContext) {
+    return this.api.consumeSigninCode(code, metricsContext)
+  }
+
   return Client
 }

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -466,8 +466,15 @@ module.exports = config => {
       )
   }
 
-  Client.prototype.smsSend = function (phoneNumber, messageId, features) {
+  Client.prototype.smsSend = function (phoneNumber, messageId, features, mailbox) {
     return this.api.smsSend(this.sessionToken, phoneNumber, messageId, features)
+      .then(result => {
+        if (mailbox) {
+          return mailbox.waitForSms(phoneNumber)
+        }
+
+        return result
+      })
   }
 
   Client.prototype.smsStatus = function (country, clientIpAddress) {

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -58,6 +58,12 @@ describe('Customs', () => {
         .then(function(result) {
           assert.equal(result, undefined, 'Nothing is returned when /passwordReset succeeds')
         })
+        .then(() => {
+          return customsNoUrl.checkIpOnly(request, action)
+        })
+        .then(result => {
+          assert.equal(result, undefined, 'Nothing is returned when /checkIpOnly succeeds')
+        })
     }
   )
 
@@ -194,6 +200,22 @@ describe('Customs', () => {
           assert.equal(err.output.statusCode, 400, 'Status Code is correct')
           assert(! err.output.payload.retryAfter, 'retryAfter field is not present')
           assert(! err.output.headers['retry-after'], 'retryAfter header is not present')
+        })
+        .then(() => {
+          customsServer.post('/checkIpOnly', function (body) {
+            assert.deepEqual(body, {
+              ip: ip,
+              action: action
+            }, 'first call to /check had expected request params')
+            return true
+          }).reply(200, {
+            block: false,
+            retryAfter: 0
+          })
+          return customsWithUrl.checkIpOnly(request, action)
+        })
+        .then(result => {
+          assert.equal(result, undefined, 'Nothing is returned when /check succeeds')
         })
     }
   )

--- a/test/local/mock-nexmo.js
+++ b/test/local/mock-nexmo.js
@@ -7,8 +7,7 @@
 const assert = require('insist')
 const MockNexmo = require('../../lib/mock-nexmo')
 const sinon = require('sinon')
-
-const BALANCE_THRESHOLD = 1.5
+const config = require('../../config').getProperties()
 
 describe('mock-nexmo', () => {
   let log
@@ -18,7 +17,7 @@ describe('mock-nexmo', () => {
     log = {
       info: sinon.spy()
     }
-    mockNexmo = new MockNexmo(log, BALANCE_THRESHOLD)
+    mockNexmo = new MockNexmo(log, config)
   })
 
   afterEach(() => {
@@ -32,7 +31,7 @@ describe('mock-nexmo', () => {
   describe('account.checkBalance', () => {
     it('returns the balance threshold', (done) => {
       mockNexmo.account.checkBalance((err, resp) => {
-        assert.equal(resp.value, BALANCE_THRESHOLD)
+        assert.equal(resp.value, config.sms.balanceThreshold)
         assert.equal(log.info.callCount, 1)
 
         done()

--- a/test/local/routes/account_devices.js
+++ b/test/local/routes/account_devices.js
@@ -195,7 +195,6 @@ describe('/account/devices/notify', function () {
     }
   }
   var mockPush = mocks.mockPush()
-  var sandbox = sinon.sandbox.create()
   var mockCustoms = mocks.mockCustoms()
   var accountRoutes = makeRoutes({
     config: config,
@@ -368,9 +367,7 @@ describe('/account/devices/notify', function () {
     config.deviceNotificationsEnabled = true
 
     mockCustoms = mocks.mockCustoms({
-      checkAuthenticated: sandbox.spy(function () {
-        throw error.tooManyRequests(1)
-      })
+      checkAuthenticated: error.tooManyRequests(1)
     })
     route = getRoute(makeRoutes({customs: mockCustoms}), '/account/devices/notify')
 

--- a/test/local/routes/signin-codes.js
+++ b/test/local/routes/signin-codes.js
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const getRoute = require('../../routes_helpers').getRoute
+const mocks = require('../../mocks')
+const P = require('../../../lib/promise')
+
+describe('/signinCodes/consume:', () => {
+  let log, db, customs, routes, route, request
+
+  describe('success:', () => {
+    beforeEach(() => setup())
+
+    it('called log.begin correctly', () => {
+      assert.equal(log.begin.callCount, 1)
+      const args = log.begin.args[0]
+      assert.equal(args.length, 2)
+      assert.equal(args[0], 'signinCodes.consume')
+      assert.equal(args[1], request)
+    })
+
+    it('called request.validateMetricsContext correctly', () => {
+      assert.equal(request.validateMetricsContext.callCount, 1)
+      const args = request.validateMetricsContext.args[0]
+      assert.equal(args.length, 0)
+    })
+
+    it('called customs.checkIpOnly correctly', () => {
+      assert.equal(customs.checkIpOnly.callCount, 1)
+      const args = customs.checkIpOnly.args[0]
+      assert.equal(args.length, 2)
+      assert.equal(args[0], request)
+      assert.equal(args[1], 'consumeSigninCode')
+    })
+
+    it('called db.consumeSigninCode correctly', () => {
+      assert.equal(db.consumeSigninCode.callCount, 1)
+      const args = db.consumeSigninCode.args[0]
+      assert.equal(args.length, 1)
+      assert.ok(Buffer.isBuffer(args[0]))
+      assert.equal(args[0].toString('base64'), '++//ff0=')
+    })
+
+    it('called log.flowEvent correctly', () => {
+      assert.equal(log.flowEvent.callCount, 1)
+
+      const args = log.flowEvent.args[0]
+      assert.equal(args.length, 1)
+      assert.equal(args[0].event, 'signinCode.consumed')
+      assert.equal(args[0].flow_id, request.payload.metricsContext.flowId)
+    })
+  })
+
+  describe('db error:', () => {
+    beforeEach(() => setup({ db: { consumeSigninCode: 'foo' } }))
+
+    it('called log.begin', () => {
+      assert.equal(log.begin.callCount, 1)
+    })
+
+    it('called request.validateMetricsContext', () => {
+      assert.equal(request.validateMetricsContext.callCount, 1)
+    })
+
+    it('called customs.checkIpOnly', () => {
+      assert.equal(customs.checkIpOnly.callCount, 1)
+    })
+
+    it('called db.consumeSigninCode', () => {
+      assert.equal(db.consumeSigninCode.callCount, 1)
+    })
+
+    it('did not call log.flowEvent', () => {
+      assert.equal(log.flowEvent.callCount, 0)
+    })
+  })
+
+  describe('customs error:', () => {
+    beforeEach(() => setup({ customs: { checkIpOnly: 'foo' } }))
+
+    it('called log.begin', () => {
+      assert.equal(log.begin.callCount, 1)
+    })
+
+    it('called request.validateMetricsContext', () => {
+      assert.equal(request.validateMetricsContext.callCount, 1)
+    })
+
+    it('called customs.checkIpOnly', () => {
+      assert.equal(customs.checkIpOnly.callCount, 1)
+    })
+
+    it('did not call db.consumeSigninCode', () => {
+      assert.equal(db.consumeSigninCode.callCount, 0)
+    })
+
+    it('did not call log.flowEvent', () => {
+      assert.equal(log.flowEvent.callCount, 0)
+    })
+  })
+
+  function setup (errors) {
+    errors = errors || {}
+
+    log = mocks.spyLog()
+    db = mocks.mockDB(null, errors.db)
+    customs = mocks.mockCustoms(errors.customs)
+    routes = makeRoutes({ log, db, customs })
+    route = getRoute(routes, '/signinCodes/consume')
+    request = mocks.mockRequest({
+      log: log,
+      payload: {
+        code: '--__ff0',
+        metricsContext: {
+          flowBeginTime: Date.now(),
+          flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        }
+      }
+    })
+    return runTest(route, request)
+  }
+})
+
+function makeRoutes (options) {
+  options = options || {}
+  const log = options.log || mocks.mockLog()
+  const db = options.db || mocks.mockDb()
+  const customs = options.customs || mocks.mockCustoms()
+  return require('../../../lib/routes/signin-codes')(log, db, { signinCodeSize: 6 }, customs)
+}
+
+function runTest (route, request) {
+  return new P((resolve, reject) => {
+    route.handler(request, response => {
+      if (response instanceof Error) {
+        reject(response)
+      } else {
+        resolve(response)
+      }
+    })
+  })
+}
+

--- a/test/local/routes/signin-codes.js
+++ b/test/local/routes/signin-codes.js
@@ -130,7 +130,7 @@ function makeRoutes (options) {
   const log = options.log || mocks.mockLog()
   const db = options.db || mocks.mockDb()
   const customs = options.customs || mocks.mockCustoms()
-  return require('../../../lib/routes/signin-codes')(log, db, { signinCodeSize: 6 }, customs)
+  return require('../../../lib/routes/signin-codes')(log, db, customs)
 }
 
 function runTest (route, request) {

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -62,12 +62,14 @@ describe('lib/senders/sms:', () => {
       sms = proxyquire(`${ROOT_DIR}/lib/senders/sms`, {
         nexmo: Nexmo
       })(log, translator, templates, {
-        apiKey: 'foo',
-        apiSecret: 'bar',
-        balanceThreshold: 1,
-        installFirefoxLink: 'https://baz/qux',
-        installFirefoxWithSigninCodeBaseUri: 'https://wibble',
-        useMock: false
+        sms: {
+          apiKey: 'foo',
+          apiSecret: 'bar',
+          balanceThreshold: 1,
+          installFirefoxLink: 'https://baz/qux',
+          installFirefoxWithSigninCodeBaseUri: 'https://wibble',
+          useMock: false
+        }
       })
     })
   })
@@ -245,11 +247,13 @@ describe('lib/senders/sms:', () => {
         nexmo: Nexmo,
         '../mock-nexmo': MockNexmo
       })(log, translator, templates, {
-        apiKey: 'foo',
-        apiSecret: 'bar',
-        balanceThreshold: 1,
-        installFirefoxLink: 'https://baz/qux',
-        useMock: true
+        sms: {
+          apiKey: 'foo',
+          apiSecret: 'bar',
+          balanceThreshold: 1,
+          installFirefoxLink: 'https://baz/qux',
+          useMock: true
+        }
       })
 
       assert.equal(mockConstructed, true)

--- a/test/mailbox.js
+++ b/test/mailbox.js
@@ -78,9 +78,14 @@ module.exports = function (host, port, printLogs) {
     return d.promise
   }
 
+  function waitForSms (phoneNumber) {
+    return waitForEmail(`sms.${phoneNumber}@restmail.net`)
+  }
+
   return {
     waitForEmail: waitForEmail,
     waitForCode: waitForCode,
+    waitForSms: waitForSms,
     eventEmitter: eventEmitter
   }
 }

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -16,6 +16,7 @@ const error = require('../lib/error')
 const CUSTOMS_METHOD_NAMES = [
   'check',
   'checkAuthenticated',
+  'checkIpOnly',
   'flag',
   'reset'
 ]
@@ -25,6 +26,7 @@ const DB_METHOD_NAMES = [
   'accountEmails',
   'accountResetToken',
   'consumeUnblockCode',
+  'consumeSigninCode',
   'createAccount',
   'createDevice',
   'createEmailBounce',
@@ -115,7 +117,7 @@ const PUSH_METHOD_NAMES = [
 module.exports = {
   generateMetricsContext: generateMetricsContext,
   mockBounces: mockObject(['check']),
-  mockCustoms: mockObject(CUSTOMS_METHOD_NAMES),
+  mockCustoms: mockCustoms,
   mockDB: mockDB,
   mockDevices: mockDevices,
   mockLog: mockLog,
@@ -124,6 +126,24 @@ module.exports = {
   mockMetricsContext: mockMetricsContext,
   mockPush: mockPush,
   mockRequest: mockRequest
+}
+
+function mockCustoms (errors) {
+  errors = errors || {}
+
+  return mockObject(CUSTOMS_METHOD_NAMES)({
+    checkAuthenticated: optionallyThrow(errors, 'checkAuthenticated'),
+    checkIpOnly: optionallyThrow(errors, 'checkIpOnly')
+  })
+}
+
+function optionallyThrow (errors, methodName) {
+  return sinon.spy(() => {
+    if (errors[methodName]) {
+      return P.reject(errors[methodName])
+    }
+    return P.resolve()
+  })
 }
 
 function mockDB (data, errors) {
@@ -159,6 +179,7 @@ function mockDB (data, errors) {
         }
       ])
     }),
+    consumeSigninCode: optionallyThrow(errors, 'consumeSigninCode'),
     createAccount: sinon.spy(() => {
       return P.resolve({
         uid: data.uid,
@@ -267,12 +288,7 @@ function mockDB (data, errors) {
         uaDeviceType: data.uaDeviceType
       })
     }),
-    verifyTokens: sinon.spy(() => {
-      if (errors.verifyTokens) {
-        return P.reject(errors.verifyTokens)
-      }
-      return P.resolve()
-    })
+    verifyTokens: optionallyThrow(errors, 'verifyTokens')
   })
 }
 

--- a/test/remote/signin_code_tests.js
+++ b/test/remote/signin_code_tests.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const TestServer = require('../test_server')
+const Client = require('../client')()
+const error = require('../../lib/error')
+const config = require('../../config').getProperties()
+const crypto = require('crypto')
+
+describe('remote signinCodes', () => {
+  let server
+
+  before(() => {
+    return TestServer.start(config)
+      .then(result => {
+        server = result
+      })
+  })
+
+  it('POST /signinCodes/consume invalid code', () => {
+    return Client.create(config.publicUrl, server.uniqueEmail(), 'wibble')
+      .then(client => {
+        return client.consumeSigninCode(crypto.randomBytes(config.signinCodeSize), {
+          metricsContext: {
+            flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            flowBeginTime: Date.now()
+          }
+        })
+          .then(result => assert.fail('/signinCodes/consume should fail'))
+          .catch(err => {
+            assert.ok(err)
+            assert.equal(err.code, 400)
+            assert.equal(err.errno, error.ERRNO.INVALID_SIGNIN_CODE)
+            assert.equal(err.message, 'Invalid signin code')
+          })
+      })
+  })
+
+  after(() => {
+    return TestServer.stop(server)
+  })
+})
+

--- a/test/remote/signin_code_tests.js
+++ b/test/remote/signin_code_tests.js
@@ -31,12 +31,19 @@ describe('remote signinCodes', function () {
 
   it('POST /signinCodes/consume invalid code', () => {
     const client = new Client(config.publicUrl)
-    return client.consumeSigninCode(crypto.randomBytes(config.signinCodeSize), {
-      metricsContext: {
-        flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        flowBeginTime: Date.now()
+    return client.consumeSigninCode(
+      crypto.randomBytes(config.signinCodeSize)
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, ''),
+      {
+        metricsContext: {
+          flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          flowBeginTime: Date.now()
+        }
       }
-    })
+    )
       .then(result => assert.fail('/signinCodes/consume should fail'))
       .catch(err => {
         assert.ok(err)

--- a/test/remote/sms_tests.js
+++ b/test/remote/sms_tests.js
@@ -10,7 +10,7 @@ const Client = require('../client')()
 const config = require('../../config').getProperties()
 const error = require('../../lib/error')
 
-describe('remote sms with signinCodes disabled', function() {
+describe('remote sms without the signinCodes feature included in the payload', function() {
   this.timeout(10000)
   let server
 
@@ -94,7 +94,7 @@ describe('remote sms with signinCodes disabled', function() {
   })
 })
 
-describe('remote sms with signinCodes enabled', function() {
+describe('remote sms with the signinCodes feature included in the payload', function() {
   this.timeout(10000)
   let server
 


### PR DESCRIPTION
Fixes #1882. ~~Do not merge until mozilla/fxa-customs-server#203 is ready.~~

This PR adds a new endpoint, `POST /signinCodes/consume`, that can be called by the content server to exchange a signin code for an email address. Future versions of the endpoint will return other properties to be used for expedited sign-in.

I struggled to write remote tests for the new endpoint. I have local tests and I have remote tests for the new db method, but I couldn't see a non-hacky way to get access to the signin code from a remote endpoint test because it's created out-of-process (so not easily mockable) and not returned to the client (it's only sent out via SMS message).

If we're okay with doing it hackishly, I could do something ugly like write the generated signin code to the file system in the mock nexmo `sendSms` handler, then read it from the file system in my test. Pretty ugly, huh? Anyone got better ideas?

@mozilla/fxa-devs r?