### PR TITLE
fix(test): Make db tests more independent and update auth-db dev version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -274,7 +274,7 @@
     "fxa-auth-db-mysql": {
       "version": "1.87.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0441ea95afc63c1e87adec46c8d6201a40d05586",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#92199bc1aedf39f54b0993c97a92de18807c88a1",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",


### PR DESCRIPTION
Noticed that the `db_tests` could not run independent tests with the `mysql` implementation. This updates tests to create a new unique user on each test. This update does increase the time for running tests but I think its worth it.

@mozilla/fxa-devs r?