### PR TITLE
fix(devices): perform string comparison when notifying devices by id

### DIFF
--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -196,7 +196,7 @@ module.exports = function (
                 // do not send the notification to that device. It will
                 // get informed about the change via WebChannel message.
                 if (originatingDeviceId) {
-                  devicesToNotify = devicesToNotify.filter(d => ! d.id.equals(originatingDeviceId))
+                  devicesToNotify = devicesToNotify.filter(d => (d.id !== originatingDeviceId))
                 }
               }
             )


### PR DESCRIPTION
Fixes #2005 

This bug is fixed in master from https://github.com/mozilla/fxa-auth-server/pull/1983. For some reason I am unable to replicate this error when testing through the remote tests. I am unsure if it has something to do with how the auth-server [client]() is created but a deviceId is not set and therefore does not go into the if block. I tried setting the `user-agent` header in the client but that did not create a device. However, manually testing a change password flow through the gui does correctly trigger the error.

Not to block deployment on having a explicit test case, mind an r @rfk?