### PR TITLE
fix(devices): handle new user agent string from Sync client lib

### DIFF
--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -573,10 +573,10 @@ describe('userAgent', () => {
         }
       }
       const context = {}
-      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Firefox)'
+      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Nightly)'
       const result = userAgent.call(context, userAgentString, log)
 
-      assert.equal(result.uaBrowser, 'Firefox')
+      assert.equal(result.uaBrowser, 'Nightly')
       assert.equal(result.uaBrowserVersion, '6.0')
       assert.equal(result.uaOS, 'iOS')
       assert.equal(result.uaOSVersion, '10.3')
@@ -616,5 +616,59 @@ describe('userAgent', () => {
       uaParser.parse.reset()
     }
   )
+
+  it('recognises new mobile Sync library user agents on Android', () => {
+    parserResult = {
+      ua: {
+        family: 'Other'
+      },
+      os: {
+        family: 'Other'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    const context = {}
+    const userAgentString = 'Mobile-Android-Sync/(Mobile; Android 4.4.2) (foo() bar)'
+    const result = userAgent.call(context, userAgentString, log)
+
+    assert.equal(result.uaBrowser, 'foo() bar')
+    assert.equal(result.uaBrowserVersion, null)
+    assert.equal(result.uaOS, 'Android')
+    assert.equal(result.uaOSVersion, '4.4.2')
+    assert.equal(result.uaDeviceType, 'mobile')
+
+    assert.equal(log.info.callCount, 0)
+
+    uaParser.parse.reset()
+  })
+
+  it('recognises new mobile Sync library user agents on iOS', () => {
+    parserResult = {
+      ua: {
+        family: 'Other'
+      },
+      os: {
+        family: 'Other'
+      },
+      device: {
+        family: 'Other'
+      }
+    }
+    const context = {}
+    const userAgentString = 'Mobile-iOS-Sync/(iPad Mini; iOS 10.3) (wibble)'
+    const result = userAgent.call(context, userAgentString, log)
+
+    assert.equal(result.uaBrowser, 'wibble')
+    assert.equal(result.uaBrowserVersion, null)
+    assert.equal(result.uaOS, 'iOS')
+    assert.equal(result.uaOSVersion, '10.3')
+    assert.equal(result.uaDeviceType, 'tablet')
+
+    assert.equal(log.info.callCount, 0)
+
+    uaParser.parse.reset()
+  })
 })
 


### PR DESCRIPTION
Fixes #1889.

Adds handling for user agent strings from the new Sync mobile library.

I was torn between adding a third distinct regex to `lib/userAgent`, thereby creating an ugly chain of if-then-else-if ugliness, or consolidating all of our ~~debt~~ regexes into a single ultra-regex. Here you can see the ultra-regex approach in all it's glory: it starts off okay but then somewhere round the middle becomes completely impenetrable, in the customary style of all great regexes.

I'm happy to revert to separate expressions and explicit conditions if people find this one too unreadable.

There is one requirement from the linked issue that is not addressed here. Quoting from it:

> * Form factor (on Android, "Mobile" or "Tablet"; on iOS, device name instead)
> ...
>
> Which can be parsed to the initial device name:
>
> ```
> <Application-name>, <OS> <form factor>
> ```

When we synthesize the device name, I'm not including the form factor as it stands. This is because we coerce the form factor to either `'mobile'` or `'tablet'` and have logic in the content server that hangs off that distinction. So the raw form factor from the user agent string, e.g. `iPhone 6S`, is not available to us at the moment.

We could add an extra column to the `devices` table, say `uaFormFactor`, but that's a bigger change involving other repos and probably not worth blocking this PR on. Even without that part of the device name in place, this PR succeeds at the main aim of parsing the new user agent string. I'll open a separate issue for incorporating form factor in to the device name.

@mozilla/fxa-devs r?

/cc @mcomella