### PR TITLE
feat(tokens): delete all account reset tokens on password reset

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -881,6 +881,12 @@ module.exports = (
       })
   }
 
+  DB.prototype.resetAccountTokens = function (uid) {
+    log.trace({ op: 'DB.resetAccountTokens', uid })
+
+    return this.pool.post(`/account/${uid}/resetTokens`)
+  }
+
   function wrapTokenNotFoundError (err) {
     if (isNotFoundError(err)) {
       err = error.invalidToken('The authentication token could not be found')

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -2078,6 +2078,13 @@ module.exports = (
             )
             .then(
               function () {
+                // Delete all passwordChangeTokens, passwordForgotTokens and
+                // accountResetTokens associated with this uid
+                return db.resetAccountTokens(accountResetToken.uid)
+              }
+            )
+            .then(
+              function () {
                 // Notify the devices that the account has changed.
                 push.notifyPasswordReset(accountResetToken.uid, devicesToNotify)
 

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -124,6 +124,7 @@ describe('/account/reset', function () {
     var clientAddress = mockRequest.app.clientAddress
     return runTest(route, mockRequest, function (res) {
       assert.equal(mockDB.resetAccount.callCount, 1)
+      assert.equal(mockDB.resetAccountTokens.callCount, 1)
 
       assert.equal(mockPush.notifyPasswordReset.callCount, 1)
       assert.deepEqual(mockPush.notifyPasswordReset.firstCall.args[0], uid)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -55,6 +55,7 @@ const DB_METHOD_NAMES = [
   'passwordChangeToken',
   'passwordForgotToken',
   'resetAccount',
+  'resetAccountTokens',
   'securityEvent',
   'securityEvents',
   'sessions',


### PR DESCRIPTION
This PR updates the auth-server to call `db.resetAccountTokens` after a successfull password reset which deletes all passwordForgotTokens, passwordChangeTokens, and accountResetTokens.

Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/288