### PR TITLE
fix(email): Escape device name in HTML emails.

### DIFF
--- a/lib/senders/partials/location/location.html
+++ b/lib/senders/partials/location/location.html
@@ -1,6 +1,6 @@
 <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/new_device_login.html
+++ b/lib/senders/templates/new_device_login.html
@@ -28,7 +28,7 @@
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
 <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/password_changed.html
+++ b/lib/senders/templates/password_changed.html
@@ -28,7 +28,7 @@
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Your Firefox Account password was successfully changed from the following device:" }}</p>
     <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/recovery.html
+++ b/lib/senders/templates/recovery.html
@@ -28,7 +28,7 @@
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "Click the button within the next hour to set a new password for your Firefox Account. The request came from the following device:" }}}</p>
     <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/unblock_code.html
+++ b/lib/senders/templates/unblock_code.html
@@ -28,7 +28,7 @@
     <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
     <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/verify_login.html
+++ b/lib/senders/templates/verify_login.html
@@ -28,7 +28,7 @@
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "For added security, please confirm this sign-in to begin syncing with this device:"}}<p/>
     <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/verify_secondary.html
+++ b/lib/senders/templates/verify_secondary.html
@@ -28,7 +28,7 @@
         <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "A request to use %(email)s as a secondary email address has been made from the following Firefox Account:"}}<p/>
         <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/lib/senders/templates/verify_sync.html
+++ b/lib/senders/templates/verify_sync.html
@@ -28,7 +28,7 @@
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Confirm you’ve received this email and we’ll help you install and sync Firefox on all your devices starting with:"}}<p/>
       <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #424f59;">
     {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
-    {{#if device }}{{{ device }}}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
     {{#if location }}{{ location }}<br/>{{/if}}
     {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -94,7 +94,6 @@ function includes(haystack, needle) {
 
 function getLocationMessage (location) {
   return {
-    device: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0',
     email: 'a@b.com',
     ip: '219.129.234.194',
     location: location,
@@ -456,6 +455,37 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, location.country))
                 assert.ok(includes(emailConfig.text, location.country))
+              }
+              mailer[type](message)
+            }
+          )
+
+          it(
+            'device name is correct for ' + type,
+            function () {
+              var message = getLocationMessage(defaultLocation)
+              message.uaBrowser = 'Firefox'
+              message.uaOS = 'BeOS'
+
+              mailer.mailer.sendMail = function (emailConfig) {
+                assert.ok(includes(emailConfig.html, 'Firefox on BeOS'))
+                assert.ok(includes(emailConfig.text, 'Firefox on BeOS'))
+              }
+              mailer[type](message)
+            }
+          )
+
+          it(
+            'device name gets HTML-escaped for ' + type,
+            function () {
+              var message = getLocationMessage(defaultLocation)
+              message.uaBrowser = 'Firefox <a>Link</a>'
+
+              mailer.mailer.sendMail = function (emailConfig) {
+                assert.ok(! includes(emailConfig.html, '<a>Link</a>'))
+                assert.ok(! includes(emailConfig.text, '<a>Link</a>'))
+                assert.ok(includes(emailConfig.html, 'Firefox &lt;a&gt;Link&lt;/a&gt;'))
+                assert.ok(includes(emailConfig.text, 'Firefox &lt;a&gt;Link&lt;/a&gt;'))
               }
               mailer[type](message)
             }


### PR DESCRIPTION
Uplift from https://github.com/mozilla/fxa-auth-server-private/pull/66