### PR TITLE
fix(email): log a 'sent' email event for each CC address

### DIFF
--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -45,9 +45,7 @@ function getHeaderValue(headerName, message){
 }
 
 function logEmailEventSent(log, message) {
-  const emailDomain = getAnonymizedEmailDomain(message.email)
   const emailEventInfo = {
-    domain: emailDomain,
     op: 'emailEvent',
     template: message.template,
     type: 'sent'
@@ -56,7 +54,13 @@ function logEmailEventSent(log, message) {
   emailEventInfo['flow_id'] = getHeaderValue('X-Flow-Id', message)
   emailEventInfo.locale = getHeaderValue('Content-Language', message)
 
-  log.info(emailEventInfo)
+  const addrs = [message.email].concat(message.ccEmails || [])
+
+  addrs.forEach(addr => {
+    const msg = Object.assign({}, emailEventInfo)
+    msg.domain = getAnonymizedEmailDomain(addr)
+    log.info(msg)
+  })
 }
 
 function logEmailEventFromMessage(log, message, type, emailDomain) {

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -56,6 +56,20 @@ describe('email utils helpers', () => {
       assert.equal(mockLog.info.args[0][0].locale, 'ru')
     })
 
+    it('should log an event per CC email', () => {
+      const mockLog = spyLog()
+      const message = {
+        email: 'user@example.domain',
+        ccEmails: ['noreply@gmail.com', 'noreply@yahoo.com'],
+        template: 'verifyEmail'
+      }
+      emailHelpers.logEmailEventSent(mockLog, message)
+      assert.equal(mockLog.info.callCount, 3)
+      assert.equal(mockLog.info.args[0][0].domain, 'other')
+      assert.equal(mockLog.info.args[1][0].domain, 'gmail.com')
+      assert.equal(mockLog.info.args[2][0].domain, 'yahoo.com')
+    })
+
   })
 
 })


### PR DESCRIPTION
We've noticed in the email dashboard that our delivery rate has climbed over 100%, and it seems to correlate with when we shipped secondary emails. If we send an email to 10 users, and 1 has a secondary email, we emit 10 `sent` events, and later SES tells us about 11 `delivery` events.

This patch records additional `sent` events for each address in the `cc` field.