### PR TITLE
feat(metrics): emit route performance events

### DIFF
--- a/test/mocks.js
+++ b/test/mocks.js
@@ -465,6 +465,9 @@ function mockRequest (data) {
     headers: data.headers || {
       'user-agent': 'test user-agent'
     },
+    info: {
+      received: data.received || Date.now() - 1
+    },
     path: data.path,
     payload: data.payload,
     query: data.query || {},


### PR DESCRIPTION
This is a slightly hackish attempt to emit a flow event that measures request times. It will be good to keep an eye on the direction of these metrics over time, as we add more features and so on. Similar data is already emitted by `log.summary` but that data doesn't end up in redshift, so we can't plot pretty charts with it in redash.

It's slightly hackish because it overloads the `flow_time` property with request time. That's okay because we're not consuming these events as part of any funnels, we're going to query them only for perf charts.

Here are some sample log lines showing the new event immediately after the equivalent request summary and route flow event:

```
request.summary {"op":"request.summary","code":200,"errno":0,"rid":"1500636184060:Phils-MacBook-Pro.local:18131:j5ds0t6g:10011","path":"/v1/account/login","lang":"en-US,en;q=0.5","agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","remoteAddressChain":["127.0.0.1"],"t":1253,"uid":"effbf65224e1427792dee1430326cd11","reason":"signin","email":"a@a.com"}
flowEvent {"event":"route./account/login.200","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","time":1500636185315,"flow_id":"8b9b69e20a9c1f441cae818153d02e4ee6021bc97a6b94ecdc97099363a2faa2","flow_time":8102,"flowCompleteSignal":"account.login"}
flowEvent {"event":"route.performance./account/login","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","time":1500636185315,"flow_id":"8b9b69e20a9c1f441cae818153d02e4ee6021bc97a6b94ecdc97099363a2faa2","flow_time":1256,"flowCompleteSignal":"account.login"}
```

@mozilla/fxa-devs r?