### PR TITLE
feat(signin): Skip signin confirmation for new accounts by default

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -545,7 +545,7 @@ var conf = convict({
     skipForNewAccounts: {
       enabled: {
         doc: 'Skip sign-in confirmation for newly-created accounts.',
-        default: false,
+        default: true,
         env: 'SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS'
       },
       maxAge: {

--- a/test/remote/account_reset_tests.js
+++ b/test/remote/account_reset_tests.js
@@ -82,7 +82,7 @@ describe('remote account reset', function() {
         .then(
           function () {
             // make sure we can still login after password reset
-            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            return Client.login(config.publicUrl, email, newPassword, {keys:true})
           }
         )
         .then(
@@ -163,7 +163,7 @@ describe('remote account reset', function() {
         .then(
           function () {
             // make sure we can still login after password reset
-            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            return Client.login(config.publicUrl, email, newPassword, {keys:true})
           }
         )
         .then(

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -25,6 +25,7 @@ describe('remote account signin verification', function() {
   let server
   before(() => {
     config.securityHistory.ipProfiling.allowedRecency = 0
+    config.signinConfirmation.skipForNewAccounts.enabled = false
     return TestServer.start(config)
       .then(s => {
         server = s

--- a/test/remote/flow_tests.js
+++ b/test/remote/flow_tests.js
@@ -80,7 +80,7 @@ describe('remote flow', function() {
         'e': '65537'
       }
       var duration = 1000 * 60 * 60 * 24 // 24 hours
-      return Client.loginAndVerify(config.publicUrl, email, password, server.mailbox, {keys:true})
+      return Client.login(config.publicUrl, email, password, server.mailbox, {keys:true})
         .then(
           function (x) {
             client = x

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -25,6 +25,8 @@ describe('remote password change', function() {
   let server
   before(() => {
     config.securityHistory.ipProfiling.allowedRecency = 0
+    config.signinConfirmation.skipForNewAccounts.enabled = false
+
     return TestServer.start(config)
       .then(s => {
         server = s

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -90,7 +90,7 @@ describe('remote password forgot', function() {
         )
         .then( // make sure we can still login after password reset
           function () {
-            return Client.loginAndVerify(config.publicUrl, email, newPassword, server.mailbox, {keys:true})
+            return Client.login(config.publicUrl, email, newPassword, {keys:true})
           }
         )
         .then(

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -25,6 +25,8 @@ describe('remote emails', function () {
       enabledEmailAddresses: /\w/
     }
     config.securityHistory.ipProfiling = {}
+    config.signinConfirmation.skipForNewAccounts.enabled = false
+
     return TestServer.start(config)
       .then(s => {
         server = s

--- a/test/remote/recovery_email_resend_code_tests.js
+++ b/test/remote/recovery_email_resend_code_tests.js
@@ -15,6 +15,7 @@ describe('remote recovery email resend code', function() {
   let server
   before(() => {
     config.securityHistory.ipProfiling.allowedRecency = 0
+    config.signinConfirmation.skipForNewAccounts.enabled = false
 
     return TestServer.start(config)
       .then(s => {

--- a/test/remote/session_tests.js
+++ b/test/remote/session_tests.js
@@ -170,7 +170,7 @@ describe('remote session', function() {
           .then(
             function (x) {
               assert.deepEqual(x, {
-                state: 'unverified',
+                state: 'verified',
                 uid: uid
               })
             }


### PR DESCRIPTION
Disabling signin confirmation caused a lot of test failures.

Tests that called `loginAndVerify` to get a verified
session have been updated to call `login`.

Tests that work with both unverified and verified sessions
are handled differently. So that it's possible to generate
unverified sessions, config in these tests override
signinConfirmation.skipForNewAccounts.enabled to false.

fixes #1991

@mozilla/fxa-devs - r?