### PR TITLE
feat(emails): Add endpoint to check if secondary emails are enabled

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [GET /account/devices (:lock: sessionToken)](#get-accountdevices)
     * [GET /account/sessions (:lock: sessionToken)](#get-accountsessions)
     * [POST /account/device/destroy (:lock: sessionToken)](#post-accountdevicedestroy)
+    * [GET /recovery_email/enabled (:lock: sessionToken)](#get-recovery_emailenabled)
     * [GET /recovery_email/status (:lock: sessionToken)](#get-recovery_emailstatus)
     * [POST /recovery_email/resend_code (:lock: sessionToken)](#post-recovery_emailresend_code)
     * [POST /recovery_email/verify_code](#post-recovery_emailverify_code)
@@ -299,7 +300,7 @@ those common validations are defined here.
 * `HEX_STRING`: `/^(?:[a-fA-F0-9]{2})+$/`
 * `URLSAFEBASE64`: `/^[a-zA-Z0-9-_]*$/`
 * `BASE_36`: `/^[a-zA-Z0-9]*$/`
-* `URL_SAFE_BASE_64`: `/^[A-Za-z0-9_-]*$/`
+* `URL_SAFE_BASE_64`: `/^[A-Za-z0-9_-]+$/`
 * `DISPLAY_SAFE_UNICODE`: `/^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uD800-\uDFFF\uE000-\uF8FF\uFFF9-\uFFFF])*$/`
 * `service`: `string, max(16), regex(/^[a-zA-Z0-9\-]*$/g)`
 * `E164_NUMBER`: `/^\+[1-9]\d{1,14}$/`
@@ -801,6 +802,9 @@ Failing requests may be caused
 by the following errors
 (this is not an exhaustive list):
 
+* `code: 400, errno: 107`:
+  Invalid parameter in request body
+
 * `code: 503, errno: 202`:
   Feature not enabled
 
@@ -1038,6 +1042,14 @@ to use the API after this request has succeeded.
   <!--begin-request-body-post-accountdevicedestroy-id-->
   
   <!--end-request-body-post-accountdevicedestroy-id-->
+
+
+#### GET /recovery_email/enabled
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-get-recovery_emailenabled-->
+Returns whether or not secondary emails is enabled for a user.
+<!--end-route-get-recovery_emailenabled-->
 
 
 #### GET /recovery_email/status
@@ -2053,7 +2065,7 @@ for an email address.
 
 ##### Request body
 
-* `code`: *string, regex(validators.URL_SAFE_BASE_64), length(CODE_LENGTH), required*
+* `code`: *string, regex(validators.URL_SAFE_BASE_64), required*
 
   <!--begin-request-body-post-signincodesconsume-code-->
   The signin code.

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1604,6 +1604,27 @@ module.exports = (
     },
     {
       method: 'GET',
+      path: '/recovery_email/enabled',
+      config: {
+        auth: {
+          strategy: 'sessionTokenWithVerificationStatus'
+        }
+      },
+      handler (request, reply) {
+        log.begin('Account.RecoveryEmailEnabled', request)
+        const sessionToken = request.auth.credentials
+        let enabled = false
+
+        // Secondary emails are enabled if feature is enabled for user and they are in a verified session
+        if (features.isSecondaryEmailEnabled(sessionToken.email) && sessionToken.tokenVerified) {
+          enabled = true
+        }
+
+        return reply({ok: enabled})
+      }
+    },
+    {
+      method: 'GET',
       path: '/recovery_email/status',
       config: {
         auth: {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1604,7 +1604,7 @@ module.exports = (
     },
     {
       method: 'GET',
-      path: '/recovery_email/enabled',
+      path: '/recovery_email/check_can_add_secondary_address',
       config: {
         auth: {
           strategy: 'sessionTokenWithVerificationStatus'

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -822,8 +822,8 @@ describe('/recovery_email', () => {
       })
     })
 
-    it('/recovery_email/enabled disabled with unverified session', () => {
-      route = getRoute(accountRoutes, '/recovery_email/enabled')
+    it('/recovery_email/check_can_add_secondary_address disabled with unverified session', () => {
+      route = getRoute(accountRoutes, '/recovery_email/check_can_add_secondary_address')
       mockRequest.auth.credentials.tokenVerified = false
       mockRequest.auth.credentials.email = 'asdf@mozilla.com'
       return runTest(route, mockRequest, (res) => {
@@ -831,8 +831,8 @@ describe('/recovery_email', () => {
       })
     })
 
-    it('/recovery_email/enabled disabled with invalid email', () => {
-      route = getRoute(accountRoutes, '/recovery_email/enabled')
+    it('/recovery_email/check_can_add_secondary_address disabled with invalid email', () => {
+      route = getRoute(accountRoutes, '/recovery_email/check_can_add_secondary_address')
       mockRequest.auth.credentials.tokenVerified = true
       mockRequest.auth.credentials.email = 'email@notvalid.com'
       return runTest(route, mockRequest, (res) => {
@@ -840,8 +840,8 @@ describe('/recovery_email', () => {
       })
     })
 
-    it('/recovery_email/enabled enabled with verified session', () => {
-      route = getRoute(accountRoutes, '/recovery_email/enabled')
+    it('/recovery_email/check_can_add_secondary_address enabled with verified session', () => {
+      route = getRoute(accountRoutes, '/recovery_email/check_can_add_secondary_address')
       mockRequest.auth.credentials.tokenVerified = true
       mockRequest.auth.credentials.email = 'asdf@mozilla.com'
       return runTest(route, mockRequest, (res) => {

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -801,4 +801,53 @@ describe('/recovery_email', () => {
         })
     })
   })
+
+  describe('can check feature enable flag', () => {
+    beforeEach(() => {
+      accountRoutes = makeRoutes({
+        checkPassword: function () {
+          return P.resolve(true)
+        },
+        config: {
+          secondaryEmail: {
+            enabled: true,
+            enabledEmailAddresses: /@mozilla\.com/
+          }
+        },
+        customs: mockCustoms,
+        db: mockDB,
+        log: mockLog,
+        mailer: mockMailer,
+        push: mockPush
+      })
+    })
+
+    it('/recovery_email/enabled disabled with unverified session', () => {
+      route = getRoute(accountRoutes, '/recovery_email/enabled')
+      mockRequest.auth.credentials.tokenVerified = false
+      mockRequest.auth.credentials.email = 'asdf@mozilla.com'
+      return runTest(route, mockRequest, (res) => {
+        assert.equal(res.ok, false, 'return ok `false` when feature is not enabled for user')
+      })
+    })
+
+    it('/recovery_email/enabled disabled with invalid email', () => {
+      route = getRoute(accountRoutes, '/recovery_email/enabled')
+      mockRequest.auth.credentials.tokenVerified = true
+      mockRequest.auth.credentials.email = 'email@notvalid.com'
+      return runTest(route, mockRequest, (res) => {
+        assert.equal(res.ok, false, 'return ok `false` when feature is not enabled for user')
+      })
+    })
+
+    it('/recovery_email/enabled enabled with verified session', () => {
+      route = getRoute(accountRoutes, '/recovery_email/enabled')
+      mockRequest.auth.credentials.tokenVerified = true
+      mockRequest.auth.credentials.email = 'asdf@mozilla.com'
+      return runTest(route, mockRequest, (res) => {
+        assert.equal(res.ok, true, 'return ok `true` when feature is enabled for user')
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
While https://github.com/mozilla/fxa-content-server/pull/5093, stopped us from spamming `500` errors, we still need a better way for checking if secondary emails is enabled for a user while returning `200`.

This follows a similar pattern that `/sms/status` endpoint uses except I call this endpoing `/recovery_email/check_can_add_secondary_address` because `/status` is already being used for checking the status of an email. Open to other names.

@mozilla/fxa-devs r?