### PR TITLE
refactor(server): eliminate some unnecessary serial invocation

### DIFF
--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -391,14 +391,10 @@ module.exports = function (
           flowBeginTime = request.payload.metricsContext.flowBeginTime
         }
 
-        request.emitMetricsEvent('password.forgot.send_code.start')
-          .then(
-            customs.check.bind(
-              customs,
-              request,
-              email,
-              'passwordForgotSendCode')
-          )
+        P.all([
+          request.emitMetricsEvent('password.forgot.send_code.start'),
+          customs.check(request, email, 'passwordForgotSendCode')
+        ])
           .then(db.emailRecord.bind(db, email))
           .then(
             function (emailRecord) {
@@ -520,14 +516,10 @@ module.exports = function (
           flowBeginTime = request.payload.metricsContext.flowBeginTime
         }
 
-        request.emitMetricsEvent('password.forgot.resend_code.start')
-          .then(
-            customs.check.bind(
-              customs,
-              request,
-              passwordForgotToken.email,
-              'passwordForgotResendCode')
-          )
+        P.all([
+          request.emitMetricsEvent('password.forgot.resend_code.start'),
+          customs.check(request, passwordForgotToken.email, 'passwordForgotResendCode')
+        ])
           .then(
             function () {
               const secondaryEmails = features.isSecondaryEmailEnabled(passwordForgotToken.email) ? db.accountEmails(passwordForgotToken.uid) : P.resolve([])
@@ -606,14 +598,10 @@ module.exports = function (
           flowBeginTime = request.payload.metricsContext.flowBeginTime
         }
 
-        request.emitMetricsEvent('password.forgot.verify_code.start')
-          .then(
-            customs.check.bind(
-              customs,
-              request,
-              passwordForgotToken.email,
-              'passwordForgotVerifyCode')
-          )
+        P.all([
+          request.emitMetricsEvent('password.forgot.verify_code.start'),
+          customs.check(request, passwordForgotToken.email, 'passwordForgotVerifyCode')
+        ])
           .then(
             function () {
               if (butil.buffersAreEqual(passwordForgotToken.passCode, code) &&


### PR DESCRIPTION
I went looking for occurrences of #1947 and couldn't actually find any. However, I did find a couple of places where different async calls were invoked serially but were not co-dependent or side-effecty in any way.

This PR eliminates them using `P.all`. I don't claim to have found every case, just a few quick wins I spotted while looking for something else.

@mozilla/fxa-devs r?