### PR TITLE
feat(errors): include conflicting device id in errno 124 response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -264,6 +264,7 @@ include additional response properties:
 * `errno: 111`: serverTime
 * `errno: 114`: retryAfter, retryAfterLocalized, verificationMethod, verificationReason
 * `errno: 120`: email
+* `errno: 124`: deviceId
 * `errno: 125`: verificationMethod, verificationReason
 * `errno: 126`: email
 * `errno: 130`: region

--- a/lib/error.js
+++ b/lib/error.js
@@ -479,15 +479,13 @@ AppError.unknownDevice = function () {
   )
 }
 
-AppError.deviceSessionConflict = function () {
-  return new AppError(
-    {
-      code: 400,
-      error: 'Bad Request',
-      errno: ERRNO.DEVICE_CONFLICT,
-      message: 'Session already registered by another device'
-    }
-  )
+AppError.deviceSessionConflict = function (deviceId) {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.DEVICE_CONFLICT,
+    message: 'Session already registered by another device'
+  }, { deviceId })
 }
 
 AppError.invalidUnblockCode = function () {


### PR DESCRIPTION
Fixes #1849.

Adds the conflicting device id to the response for errno 124 / `deviceSessionConflict`, which enables clients to save a server round-trip when they encounter that error.

@mozilla/fxa-devs r?

/cc @eoger
