### PR TITLE
fix(db): expose config options for Poolee timeout and maxPending

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -115,6 +115,20 @@ var conf = convict({
       env: 'DB_CONNECTION_TIMEOUT',
       doc: 'Timeout in milliseconds after which the mailer will stop trying to connect to the database',
       format: 'duration'
+    },
+    poolee: {
+      timeout: {
+        default: '5 seconds',
+        format: 'duration',
+        env: 'DB_POOLEE_TIMEOUT',
+        doc: 'Time in milliseconds to wait for db query completion'
+      },
+      maxPending: {
+        default: 1000,
+        format: 'int',
+        env: 'DB_POOLEE_MAX_PENDING',
+        doc: 'Number of pending requests to auth-db-mysql to allow'
+      }
     }
   },
   httpdb: {

--- a/lib/db.js
+++ b/lib/db.js
@@ -52,7 +52,12 @@ module.exports = (
   }
 
   function DB(options) {
-    this.pool = new Pool(options.url)
+    let pooleeOptions = {}
+    if (config && config.db && config.db.poolee) {
+      pooleeOptions = config.db.poolee
+    }
+
+    this.pool = new Pool(options.url, pooleeOptions)
     if (config.redis.enabled) {
       const redisConfig = {
         host: config.redis.host,

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -27,6 +27,7 @@ function Pool(url, options) {
     [parsedUrl.host],
     {
       timeout: options.timeout || 5000,
+      maxPending: options.maxPending || 1000,
       keepAlive: true,
       maxRetries: 0
     }


### PR DESCRIPTION
This allows the `Poolee` config options `timeout` and `maxPending` to be set from the environment as `DB_POOLEE_TIMEOUT` and `DB_POOLEE_MAX_PENDING`.

r? - @rfk 