### PR TITLE
fix(sms): ditch the balance checks due to rate-limiting woe

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -708,12 +708,6 @@ var conf = convict({
       format: String,
       env: 'SMS_API_SECRET'
     },
-    balanceThreshold: {
-      doc: 'Minimum balance (in Euros) necessary for status to be deemed "good"',
-      default: 1,
-      format: Number,
-      env: 'SMS_MINIMUM_BALANCE'
-    },
     isStatusGeoEnabled: {
       doc: 'Indicates whether the status endpoint should do geo-ip lookup',
       default: true,

--- a/lib/mock-nexmo.js
+++ b/lib/mock-nexmo.js
@@ -5,13 +5,10 @@
 'use strict'
 
 /**
- * Mock out Nexmo for functional tests. `checkBalance` always
- * returns `balanceThreshold`, and `sendSms` always pretends
- * the message is sent successfully.
+ * Mock out Nexmo for functional tests. `sendSms` always succeeds.
  */
 
 function MockNexmo(log, config) {
-  const balanceThreshold = config.sms.balanceThreshold
   const mailerOptions = {
     host: config.smtp.host,
     secure: config.smtp.secure,
@@ -27,18 +24,6 @@ function MockNexmo(log, config) {
   const mailer = require('nodemailer').createTransport(mailerOptions)
 
   return {
-    account: {
-      /**
-       * Always returns the `balanceThreshold`
-       */
-      checkBalance: function checkBalance (callback) {
-        log.info({ op: 'sms.balance.mock' })
-
-        callback(null, {
-          value: balanceThreshold
-        })
-      }
-    },
     message: {
       /**
        * Drop message on the ground, call callback with `0` (send-OK) status.

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -122,8 +122,8 @@ module.exports = (log, db, config, customs, sms) => {
 
         let country
 
-        return P.all([ getLocation(), getBalance() ])
-          .spread(createResponse)
+        return getLocation()
+          .then(createResponse)
           .then(reply, reply)
 
         function getLocation () {
@@ -131,7 +131,7 @@ module.exports = (log, db, config, customs, sms) => {
 
           if (! forcedCountry && ! IS_STATUS_GEO_ENABLED) {
             log.warn({ op: 'sms.getGeoData', warning: 'skipping geolocation step' })
-            return true
+            return P.resolve(true)
           }
 
           return P.resolve()
@@ -158,17 +158,8 @@ module.exports = (log, db, config, customs, sms) => {
             })
         }
 
-        function getBalance () {
-          return sms.balance()
-            .then(balance => balance.isOk)
-            .catch(err => {
-              log.error({ op: 'sms.balance', err: err })
-              throw error.unexpectedError()
-            })
-        }
-
-        function createResponse (isLocationOk, isBalanceOk) {
-          return { ok: isLocationOk && isBalanceOk, country }
+        function createResponse (isLocationOk) {
+          return { ok: isLocationOk, country }
         }
       }
     }

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -17,7 +17,6 @@ module.exports = function (log, translator, templates, config) {
   })
 
   var sendSms = promisify('sendSms', nexmo.message)
-  var checkBalance = promisify('checkBalance', nexmo.account)
   var NEXMO_ERRORS = new Map([
     [ '1', error.tooManyRequests(smsConfig.throttleWaitTime) ]
   ])
@@ -63,20 +62,6 @@ module.exports = function (log, translator, templates, config) {
             log.error({ op: 'sms.send.error', reason: reason, status: status })
             throw NEXMO_ERRORS.get(status) || error.messageRejected(reason, status)
           }
-        })
-    },
-
-    balance: function () {
-      log.trace({ op: 'sms.balance' })
-
-      return checkBalance()
-        .then(function (result) {
-          var balance = result.value
-          var isOk = balance >= smsConfig.balanceThreshold
-
-          log.info({ op: 'sms.balance.success', balance: balance, isOk: isOk })
-
-          return { value: balance, isOk: isOk }
         })
     }
   }

--- a/test/local/mock-nexmo.js
+++ b/test/local/mock-nexmo.js
@@ -28,17 +28,6 @@ describe('mock-nexmo', () => {
     assert.ok(mockNexmo)
   })
 
-  describe('account.checkBalance', () => {
-    it('returns the balance threshold', (done) => {
-      mockNexmo.account.checkBalance((err, resp) => {
-        assert.equal(resp.value, config.sms.balanceThreshold)
-        assert.equal(log.info.callCount, 1)
-
-        done()
-      })
-    })
-  })
-
   describe('message.sendSms', () => {
     it('returns status: 0 with options, callback', (done) => {
       mockNexmo.message.sendSms('senderid', '+019999999999', 'message', {}, (err, resp) => {

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -417,12 +417,11 @@ describe('/sms/status', () => {
     })
   })
 
-  describe('getGeoData returns US and sms.balance returns isOk:true', () => {
+  describe('getGeoData returns US', () => {
     let response
 
     beforeEach(() => {
       geodbResult = P.resolve({ location: { countryCode: 'US' } })
-      sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .then(r => response = r)
     })
@@ -446,53 +445,16 @@ describe('/sms/status', () => {
       assert.equal(args[0], request.app.clientAddress)
     })
 
-    it('called sms.balance correctly', () => {
-      assert.equal(sms.balance.callCount, 1)
-      assert.equal(sms.balance.args[0].length, 0)
-    })
-
     it('did not call log.error', () => {
       assert.equal(log.error.callCount, 0)
     })
   })
 
-  describe('getGeoData returns US and sms.balance returns isOk:false', () => {
-    let response
-
-    beforeEach(() => {
-      geodbResult = P.resolve({ location: { countryCode: 'US' } })
-      sms.balance = sinon.spy(() => P.resolve({ isOk: false }))
-      return runTest(route, request)
-        .then(r => response = r)
-    })
-
-    it('returned the correct response', () => {
-      assert.deepEqual(response, { ok: false, country: 'US' })
-    })
-
-    it('called log.begin once', () => {
-      assert.equal(log.begin.callCount, 1)
-    })
-
-    it('called geodb once', () => {
-      assert.equal(geodb.callCount, 1)
-    })
-
-    it('called sms.balance once', () => {
-      assert.equal(sms.balance.callCount, 1)
-    })
-
-    it('did not call log.error', () => {
-      assert.equal(log.error.callCount, 0)
-    })
-  })
-
-  describe('getGeoData returns CA and sms.balance returns isOk:true', () => {
+  describe('getGeoData returns CA', () => {
     let response
 
     beforeEach(() => {
       geodbResult = P.resolve({ location: { countryCode: 'CA' } })
-      sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .then(r => response = r)
     })
@@ -509,50 +471,8 @@ describe('/sms/status', () => {
       assert.equal(geodb.callCount, 1)
     })
 
-    it('called sms.balance once', () => {
-      assert.equal(sms.balance.callCount, 1)
-    })
-
     it('did not call log.error', () => {
       assert.equal(log.error.callCount, 0)
-    })
-  })
-
-  describe('sms.balance fails', () => {
-    let err
-
-    beforeEach(() => {
-      geodbResult = P.resolve({ location: { countryCode: 'US' } })
-      sms.balance = sinon.spy(() => P.reject(new Error('foo')))
-      return runTest(route, request)
-        .catch(e => err = e)
-    })
-
-    it('threw the correct error data', () => {
-      assert.ok(err instanceof AppError)
-      assert.equal(err.errno, AppError.ERRNO.UNEXPECTED_ERROR)
-      assert.equal(err.message, 'Unspecified error')
-    })
-
-    it('called log.begin once', () => {
-      assert.equal(log.begin.callCount, 1)
-    })
-
-    it('called geodb once', () => {
-      assert.equal(geodb.callCount, 1)
-    })
-
-    it('called sms.balance once', () => {
-      assert.equal(sms.balance.callCount, 1)
-    })
-
-    it('called log.error correctly', () => {
-      assert.equal(log.error.callCount, 1)
-      const args = log.error.args[0]
-      assert.equal(args.length, 1)
-      assert.equal(args[0].op, 'sms.balance')
-      assert.ok(args[0].err instanceof Error)
-      assert.equal(args[0].err.message, 'foo')
     })
   })
 
@@ -561,7 +481,6 @@ describe('/sms/status', () => {
 
     beforeEach(() => {
       geodbResult = P.reject(new Error('bar'))
-      sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .catch(e => err = e)
     })
@@ -578,10 +497,6 @@ describe('/sms/status', () => {
 
     it('called geodb once', () => {
       assert.equal(geodb.callCount, 1)
-    })
-
-    it('called sms.balance once', () => {
-      assert.equal(sms.balance.callCount, 1)
     })
 
     it('called log.error correctly', () => {
@@ -599,7 +514,6 @@ describe('/sms/status', () => {
 
     beforeEach(() => {
       geodbResult = P.resolve({})
-      sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
       return runTest(route, request)
         .then(r => response = r)
     })
@@ -614,10 +528,6 @@ describe('/sms/status', () => {
 
     it('called geodb once', () => {
       assert.equal(geodb.callCount, 1)
-    })
-
-    it('called sms.balance once', () => {
-      assert.equal(sms.balance.callCount, 1)
     })
 
     it('called log.error correctly', () => {
@@ -654,7 +564,6 @@ describe('/sms/status with disabled geo-ip lookup', () => {
       },
       log: log
     })
-    sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
     return runTest(route, request)
       .then(r => response = r)
   })
@@ -679,10 +588,6 @@ describe('/sms/status with disabled geo-ip lookup', () => {
 
   it('did not call geodb', () => {
     assert.equal(geodb.callCount, 0)
-  })
-
-  it('called sms.balance once', () => {
-    assert.equal(sms.balance.callCount, 1)
   })
 
   it('did not call log.error', () => {
@@ -714,7 +619,6 @@ describe('/sms/status with query param and enabled geo-ip lookup', () => {
       },
       log: log
     })
-    sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
     return runTest(route, request)
       .then(r => response = r)
   })
@@ -729,10 +633,6 @@ describe('/sms/status with query param and enabled geo-ip lookup', () => {
 
   it('did not call geodb', () => {
     assert.equal(geodb.callCount, 0)
-  })
-
-  it('called sms.balance once', () => {
-    assert.equal(sms.balance.callCount, 1)
   })
 
   it('did not call log.error', () => {
@@ -764,7 +664,6 @@ describe('/sms/status with query param and disabled geo-ip lookup', () => {
       },
       log: log
     })
-    sms.balance = sinon.spy(() => P.resolve({ isOk: true }))
     return runTest(route, request)
       .then(r => response = r)
   })
@@ -779,10 +678,6 @@ describe('/sms/status with query param and disabled geo-ip lookup', () => {
 
   it('did not call geodb', () => {
     assert.equal(geodb.callCount, 0)
-  })
-
-  it('called sms.balance once', () => {
-    assert.equal(sms.balance.callCount, 1)
   })
 
   it('did not call log.error', () => {


### PR DESCRIPTION
As can be seen in [this dashboard](https://kibana-fxa-us-west-2.prod.mozaws.net/#/dashboard/elasticsearch/PROD%20-%20Auth%20SMS%20status%20errors), we are being rate-limited on the Nexmo balance check:

<img width="481" alt="429 errors from the Nexmo balance check" src="https://cloud.githubusercontent.com/assets/64367/26691694/ff634424-46f5-11e7-843c-44c259837b42.png" />

I have [another branch](https://github.com/mozilla/fxa-auth-server/compare/phil/sms-balance-cached?expand=1) that leans on memcached to avoid the problem but, based on feedback in the meeting just now, it seems like there is more support for just ditching the balance check entirely and assuming we have credit. If sending the SMS fails, we can handle that error there and then.

So that is what this PR does, removes the balance check entirely. Speak up if you think that is the wrong answer, I'm happy to finish off my other branch (I just need to fix the tests). Alternatively, if we think this is the right answer, then we also need to decide whether it should be uplifted to train 88, or even 87 perhaps.

@mozilla/fxa-devs r?
