### PR TITLE
[l10n] Change "to" to "from" in remove secondary email message

### DIFF
--- a/lib/senders/partials/post_remove_secondary.html
+++ b/lib/senders/partials/post_remove_secondary.html
@@ -5,7 +5,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email removed" }}</h1>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
     </td>
 </tr>
 

--- a/lib/senders/templates/post_remove_secondary.html
+++ b/lib/senders/templates/post_remove_secondary.html
@@ -25,7 +25,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email removed" }}</h1>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully removed %(secondaryEmail)s as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}</p>
     </td>
 </tr>
 

--- a/lib/senders/templates/post_remove_secondary.txt
+++ b/lib/senders/templates/post_remove_secondary.txt
@@ -1,6 +1,6 @@
 {{t "Secondary email removed" }}
 
-{{{t "You have successfully removed %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}
+{{{t "You have successfully removed %(secondaryEmail)s as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address." }}}
 
 {{t "Manage account:"}} {{{ link }}}
 


### PR DESCRIPTION
I think it happened due to copy & paste from "You have successfully verified %(secondaryEmail)s as a secondary email to your Firefox Account" sentence. Decided to solve after discussion in mozilla:l10n irc channel.