### PR TITLE
chore(docs): git add generated api docs in precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "precommit": "node scripts/write-api-docs",
+    "precommit": "node scripts/write-api-docs && git add docs/api.md",
     "prepush": "grunt quicklint && grunt templates && git status -s | (! grep 'M lib/senders/templates/')",
     "postinstall": "scripts/download_l10n.sh",
     "shrinkwrap": "npmshrink && npm run postinstall",


### PR DESCRIPTION
@seanmonstar pointed this out in IRC last week, that the current precommit behaviour is weird because it leaves an unstaged change in your tree. He also pointed out that the correct approach is to to explicitly `git add` inside the hook, so that the change is magically included in the original commit. This PR does that.

@mozilla/fxa-devs r?