### PR TITLE
Backport ECDH key validation from private repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="1.87.1"></a>
+## [1.87.1](https://github.com/mozilla/fxa-auth-server/compare/v1.87.0...v1.87.1) (2017-05-26)
+
+
+### Bug Fixes
+
+* **push:** add extra logs ([5362c64](https://github.com/mozilla/fxa-auth-server/commit/5362c64))
+* **push:** Validate push public keys at registration time. ([8920a01](https://github.com/mozilla/fxa-auth-server/commit/8920a01))
+
+
+
 <a name="1.87.0"></a>
 # [1.87.0](https://github.com/mozilla/fxa-auth-server/compare/v1.86.0...v1.87.0) (2017-05-17)
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -175,7 +175,9 @@ module.exports = function (log, db, config) {
    * Checks whether the given string is a valid public key for push.
    * This is a little tricky because we need to work around a bug in nodejs
    * where using an invalid ECDH key can cause a later (unrelated) attempt
-   * to generate an RSA signature to fail :-(
+   * to generate an RSA signature to fail:
+   *
+   *   https://github.com/nodejs/node/pull/13275
    *
    * @param key
    * The public key as a b64url string.

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1256,6 +1256,13 @@ module.exports = (
         var payload = request.payload
         var sessionToken = request.auth.credentials
 
+        // Some additional, slightly tricky validation to detect bad public keys.
+        if (payload.pushPublicKey) {
+          if (! push.isValidPublicKey(payload.pushPublicKey)) {
+            throw error.invalidRequestParameter('invalid pushPublicKey')
+          }
+        }
+
         if (payload.id) {
           // Don't write out the update if nothing has actually changed.
           if (isSpuriousUpdate(payload, sessionToken)) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "dependencies": {
     "acorn": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -14,7 +14,8 @@ var fs = require('fs')
 var path = require('path')
 
 const P = require(`${ROOT_DIR}/lib/promise`)
-const mockLog = require('../mocks').mockLog
+const mocks = require('../mocks')
+const mockLog = mocks.mockLog
 var mockUid = Buffer.from('foo')
 var mockConfig = {}
 
@@ -36,7 +37,7 @@ var mockDevices = [
     'name': 'My Phone',
     'type': 'mobile',
     'pushCallback': 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
-    'pushPublicKey': 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXwAdITiPFcSUsaRI2nlzTNRn++q36F38XrH8m8sf28DQ+2Oob5SUzvgjVS0e70pIqH6bSXDgPc8mKtSs9Zi26Q==',
+    'pushPublicKey': mocks.MOCK_PUSH_KEY,
     'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong=='
   },
   {
@@ -46,7 +47,7 @@ var mockDevices = [
     'name': 'My Desktop',
     'type': null,
     'pushCallback': 'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
-    'pushPublicKey': 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXwAdITiPFcSUsaRI2nlzTNRn++q36F38XrH8m8sf28DQ+2Oob5SUzvgjVS0e70pIqH6bSXDgPc8mKtSs9Zi26Q==',
+    'pushPublicKey': mocks.MOCK_PUSH_KEY,
     'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong=='
   }
 ]
@@ -402,6 +403,88 @@ describe('push', () => {
       }
 
       var push = proxyquire(pushModulePath, mocks)(thisMockLog, mockDb, mockConfig)
+      // Careful, the argument gets modified in-place.
+      var device = JSON.parse(JSON.stringify(mockDevices[0]))
+      return push.sendPush(mockUid, [device], 'accountVerify')
+        .then(() => {
+          assert.equal(count, 1)
+        })
+    }
+  )
+
+  it(
+    'push resets device push data when a failure is caused by bad encryption keys',
+    () => {
+      var mockDb = {
+        updateDevice: sinon.spy(function () {
+          return P.resolve()
+        })
+      }
+
+      let count = 0
+      var thisMockLog = mockLog({
+        info: function (log) {
+          if (log.name === 'push.account_verify.reset_settings') {
+            // web-push failed
+            assert.equal(mockDb.updateDevice.callCount, 1, 'db.updateDevice was called once')
+            var args = mockDb.updateDevice.args[0]
+            assert.equal(args.length, 3, 'db.updateDevice was passed three arguments')
+            assert.equal(args[1], null, 'sessionTokenId argument was null')
+            count++
+          }
+        }
+      })
+
+      var mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            var err = new Error('Failed')
+            return P.reject(err)
+          }
+        }
+      }
+
+      var push = proxyquire(pushModulePath, mocks)(thisMockLog, mockDb, mockConfig)
+      // Careful, the argument gets modified in-place.
+      var device = JSON.parse(JSON.stringify(mockDevices[0]))
+      device.pushPublicKey = 'E' + device.pushPublicKey.substring(1) // make the key invalid
+      return push.sendPush(mockUid, [device], 'accountVerify')
+        .then(() => {
+          assert.equal(count, 1)
+        })
+    }
+  )
+
+  it(
+    'push does not reset device push data after an unexpected failure',
+    () => {
+      var mockDb = {
+        updateDevice: sinon.spy(function () {
+          return P.resolve()
+        })
+      }
+
+      let count = 0
+      var thisMockLog = mockLog({
+        info: function (log) {
+          if (log.name === 'push.account_verify.failed') {
+            // web-push failed
+            assert.equal(mockDb.updateDevice.callCount, 0, 'db.updateDevice was not called')
+            count++
+          }
+        }
+      })
+
+      var mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            var err = new Error('Failed')
+            return P.reject(err)
+          }
+        }
+      }
+
+      var push = proxyquire(pushModulePath, mocks)(thisMockLog, mockDb, mockConfig)
       return push.sendPush(mockUid, [mockDevices[0]], 'accountVerify')
         .then(() => {
           assert.equal(count, 1)
@@ -476,7 +559,14 @@ describe('push', () => {
   it(
     'notifyDeviceDisconnected calls pushToAllDevices',
     () => {
-      var push = require(pushModulePath)(mockLog(), mockDbResult, mockConfig)
+      var mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            return P.resolve()
+          }
+        }
+      }
+      var push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
       sinon.spy(push, 'pushToAllDevices')
       var idToDisconnect = mockDevices[0].id
       var expectedData = {
@@ -649,7 +739,7 @@ describe('push', () => {
       var push = proxyquire(pushModulePath, mocks)(thisMockLog, mockDbResult, mockConfig)
       return push.sendPush(mockUid, mockDevices, 'accountVerify')
         .then(() => {
-          assert.equal(count, 1)
+          assert.equal(count, 2)
         })
     }
   )

--- a/test/local/routes/account_devices.js
+++ b/test/local/routes/account_devices.js
@@ -122,7 +122,7 @@ describe('/account/device', function () {
     payload.name = 'my even awesomer device'
     payload.type = 'phone'
     payload.pushCallback = 'https://push.services.mozilla.com/123456'
-    payload.pushPublicKey = 'SomeEncodedBinaryStuffThatDoesntGetValidedByThisTest'
+    payload.pushPublicKey = mocks.MOCK_PUSH_KEY
 
     return runTest(route, mockRequest, function (response) {
       assert.equal(mockLog.increment.callCount, 5, 'the counters were incremented')

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -113,6 +113,7 @@ const PUSH_METHOD_NAMES = [
 ]
 
 module.exports = {
+  MOCK_PUSH_KEY: 'BDLugiRzQCANNj5KI1fAqui8ELrE7qboxzfa5K_R0wnUoJ89xY1D_SOXI_QJKNmellykaW_7U2BZ7hnrPW3A3LM',
   generateMetricsContext: generateMetricsContext,
   mockBounces: mockObject(['check']),
   mockCustoms: mockObject(CUSTOMS_METHOD_NAMES),

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -387,7 +387,7 @@ describe('remote password forgot', function() {
               name: 'baz',
               type: 'mobile',
               pushCallback: 'https://updates.push.services.mozilla.com/qux',
-              pushPublicKey: base64url(Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])),
+              pushPublicKey: mocks.MOCK_PUSH_KEY,
               pushAuthKey: base64url(crypto.randomBytes(16))
             })
           }


### PR DESCRIPTION
This backports the now-deployed-to-production code from https://github.com/mozilla/fxa-auth-server-private/pull/65 into the public repo.  It validates incoming push public keys before writing them to the db, and does so in a way that works around a bug node's handling of invalid keys:

  https://github.com/nodejs/node/pull/13275

@vladikoff r?