### PR TITLE
feat(metrics): emit a flow.continued event for signinCodes

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -909,12 +909,12 @@ module.exports = (
       )
   }
 
-  DB.prototype.createSigninCode = function (uid) {
+  DB.prototype.createSigninCode = function (uid, flowId) {
     log.trace({ op: 'DB.createSigninCode' })
 
     return random(config.signinCodeSize)
       .then(code => {
-        const data = { uid, createdAt: Date.now() }
+        const data = { uid, createdAt: Date.now(), flowId }
         return this.pool.put(`/signinCodes/${code.toString('hex')}`, data)
           .then(() => code, err => {
             if (isRecordAlreadyExistsError(err)) {

--- a/lib/routes/signin-codes.js
+++ b/lib/routes/signin-codes.js
@@ -51,6 +51,11 @@ module.exports = (log, db, customs) => {
           return db.consumeSigninCode(code)
             .then(result => {
               return request.emitMetricsEvent('signinCode.consumed')
+                .then(() => {
+                  if (result.flowId) {
+                    return request.emitMetricsEvent(`flow.continued.${result.flowId}`)
+                  }
+                })
                 .then(() => result)
             })
         }

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -87,7 +87,8 @@ module.exports = (log, db, config, customs, sms) => {
 
         function createSigninCode () {
           if (request.app.features.has('signinCodes')) {
-            return db.createSigninCode(sessionToken.uid)
+            return request.gatherMetricsContext({})
+              .then(metricsContext => db.createSigninCode(sessionToken.uid, metricsContext.flow_id))
           }
         }
 

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -100,8 +100,9 @@ describe('/sms with the signinCodes feature included in the payload', () => {
       it('called db.createSigninCode correctly', () => {
         assert.equal(db.createSigninCode.callCount, 1)
         const args = db.createSigninCode.args[0]
-        assert.equal(args.length, 1)
+        assert.equal(args.length, 2)
         assert.equal(args[0], 'bar')
+        assert.equal(args[1], request.payload.metricsContext.flowId)
       })
 
       it('called sms.send correctly', () => {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -178,7 +178,15 @@ function mockDB (data, errors) {
         }
       ])
     }),
-    consumeSigninCode: optionallyThrow(errors, 'consumeSigninCode'),
+    consumeSigninCode: sinon.spy(() => {
+      if (errors.consumeSigninCode) {
+        return P.reject(errors.consumeSigninCode)
+      }
+      return P.resolve({
+        email: data.email,
+        flowId: data.flowId
+      })
+    }),
     createAccount: sinon.spy(() => {
       return P.resolve({
         uid: data.uid,


### PR DESCRIPTION
Fixes #1945. See also mozilla/fxa-auth-db-mysql#248.

I've written this PR, both the tests and the production code, so that it can land independently of the related db change. If that PR doesn't make it or is held up for whatever reason, this one can still land without issues (and vice versa). I opted to do it this way so that they can be reviewed in tandem for train 90, without concerns for deployment order or any of that jazz.

Hopefully the changes here are straightforward. We send `flowId` to the db when creating the signinCode, which will be ignored by the db until mozilla/fxa-auth-db-mysql#248 lands. When consuming the signinCode, if a flow id is returned by the db, we emit a `flow.continued` event using said flow id as the `entrypoint`.

This is so that we can link together the two flows at either end of connect another device in redshift. I will also update the redshift schema to increase the length of the `entrypoint` column, and PR the import scripts likewise.

@mozilla/fxa-devs r?