### PR TITLE
feat(emails): Add change email

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [GET /recovery_emails (:lock: sessionToken)](#get-recovery_emails)
     * [POST /recovery_email (:lock: sessionToken)](#post-recovery_email)
     * [POST /recovery_email/destroy (:lock: sessionToken)](#post-recovery_emaildestroy)
+    * [POST /recovery_email/set_primary (:lock: sessionToken)](#post-recovery_emailset_primary)
   * [Password](#password)
     * [POST /password/change/start](#post-passwordchangestart)
     * [POST /password/change/finish (:lock: passwordChangeToken)](#post-passwordchangefinish)
@@ -245,6 +246,10 @@ for `code` and `errno` are:
   Reset password with this email type is not currently supported
 * `code: 400, errno: 146`:
   Invalid signin code
+* `code: 400, errno: 147`:
+  Can not change primary email to an unverified email
+* `code: 400, errno: 148`:
+  Can not change primary email to an email that does not belong to this account
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -516,6 +521,12 @@ Obtain a `sessionToken` and, optionally, a `keyFetchToken` if `keys=true`.
   
   <!--end-request-body-post-accountlogin-metricsContext-->
 
+* `originalLoginEmail`: *validators.email.optional*
+
+  <!--begin-request-body-post-accountlogin-originalLoginEmail-->
+  This parameter is the original email used to login with. Typically, it is specified after a user logins with a different email case, or changed their primary email address.
+  <!--end-request-body-post-accountlogin-originalLoginEmail-->
+
 ##### Response body
 
 * `uid`: *string, regex(HEX_STRING), required*
@@ -572,11 +583,11 @@ by the following errors
 * `code: 400, errno: 142`:
   Sign in with this email type is not currently supported
 
-* `code: 400, errno: 103`:
-  Incorrect password
-
 * `code: 400, errno: 127`:
   Invalid unblock code
+
+* `code: 400, errno: 103`:
+  Incorrect password
 
 
 #### GET /account/status
@@ -1561,6 +1572,41 @@ by the following errors
 
 * `code: 400, errno: 138`:
   Unverified session
+
+
+#### POST /recovery_email/set_primary
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-post-recovery_emailset_primary-->
+This endpoint changes a user's primary email address. This email address must
+belong to the user and be verified.
+<!--end-route-post-recovery_emailset_primary-->
+
+##### Request body
+
+* `email`: *validators.email.required*
+
+  <!--begin-request-body-post-recovery_emailset_primary-email-->
+  The new primary email address of the user.
+  <!--end-request-body-post-recovery_emailset_primary-email-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+* `code: 503, errno: 202`:
+  Feature not enabled
+
+* `code: 400, errno: 138`:
+  Unverified session
+
+* `code: 400, errno: 148`:
+  Can not change primary email to an email that does not belong to this account
+
+* `code: 400, errno: 147`:
+  Can not change primary email to an unverified email
 
 
 ### Password

--- a/lib/error.js
+++ b/lib/error.js
@@ -54,6 +54,8 @@ var ERRNO = {
   VERIFIED_SECONDARY_EMAIL_EXISTS: 144,
   RESET_PASSWORD_WITH_SECONDARY_EMAIL: 145,
   INVALID_SIGNIN_CODE: 146,
+  CHANGE_EMAIL_TO_UNVERIFIED_EMAIL: 147,
+  CHANGE_EMAIL_TO_UNOWNED_EMAIL: 148,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -670,6 +672,24 @@ AppError.invalidSigninCode = function () {
     error: 'Bad Request',
     errno: ERRNO.INVALID_SIGNIN_CODE,
     message: 'Invalid signin code'
+  })
+}
+
+AppError.cannotChangeEmailToUnverifiedEmail = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.CHANGE_EMAIL_TO_UNVERIFIED_EMAIL,
+    message: 'Can not change primary email to an unverified email'
+  })
+}
+
+AppError.cannotChangeEmailToUnownedEmail = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.CHANGE_EMAIL_TO_UNOWNED_EMAIL,
+    message: 'Can not change primary email to an email that does not belong to this account'
   })
 }
 

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -139,8 +139,8 @@ module.exports = function (log) {
     return linkAttributes(this.createSupportLink(templateName))
   }
 
-  Mailer.prototype._passwordResetLinkAttributes = function (email, templateName) {
-    return linkAttributes(this.createPasswordResetLink(email, templateName))
+  Mailer.prototype._passwordResetLinkAttributes = function (email, templateName, emailToHashWith) {
+    return linkAttributes(this.createPasswordResetLink(email, templateName, emailToHashWith))
   }
 
   Mailer.prototype._passwordChangeLinkAttributes = function (email, templateName) {
@@ -522,6 +522,7 @@ module.exports = function (log) {
     if (message.service) { query.service = message.service }
     if (message.redirectTo) { query.redirectTo = message.redirectTo }
     if (message.resume) { query.resume = message.resume }
+    if (message.emailToHashWith) { query.emailToHashWith = message.emailToHashWith }
 
     var links = this._generateLinks(this.passwordResetUrl, message.email, query, templateName)
 
@@ -882,8 +883,8 @@ module.exports = function (log) {
     links['passwordChangeLink'] = this.createPasswordChangeLink(email, templateName)
     links['passwordChangeLinkAttributes'] = this._passwordChangeLinkAttributes(email, templateName)
 
-    links['resetLink'] = this.createPasswordResetLink(email, templateName)
-    links['resetLinkAttributes'] = this._passwordResetLinkAttributes(email, templateName)
+    links['resetLink'] = this.createPasswordResetLink(email, templateName, query.emailToHashWith)
+    links['resetLinkAttributes'] = this._passwordResetLinkAttributes(email, templateName, query.emailToHashWith)
 
     links['androidLink'] = this._generateUTMLink(this.androidUrl, query, templateName, 'connect-android')
     links['iosLink'] = this._generateUTMLink(this.iosUrl, query, templateName, 'connect-ios')
@@ -901,16 +902,16 @@ module.exports = function (log) {
     return links
   }
 
-  Mailer.prototype.createPasswordResetLink = function (email, templateName) {
+  Mailer.prototype.createPasswordResetLink = function (email, templateName, emailToHashWith) {
     // Default `reset_password_confirm` to false, to show warnings about
     // resetting password and sync data
-    var query = { email: email, reset_password_confirm: false }
+    var query = { email: email, reset_password_confirm: false, email_to_hash_with : emailToHashWith}
 
     return this._generateUTMLink(this.initiatePasswordResetUrl, query, templateName, 'reset-password')
   }
 
   Mailer.prototype.createPasswordChangeLink = function (email, templateName) {
-    var query = { email: email }
+    var query = {email: email}
 
     return this._generateUTMLink(this.initiatePasswordChangeUrl, query, templateName, 'change-password')
   }

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -189,6 +189,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
             return mailer.recoveryEmail({
               ccEmails: ccEmails,
               email: primaryEmail,
+              emailToHashWith: account.email,
               flowId: opts.flowId,
               flowBeginTime: opts.flowBeginTime,
               token: opts.token.data,

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -141,7 +141,8 @@ module.exports = config => {
         resume: opts.resume || undefined,
         reason: opts.reason || undefined,
         device: opts.device || undefined,
-        metricsContext: opts.metricsContext || undefined
+        metricsContext: opts.metricsContext || undefined,
+        originalLoginEmail: opts.originalLoginEmail || undefined
       },
       {
         'accept-language': opts.lang
@@ -651,6 +652,22 @@ module.exports = config => {
         return this.doRequest(
           'POST',
           this.baseURL + '/recovery_email/destroy',
+          token,
+          {
+            email: email
+          }
+        )
+      }.bind(this)
+    )
+  }
+
+  ClientApi.prototype.setPrimaryEmail = function (sessionTokenHex, email) {
+    var o = sessionTokenHex ? tokens.SessionToken.fromHex(sessionTokenHex) : P.resolve(null)
+    return o.then(
+      function (token) {
+        return this.doRequest(
+          'POST',
+          this.baseURL + '/recovery_email/set_primary',
           token,
           {
             email: email

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -436,6 +436,10 @@ module.exports = config => {
     return this.api.deleteEmail(this.sessionToken, email)
   }
 
+  Client.prototype.setPrimaryEmail = function (email) {
+    return this.api.setPrimaryEmail(this.sessionToken, email)
+  }
+
   Client.prototype.sendUnblockCode = function (email) {
     return this.api.sendUnblockCode(email)
   }
@@ -444,8 +448,17 @@ module.exports = config => {
     if (! this.accountResetToken) {
       throw new Error('call verifyPasswordResetCode before calling resetPassword')
     }
-    // this will generate a new wrapKb on the server
-    return this.setupCredentials(this.email, newPassword)
+
+    // With introduction of change email, the client can choose what to hash the password with.
+    // To keep consistency, we hash with the email used to originally create the account.
+    // This will generate a new wrapKb on the server
+    var email = this.email
+
+    if (options && options.emailToHashWith) {
+      email = options.emailToHashWith
+    }
+
+    return this.setupCredentials(email, newPassword)
       .then(
         function (/* bundle */) {
           return this.api.accountReset(

--- a/test/local/ip_profiling.js
+++ b/test/local/ip_profiling.js
@@ -135,12 +135,13 @@ var mockCustoms = {
   flag: () => P.resolve()
 }
 
-mockDB.emailRecord = function () {
+mockDB.accountRecord = function () {
   return P.resolve({
     authSalt: crypto.randomBytes(32),
     data: crypto.randomBytes(32),
     email: TEST_EMAIL,
     emailVerified: true,
+    primaryEmail: {normalizedEmail: TEST_EMAIL, email: TEST_EMAIL, isVerified: true, isPrimary: true},
     kA: crypto.randomBytes(32),
     lastAuthAt: function () {
       return Date.now()
@@ -244,12 +245,13 @@ describe('IP Profiling', () => {
         uid: uid
       })
 
-      mockDB.emailRecord = function () {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: crypto.randomBytes(32),
           data: crypto.randomBytes(32),
           email: forceSigninEmail,
           emailVerified: true,
+          primaryEmail: {normalizedEmail: forceSigninEmail, email: forceSigninEmail, isVerified: true, isPrimary: true},
           kA: crypto.randomBytes(32),
           lastAuthAt: function () {
             return Date.now()
@@ -309,12 +311,13 @@ describe('IP Profiling', () => {
         uid: uid
       })
 
-      mockDB.emailRecord = function () {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: crypto.randomBytes(32),
           data: crypto.randomBytes(32),
           email: TEST_EMAIL,
           emailVerified: true,
+          primaryEmail: {normalizedEmail: TEST_EMAIL, email: TEST_EMAIL, isVerified: true, isPrimary: true},
           kA: crypto.randomBytes(32),
           lastAuthAt: function () {
             return Date.now()

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -656,8 +656,8 @@ describe('/recovery_email', () => {
 
   describe('/recovery_email', () => {
     beforeEach(() => {
-      mockDB.emailRecord = sinon.spy(() => {
-        return P.reject(error.unknownAccount())
+      mockDB.getSecondaryEmail = sinon.spy(() => {
+        return P.reject(error.unknownSecondaryEmail())
       })
     })
 
@@ -703,9 +703,11 @@ describe('/recovery_email', () => {
     })
 
     it('creates secondary email if another user unverified primary more than day old, deletes unverified account', () => {
-      mockDB.emailRecord = sinon.spy(() => {
+      mockDB.getSecondaryEmail = sinon.spy(() => {
         return P.resolve({
-          emailVerified: false,
+          isVerified: false,
+          isPrimary: true,
+          normalizedEmail: TEST_EMAIL,
           createdAt: Date.now() - MS_IN_DAY,
           uid: crypto.randomBytes(16)
         })
@@ -728,9 +730,11 @@ describe('/recovery_email', () => {
     })
 
     it('fails create email if another user unverified primary less than day old', () => {
-      mockDB.emailRecord = sinon.spy(() => {
+      mockDB.getSecondaryEmail = sinon.spy(() => {
         return P.resolve({
-          emailVerified: false,
+          isVerified: false,
+          isPrimary: true,
+          normalizedEmail: TEST_EMAIL,
           createdAt: Date.now(),
           uid: crypto.randomBytes(16)
         })

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -105,7 +105,7 @@ describe('/password', () => {
       })
       return runRoute(passwordRoutes, '/password/forgot/send_code', mockRequest)
       .then(function(response) {
-        assert.equal(mockDB.emailRecord.callCount, 1, 'db.emailRecord was called once')
+        assert.equal(mockDB.accountRecord.callCount, 1, 'db.emailRecord was called once')
 
         assert.equal(mockDB.createPasswordForgotToken.callCount, 1, 'db.createPasswordForgotToken was called once')
         var args = mockDB.createPasswordForgotToken.args[0]

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -24,6 +24,7 @@ const CUSTOMS_METHOD_NAMES = [
 const DB_METHOD_NAMES = [
   'account',
   'accountEmails',
+  'accountRecord',
   'accountResetToken',
   'consumeUnblockCode',
   'consumeSigninCode',
@@ -155,6 +156,7 @@ function mockDB (data, errors) {
         email: data.email,
         emailCode: data.emailCode,
         emailVerified: data.emailVerified,
+        primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
         uid: data.uid,
         verifierSetAt: Date.now(),
         wrapWrapKb: data.wrapWrapKb
@@ -177,6 +179,25 @@ function mockDB (data, errors) {
           isPrimary: false
         }
       ])
+    }),
+    accountRecord: sinon.spy(() => {
+      if (errors.emailRecord) {
+        return P.reject(errors.emailRecord)
+      }
+      return P.resolve({
+        authSalt: crypto.randomBytes(32),
+        createdAt: data.createdAt || Date.now(),
+        data: crypto.randomBytes(32),
+        email: data.email,
+        emailVerified: data.emailVerified,
+        primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
+        kA: crypto.randomBytes(32),
+        lastAuthAt: () => {
+          return Date.now()
+        },
+        uid: data.uid,
+        wrapWrapKb: crypto.randomBytes(32)
+      })
     }),
     consumeSigninCode: sinon.spy(() => {
       if (errors.consumeSigninCode) {
@@ -262,6 +283,7 @@ function mockDB (data, errors) {
         data: crypto.randomBytes(32).toString('hex'),
         email: data.email,
         emailVerified: data.emailVerified,
+        primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
         kA: crypto.randomBytes(32).toString('hex'),
         lastAuthAt: () => {
           return Date.now()

--- a/test/remote/recovery_email_change_email.js
+++ b/test/remote/recovery_email_change_email.js
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const TestServer = require('../test_server')
+const Client = require('../client')()
+
+let config, server, client, email, secondEmail
+const password = 'allyourbasearebelongtous', newPassword = 'newpassword'
+
+describe('remote change email', function () {
+  this.timeout(30000)
+
+  before(() => {
+    config = require('../../config').getProperties()
+    config.secondaryEmail = {
+      enabled: true,
+      enabledEmailAddresses: /\w/
+    }
+    config.securityHistory.ipProfiling = {}
+    return TestServer.start(config)
+      .then(s => {
+        server = s
+      })
+  })
+
+  beforeEach(() => {
+    email = server.uniqueEmail()
+    secondEmail = server.uniqueEmail()
+    return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
+      .then(function (x) {
+        client = x
+        assert.ok(client.authAt, 'authAt was set')
+      })
+      .then(function () {
+        return client.emailStatus()
+      })
+      .then(function (status) {
+        assert.equal(status.verified, true, 'account is verified')
+        return client.createEmail(secondEmail)
+      })
+      .then((res) => {
+        assert.ok(res, 'ok response')
+        return server.mailbox.waitForEmail(secondEmail)
+      })
+      .then((emailData) => {
+        const templateName = emailData['headers']['x-template-name']
+        const emailCode = emailData['headers']['x-verify-code']
+        assert.equal(templateName, 'verifySecondaryEmail', 'email template name set')
+        assert.ok(emailCode, 'emailCode set')
+        return client.verifySecondaryEmail(emailCode, secondEmail)
+      })
+      .then((res) => {
+        assert.ok(res, 'ok response')
+        return client.accountEmails()
+      })
+      .then((res) => {
+        assert.equal(res.length, 2, 'returns number of emails')
+        assert.equal(res[1].email, secondEmail, 'returns correct email')
+        assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+        assert.equal(res[1].verified, true, 'returns correct verified')
+        return server.mailbox.waitForEmail(email)
+      })
+  })
+
+  describe('should change primary email', () => {
+    it('fails to change email to an that is not owned by user', () => {
+      const userEmail2 = server.uniqueEmail()
+      const anotherEmail = server.uniqueEmail()
+      return Client.createAndVerify(config.publicUrl, userEmail2, password, server.mailbox)
+        .then(function (client2) {
+          return client2.createEmail(anotherEmail)
+        })
+        .then(function () {
+          return client.setPrimaryEmail(anotherEmail)
+            .then(() => {
+              assert.fail('Should not have set email that belongs to another account')
+            })
+        })
+        .catch((err) => {
+          assert.equal(err.errno, 148, 'returns correct errno')
+          assert.equal(err.code, 400, 'returns correct error code')
+        })
+    })
+
+    it('fails to change email to unverified email', () => {
+      const someEmail = server.uniqueEmail()
+      return client.createEmail(someEmail)
+        .then(() => {
+          return client.setPrimaryEmail(someEmail)
+            .then(() => {
+              assert.fail('Should not have set email to an unverified email')
+            })
+        })
+        .catch((err) => {
+          assert.equal(err.errno, 147, 'returns correct errno')
+          assert.equal(err.code, 400, 'returns correct error code')
+        })
+    })
+
+    it('can change primary email', () => {
+      return client.setPrimaryEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return client.accountEmails()
+        })
+        .then((res) => {
+          assert.equal(res.length, 2, 'returns number of emails')
+          assert.equal(res[0].email, secondEmail, 'returns correct email')
+          assert.equal(res[0].isPrimary, true, 'returns correct isPrimary')
+          assert.equal(res[0].verified, true, 'returns correct verified')
+          assert.equal(res[1].email, email, 'returns correct email')
+          assert.equal(res[1].isPrimary, false, 'returns correct isPrimary')
+          assert.equal(res[1].verified, true, 'returns correct verified')
+        })
+    })
+
+    it('can login', () => {
+      return client.setPrimaryEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+
+          // Verify account can login with new primary email
+          return Client.login(config.publicUrl, secondEmail, password)
+            .then(() => {
+              assert.fail(new Error('Should have returned correct email for user to login'))
+            })
+        })
+        .catch((err) => {
+          // Login should fail for this user and return the normalizedEmail used when
+          // the account was created. We then attempt to re-login with this email and pass
+          // the original email used to login
+          assert.equal(err.code, 400, 'correct error code')
+          assert.equal(err.errno, 120, 'correct errno code')
+          assert.equal(err.email, email, 'correct hashed email returned')
+
+          return Client.login(config.publicUrl, err.email, password, {originalLoginEmail: secondEmail})
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+        })
+    })
+
+    it('can change password', () => {
+      return client.setPrimaryEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return Client.login(config.publicUrl, email, password, {originalLoginEmail: secondEmail})
+        })
+        .then((res) => {
+          client = res
+          return client.changePassword(newPassword)
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          return Client.login(config.publicUrl, email, newPassword, {originalLoginEmail: secondEmail})
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+        })
+    })
+
+    it('can reset password', () => {
+      return client.setPrimaryEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response')
+          client.email = secondEmail
+          return client.forgotPassword()
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(secondEmail)
+        })
+        .then((code) => {
+          assert.ok(code, 'code is set')
+          return resetPassword(client, code, newPassword, undefined, {emailToHashWith: email})
+        }).then((res) => {
+          assert.ok(res, 'ok response')
+          return Client.login(config.publicUrl, email, newPassword, {originalLoginEmail: secondEmail})
+        })
+        .then((res) => {
+          assert.ok(res, 'ok response')
+        })
+    })
+  })
+
+  after(() => {
+    return TestServer.stop(server)
+  })
+
+  function resetPassword(client, code, newPassword, headers, options) {
+    return client.verifyPasswordResetCode(code, headers, options)
+      .then(function () {
+        return client.resetPassword(newPassword, {}, options)
+      })
+  }
+})


### PR DESCRIPTION
This PR exposes the ability of a user to change their primary email address. 

A couple of notes,
- It also is updates `db.account`, `db.emailRecord` to return the same account object that `db.accountRecord` returns. 
- This account object contains a `primaryEmail` object that contains the true primary email address, regardless if the user has changed it or not.
- To keep backwards compatibility with reset password, `emailToHashWith` is sent over in the reset request. The content server correctly accepts this and hashes the new password with this value. This keeps the contract we currently have that password resets are hashed with the original account email.

To test locally, use https://github.com/mozilla/fxa-content-server/pull/5242 and https://github.com/mozilla/fxa-js-client/pull/255.

@philbooth / @mozilla/fxa-devs r?