### PR TITLE
fix(email): check case insensitive headers in EmailSent event

### DIFF
--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const emailHelpers = require('../../../lib/email/utils/helpers')
+const spyLog = require('../../mocks').spyLog
+
+
+describe('email utils helpers', () => {
+  describe('getHeaderValue', () => {
+
+    it('works with message.mail.headers', () => {
+      const message = {
+        mail: {
+          headers: [{
+            name: 'content-language',
+            value: 'en-US'
+          }]
+        }
+      }
+
+      const value = emailHelpers.getHeaderValue('Content-Language', message)
+      assert.equal(value, message.mail.headers[0].value)
+    })
+
+
+    it('works with message.headers', () => {
+      const message = {
+        headers: [{
+          name: 'content-language',
+          value: 'ru'
+        }]
+      }
+
+      const value = emailHelpers.getHeaderValue('Content-Language', message)
+      assert.equal(value, message.headers[0].value)
+    })
+
+  })
+
+  describe('logEmailEventSent', () => {
+    it('should check headers case-insensitively', () => {
+      const mockLog = spyLog()
+      const message = {
+        email: 'user@example.domain',
+        template: 'verifyEmail',
+        headers: {
+          'cOnTeNt-LaNgUaGe': 'ru'
+        }
+      }
+      emailHelpers.logEmailEventSent(mockLog, message)
+      assert.equal(mockLog.info.callCount, 1)
+      assert.equal(mockLog.info.args[0][0].locale, 'ru')
+    })
+
+  })
+
+})


### PR DESCRIPTION
This may not have been an issue, but when I was building some graphs, I noticed some missing data for locale related to `sent` events, and went sniffing. This simply makes getting headers use the same logic for all 3 email events, which is consistent.

While in there, adding tests for the functionality I was changing (not the whole thing, that for some other eager soul!)