### PR TITLE
Move session token to redis

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -27,5 +27,12 @@
   },
   "secondaryEmail": {
     "enabled": true
+  },
+  "lastAccessTimeUpdates": {
+    "enabled": true,
+    "sampleRate": 1
+  },
+  "redis": {
+    "enabled": true
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -334,6 +334,32 @@ var conf = convict({
       env: 'SUPPORTED_LANGS'
     }
   },
+  redis: {
+    enabled: {
+      default: true,
+      doc: 'Enable redis cache',
+      format: Boolean,
+      env: 'USE_REDIS'
+    },
+    host: {
+      default: '127.0.0.1',
+      env: 'REDIS_HOST',
+      format: String,
+      doc: 'url for redis host',
+    },
+    port: {
+      default: 6379,
+      env: 'REDIS_PORT',
+      format: 'port',
+      doc: 'port for redis server'
+    },
+    sessionsKeyPrefix: {
+      default: 'fxa-auth-session',
+      env: 'SESSIONS_REDIS_KEY_PREFIX',
+      format: String,
+      doc: 'which key prefix to store sessions in redis under'
+    }
+  },
   tokenLifetimes: {
     accountResetToken: {
       format: 'duration',
@@ -576,14 +602,8 @@ var conf = convict({
     sampleRate: {
       doc: 'sample rate for updates to the lastAccessTime session token property, in the range 0..1',
       format: Number,
-      default: 1,
+      default: 0.3,
       env: 'LASTACCESSTIME_UPDATES_SAMPLE_RATE'
-    },
-    enabledEmailAddresses: {
-      doc: 'regex matching enabled email addresses for updates to the lastAccessTime session token property',
-      format: RegExp,
-      default: /.+@mozilla\.com$/,
-      env: 'LASTACCESSTIME_UPDATES_EMAIL_ADDRESSES'
     }
   },
   signinUnblock: {

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,6 +10,10 @@ const Pool = require('./pool')
 const userAgent = require('./userAgent')
 
 const random = require('./crypto/random')
+const redis = require('redis')
+
+P.promisifyAll(redis.RedisClient.prototype)
+P.promisifyAll(redis.Multi.prototype)
 
 module.exports = (
   config,
@@ -27,6 +31,18 @@ module.exports = (
 
   function DB(options) {
     this.pool = new Pool(options.url)
+    if (config.redis.enabled) {
+      const redisConfig = {
+        host: config.redis.host,
+        port: config.redis.port,
+        prefix: config.redis.sessionsKeyPrefix
+      }
+      log.info({op: 'db.redis.enabled', config: redisConfig})
+      this.redis = redis.createClient(redisConfig)
+    } else {
+      this.redis = false
+      log.info({op: 'db.redis.disabled'})
+    }
   }
 
   DB.connect = function (options) {
@@ -212,7 +228,31 @@ module.exports = (
 
   DB.prototype.sessions = function (uid) {
     log.trace({ op: 'DB.sessions', uid: uid })
-    return this.pool.get('/account/' + uid + '/sessions')
+    const promises = [
+      this.pool.get('/account/' + uid + '/sessions')
+    ]
+
+    if (this.redis) {
+      promises.push(this.redis.getAsync(uid))
+    }
+
+    return P.all(promises)
+      .spread((mysqlSessionTokens, redisTokens) => {
+        // for each db session token, if there is a matching redis token
+        // overwrite the properties of the db token with the redis token values
+        const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : []
+        const sessions = mysqlSessionTokens.map((sessionToken) => {
+          const redisToken = redisSessionTokens.find(tok => tok.tokenId === sessionToken.tokenId)
+          const mergedToken = Object.assign({}, sessionToken, redisToken)
+          return mergedToken
+        })
+        log.info({
+          op: 'db.sessions.count',
+          mysql: mysqlSessionTokens.length,
+          redis: redisSessionTokens.length
+        })
+        return sessions
+      })
   }
 
   DB.prototype.sessionToken = function (id) {
@@ -349,46 +389,49 @@ module.exports = (
 
   DB.prototype.devices = function (uid) {
     log.trace({ op: 'DB.devices', uid: uid })
+    const promises = [
+      this.pool.get('/account/' + uid + '/devices')
+    ]
 
-    return this.pool.get('/account/' + uid + '/devices')
-      .then(
-        function (body) {
-          return body.map(function (item) {
-            return {
-              id: item.id,
-              sessionToken: item.sessionTokenId,
-              lastAccessTime: marshallLastAccessTime(item.lastAccessTime, uid, item.email),
-              name: item.name,
-              type: item.type,
-              pushCallback: item.callbackURL,
-              pushPublicKey: item.callbackPublicKey,
-              pushAuthKey: item.callbackAuthKey,
-              uaBrowser: item.uaBrowser,
-              uaBrowserVersion: item.uaBrowserVersion,
-              uaOS: item.uaOS,
-              uaOSVersion: item.uaOSVersion,
-              uaDeviceType: item.uaDeviceType
-            }
-          })
-        },
-        function (err) {
-          if (isNotFoundError(err)) {
-            throw error.unknownAccount()
-          }
-          throw err
-        }
-      )
-  }
-
-  function marshallLastAccessTime (lastAccessTime, uid, email) {
-    // Updating lastAccessTime on session tokens may not be enabled.
-    // If it isn't, return null instead of the timestamp so that the
-    // content server knows not to display it to users.
-    if (features.isLastAccessTimeEnabledForUser(uid, email)) {
-      return lastAccessTime
+    if (this.redis) {
+      promises.push(this.redis.getAsync(uid))
     }
-
-    return null
+    return P.all(promises)
+      .spread((devices, redisTokens) => {
+        const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : []
+        log.info({
+          op: 'db.devices.redisSessionTokens',
+          hasRedisTokens: !! redisSessionTokens.length,
+          numRedisTokens: redisSessionTokens.length
+        })
+        // for each device, if there is a redis token with a matching tokenId
+        // overwrite device's ua properties and lastAccessTime with redis token values
+        return devices.map(device => {
+          const token = redisSessionTokens.find(tok => tok.tokenId === device.sessionTokenId)
+          const mergedInfo = Object.assign({}, device, token)
+          return {
+            id: device.id,
+            sessionToken: device.sessionTokenId,
+            lastAccessTime: mergedInfo.lastAccessTime,
+            name: device.name,
+            type: device.type,
+            pushCallback: device.callbackURL,
+            pushPublicKey: device.callbackPublicKey,
+            pushAuthKey: device.callbackAuthKey,
+            uaBrowser: mergedInfo.uaBrowser,
+            uaBrowserVersion: mergedInfo.uaBrowserVersion,
+            uaOS: mergedInfo.uaOS,
+            uaOSVersion: mergedInfo.uaOSVersion,
+            uaDeviceType: mergedInfo.uaDeviceType
+          }
+        })
+      })
+      .catch(err =>{
+        if (isNotFoundError(err)) {
+          throw error.unknownAccount()
+        }
+        throw err
+      })
   }
 
   DB.prototype.sessionWithDevice = function (id) {
@@ -419,19 +462,41 @@ module.exports = (
 
   DB.prototype.updateSessionToken = function (token, userAgentString) {
     log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
-
-    if (! token.update(userAgentString)) {
+    if (! token.update(userAgentString) || ! this.redis) {
       return P.resolve()
     }
 
-    return this.pool.post('/sessionToken/' + token.id + '/update', {
+    const uid = token.uid
+    const newToken = [{
+      tokenId: token.id,
+      uid: uid,
       uaBrowser: token.uaBrowser,
       uaBrowserVersion: token.uaBrowserVersion,
       uaOS: token.uaOS,
       uaOSVersion: token.uaOSVersion,
       uaDeviceType: token.uaDeviceType,
-      lastAccessTime: token.lastAccessTime
-    })
+      lastAccessTime: token.lastAccessTime,
+      createdAt: token.createdAt
+    }]
+    let sessionTokens = []
+    if (features.isLastAccessTimeEnabledForUser(uid)) {
+      // get the array of session tokens associated with the given uid
+      return this.redis.getAsync(uid)
+      .then(res => {
+        if (res) {
+          res = JSON.parse(res)
+          // remove the token that we want to update from the array
+          const filteredRes = res.filter(tok => tok.tokenId !== token.id)
+          sessionTokens = sessionTokens.concat(filteredRes)
+        }
+        // add new updated token into array, and set the resulting array as the new value
+        sessionTokens = sessionTokens.concat(newToken)
+        return this.redis.setAsync(uid, JSON.stringify(sessionTokens))
+      })
+      .then(() => sessionTokens)
+    } else {
+      return P.resolve()
+    }
   }
 
   DB.prototype.createDevice = function (uid, sessionTokenId, deviceInfo) {
@@ -518,18 +583,33 @@ module.exports = (
 
   DB.prototype.deleteAccount = function (authToken) {
     log.trace({ op: 'DB.deleteAccount', uid: authToken && authToken.uid })
-    return this.pool.del('/account/' + authToken.uid)
+    const promises = [this.pool.del('/account/' + authToken.uid)]
+    if (this.redis) {
+      promises.push(this.redis.del(authToken.uid))
+    }
+    return P.all(promises)
   }
 
   DB.prototype.deleteSessionToken = function (sessionToken) {
+    const uid = sessionToken && sessionToken.uid
     log.trace(
       {
         op: 'DB.deleteSessionToken',
         id: sessionToken && sessionToken.id,
-        uid: sessionToken && sessionToken.uid
+        uid: uid
       }
     )
-    return this.pool.del('/sessionToken/' + sessionToken.id)
+    const promises = [this.pool.del('/sessionToken/' + sessionToken.id)]
+    if (this.redis) {
+      promises.push(this.redis.getAsync(uid))
+    }
+    return P.all(promises)
+      .spread((deleteRes, redisTokens) => {
+        const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : []
+        const tokenToDeleteIndex = redisSessionTokens.findIndex((tok) => tok.tokenId === sessionToken.id)
+        redisSessionTokens.splice(tokenToDeleteIndex, 1)
+        return this.redis.setAsync(uid, JSON.stringify(redisSessionTokens))
+      })
   }
 
   DB.prototype.deleteKeyFetchToken = function (keyFetchToken) {
@@ -623,10 +703,14 @@ module.exports = (
   DB.prototype.resetAccount = function (accountResetToken, data) {
     log.trace({ op: 'DB.resetAccount', uid: accountResetToken && accountResetToken.uid })
     data.verifierSetAt = Date.now()
-    return this.pool.post(
+    const promises = [this.pool.post(
       '/account/' + accountResetToken.uid + '/reset',
       data
-    )
+    )]
+    if (this.redis) {
+      promises.push(this.redis.del(accountResetToken.uid))
+    }
+    return P.all(promises)
   }
 
   DB.prototype.verifyEmail = function (account, emailCode) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -462,11 +462,13 @@ module.exports = (
 
   DB.prototype.updateSessionToken = function (token, userAgentString) {
     log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
-    if (! token.update(userAgentString) || ! this.redis) {
+
+    const uid = token.uid
+    if (! this.redis || ! features.isLastAccessTimeEnabledForUser(uid)) {
       return P.resolve()
     }
 
-    const uid = token.uid
+    token.update(userAgentString)
     const newToken = [{
       tokenId: token.id,
       uid: uid,
@@ -479,24 +481,20 @@ module.exports = (
       createdAt: token.createdAt
     }]
     let sessionTokens = []
-    if (features.isLastAccessTimeEnabledForUser(uid)) {
-      // get the array of session tokens associated with the given uid
-      return this.redis.getAsync(uid)
-      .then(res => {
-        if (res) {
-          res = JSON.parse(res)
-          // remove the token that we want to update from the array
-          const filteredRes = res.filter(tok => tok.tokenId !== token.id)
-          sessionTokens = sessionTokens.concat(filteredRes)
-        }
-        // add new updated token into array, and set the resulting array as the new value
-        sessionTokens = sessionTokens.concat(newToken)
-        return this.redis.setAsync(uid, JSON.stringify(sessionTokens))
-      })
-      .then(() => sessionTokens)
-    } else {
-      return P.resolve()
-    }
+    // get the array of session tokens associated with the given uid
+    return this.redis.getAsync(uid)
+    .then(res => {
+      if (res) {
+        res = JSON.parse(res)
+        // remove the token that we want to update from the array
+        const filteredRes = res.filter(tok => tok.tokenId !== token.id)
+        sessionTokens = sessionTokens.concat(filteredRes)
+      }
+      // add new updated token into array, and set the resulting array as the new value
+      sessionTokens = sessionTokens.concat(newToken)
+      return this.redis.setAsync(uid, JSON.stringify(sessionTokens))
+    })
+    .then(() => sessionTokens)
   }
 
   DB.prototype.createDevice = function (uid, sessionTokenId, deviceInfo) {

--- a/lib/features.js
+++ b/lib/features.js
@@ -21,11 +21,9 @@ module.exports = config => {
      * @param uid   Buffer or String
      * @param email String
      */
-    isLastAccessTimeEnabledForUser (uid, email) {
-      return lastAccessTimeUpdates.enabled && (
-        isSampledUser(lastAccessTimeUpdates.sampleRate, uid, 'lastAccessTimeUpdates') ||
-        lastAccessTimeUpdates.enabledEmailAddresses.test(email)
-      )
+    isLastAccessTimeEnabledForUser (uid) {
+      return lastAccessTimeUpdates.enabled &&
+        isSampledUser(lastAccessTimeUpdates.sampleRate, uid, 'lastAccessTimeUpdates')
     },
 
     /**

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -5,15 +5,8 @@
 'use strict'
 
 const userAgent = require('../userAgent')
-const ONE_HOUR = 60 * 60 * 1000
-
-// setting to "forever" to eliminate ~99% of the updates to sessionToken
-// (A small percentage do qualify as "fresh" due to changes in UA).
-// See https://github.com/mozilla/fxa-auth-server/pull/1169
-const TOKEN_FRESHNESS_THRESHOLD = 50 * 365 * 24 * ONE_HOUR // 50 years or post Y2038 ;-)
 
 module.exports = (log, Token, config) => {
-  const features = require('../features')(config)
 
   class SessionToken extends Token {
 
@@ -56,14 +49,7 @@ module.exports = (log, Token, config) => {
       }
     }
 
-    // Parse the user agent string, then check the result to see whether
-    // the session token needs updating.
-    //
-    // If the session token has not changed, allowing up to an hour of
-    // leeway for lastAccessTime, return false.
-    //
-    // Otherwise, update properties on this then return true.
-    //
+    // Parse the user agent string, then update properties on this
     // It is the caller's responsibility to update the database.
     update(userAgentString) {
       log.trace({ op: 'SessionToken.update', uid: this.uid })
@@ -72,34 +58,9 @@ module.exports = (log, Token, config) => {
         lastAccessTime: Date.now()
       }, userAgentString, log)
 
-      if (this.isFresh(freshData)) {
-        return false
-      }
-
       this.setUserAgentInfo(freshData)
 
       return true
-    }
-
-    isFresh(freshData) {
-      var result = this.uaBrowser === freshData.uaBrowser &&
-        this.uaBrowserVersion === freshData.uaBrowserVersion &&
-        this.uaOS === freshData.uaOS &&
-        this.uaOSVersion === freshData.uaOSVersion &&
-        this.uaDeviceType === freshData.uaDeviceType &&
-        (
-          ! features.isLastAccessTimeEnabledForUser(this.uid, this.email) ||
-          this.lastAccessTime + TOKEN_FRESHNESS_THRESHOLD > freshData.lastAccessTime
-        )
-
-      log.info({
-        op: 'SessionToken.isFresh',
-        uid: this.uid,
-        tokenAge: freshData.lastAccessTime - this.lastAccessTime,
-        fresh: result
-      })
-
-      return result
     }
 
     setUserAgentInfo(data) {
@@ -126,5 +87,3 @@ module.exports = (log, Token, config) => {
   return SessionToken
 }
 
-// For use by the tests.
-module.exports.TOKEN_FRESHNESS_THRESHOLD = TOKEN_FRESHNESS_THRESHOLD

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1378,7 +1378,7 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "assert-plus@1.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
@@ -1476,7 +1476,7 @@
             },
             "node-uuid": {
               "version": "1.4.8",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
             "oauth-sign": {
@@ -1682,7 +1682,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.4.0",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -2038,7 +2038,7 @@
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "escape-string-regexp@1.0.5",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
@@ -2337,7 +2337,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2395,7 +2395,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2455,9 +2455,9 @@
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
-              "version": "2.3.2",
+              "version": "2.3.3",
               "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -2476,12 +2476,12 @@
                 },
                 "safe-buffer": {
                   "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.0 <5.2.0",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                 },
                 "string_decoder": {
                   "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.0 <1.1.0",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                 },
                 "util-deprecate": {
@@ -3437,7 +3437,7 @@
                 },
                 "normalize-package-data": {
                   "version": "2.4.0",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "normalize-package-data@>=2.3.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
                   "dependencies": {
                     "hosted-git-info": {
@@ -3621,9 +3621,9 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "readable-stream@>=2.1.5 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -3647,12 +3647,12 @@
                         },
                         "safe-buffer": {
                           "version": "5.1.1",
-                          "from": "safe-buffer@>=5.1.0 <5.2.0",
+                          "from": "safe-buffer@>=5.1.1 <5.2.0",
                           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.0 <1.1.0",
+                          "from": "string_decoder@>=1.0.3 <1.1.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                         },
                         "util-deprecate": {
@@ -3735,9 +3735,9 @@
           "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
           "dependencies": {
             "irregular-plurals": {
-              "version": "1.2.0",
+              "version": "1.3.0",
               "from": "irregular-plurals@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz"
             }
           }
         },
@@ -3760,7 +3760,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -3815,9 +3815,9 @@
               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "3.0.1",
+                  "version": "3.0.2",
                   "from": "js-tokens@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
                 }
               }
             },
@@ -3837,9 +3837,9 @@
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.3.2",
+                  "version": "2.3.3",
                   "from": "readable-stream@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -3858,12 +3858,12 @@
                     },
                     "safe-buffer": {
                       "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.0 <5.2.0",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
                       "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.0 <1.1.0",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                     },
                     "util-deprecate": {
@@ -4746,22 +4746,22 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <2.0.0",
+              "from": "chalk@1.1.3",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "ansi-styles@2.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@1.0.5",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "has-ansi@2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -4773,7 +4773,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "strip-ansi@3.0.1",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -4785,7 +4785,7 @@
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "supports-color@2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
@@ -5307,9 +5307,9 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "readable-stream@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -5328,12 +5328,12 @@
                         },
                         "safe-buffer": {
                           "version": "5.1.1",
-                          "from": "safe-buffer@>=5.1.0 <5.2.0",
+                          "from": "safe-buffer@>=5.1.1 <5.2.0",
                           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.0 <1.1.0",
+                          "from": "string_decoder@>=1.0.3 <1.1.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                         },
                         "util-deprecate": {
@@ -5375,40 +5375,40 @@
                       "from": "ajv@4.11.8",
                       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
                     },
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    },
                     "aproba": {
                       "version": "1.1.1",
                       "from": "aproba@1.1.1",
                       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@2.1.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.1.4",
                       "from": "are-we-there-yet@1.1.4",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
                     },
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "from": "asynckit@0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "aws-sign2": {
                       "version": "0.6.0",
                       "from": "aws-sign2@0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@0.4.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                     },
                     "aws4": {
                       "version": "1.6.0",
@@ -5465,15 +5465,15 @@
                       "from": "combined-stream@1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
-                    "console-control-strings": {
-                      "version": "1.1.0",
-                      "from": "console-control-strings@1.1.0",
-                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-                    },
                     "concat-map": {
                       "version": "0.0.1",
                       "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "from": "console-control-strings@1.1.0",
+                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5555,11 +5555,6 @@
                       "from": "glob@7.1.2",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
                     },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "from": "har-validator@4.2.1",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-                    },
                     "graceful-fs": {
                       "version": "4.1.11",
                       "from": "graceful-fs@4.1.11",
@@ -5569,6 +5564,11 @@
                       "version": "1.0.5",
                       "from": "har-schema@1.0.5",
                       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "from": "har-validator@4.2.1",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
@@ -5615,15 +5615,15 @@
                       "from": "is-typedarray@1.0.0",
                       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
@@ -5825,15 +5825,15 @@
                       "from": "tar@2.2.1",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tar-pack": {
-                      "version": "3.4.0",
-                      "from": "tar-pack@3.4.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
-                    },
                     "tough-cookie": {
                       "version": "2.3.2",
                       "from": "tough-cookie@2.3.2",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+                    },
+                    "tar-pack": {
+                      "version": "3.4.0",
+                      "from": "tar-pack@3.4.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.6.0",
@@ -8315,7 +8315,7 @@
         "uap-core": {
           "version": "0.5.0",
           "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#6ba43604ec629f2bb3a126da8f93dea51b226149"
+          "resolved": "git://github.com/ua-parser/uap-core.git#4af9a7ef62da597979d80f198f244e0763891ec4"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -8411,9 +8411,9 @@
                   "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
                   "dependencies": {
                     "httpreq": {
-                      "version": "0.4.23",
+                      "version": "0.4.24",
                       "from": "httpreq@>=0.4.22",
-                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz"
+                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz"
                     },
                     "underscore": {
                       "version": "1.7.0",
@@ -8459,9 +8459,9 @@
                   "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
                   "dependencies": {
                     "httpreq": {
-                      "version": "0.4.23",
+                      "version": "0.4.24",
                       "from": "httpreq@>=0.4.22",
-                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz"
+                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz"
                     },
                     "underscore": {
                       "version": "1.7.0",
@@ -8495,9 +8495,9 @@
                   "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
                   "dependencies": {
                     "httpreq": {
-                      "version": "0.4.23",
+                      "version": "0.4.24",
                       "from": "httpreq@>=0.4.22",
-                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz"
+                      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz"
                     },
                     "underscore": {
                       "version": "1.7.0",
@@ -8757,15 +8757,15 @@
           "from": "babel-generator@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz"
         },
-        "babel-runtime": {
-          "version": "6.18.0",
-          "from": "babel-runtime@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
-        },
         "babel-messages": {
           "version": "6.8.0",
           "from": "babel-messages@>=6.8.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.18.0",
+          "from": "babel-runtime@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
         },
         "babel-template": {
           "version": "6.16.0",
@@ -8787,15 +8787,15 @@
           "from": "babylon@>=6.13.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz"
         },
-        "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
         "brace-expansion": {
           "version": "1.1.6",
           "from": "brace-expansion@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
         },
         "braces": {
           "version": "1.8.5",
@@ -8807,30 +8807,30 @@
           "from": "builtin-modules@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
         },
-        "center-align": {
-          "version": "0.1.3",
-          "from": "center-align@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
-        },
         "camelcase": {
           "version": "1.2.1",
           "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "from": "center-align@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
-        "commondir": {
-          "version": "1.0.1",
-          "from": "commondir@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
-        },
         "code-point-at": {
           "version": "1.0.1",
           "from": "code-point-at@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz"
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "from": "commondir@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
         },
         "concat-map": {
           "version": "0.0.1",
@@ -8877,15 +8877,15 @@
           "from": "esutils@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
-        "expand-range": {
-          "version": "1.8.2",
-          "from": "expand-range@>=1.8.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-        },
         "expand-brackets": {
           "version": "0.1.5",
           "from": "expand-brackets@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "from": "expand-range@>=1.8.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
         },
         "extglob": {
           "version": "0.3.2",
@@ -8982,15 +8982,15 @@
           "from": "invert-kv@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
         },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "from": "is-arrayish@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-        },
         "is-buffer": {
           "version": "1.1.4",
           "from": "is-buffer@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "from": "is-arrayish@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -9007,15 +9007,15 @@
           "from": "is-equal-shallow@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
         },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
         "is-extendable": {
           "version": "0.1.1",
           "from": "is-extendable@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "from": "is-extglob@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
         },
         "is-finite": {
           "version": "1.0.2",
@@ -9072,15 +9072,15 @@
           "from": "js-tokens@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
         },
-        "jsesc": {
-          "version": "1.3.0",
-          "from": "jsesc@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-        },
         "kind-of": {
           "version": "3.0.4",
           "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "from": "jsesc@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -9137,11 +9137,6 @@
           "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
-        "normalize-package-data": {
-          "version": "2.3.5",
-          "from": "normalize-package-data@>=2.3.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-        },
         "normalize-path": {
           "version": "2.0.1",
           "from": "normalize-path@>=2.0.1 <3.0.0",
@@ -9151,6 +9146,11 @@
           "version": "1.0.1",
           "from": "number-is-nan@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        },
+        "normalize-package-data": {
+          "version": "2.3.5",
+          "from": "normalize-package-data@>=2.3.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
@@ -9182,15 +9182,15 @@
           "from": "os-locale@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
         },
-        "parse-glob": {
-          "version": "3.0.4",
-          "from": "parse-glob@>=3.0.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
-        },
         "parse-json": {
           "version": "2.2.0",
           "from": "parse-json@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "from": "parse-glob@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
         },
         "path-exists": {
           "version": "2.1.0",
@@ -9237,15 +9237,15 @@
           "from": "preserve@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
         },
-        "randomatic": {
-          "version": "1.1.5",
-          "from": "randomatic@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
-        },
         "pseudomap": {
           "version": "1.0.2",
           "from": "pseudomap@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "from": "randomatic@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -9561,6 +9561,28 @@
         }
       }
     },
+    "redis": {
+      "version": "2.7.1",
+      "from": "redis@2.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.7.1.tgz",
+      "dependencies": {
+        "double-ended-queue": {
+          "version": "2.1.0-0",
+          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
+        },
+        "redis-commands": {
+          "version": "1.3.1",
+          "from": "redis-commands@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+        },
+        "redis-parser": {
+          "version": "2.6.0",
+          "from": "redis-parser@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz"
+        }
+      }
+    },
     "request": {
       "version": "2.79.0",
       "from": "request@2.79.0",
@@ -9622,7 +9644,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <1.2.0",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -9632,7 +9654,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
@@ -10194,9 +10216,9 @@
                   "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.3.2",
+                  "version": "2.3.3",
                   "from": "readable-stream@>=2.2.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -10220,7 +10242,7 @@
                     },
                     "string_decoder": {
                       "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.0 <1.1.0",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                     },
                     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "nodemailer": "2.7.2",
     "po2json": "0.4.5",
     "poolee": "1.0.1",
+    "redis": "2.7.1",
     "request": "2.79.0",
     "restify": "4.3.0",
     "restify-safe-json-formatter": "0.2.0",

--- a/test/local/features.js
+++ b/test/local/features.js
@@ -167,11 +167,6 @@ describe('features', () => {
 
       config.lastAccessTimeUpdates.enabled = true
       config.lastAccessTimeUpdates.sampleRate = 0
-      config.lastAccessTimeUpdates.enabledEmailAddresses = /.+@mozilla\.com$/
-      assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), true, 'should return true when email address matches')
-
-      config.lastAccessTimeUpdates.enabledEmailAddresses = /.+@mozilla\.org$/
-      assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when email address does not match')
 
       config.lastAccessTimeUpdates.sampleRate = 0.03
       assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), true, 'should return true when sample rate matches')
@@ -181,7 +176,6 @@ describe('features', () => {
 
       config.lastAccessTimeUpdates.enabled = false
       config.lastAccessTimeUpdates.sampleRate = 0.03
-      config.lastAccessTimeUpdates.enabledEmailAddresses = /.+@mozilla\.com$/
       assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when feature is disabled')
     }
   )

--- a/test/remote/account_locale_tests.js
+++ b/test/remote/account_locale_tests.js
@@ -9,6 +9,7 @@ const TestServer = require('../test_server')
 const Client = require('../client')()
 
 var config = require('../../config').getProperties()
+config.redis.enabled = false
 var key = {
   'algorithm': 'RS',
   'n': '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -8,6 +8,7 @@ const assert = require('insist')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var config = require('../../config').getProperties()
+config.redis.enabled = false
 var url = require('url')
 var jwtool = require('fxa-jwtool')
 var pubSigKey = jwtool.JWK.fromFile(config.publicKeyFile)

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -10,6 +10,7 @@ const Client = require('../client')()
 var jwtool = require('fxa-jwtool')
 
 var config = require('../../config').getProperties()
+config.redis.enabled = false
 var pubSigKey = jwtool.JWK.fromFile(config.publicKeyFile)
 
 var publicKey = {

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -42,8 +42,6 @@ const DB = proxyquire('../../lib/db', { redis: {
   UnblockCode
 )
 
-var TOKEN_FRESHNESS_THRESHOLD = require('../../lib/tokens/session_token').TOKEN_FRESHNESS_THRESHOLD
-
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex').toString('hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex').toString('hex')
 
@@ -165,13 +163,6 @@ describe('remote db', function() {
           return sessionToken
         })
         .then(function(sessionToken) {
-          sessionToken.lastAccessTime -= 59 * 60 * 1000
-          return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
-        })
-        .then(function() {
-          return db.sessionToken(tokenId)
-        })
-        .then(function(sessionToken) {
           // override lastAccessTimeUpdates flag
           lastAccessTimeUpdates.enabled = false
           return db.updateSessionToken(sessionToken)
@@ -181,17 +172,9 @@ describe('remote db', function() {
           assert.equal(redisSetSpy.lastCall, null, 'session token was not updated if lastAccessTimeUpdates flag is false')
           // reset lastAccessTimeUpdates flag
           lastAccessTimeUpdates.enabled = true
-          return
-        })
-        .then(function() {
-          return db.sessions(account.uid)
-        })
-        .then(function(sessionTokens) {
-          assert.equal(redisSetSpy.lastCall, null, 'session token was not updated if token.update call succeeds')
           return db.sessionToken(tokenId)
         })
         .then(function(sessionToken) {
-          sessionToken.lastAccessTime -= TOKEN_FRESHNESS_THRESHOLD
           return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
         })
         .then(function(sessionTokens) {
@@ -393,9 +376,9 @@ describe('remote db', function() {
             assert.equal(device.uaDeviceType, null, 'device.uaDeviceType is correct')
 
             return db.deleteDevice(account.uid, deviceInfo.id)
-            .catch(function () {
-              assert(false, 'deleting a device should not have failed')
-            })
+              .catch(function () {
+                assert(false, 'deleting a device should not have failed')
+              })
           })
           .then(function () {
             // Fetch all of the devices for the account

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -9,6 +9,8 @@ var uuid = require('uuid')
 var crypto = require('crypto')
 var base64url = require('base64url')
 const sinon = require('sinon')
+var proxyquire = require('proxyquire')
+
 const log = { trace () {}, info () {}, error () {} }
 
 var config = require('../../config').getProperties()
@@ -23,8 +25,18 @@ const lastAccessTimeUpdates = {
 const Token = require('../../lib/tokens')(log, {
   lastAccessTimeUpdates: lastAccessTimeUpdates
 })
-const DB = require('../../lib/db')(
-  { lastAccessTimeUpdates, signinCodeSize: config.signinCodeSize },
+const redisGetSpy = sinon.stub()
+const redisSetSpy = sinon.stub()
+const redisDelSpy = sinon.stub()
+
+const DB = proxyquire('../../lib/db', { redis: {
+  createClient: () => ({
+    getAsync: redisGetSpy,
+    setAsync: redisSetSpy,
+    del: redisDelSpy
+  })
+}})(
+  { lastAccessTimeUpdates, signinCodeSize: config.signinCodeSize , redis: { enabled: true }},
   log,
   Token,
   UnblockCode
@@ -121,6 +133,7 @@ describe('remote db', function() {
         .then(function(sessionToken) {
           assert.deepEqual(sessionToken.uid, account.uid)
           tokenId = sessionToken.tokenId
+          redisGetSpy.returns(P.resolve(null))
           return db.sessions(account.uid)
         })
         .then(function(sessions) {
@@ -159,24 +172,48 @@ describe('remote db', function() {
           return db.sessionToken(tokenId)
         })
         .then(function(sessionToken) {
-          assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt, 'session token was not updated')
-          return sessionToken
+          // override lastAccessTimeUpdates flag
+          lastAccessTimeUpdates.enabled = false
+          return db.updateSessionToken(sessionToken)
+        })
+        .then(function(result) {
+          assert.equal(undefined, result)
+          assert.equal(redisSetSpy.lastCall, null, 'session token was not updated if lastAccessTimeUpdates flag is false')
+          // reset lastAccessTimeUpdates flag
+          lastAccessTimeUpdates.enabled = true
+          return
+        })
+        .then(function() {
+          return db.sessions(account.uid)
+        })
+        .then(function(sessionTokens) {
+          assert.equal(redisSetSpy.lastCall, null, 'session token was not updated if token.update call succeeds')
+          return db.sessionToken(tokenId)
         })
         .then(function(sessionToken) {
           sessionToken.lastAccessTime -= TOKEN_FRESHNESS_THRESHOLD
           return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0')
         })
-        .then(function() {
+        .then(function(sessionTokens) {
+          assert.equal(redisSetSpy.lastCall.args[0], account.uid)
+
+          const redisSetArgs = JSON.parse(redisSetSpy.lastCall.args[1])
+          const token = redisSetArgs[0]
+          assert.equal(token.tokenId, tokenId)
+          assert.equal(token.uid, account.uid)
+          assert.equal(token.uaBrowser, 'Firefox')
+          assert.equal(token.uaBrowserVersion, '41')
+          assert.equal(token.uaOS, 'Mac OS X')
+          assert.equal(token.uaOSVersion, '10.10')
+          assert.ok(token.lastAccessTime)
+          assert.ok(token.createdAt)
           return db.sessionToken(tokenId)
-        })
-        .then(function(sessionToken) {
-          assert.ok(sessionToken.lastAccessTime > sessionToken.createdAt, 'session token was updated')
-          return sessionToken
         })
         .then(function(sessionToken) {
           return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0')
         })
-        .then(function() {
+        .then(function(tokens) {
+          redisGetSpy.returns(P.resolve(JSON.stringify(tokens)))
           return db.sessions(account.uid)
         })
         .then(function(sessions) {
@@ -189,19 +226,31 @@ describe('remote db', function() {
           return db.sessionToken(tokenId)
         })
         .then(function(sessionToken) {
-          assert.equal(sessionToken.uaBrowser, 'Firefox Mobile')
+          // this returns previously stored data since sessionToken doesnt read from cache
+          assert.equal(sessionToken.uaBrowser, 'Firefox')
           assert.equal(sessionToken.uaBrowserVersion, '41')
-          assert.equal(sessionToken.uaOS, 'Android')
-          assert.equal(sessionToken.uaOSVersion, '4.4')
-          assert.equal(sessionToken.uaDeviceType, 'mobile')
+          assert.equal(sessionToken.uaOS, 'Mac OS X')
+          assert.equal(sessionToken.uaOSVersion, '10.10')
           assert.ok(sessionToken.lastAccessTime >= sessionToken.createdAt)
           assert.ok(sessionToken.lastAccessTime <= Date.now())
           return sessionToken
         })
         .then(function(sessionToken) {
+          const mockTokens = JSON.stringify([{
+            uid: sessionToken.uid,
+            id: 'idToNotDelete'
+          }, {
+            uid: sessionToken.uid,
+            id: sessionToken.id
+          }])
+          redisGetSpy.returns(P.resolve(mockTokens))
           return db.deleteSessionToken(sessionToken)
         })
         .then(function() {
+          const redisSetArgs = JSON.parse(redisSetSpy.lastCall.args[1])
+          assert.equal(redisSetArgs.length, 1)
+          assert.equal(redisSetArgs[0].id, 'idToNotDelete')
+
           return db.sessionToken(tokenId)
           .then(function(sessionToken) {
             assert(false, 'The above sessionToken() call should fail, since the sessionToken has been deleted')
@@ -217,6 +266,7 @@ describe('remote db', function() {
   it(
     'device registration',
     () => {
+      redisGetSpy.returns(P.resolve(null))
       var sessionToken
       var deviceInfo = {
         id: crypto.randomBytes(16).toString('hex'),
@@ -319,7 +369,9 @@ describe('remote db', function() {
                 assert(false, 'updating a new device or existing session token should not have failed')
               })
           })
-          .then(function (device) {
+          .then(function (results) {
+            var sessionTokens = results[1]
+            redisGetSpy.returns(P.resolve(JSON.stringify(sessionTokens)))
             // Fetch all of the devices for the account
             return db.devices(account.uid)
           })
@@ -339,21 +391,11 @@ describe('remote db', function() {
             assert.equal(device.uaOS, 'Mac OS X', 'device.uaOS is correct')
             assert.equal(device.uaOSVersion, '10.10', 'device.uaOSVersion is correct')
             assert.equal(device.uaDeviceType, null, 'device.uaDeviceType is correct')
-            // Disable the lastAccessTime property
-            lastAccessTimeUpdates.enabled = false
-            // Fetch all of the devices for the account
-            return db.devices(account.uid)
-          })
-          .then(function(devices) {
-            assert.equal(devices.length, 1, 'devices array still contains one item')
-            assert.equal(devices[0].lastAccessTime, null, 'device.lastAccessTime should be null')
-            // Reinstate the lastAccessTime property
-            lastAccessTimeUpdates.enabled = true
-            // Delete the device
+
             return db.deleteDevice(account.uid, deviceInfo.id)
-              .catch(function () {
-                assert(false, 'deleting a device should not have failed')
-              })
+            .catch(function () {
+              assert(false, 'deleting a device should not have failed')
+            })
           })
           .then(function () {
             // Fetch all of the devices for the account
@@ -555,6 +597,8 @@ describe('remote db', function() {
           return db.resetAccount(accountResetToken, account)
         })
         .then(function() {
+          assert.equal(redisDelSpy.lastCall.args[0], account.uid)
+          redisDelSpy.reset()
           // account should STILL exist for this email address
           return db.accountExists(account.email)
         })
@@ -723,6 +767,8 @@ describe('remote db', function() {
           return db.deleteAccount(emailRecord)
         })
         .then(function() {
+          assert.equal(redisDelSpy.lastCall.args[0], account.uid)
+          redisDelSpy.reset()
           // account should no longer exist for this email address
           return db.accountExists(account.email)
         })

--- a/test/remote/verifier_upgrade_tests.js
+++ b/test/remote/verifier_upgrade_tests.js
@@ -8,7 +8,7 @@ const assert = require('insist')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var createDBServer = require('fxa-auth-db-mysql')
-var log = { trace() {} }
+var log = { trace() {}, info() {} }
 
 var config = require('../../config').getProperties()
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/1044
Ready for review

Sample of what the redis key/val looks like:
```
{"fxa-auth-session740eb35a75bd4908b8fcbe9efd5a29ad":"[{\"tokenId\":\"781d1b50c3114d60b778a605c576cb82eaa1022165a3ce05aaa855e0585325ec\",\"uid\":\"740eb35a75bd4908b8fcbe9efd5a29ad\",\"uaBrowser\":\"Firefox\",\"uaBrowserVersion\":\"54\",\"uaOS\":\"Mac OS X\",\"uaOSVersion\":\"10.12\",\"uaDeviceType\":null,\"lastAccessTime\":1499357068854,\"createdAt\":1499357068854}]"}
```