### PR TITLE
fix(server): step in before node-uap parses Sync UA strings

### DIFF
--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -503,17 +503,7 @@ describe('userAgent', () => {
   it(
     'recognises old Firefox-iOS user agents',
     () => {
-      parserResult = {
-        ua: {
-          family: 'Other'
-        },
-        os: {
-          family: 'iOS'
-        },
-        device: {
-          family: 'Other'
-        }
-      }
+      parserResult = null
       const context = {}
       const userAgentString = 'Firefox-iOS-FxA/5.3 (Firefox)'
       const result = userAgent.call(context, userAgentString, log)
@@ -530,48 +520,9 @@ describe('userAgent', () => {
   )
 
   it(
-    'preserves device type on old Firefox-iOS user agents',
-    () => {
-      parserResult = {
-        ua: {
-          family: 'Other'
-        },
-        os: {
-          family: 'Other'
-        },
-        device: {
-          family: 'iPad'
-        }
-      }
-      const context = {}
-      const userAgentString = 'Firefox-iOS-FxA/6.0 (Firefox)'
-      const result = userAgent.call(context, userAgentString, log)
-
-      assert.equal(result.uaBrowser, 'Firefox')
-      assert.equal(result.uaBrowserVersion, '6.0')
-      assert.equal(result.uaOS, 'iOS')
-      assert.equal(result.uaDeviceType, 'tablet')
-
-      assert.equal(log.info.callCount, 0)
-
-      uaParser.parse.reset()
-    }
-  )
-
-  it(
     'recognises new Firefox-iOS user agents',
     () => {
-      parserResult = {
-        ua: {
-          family: 'Other'
-        },
-        os: {
-          family: 'Other'
-        },
-        device: {
-          family: 'Other'
-        }
-      }
+      parserResult = null
       const context = {}
       const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Nightly)'
       const result = userAgent.call(context, userAgentString, log)
@@ -589,19 +540,29 @@ describe('userAgent', () => {
   )
 
   it(
+    'recognises new Firefox-iOS user agent on iPads',
+    () => {
+      parserResult = null
+      const context = {}
+      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPad Mini; iPhone OS 10.3) (Nightly)'
+      const result = userAgent.call(context, userAgentString, log)
+
+      assert.equal(result.uaBrowser, 'Nightly')
+      assert.equal(result.uaBrowserVersion, '6.0')
+      assert.equal(result.uaOS, 'iOS')
+      assert.equal(result.uaOSVersion, '10.3')
+      assert.equal(result.uaDeviceType, 'tablet')
+
+      assert.equal(log.info.callCount, 0)
+
+      uaParser.parse.reset()
+    }
+  )
+
+  it(
     'recognises Firefox-Android user agents',
     () => {
-      parserResult = {
-        ua: {
-          family: 'Other'
-        },
-        os: {
-          family: 'Android'
-        },
-        device: {
-          family: 'Other'
-        }
-      }
+      parserResult = null
       const context = {}
       const userAgentString = 'Firefox-Android-FxAccounts/49.0.2 (Firefox)'
       const result = userAgent.call(context, userAgentString, log)
@@ -618,25 +579,15 @@ describe('userAgent', () => {
   )
 
   it('recognises new mobile Sync library user agents on Android', () => {
-    parserResult = {
-      ua: {
-        family: 'Other'
-      },
-      os: {
-        family: 'Other'
-      },
-      device: {
-        family: 'Other'
-      }
-    }
+    parserResult = null
     const context = {}
-    const userAgentString = 'Mobile-Android-Sync/(Mobile; Android 4.4.2) (foo() bar)'
+    const userAgentString = 'Mobile-Android-Sync/(Mobile; Android 6.0) (foo() bar)'
     const result = userAgent.call(context, userAgentString, log)
 
     assert.equal(result.uaBrowser, 'foo() bar')
     assert.equal(result.uaBrowserVersion, null)
     assert.equal(result.uaOS, 'Android')
-    assert.equal(result.uaOSVersion, '4.4.2')
+    assert.equal(result.uaOSVersion, '6.0')
     assert.equal(result.uaDeviceType, 'mobile')
 
     assert.equal(log.info.callCount, 0)
@@ -645,17 +596,7 @@ describe('userAgent', () => {
   })
 
   it('recognises new mobile Sync library user agents on iOS', () => {
-    parserResult = {
-      ua: {
-        family: 'Other'
-      },
-      os: {
-        family: 'Other'
-      },
-      device: {
-        family: 'Other'
-      }
-    }
+    parserResult = null
     const context = {}
     const userAgentString = 'Mobile-iOS-Sync/(iPad Mini; iOS 10.3) (wibble)'
     const result = userAgent.call(context, userAgentString, log)


### PR DESCRIPTION
Fixes #1889.

The code for parsing Sync UA strings assumed that `node-uap` would fail to parse first. But actually it ends up with the browser name `Android` and the browser version `6` when parsing @mcomella's string from https://github.com/mozilla/fxa-auth-server/issues/1889#issuecomment-309182938:

```
Mobile-Android-Sync/(Mobile; Android 6.0) (Unknown app)
```

To fix that, I've promoted our regex to run first, only calling `node-uap` if it doesn't match. This allows the above user agent string to work correctly, producing the following entry in the devices view:

<img width="516" alt="Screen shot of the devices view showing an item that uses the Sync library user-agent string" src="https://user-images.githubusercontent.com/64367/27252915-4bc33884-5361-11e7-998b-7208a941e3be.png" />

Sorry for not catching this before @mcomella!

@mozilla/fxa-devs r?
