### PR TITLE
fix(emails): Check secondary emails feature flag against account email

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -250,6 +250,8 @@ for `code` and `errno` are:
   Can not change primary email to an unverified email
 * `code: 400, errno: 148`:
   Can not change primary email to an email that does not belong to this account
+* `code: 400, errno: 149`:
+  This email can not currently be used to login
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -582,6 +584,9 @@ by the following errors
 
 * `code: 400, errno: 142`:
   Sign in with this email type is not currently supported
+
+* `code: 400, errno: 149`:
+  This email can not currently be used to login
 
 * `code: 400, errno: 127`:
   Invalid unblock code

--- a/lib/db.js
+++ b/lib/db.js
@@ -380,7 +380,9 @@ module.exports = (
         },
         (err) => {
           if (isNotFoundError(err)) {
-            err = error.unknownAccount(email)
+            // There is a possibility that this email exists on the account table (ex. deleted from emails table)
+            // Lets check before throwing account not found.
+            return this.emailRecord(email)
           }
           throw err
         }

--- a/lib/error.js
+++ b/lib/error.js
@@ -56,6 +56,7 @@ var ERRNO = {
   INVALID_SIGNIN_CODE: 146,
   CHANGE_EMAIL_TO_UNVERIFIED_EMAIL: 147,
   CHANGE_EMAIL_TO_UNOWNED_EMAIL: 148,
+  LOGIN_WITH_INVALID_EMAIL: 149,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -690,6 +691,15 @@ AppError.cannotChangeEmailToUnownedEmail = function () {
     error: 'Bad Request',
     errno: ERRNO.CHANGE_EMAIL_TO_UNOWNED_EMAIL,
     message: 'Can not change primary email to an email that does not belong to this account'
+  })
+}
+
+AppError.cannotLoginWithEmail = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.LOGIN_WITH_INVALID_EMAIL,
+    message: 'This email can not currently be used to login'
   })
 }
 

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -279,7 +279,7 @@ module.exports = function (log, config, error, bounces, translator, sender) {
           })
       },
       sendPostVerifySecondaryEmail: function (emails, account, opts) {
-        var primaryEmail = account.email
+        var primaryEmail = account.primaryEmail.email
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -156,6 +156,7 @@ function mockDB (data, errors) {
         emailCode: data.emailCode,
         emailVerified: data.emailVerified,
         primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
+        emails: [{normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true}],
         uid: data.uid,
         verifierSetAt: Date.now(),
         wrapWrapKb: data.wrapWrapKb
@@ -190,6 +191,7 @@ function mockDB (data, errors) {
         email: data.email,
         emailVerified: data.emailVerified,
         primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
+        emails: [{normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true}],
         kA: crypto.randomBytes(32),
         lastAuthAt: () => {
           return Date.now()
@@ -283,6 +285,7 @@ function mockDB (data, errors) {
         email: data.email,
         emailVerified: data.emailVerified,
         primaryEmail: {normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true},
+        emails: [{normalizedEmail: data.email.toLowerCase(), email: data.email, isVerified: data.emailVerified, isPrimary: true}],
         kA: crypto.randomBytes(32).toString('hex'),
         lastAuthAt: () => {
           return Date.now()

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -96,8 +96,11 @@ TestServer.prototype.stop = function () {
   }
 }
 
-TestServer.prototype.uniqueEmail = function () {
-  return crypto.randomBytes(10).toString('hex') + '@restmail.net'
+TestServer.prototype.uniqueEmail = function (domain) {
+  if (! domain) {
+    domain = '@restmail.net'
+  }
+  return crypto.randomBytes(10).toString('hex') + domain
 }
 
 TestServer.prototype.uniqueUnicodeEmail = function () {


### PR DESCRIPTION
This PR updates the secondary emails endpoints to use the original account email as the feature flag. This fixes an issue where the feature would be disabled when a user changed their primary email address to one that wasn't supported in the regex. Ex. signup with `test@mozilla.com` then change to `a@a.com`, you should still have access to feature even though `a@a.com` is not in regex.

@mozilla/fxa-devs r?
