### PR TITLE
feat(account): receive marketingOptIn when verifying email codes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -406,13 +406,6 @@ if the url has a query parameter of `keys=true`.
   
   <!--end-request-body-post-accountcreate-metricsContext-->
 
-* `marketingOptIn`: *boolean*
-
-  <!--begin-request-body-post-accountcreate-marketingOptIn-->
-  Set to true if the user has opted-in to our marketing. When verified,
-  the auth-server will notify Basket.
-  <!--end-request-body-post-accountcreate-marketingOptIn-->
-
 ##### Response body
 
 * `uid`: *string, regex(HEX_STRING), required*
@@ -910,6 +903,13 @@ not just the one being attached to the Firefox account.
   <!--begin-request-body-post-recovery_emailverify_code-type-->
   The type of code being verified.
   <!--end-request-body-post-recovery_emailverify_code-type-->
+
+* `marketingOptIn`: *boolean*
+
+  <!--begin-request-body-post-recovery_emailverify_code-marketingOptIn-->
+  Set to true if the user has opted-in to our marketing. When verified,
+  the auth-server will notify Basket.
+  <!--end-request-body-post-recovery_emailverify_code-marketingOptIn-->
 
 ##### Error responses
 

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -226,12 +226,6 @@ describe('/account/create', () => {
     })
     const mockMailer = mocks.mockMailer()
     const mockPush = mocks.mockPush()
-    const mockMarketingCache = {
-      set: sinon.spy(() => P.resolve())
-    }
-    const requireMocks = {
-      '../cache': () => mockMarketingCache
-    }
     const accountRoutes = makeRoutes({
       config: {
         securityHistory: {
@@ -252,7 +246,7 @@ describe('/account/create', () => {
         }
       },
       push: mockPush
-    }, requireMocks)
+    })
     const route = getRoute(accountRoutes, '/account/create')
 
     return {
@@ -262,7 +256,6 @@ describe('/account/create', () => {
       mockDB,
       mockLog,
       mockMailer,
-      mockMarketingCache,
       mockMetricsContext,
       mockRequest,
       route,
@@ -276,7 +269,6 @@ describe('/account/create', () => {
     const clientAddress = mocked.clientAddress
     const emailCode = mocked.emailCode
     const keyFetchTokenId = mocked.keyFetchTokenId
-    const mockMarketingCache = mocked.mockMarketingCache
     const mockDB = mocked.mockDB
     const mockLog = mocked.mockLog
     const mockMailer = mocked.mockMailer
@@ -304,8 +296,6 @@ describe('/account/create', () => {
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
         time: now
       }, 'it contained the correct metrics context metadata')
-
-      assert.equal(mockMarketingCache.set.callCount, 0)
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
       var args = mockLog.activityEvent.args[0]
@@ -378,22 +368,6 @@ describe('/account/create', () => {
 
       assert.equal(mockLog.error.callCount, 0)
     }).finally(() => Date.now.restore())
-  })
-
-  it('should set cache if marketingOptIn is set', () => {
-    const mocked = setup()
-    const mockMarketingCache = mocked.mockMarketingCache
-    const mockRequest = mocked.mockRequest
-    const route = mocked.route
-    const uid = mocked.uid
-
-    mockRequest.payload.marketingOptIn = true
-
-    return runTest(route, mockRequest, () => {
-      assert.equal(mockMarketingCache.set.callCount, 1)
-      assert.equal(mockMarketingCache.set.args[0][0], uid)
-      assert.equal(mockMarketingCache.set.args[0][1], true)
-    })
   })
 })
 

--- a/test/local/routes/recovery_email.js
+++ b/test/local/routes/recovery_email.js
@@ -395,13 +395,6 @@ describe('/recovery_email/verify_code', function () {
   var mockMailer = mocks.mockMailer()
   const mockPush = mocks.mockPush()
   var mockCustoms = mocks.mockCustoms()
-  let marketingOptIn = false
-  const mockMarketingCache = {
-    get: sinon.spy(() => P.resolve(marketingOptIn))
-  }
-  const requireMocks = {
-    '../cache': () => mockMarketingCache
-  }
   var accountRoutes = makeRoutes({
     checkPassword: function () {
       return P.resolve(true)
@@ -417,7 +410,7 @@ describe('/recovery_email/verify_code', function () {
     log: mockLog,
     mailer: mockMailer,
     push: mockPush
-  }, requireMocks)
+  })
   var route = getRoute(accountRoutes, '/recovery_email/verify_code')
   describe('verifyTokens rejects with INVALID_VERIFICATION_CODE', function () {
 
@@ -469,7 +462,7 @@ describe('/recovery_email/verify_code', function () {
     })
 
     it('with marketingOptIn', () => {
-      marketingOptIn = true
+      mockRequest.payload.marketingOptIn = true
       return runTest(route, mockRequest, function (response) {
         assert.equal(mockLog.notifyAttachedServices.callCount, 1, 'logs verified')
         const args = mockLog.notifyAttachedServices.args[0]
@@ -480,7 +473,7 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(JSON.stringify(response), '{}')
       })
         .then(function () {
-          marketingOptIn = false
+          delete mockRequest.payload.marketingOptIn
           mockDB.verifyTokens.reset()
           mockDB.verifyEmail.reset()
           mockLog.activityEvent.reset()


### PR DESCRIPTION
After conversing with @shane-tomlinson in IRC, we decided it would be better to save the opt-in intent in the resume token, and send a parameter to `/recovery_email/verify_code`, instead of the auth server having to deal with a cache and expiring values and other unnecessary complexity.

Fixes #1973 for real.