### PR TITLE
fix(sms): Use the real email sender when sending via MockNexmo

### DIFF
--- a/lib/mock-nexmo.js
+++ b/lib/mock-nexmo.js
@@ -40,7 +40,6 @@ function MockNexmo(log, config) {
         // HACK: Enable remote tests to see what was sent
         mailer.sendMail({
           from: config.smtp.sender,
-          sender: config.smtp.sender,
           to: `sms.${phoneNumber}@restmail.net`,
           subject: 'MockNexmo.message.sendSms',
           text: message

--- a/lib/mock-nexmo.js
+++ b/lib/mock-nexmo.js
@@ -39,7 +39,8 @@ function MockNexmo(log, config) {
 
         // HACK: Enable remote tests to see what was sent
         mailer.sendMail({
-          from: `sms.${senderId}@restmail.net`,
+          from: config.smtp.sender,
+          sender: config.smtp.sender,
           to: `sms.${phoneNumber}@restmail.net`,
           subject: 'MockNexmo.message.sendSms',
           text: message

--- a/test/local/mock-nexmo.js
+++ b/test/local/mock-nexmo.js
@@ -5,7 +5,9 @@
 'use strict'
 
 const assert = require('insist')
-const proxyquire = require('proxyquire')
+// noPreserveCache is needed to prevent the mock mailer from
+// being used for all future tests that include mock-nexmo.
+const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
 const config = require('../../config').getProperties()
 
@@ -50,7 +52,6 @@ describe('mock-nexmo', () => {
         assert.equal(mailer.sendMail.callCount, 1)
         const sendConfig = mailer.sendMail.args[0][0]
         assert.equal(sendConfig.from, config.smtp.sender)
-        assert.equal(sendConfig.sender, config.smtp.sender)
         assert.equal(sendConfig.to, 'sms.+019999999999@restmail.net')
         assert.equal(sendConfig.subject, 'MockNexmo.message.sendSms')
         assert.equal(sendConfig.text, 'message')
@@ -69,7 +70,6 @@ describe('mock-nexmo', () => {
         assert.equal(mailer.sendMail.callCount, 1)
         const sendConfig = mailer.sendMail.args[0][0]
         assert.equal(sendConfig.from, config.smtp.sender)
-        assert.equal(sendConfig.sender, config.smtp.sender)
         assert.equal(sendConfig.to, 'sms.+019999999999@restmail.net')
         assert.equal(sendConfig.subject, 'MockNexmo.message.sendSms')
         assert.equal(sendConfig.text, 'message')


### PR DESCRIPTION
We were using a made up sender, which caused our email provider
to drop the messages on the ground when testing on fxa-ci. Messages
were reported as delivered, but never seen again.

@philbooth - r?

FWIW, this is the code that's running on fxa-ci right now.