### PR TITLE
fix(email): Notify all verified emails when a secondary email is removed

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -24,6 +24,7 @@ module.exports = function (log) {
     'passwordResetRequiredEmail': 'password-reset-required',
     'passwordChangedEmail': 'password-changed-success',
     'passwordResetEmail': 'password-reset-success',
+    'postRemoveSecondaryEmail': 'account-email-removed',
     'postVerifyEmail': 'account-verified',
     'postVerifySecondaryEmail': 'account-email-verified',
     'recoveryEmail': 'forgot-password',
@@ -44,6 +45,7 @@ module.exports = function (log) {
     'passwordChangedEmail': 'password-change',
     'passwordResetEmail': 'password-reset',
     'passwordResetRequiredEmail': 'password-reset',
+    'postRemoveSecondaryEmail': 'account-email-removed',
     'postVerifyEmail': 'connect-device',
     'postVerifySecondaryEmail': 'manage-account',
     'recoveryEmail': 'reset-password',
@@ -773,6 +775,45 @@ module.exports = function (log) {
       email: message.email,
       headers: headers,
       subject: gettext('Secondary Firefox Account email added'),
+      template: templateName,
+      templateValues: {
+        androidLink: links.androidLink,
+        iosLink: links.iosLink,
+        link: links.link,
+        privacyUrl: links.privacyUrl,
+        supportUrl: links.supportUrl,
+        secondaryEmail: message.secondaryEmail,
+        supportLinkAttributes: links.supportLinkAttributes
+      },
+      uid: message.uid
+    })
+  }
+
+  Mailer.prototype.postRemoveSecondaryEmail = function (message) {
+    log.trace({ op: 'mailer.postRemoveSecondaryEmail', email: message.email, uid: message.uid })
+
+    var templateName = 'postRemoveSecondaryEmail'
+    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+
+    var headers = {
+      'X-Link': links.link
+    }
+
+    if (this.sesConfigurationSet) {
+      headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
+    }
+
+    if (message.flowBeginTime && message.flowId) {
+      headers['X-Flow-Id'] = message.flowId
+      headers['X-Flow-Begin-Time'] = message.flowBeginTime
+    }
+
+    return this.send({
+      acceptLanguage: message.acceptLanguage,
+      email: message.email,
+      ccEmails: message.ccEmails,
+      headers: headers,
+      subject: gettext('Secondary Firefox Account email removed'),
       template: templateName,
       templateValues: {
         androidLink: links.androidLink,

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -278,6 +278,21 @@ module.exports = function (log, config, error, bounces, translator, sender) {
             })
           })
       },
+      sendPostRemoveSecondaryEmail: function (emails, account, opts) {
+        return getSafeMailerWithEmails(emails)
+          .then(function (result) {
+            var mailer = result.ungatedMailer
+            var primaryEmail = result.ungatedPrimaryEmail
+            var ccEmails = result.ungatedCcEmails
+
+            return mailer.postRemoveSecondaryEmail({
+              email: primaryEmail,
+              ccEmails: ccEmails,
+              secondaryEmail: opts.secondaryEmail,
+              acceptLanguage: opts.acceptLanguage || defaultLanguage
+            })
+          })
+      },
       sendPostVerifySecondaryEmail: function (emails, account, opts) {
         var primaryEmail = account.primaryEmail.email
 

--- a/lib/senders/partials/post_remove_secondary.html
+++ b/lib/senders/partials/post_remove_secondary.html
@@ -1,0 +1,40 @@
+<% extends "partials/base/base.html" %>
+
+<% block content %>
+<!--Header Area-->
+<tr style="page-break-before: always">
+    <td valign="top">
+        <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email removed" }}</h1>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
+    </td>
+</tr>
+
+<!--Button Area-->
+<tr height="50">
+    <td align="center" valign="top">
+        <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0996f8; border-radius: 4px; height: 50px; width: 310px !important;">
+            <tr style="page-break-before: always">
+                <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0996f8">
+                        <w:anchorlock/>
+                        <center>
+                    <![endif]-->
+                    <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Manage account"}}</a>
+                    <!--[if mso]>
+                    </center>
+                    </v:roundrect>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+<!--Button Area-->
+<tr style="page-break-before: always">
+    <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+        <br/>
+        <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
+    </td>
+</tr>
+<% endblock %>

--- a/lib/senders/templates/index.js
+++ b/lib/senders/templates/index.js
@@ -60,6 +60,7 @@ module.exports = function () {
       'password_changed',
       'password_reset',
       'password_reset_required',
+      'post_remove_secondary',
       'post_verify',
       'post_verify_secondary',
       'recovery',

--- a/lib/senders/templates/post_remove_secondary.html
+++ b/lib/senders/templates/post_remove_secondary.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>{{t "Firefox Accounts"}}</title>
+</head>
+
+<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="310" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 310px; margin: 0 auto;">
+
+<!--Logo-->
+<tr style="page-break-before: always">
+  <td align="center" id="firefox-logo" style="padding: 20px 0;">
+    {{^if sync}}
+      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+  </td>
+</tr>
+
+
+<!--Header Area-->
+<tr style="page-break-before: always">
+    <td valign="top">
+        <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email removed" }}</h1>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
+    </td>
+</tr>
+
+<!--Button Area-->
+<tr height="50">
+    <td align="center" valign="top">
+        <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0996f8; border-radius: 4px; height: 50px; width: 310px !important;">
+            <tr style="page-break-before: always">
+                <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0996f8">
+                        <w:anchorlock/>
+                        <center>
+                    <![endif]-->
+                    <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Manage account"}}</a>
+                    <!--[if mso]>
+                    </center>
+                    </v:roundrect>
+                    <![endif]-->
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+<!--Button Area-->
+<tr style="page-break-before: always">
+    <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+        <br/>
+        <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
+    </td>
+</tr>
+
+
+<tr style="page-break-before: always">
+  <td valign="top">
+    <p style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #8A9BA8; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+    <br />
+    <a href="{{{privacyUrl}}}" style="color: #0996f8; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Mozilla Privacy Policy" }}</a></p>
+  </td>
+</tr>
+
+</table>
+
+</body>
+</html>

--- a/lib/senders/templates/post_remove_secondary.txt
+++ b/lib/senders/templates/post_remove_secondary.txt
@@ -1,0 +1,10 @@
+{{t "Secondary email removed" }}
+
+{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}
+
+{{t "Manage account:"}} {{{ link }}}
+
+{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit %(supportUrl)s"}}}
+
+Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+{{t "Mozilla Privacy Policy" }} {{{privacyUrl}}}

--- a/scripts/write-emails-to-disk.js
+++ b/scripts/write-emails-to-disk.js
@@ -103,6 +103,7 @@ function sendMail(mailer, messageToSend) {
     locations: [],
     redirectTo: 'https://redirect.com/',
     resume: 'eyJjYW1wYWlnbiI6bnVsbCwiZW50cnlwb2ludCI6bnVsbCwiZmxvd0lkIjoiM2Q1ODZiNzY4Mzc2NGJhOWFiNzhkMzMxMTdjZDU4Y2RmYjk3Mzk5MWU5NTk0NjgxODBlMDUyMmY2MThhNmEyMSIsInJlc2V0UGFzc3dvcmRDb25maXJtIjp0cnVlLCJ1bmlxdWVVc2VySWQiOiI1ODNkOGFlYS00NzU3LTRiZTQtYWJlNC0wZWQ2NWZhY2Y2YWQiLCJ1dG1DYW1wYWlnbiI6bnVsbCwidXRtQ29udGVudCI6bnVsbCwidXRtTWVkaXVtIjpudWxsLCJ1dG1Tb3VyY2UiOm51bGwsInV0bVRlcm0iOm51bGx9',
+    secondaryEmail: 'secondary@email',
     service: 'sync',
     token: '47b22cd271963448cf36da95cccfcfb342b5693d66f58aa635f9a95579431002',
     timeZone: 'Europe/Madrid',

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -39,6 +39,7 @@ var typesContainSupportLinks = [
   'newDeviceLoginEmail',
   'passwordChangedEmail',
   'passwordResetEmail',
+  'postRemoveSecondaryEmail',
   'postVerifyEmail',
   'postVerifySecondaryEmail',
   'recoveryEmail',

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -84,6 +84,7 @@ const MAILER_METHOD_NAMES = [
   'sendNewDeviceLoginNotification',
   'sendPasswordChangedNotification',
   'sendPasswordResetNotification',
+  'sendPostRemoveSecondaryEmail',
   'sendPostVerifyEmail',
   'sendPostVerifySecondaryEmail',
   'sendUnblockCode',

--- a/test/remote/recovery_email_change_email.js
+++ b/test/remote/recovery_email_change_email.js
@@ -202,6 +202,13 @@ describe('remote change email', function () {
           assert.equal(res[0].email, secondEmail, 'returns correct email')
           assert.equal(res[0].isPrimary, true, 'returns correct isPrimary')
           assert.equal(res[0].verified, true, 'returns correct verified')
+
+          // Primary account is notified that secondary email has been removed
+          return server.mailbox.waitForEmail(secondEmail)
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name']
+          assert.equal(templateName, 'postRemoveSecondaryEmail', 'email template name set')
         })
     })
 


### PR DESCRIPTION
The last pieces to #1948, notify verified emails when a secondary email has been removed.

Fixes #1948 

![screen shot 2017-07-25 at 4 10 26 pm](https://user-images.githubusercontent.com/1295288/28591475-dda77408-7153-11e7-892a-c3326e91b8b3.png)

Matches these [mockup at the bottom](https://docs.google.com/document/d/1I7TSNa7mvUFipX48OhGSRbuVybIqSb5QdnCmivSjl-c/edit), with the exception of app links which will be worked as part of https://github.com/mozilla/fxa-auth-server/issues/1859.

@mozilla/fxa-devs r?