### PR TITLE
feat(email): When primary email bouncy, send to secondary email

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -908,8 +908,7 @@ module.exports = (
             && ! doSigninConfirmation
             && emailRecord.emailVerified
           if (shouldSendNewDeviceLoginEmail) {
-            const secondaryEmails = features.isSecondaryEmailEnabled(emailRecord.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
-            return P.all([getGeoData(ip), secondaryEmails])
+            return P.all([getGeoData(ip), db.accountEmails(sessionToken.uid)])
               .spread((geoData, emails) => {
                 // New device notifications are always sent to the primary account email (emailRecord.email)
                 // and CCed to all secondary email if enabled.
@@ -950,8 +949,7 @@ module.exports = (
               tokenVerificationId: tokenVerificationId
             })
 
-            const secondaryEmails = features.isSecondaryEmailEnabled(emailRecord.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
-            return P.all([getGeoData(ip), secondaryEmails])
+            return P.all([getGeoData(ip), db.accountEmails(sessionToken.uid)])
               .spread((geoData, emails) => {
                 return mailer.sendVerifyLoginEmail(
                   emails,
@@ -1362,8 +1360,7 @@ module.exports = (
           )
 
         function setVerifyCode() {
-          const secondaryEmails = features.isSecondaryEmailEnabled(sessionToken.email) ? db.accountEmails(sessionToken.uid) : P.resolve([])
-          return secondaryEmails
+          return db.accountEmails(sessionToken.uid)
             .then((emailData) => {
               if (email) {
                 // If an email address is specified in payload, this is a request to verify

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -259,7 +259,7 @@ module.exports = function (
             .then(
               function (accountData) {
                 account = accountData
-                return features.isSecondaryEmailEnabled(account.email) ? db.accountEmails(passwordChangeToken.uid) : P.resolve([])
+                return db.accountEmails(passwordChangeToken.uid)
               }
             )
             .then(
@@ -434,8 +434,7 @@ module.exports = function (
           )
           .then(
             function (passwordForgotToken) {
-              const secondaryEmails = features.isSecondaryEmailEnabled(email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
-              return P.all([getGeoData(ip), secondaryEmails])
+              return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
                   return mailer.sendRecoveryCode(
                     emails,
@@ -531,8 +530,7 @@ module.exports = function (
         ])
           .then(
             function () {
-              const secondaryEmails = features.isSecondaryEmailEnabled(passwordForgotToken.email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
-              return P.all([getGeoData(ip), secondaryEmails])
+              return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
                   return mailer.sendRecoveryCode(
                     emails,
@@ -618,8 +616,7 @@ module.exports = function (
                 db.forgotPasswordVerified(passwordForgotToken)
                   .then(
                     function (accountResetToken) {
-                      const secondaryEmails = features.isSecondaryEmailEnabled(passwordForgotToken.email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
-                      return secondaryEmails
+                      return db.accountEmails(passwordForgotToken.uid)
                         .then((emails) => {
                           return mailer.sendPasswordResetNotification(
                             emails,

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -92,7 +92,7 @@ describe('lib/senders/index', () => {
             return email.sendVerifyLoginEmail(EMAILS, acct, {code: code})
           })
           .then(() => {
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
             assert.equal(email._ungatedMailer.verifyLoginEmail.callCount, 1)
 
             const args = email._ungatedMailer.verifyLoginEmail.getCall(0).args
@@ -120,7 +120,7 @@ describe('lib/senders/index', () => {
             return email.sendRecoveryCode(EMAILS, acct, {code: code, token: token})
           })
           .then(() => {
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
             assert.equal(email._ungatedMailer.recoveryEmail.callCount, 1)
 
             const args = email._ungatedMailer.recoveryEmail.getCall(0).args
@@ -147,7 +147,7 @@ describe('lib/senders/index', () => {
             assert.equal(args[0].email, EMAIL, 'email correctly set')
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
           })
       })
     })
@@ -168,7 +168,7 @@ describe('lib/senders/index', () => {
             assert.equal(args[0].email, EMAIL, 'email correctly set')
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
           })
       })
     })
@@ -189,7 +189,7 @@ describe('lib/senders/index', () => {
             assert.equal(args[0].email, EMAIL, 'email correctly set')
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
           })
       })
     })
@@ -233,7 +233,7 @@ describe('lib/senders/index', () => {
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
             assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
 
-            assert.equal(bounces.check.callCount, 1)
+            assert.equal(bounces.check.callCount, 3)
           })
       })
     })
@@ -253,14 +253,41 @@ describe('lib/senders/index', () => {
             return email.sendUnblockCode(EMAILS, acct, {code: code})
           })
           .catch(e => {
-            assert.equal(errorBounces.check.callCount, 1)
+            assert.equal(errorBounces.check.callCount, 3)
             assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT)
 
-            assert.equal(log.info.callCount, 1)
+            assert.equal(log.info.callCount, 3)
             const msg = log.info.args[0][0]
             assert.equal(msg.op, 'mailer.blocked')
             assert.equal(msg.errno, e.errno)
             assert.equal(msg.bouncedAt, DATE)
+          })
+      })
+
+      it('on gated primary email, sends to secondary', () => {
+        const log = mocks.spyLog()
+        const DATE = Date.now() - 10000
+        let email
+        const errorBounces = {
+          check: sinon.spy((email) => {
+            if (email === EMAIL) {
+              return P.reject(error.emailComplaint(DATE))
+            }
+            return P.resolve({})
+          })
+        }
+        return createSender(config, errorBounces, log)
+          .then(e => {
+            email = e
+            email._ungatedMailer.unblockCodeEmail = sinon.spy(() => P.resolve({}))
+            return email.sendUnblockCode(EMAILS, acct, {code: code})
+          })
+          .then(() => {
+            const args = email._ungatedMailer.unblockCodeEmail.getCall(0).args
+            assert.equal(args[0].email, EMAILS[1].email, 'email correctly set')
+            assert.equal(args[0].ccEmails.length, 1, 'email correctly set')
+            assert.equal(args[0].ccEmails[0], EMAILS[1].email, 'cc email correctly set')
+            assert.equal(errorBounces.check.callCount, 3)
           })
       })
     })


### PR DESCRIPTION
This PR does a couple things to verify we are not sending to bouncy emails.

* Don't send to any bounced secondary emails
* If primary email bounced and their exisits a secondary email, send to that email.

Fixes #1953 