### PR TITLE
fix(server): do not return flowId from consumeSigninCode endpoint

### DIFF
--- a/lib/routes/signin-codes.js
+++ b/lib/routes/signin-codes.js
@@ -56,7 +56,7 @@ module.exports = (log, db, customs) => {
                     return request.emitMetricsEvent(`flow.continued.${result.flowId}`)
                   }
                 })
-                .then(() => result)
+                .then(() => ({ email: result.email }))
             })
         }
       }

--- a/test/local/routes/signin-codes.js
+++ b/test/local/routes/signin-codes.js
@@ -10,10 +10,14 @@ const mocks = require('../../mocks')
 const P = require('../../../lib/promise')
 
 describe('/signinCodes/consume:', () => {
-  let log, db, customs, routes, route, request
+  let log, db, customs, routes, route, request, response
 
   describe('success, db does not return flowId:', () => {
-    beforeEach(() => setup({ db: { email: 'foo@bar' } }))
+    beforeEach(() => setup({ db: { email: 'foo@bar' } }).then(r => response = r))
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, { email: 'foo@bar' })
+    })
 
     it('called log.begin correctly', () => {
       assert.equal(log.begin.callCount, 1)
@@ -56,7 +60,11 @@ describe('/signinCodes/consume:', () => {
   })
 
   describe('success, db returns flowId:', () => {
-    beforeEach(() => setup({ db: { email: 'foo@bar', flowId: 'baz' } }))
+    beforeEach(() => setup({ db: { email: 'foo@bar', flowId: 'baz' } }).then(r => response = r))
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, { email: 'foo@bar' })
+    })
 
     it('called log.begin once', () => {
       assert.equal(log.begin.callCount, 1)


### PR DESCRIPTION
Fixes a bug I introduced with #1946 and mozilla/fxa-auth-db-mysql#248.

Those changes return a `flowId` property from `db.consumeSigninCode`. However, response validation on the auth server endpoint only permits an `email` property.

This PR ensures that we don't fail response validation by dropping `flowId` from the result object.

@mozilla/fxa-devs r?