### PR TITLE
fix(tests): add missing timeouts to remote tests

### DIFF
--- a/test/remote/mailer_db_tests.js
+++ b/test/remote/mailer_db_tests.js
@@ -14,8 +14,10 @@ var testHelper = require('../mailer_helper')
 
 var DB = require('../../lib/senders/db')()
 
-describe('mailer db', () => {
+describe('mailer db', function () {
   let dbServer, dbConn
+
+  this.timeout(10000)
 
   before(() => {
     return dbConn = TestServer.start(config)

--- a/test/remote/mailer_reminder_db_tests.js
+++ b/test/remote/mailer_reminder_db_tests.js
@@ -14,8 +14,10 @@ var testHelper = require('../mailer_helper')
 
 var DB = require('../../lib/senders/db')()
 
-describe('mailer reminder db', () => {
+describe('mailer reminder db', function () {
   let dbServer, dbConn
+
+  this.timeout(10000)
 
   before(() => {
     return dbConn = TestServer.start(config)


### PR DESCRIPTION
Maybe fixes #1927?

@shane-tomlinson, I'm not sure whether this will address the problems you're having in #1925 but these are the only two remote tests that don't call `this.timeout`.

@mozilla/fxa-devs r?