### PR TITLE
feat(bounces): add tiers to bounce blocklist

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -8,6 +8,10 @@ var url = require('url')
 var convict = require('convict')
 var DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages')
 
+const ONE_DAY = 1000 * 60 * 60 * 24
+const ONE_YEAR = ONE_DAY * 365
+const FIVE_MINUTES = 1000 * 60 * 5
+
 var conf = convict({
   env: {
     doc: 'The current node.js environment',
@@ -268,43 +272,28 @@ var conf = convict({
         env: 'BOUNCES_ENABLED'
       },
       complaint: {
-        duration: {
-          doc: 'Time until a complaint is no longer counted',
-          default: '1 year',
-          format: 'duration',
-          env: 'BOUNCES_COMPLAINT_DURATION'
+        doc: 'Tiers of max allowed complaints per amount of milliseconds',
+        default: {
+          0: ONE_YEAR
         },
-        max: {
-          doc: 'Maximum number of complaints before blocking emails',
-          default: 0,
-          env: 'BOUNCES_COMPLAINT_MAX'
-        }
+        env: 'BOUNCES_COMPLAINT'
       },
       hard: {
-        duration: {
-          doc: 'Time until a hard bounce is no longer counted',
-          default: '1 year',
-          format: 'duration',
-          env: 'BOUNCES_HARD_DURATION'
+        doc: 'Tiers of max allowed hard bounces per amount of milliseconds',
+        default: {
+          // 0 are allowed in the past day.
+          // 1 is allowed in the past year.
+          0: ONE_DAY,
+          1: ONE_YEAR
         },
-        max: {
-          doc: 'Maximum number of hard bounces before blocking emails',
-          default: 0,
-          env: 'BOUNCES_HARD_MAX'
-        }
+        env: 'BOUNCES_HARD'
       },
       soft: {
-        duration: {
-          doc: 'Time until a soft bounce is no longer counted',
-          default: '5 minutes',
-          format: 'duration',
-          env: 'BOUNCES_SOFT_DURATION'
+        doc: 'Tiers of max allowed soft bounces per amount of milliseconds',
+        default: {
+          0: FIVE_MINUTES
         },
-        max: {
-          doc: 'Maximum number of soft bounces before blocking emails',
-          default: 0,
-          env: 'BOUNCES_SOFT_MAX'
-        }
+        env: 'BOUNCES_SOFT'
       }
     }
   },

--- a/lib/error.js
+++ b/lib/error.js
@@ -540,30 +540,36 @@ AppError.messageRejected = (reason, reasonCode) => {
   })
 }
 
-AppError.emailComplaint = () => {
+AppError.emailComplaint = (bouncedAt) => {
   return new AppError({
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.BOUNCE_COMPLAINT,
     message: 'Email account sent complaint'
+  }, {
+    bouncedAt
   })
 }
 
-AppError.emailBouncedHard = () => {
+AppError.emailBouncedHard = (bouncedAt) => {
   return new AppError({
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.BOUNCE_HARD,
     message: 'Email account hard bounced'
+  }, {
+    bouncedAt
   })
 }
 
-AppError.emailBouncedSoft = () => {
+AppError.emailBouncedSoft = (bouncedAt) => {
   return new AppError({
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.BOUNCE_SOFT,
     message: 'Email account soft bounced'
+  }, {
+    bouncedAt
   })
 }
 

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -28,12 +28,17 @@ module.exports = function (log, config, error, bounces, translator, sender) {
     function getSafeMailer(email) {
       return bounces.check(email)
         .return(ungatedMailer)
-        .catch(function (err) {
-          log.info({
+        .catch(function (e) {
+          var info = {
             op: 'mailer.blocked',
-            errno: err.errno
-          })
-          throw err
+            errno: e.errno
+          }
+          var bouncedAt = e.output && e.output.payload && e.output.payload.bouncedAt
+          if (bouncedAt) {
+            info.bouncedAt = bouncedAt
+          }
+          log.info(info)
+          throw e
         })
     }
 

--- a/test/local/bounces.js
+++ b/test/local/bounces.js
@@ -21,14 +21,6 @@ const NOW = Date.now()
 
 describe('bounces', () => {
 
-  describe('config', () => {
-    it('should have default durations set', () => {
-      assert.equal(config.smtp.bounces.soft.duration, 1000 * 60 * 5)
-      assert.equal(config.smtp.bounces.hard.duration, 1000 * 60 * 60 * 24 * 365)
-      assert.equal(config.smtp.bounces.complaint.duration, 1000 * 60 * 60 * 24 * 365)
-    })
-  })
-
   it('succeeds if bounces not over limit', () => {
     const db = {
       emailBounces: sinon.spy(() => P.resolve([]))
@@ -45,7 +37,7 @@ describe('bounces', () => {
       bounces: {
         enabled: true,
         complaint: {
-          max: 0
+          0: Infinity
         }
       }
     }
@@ -73,15 +65,21 @@ describe('bounces', () => {
       bounces: {
         enabled: true,
         hard: {
-          max: 0
+          0: 100,
+          1: 5000
         }
       }
     }
+    const DATE = Date.now() - 1000
     const db = {
       emailBounces: sinon.spy(() => P.resolve([
         {
           bounceType: BOUNCE_TYPE_HARD,
-          createdAt: NOW
+          createdAt: DATE
+        },
+        {
+          bounceType: BOUNCE_TYPE_HARD,
+          createdAt: DATE - 1000
         }
       ]))
     }
@@ -91,6 +89,7 @@ describe('bounces', () => {
         e => {
           assert.equal(db.emailBounces.callCount, 1)
           assert.equal(e.errno, error.ERRNO.BOUNCE_HARD)
+          assert.equal(e.output.payload.bouncedAt, DATE)
         }
       )
   })
@@ -101,8 +100,8 @@ describe('bounces', () => {
       bounces: {
         enabled: true,
         hard: {
-          max: 0,
-          duration: 5000
+          0: 5000,
+          1: 50000
         }
       }
     }


### PR DESCRIPTION
The config for each bounce type can now contain a map of counts vs
durations. This allows a tiered approach to blocking email actions based
on bounce history.

For example:

```
{
  0: 5000,
  5: 20000
}
```

This tier mapping is translated as "more than 0 in 5 seconds" or "more
than 5 in 20 seconds". If either condition is true, the appropriate
error is thrown.

The thrown error also now includes the timestamp of the latest bounce, to
allow for reporting of when exactly that bounce was recorded at.

Closes #1893