### PR TITLE
fix(push): Dont notify the originating device about pwd change.

### DIFF
--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -193,7 +193,7 @@ module.exports = function (
               function(devices) {
                 devicesToNotify = devices
                 // If the originating sessionToken belongs to a device,
-                // do not send the notification to that device.  It will
+                // do not send the notification to that device. It will
                 // get informed about the change via WebChannel message.
                 if (originatingDeviceId) {
                   devicesToNotify = devicesToNotify.filter(d => ! d.id.equals(originatingDeviceId))

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -156,7 +156,7 @@ module.exports = function (
         var wantsKeys = requestHelper.wantsKeys(request)
         const ip = request.app.clientAddress
         var account, verifyHash, sessionToken, keyFetchToken, verifiedStatus,
-          devicesToNotify
+          devicesToNotify, originatingDeviceId
 
         getSessionVerificationStatus()
           .then(fetchDevicesToNotify)
@@ -169,10 +169,13 @@ module.exports = function (
 
         function getSessionVerificationStatus() {
           if (sessionTokenId) {
-            return db.sessionTokenWithVerificationStatus(sessionTokenId)
+            return db.sessionWithDevice(sessionTokenId)
               .then(
                 function (tokenData) {
                   verifiedStatus = tokenData.tokenVerified
+                  if (tokenData.deviceId) {
+                    originatingDeviceId = tokenData.deviceId
+                  }
                 }
               )
           } else {
@@ -189,6 +192,12 @@ module.exports = function (
             .then(
               function(devices) {
                 devicesToNotify = devices
+                // If the originating sessionToken belongs to a device,
+                // do not send the notification to that device.  It will
+                // get informed about the change via WebChannel message.
+                if (originatingDeviceId) {
+                  devicesToNotify = devicesToNotify.filter(d => ! d.id.equals(originatingDeviceId))
+                }
               }
             )
         }

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -265,9 +265,14 @@ describe('/password', () => {
       'smoke',
       () => {
         var uid = uuid.v4('binary').toString('hex')
+        var devices = [
+          { uid: uid, id: crypto.randomBytes(16) },
+          { uid: uid, id: crypto.randomBytes(16) }
+        ]
         var mockDB = mocks.mockDB({
           email: TEST_EMAIL,
-          uid: uid
+          uid: uid,
+          devices: devices
         })
         var mockPush = mocks.mockPush()
         var mockMailer = mocks.mockMailer()
@@ -298,8 +303,9 @@ describe('/password', () => {
           assert.equal(mockDB.deletePasswordChangeToken.callCount, 1)
           assert.equal(mockDB.resetAccount.callCount, 1)
 
-          assert.equal(mockPush.notifyPasswordChanged.callCount, 1)
-          assert.deepEqual(mockPush.notifyPasswordChanged.firstCall.args[0], uid)
+          assert.equal(mockPush.notifyPasswordChanged.callCount, 1, 'sent a push notification of the change')
+          assert.deepEqual(mockPush.notifyPasswordChanged.firstCall.args[0], uid, 'notified the correct uid')
+          assert.deepEqual(mockPush.notifyPasswordChanged.firstCall.args[1], [devices[1]], 'notified only the second device')
 
           assert.equal(mockDB.account.callCount, 1)
           assert.equal(mockMailer.sendPasswordChangedNotification.callCount, 1)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -295,6 +295,23 @@ function mockDB (data, errors) {
         uaDeviceType: data.uaDeviceType
       })
     }),
+    sessionWithDevice: sinon.spy(() => {
+      var res = {
+        tokenVerified: true,
+        uaBrowser: data.uaBrowser,
+        uaBrowserVersion: data.uaBrowserVersion,
+        uaOS: data.uaOS,
+        uaOSVersion: data.uaOSVersion,
+        uaDeviceType: data.uaDeviceType
+      }
+      if (data.devices && data.devices.length > 0) {
+        Object.keys(data.devices[0]).forEach(key => {
+          var keyOnSession = 'device' + key.charAt(0).toUpperCase() + key.substr(1)
+          res[keyOnSession] = data.devices[0][key]
+        })
+      }
+      return P.resolve(res)
+    }),
     verifyTokens: optionallyThrow(errors, 'verifyTokens')
   })
 }


### PR DESCRIPTION
The originating device should already know about the pwd change thanks to a local WebChannel message from the content-server. Avoid sending it a push notification as well, since this could race with the WebChannel message and produce confusion.

WIP, Connects to #1929 