### PR TITLE
feat(account): send marketingOptIn to attached services on registration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -406,6 +406,13 @@ if the url has a query parameter of `keys=true`.
   
   <!--end-request-body-post-accountcreate-metricsContext-->
 
+* `marketingOptIn`: *boolean*
+
+  <!--begin-request-body-post-accountcreate-marketingOptIn-->
+  Set to true if the user has opted-in to our marketing. When verified,
+  the auth-server will notify Basket.
+  <!--end-request-body-post-accountcreate-marketingOptIn-->
+
 ##### Response body
 
 * `uid`: *string, regex(HEX_STRING), required*

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -4,7 +4,6 @@
 
 'use strict'
 
-const crypto = require('crypto')
 const Memcached = require('memcached')
 const P = require('./promise')
 
@@ -26,40 +25,40 @@ module.exports = (log, config, namespace) => {
 
   return {
     /**
-     * Delete data from the cache, keyed by a hash of
-     * `token.uid` and `token.id`. Fails silently if
-     * the cache is not enabled.
+     * Delete data from the cache, keyed by a string.
      *
-     * @param token
+     * Fails silently if the cache is not enabled.
+     *
+     * @param {string} key
      */
-    del (token) {
+    del (key) {
       return getCache()
-        .then(cache => cache.delAsync(getKey(token)))
+        .then(cache => cache.delAsync(key))
     },
 
     /**
-     * Fetch data from the cache, keyed by a hash of
-     * `token.uid` and `token.id`. Fails silently if
-     * the cache is not enabled.
+     * Fetch data from the cache, keyed by a string.
      *
-     * @param token
+     * Fails silently if the cache is not enabled.
+     *
+     * @param {string} key
      */
-    get (token) {
+    get (key) {
       return getCache()
-        .then(cache => cache.getAsync(getKey(token)))
+        .then(cache => cache.getAsync(key))
     },
 
     /**
-     * Fetch data from the cache, keyed by a hash of
-     * `token.uid` and `token.id`. Fails silently if
-     * the cache is not enabled.
+     * Fetch data from the cache, keyed by a string.
      *
-     * @param token
+     * Fails silently if the cache is not enabled.
+     *
+     * @param {string} key
      * @param data
      */
-    set (token, data) {
+    set (key, data) {
       return getCache()
-        .then(cache => cache.setAsync(getKey(token), data, CACHE_LIFETIME))
+        .then(cache => cache.setAsync(key, data, CACHE_LIFETIME))
     }
   }
 
@@ -91,17 +90,3 @@ module.exports = (log, config, namespace) => {
       })
   }
 }
-
-function getKey (token) {
-  if (! token || ! token.uid || ! token.id) {
-    const err = new Error('Invalid token')
-    throw err
-  }
-
-  const hash = crypto.createHash('sha256')
-  hash.update(token.uid)
-  hash.update(token.id)
-
-  return hash.digest('base64')
-}
-

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -46,7 +46,7 @@ module.exports = function (log, config) {
     }
 
     return P.resolve()
-      .then(() => cache.set(token, metadata))
+      .then(() => cache.set(getKey(token), metadata))
       .catch(err => log.error({
         op: 'metricsContext.stash',
         err: err,
@@ -79,7 +79,7 @@ module.exports = function (log, config) {
 
         token = getToken(this)
         if (token) {
-          return cache.get(token)
+          return cache.get(getKey(token))
         }
       })
       .then(metadata => {
@@ -124,7 +124,7 @@ module.exports = function (log, config) {
       .then(() => {
         const token = getToken(this)
         if (token) {
-          return cache.del(token)
+          return cache.del(getKey(token))
         }
       })
   }
@@ -231,6 +231,19 @@ function calculateFlowTime (time, flowBeginTime) {
   }
 
   return time - flowBeginTime
+}
+
+function getKey (token) {
+  if (! token || ! token.uid || ! token.id) {
+    const err = new Error('Invalid token')
+    throw err
+  }
+
+  const hash = crypto.createHash('sha256')
+  hash.update(token.uid)
+  hash.update(token.id)
+
+  return hash.digest('base64')
 }
 
 // HACK: Force the API docs to expand SCHEMA inline

--- a/test/local/cache.js
+++ b/test/local/cache.js
@@ -61,7 +61,7 @@ describe('cache:', () => {
 
     describe('del:', () => {
       beforeEach(() => {
-        return cache.del(token)
+        return cache.del(digest)
       })
 
       it('calls memcached.delAsync correctly', () => {
@@ -76,28 +76,11 @@ describe('cache:', () => {
       })
     })
 
-    describe('del with bad token:', () => {
-      let error
-
-      beforeEach(() => {
-        return cache.del({ id: token.id })
-          .catch(e => error = e)
-      })
-
-      it('rejects correctly', () => {
-        assert.equal(error.message, 'Invalid token')
-      })
-
-      it('does not call memcached.delAsync', () => {
-        assert.equal(Memcached.prototype.delAsync.callCount, 0)
-      })
-    })
-
     describe('get:', () => {
       let result
 
       beforeEach(() => {
-        return cache.get(token)
+        return cache.get(digest)
           .then(r => result = r)
       })
 
@@ -117,26 +100,9 @@ describe('cache:', () => {
       })
     })
 
-    describe('get with bad token:', () => {
-      let error
-
-      beforeEach(() => {
-        return cache.get({ uid: token.uid })
-          .catch(e => error = e)
-      })
-
-      it('rejects correctly', () => {
-        assert.equal(error.message, 'Invalid token')
-      })
-
-      it('does not call memcached.getAsync', () => {
-        assert.equal(Memcached.prototype.getAsync.callCount, 0)
-      })
-    })
-
     describe('set:', () => {
       beforeEach(() => {
-        return cache.set(token, 'wibble')
+        return cache.set(digest, 'wibble')
       })
 
       it('calls memcached.setAsync correctly', () => {
@@ -152,23 +118,6 @@ describe('cache:', () => {
         assert.equal(log.error.callCount, 0)
       })
     })
-
-    describe('set with bad token:', () => {
-      let error
-
-      beforeEach(() => {
-        return cache.set({ id: token.id }, {})
-          .catch(e => error = e)
-      })
-
-      it('rejects correctly', () => {
-        assert.equal(error.message, 'Invalid token')
-      })
-
-      it('does not call memcached.setAsync', () => {
-        assert.equal(Memcached.prototype.setAsync.callCount, 0)
-      })
-    })
   })
 
   describe('memcached rejects:', () => {
@@ -182,7 +131,7 @@ describe('cache:', () => {
       let error
 
       beforeEach(() => {
-        return cache.del(token)
+        return cache.del(digest)
           .catch(e => error = e)
       })
 
@@ -195,7 +144,7 @@ describe('cache:', () => {
       let error
 
       beforeEach(() => {
-        return cache.get(token)
+        return cache.get(digest)
           .catch(e => error = e)
       })
 
@@ -208,7 +157,7 @@ describe('cache:', () => {
       let error
 
       beforeEach(() => {
-        return cache.set(token, 'wibble')
+        return cache.set(digest, 'wibble')
           .catch(e => error = e)
       })
 


### PR DESCRIPTION
Adds optional `marketingOptIn` payload parameter to `/account/create`.

If set, a flag is set in memcached that the user opted in to marketing.
The `/recovery_email/verify_code` route will check memcached for this
flag, and if found, will set `marketingOptIn` to the message sent to
attached services (SNS).

Closes #1973