### PR TITLE
Make our test suite faster (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 script:
   - if [ $DB == "mysql" ]; then ./scripts/start-travis-auth-db-mysql.sh; fi
-  - COVERALLS_REPO_TOKEN=vKN3jjhAOwxkv9HG0VBX4EYIlWLPwiJ9d npm test
+  - COVERALLS_REPO_TOKEN=vKN3jjhAOwxkv9HG0VBX4EYIlWLPwiJ9d npm run test-ci
   - npm run test-e2e
   # Test fxa-auth-mailer
   - grunt templates

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
 
 test:
   override:
-    - docker run fxa-auth-server:test npm test
+    - docker run fxa-auth-server:test npm run test-ci
 
 deployment:
   hub_latest:

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "shrinkwrap": "npmshrink && npm run postinstall",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
-    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar scripts/test-local.sh",
+    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar VERIFIER_VERSION=0 MEMCACHE_METRICS_CONTEXT_ADDRESS=none NO_COVERAGE=1 scripts/test-local.sh",
+    "test-ci": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar scripts/test-local.sh",
     "test-e2e": "NODE_ENV=dev mocha test/e2e",
-    "test-quick": "npm run tq",
-    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha --timeout=300000 test/remote",
-    "tq": "NODE_ENV=dev mocha test/local 2>/dev/null && NODE_ENV=dev CORS_ORIGIN=https://bar scripts/test-remote-quick.js"
+    "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha --timeout=300000 test/remote"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**tl;dr** - This makes `npm test` about 112 seconds faster (almost 2 minutes!).

We've added a bunch of tests for some new big features, around SMS, secondary emails, signinCodes, and such. So our test execution time has been slowly growing again. I took another swing at counteracting that.

The changes:

- When running our remote tests, every time we restarted the server, we
would re-parse all of the po translation files. Each time takes around
500ms. By caching files we've already parsed, this shaves around 12s off
the remote test suite.

Since `npm test` is what we run constantly when working on features, if
we can make it faster, we make development faster.

- Disable memcache. We never specifically start a memcached, but the
  tests were running trying to look for it. With the default settings
  being to retry once with a 500ms timeout, many test would hang for 1s
  checking memcached for data that wasn't even useful to the test. By
  setting to 'none', this saved 45s.

- Disable scrypt. scrypt is **slow**. While developing locally, and
  running the tests, we don't actually need to test that some value run
  through scrypt turns out to be correctly encrypted. By using the
  verifier version '0', this saved 55s.

- Disable coverage. Using coverage takes some time to instrument the
  code, and spawn in a child process. While nyc is pretty good at caching,
  and the slow down isn't that much, it's also more annoying to debug
  with. First, it ruins all stack trace lines numbers. Second, it spits a
  gigantic coverage report at the end of the test run, requiring scrolling
  back up to see the actual test results.

To make sure we still run the test suite with the default options
enabled, this provides a `test-ci` target, that is enabled to be always
be run from TravisCI and Circle.