### PR TITLE
feat(devices): include form factor in synthesized device name

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -462,7 +462,8 @@ module.exports = (
             uaBrowserVersion: mergedInfo.uaBrowserVersion,
             uaOS: mergedInfo.uaOS,
             uaOSVersion: mergedInfo.uaOSVersion,
-            uaDeviceType: mergedInfo.uaDeviceType
+            uaDeviceType: mergedInfo.uaDeviceType,
+            uaFormFactor: mergedInfo.uaFormFactor
           }
         })
       })
@@ -517,6 +518,7 @@ module.exports = (
       uaOS: token.uaOS,
       uaOSVersion: token.uaOSVersion,
       uaDeviceType: token.uaDeviceType,
+      uaFormFactor: token.uaFormFactor,
       lastAccessTime: token.lastAccessTime,
       createdAt: token.createdAt
     }

--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -296,6 +296,7 @@ module.exports = (log, db, config, customs, push, devices) => {
               delete device.uaOS
               delete device.uaOSVersion
               delete device.uaDeviceType
+              delete device.uaFormFactor
 
               return device
             }))

--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -276,29 +276,20 @@ module.exports = (log, db, config, customs, push, devices) => {
         db.devices(uid)
           .then(deviceArray => {
             reply(deviceArray.map(device => {
-              if (! device.name) {
-                device.name = devices.synthesizeName(device)
+              return {
+                id: device.id,
+                isCurrentDevice: device.sessionToken === sessionToken.tokenId,
+                lastAccessTime: device.lastAccessTime,
+                lastAccessTimeFormatted: localizeTimestamp.format(
+                  device.lastAccessTime,
+                  request.headers['accept-language']
+                ),
+                name: device.name || devices.synthesizeName(device),
+                type: device.type || device.uaDeviceType || 'desktop',
+                pushCallback: device.pushCallback,
+                pushPublicKey: device.pushPublicKey,
+                pushAuthKey: device.pushAuthKey
               }
-
-              if (! device.type) {
-                device.type = device.uaDeviceType || 'desktop'
-              }
-
-              device.isCurrentDevice = device.sessionToken === sessionToken.tokenId
-
-              device.lastAccessTimeFormatted = localizeTimestamp.format(
-                device.lastAccessTime,
-                request.headers['accept-language']
-              )
-              delete device.sessionToken
-              delete device.uaBrowser
-              delete device.uaBrowserVersion
-              delete device.uaOS
-              delete device.uaOSVersion
-              delete device.uaDeviceType
-              delete device.uaFormFactor
-
-              return device
             }))
           },
           reply

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -75,6 +75,7 @@ module.exports = (log, Token, config) => {
       this.uaOS = data.uaOS
       this.uaOSVersion = data.uaOSVersion
       this.uaDeviceType = data.uaDeviceType
+      this.uaFormFactor = data.uaFormFactor
       this.lastAccessTime = data.lastAccessTime
     }
 

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -42,7 +42,8 @@ module.exports = function (userAgentString) {
     this.uaBrowserVersion = matches[3] || null
     this.uaOS = matches[2]
     this.uaOSVersion = matches[5]
-    this.uaDeviceType = marshallFormFactor(matches[4])
+    this.uaDeviceType = marshallDeviceType(matches[4])
+    this.uaFormFactor = matches[4] || null
   } else {
     const userAgentData = ua.parse(userAgentString)
 
@@ -51,6 +52,7 @@ module.exports = function (userAgentString) {
     this.uaOS = getFamily(userAgentData.os) || null
     this.uaOSVersion = getVersion(userAgentData.os) || null
     this.uaDeviceType = getDeviceType(userAgentData) || null
+    this.uaFormFactor = getFormFactor(userAgentData) || null
   }
 
   return this
@@ -84,6 +86,12 @@ function getDeviceType (data) {
   }
 }
 
+function getFormFactor (data) {
+  if (data.device && data.device.brand !== 'Generic') {
+    return getFamily(data.device)
+  }
+}
+
 function isMobileOS (os) {
   return MOBILE_OS_FAMILIES.has(os.family)
 }
@@ -91,8 +99,9 @@ function isMobileOS (os) {
 function isTablet(data) {
   // 'tablets' are iPads and Android devices with no word 'Mobile' in them.
   // Ref: https://webmasters.googleblog.com/2011/03/mo-better-to-also-detect-mobile-user.html
-  if (getFamily(data.device)) {
-    if (data.device.family === 'iPad' ||
+  const deviceFamily = getFamily(data.device)
+  if (deviceFamily) {
+    if (/iPad/.test(deviceFamily) ||
        (data.os && data.os.family === 'Android' && data.userAgent.indexOf('Mobile') === -1)
     ) {
       return true
@@ -102,7 +111,7 @@ function isTablet(data) {
   return false
 }
 
-function marshallFormFactor (formFactor) {
+function marshallDeviceType (formFactor) {
   if (/iPad/.test(formFactor) || /tablet/i.test(formFactor)) {
     return 'tablet'
   }

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -208,41 +208,57 @@ describe('devices', () => {
         uaBrowser: 'foo',
         uaBrowserVersion: 'bar',
         uaOS: 'baz',
-        uaOSVersion: 'qux'
-      }), 'foo bar, baz qux', 'result is correct when all ua properties are set')
+        uaOSVersion: 'qux',
+        uaFormFactor: 'wibble'
+      }), 'foo bar, baz wibble', 'result is correct when all ua properties are set')
 
       assert.equal(devices.synthesizeName({
         uaBrowserVersion: 'foo',
         uaOS: 'bar',
-        uaOSVersion: 'baz'
-      }), 'bar baz', 'result is correct when uaBrowser property is missing')
+        uaOSVersion: 'baz',
+        uaFormFactor: 'wibble'
+      }), 'bar wibble', 'result is correct when uaBrowser property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
         uaOS: 'bar',
-        uaOSVersion: 'baz'
-      }), 'foo, bar baz', 'result is correct when uaBrowserVersion property is missing')
+        uaOSVersion: 'baz',
+        uaFormFactor: 'wibble'
+      }), 'foo, bar wibble', 'result is correct when uaBrowserVersion property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
         uaBrowserVersion: 'bar',
-        uaOSVersion: 'baz'
-      }), 'foo bar', 'result is correct when uaOS property is missing')
+        uaOSVersion: 'baz',
+        uaFormFactor: 'wibble'
+      }), 'foo bar, wibble', 'result is correct when uaOS property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
         uaBrowserVersion: 'bar',
-        uaOS: 'baz'
-      }), 'foo bar, baz', 'result is correct when uaOSVersion property is missing')
+        uaOS: 'baz',
+        uaFormFactor: 'wibble'
+      }), 'foo bar, baz wibble', 'result is correct when uaOSVersion property is missing')
+
+      assert.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux'
+      }), 'foo bar, baz qux', 'result is correct when uaFormFactor property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'wibble',
         uaBrowserVersion: 'blee'
-      }), 'wibble blee', 'result is correct when both uaOS properties are missing')
+      }), 'wibble blee', 'result is correct when uaOS and uaFormFactor properties are missing')
 
       assert.equal(devices.synthesizeName({
         uaOS: 'foo'
       }), 'foo', 'result is correct when only uaOS property is present')
+
+      assert.equal(devices.synthesizeName({
+        uaFormFactor: 'bar'
+      }), 'bar', 'result is correct when only uaFormFactor property is present')
 
       assert.equal(devices.synthesizeName({
         uaOSVersion: 'foo'

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -182,6 +182,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
             uaOS: 'baz',
             uaOSVersion: 'qux',
             uaDeviceType: 'wibble',
+            uaFormFactor: 'blee',
             lastAccessTime: 'mnngh'
           })
           assert.notEqual(token.data, 'foo', 'data was not updated')
@@ -201,6 +202,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
           assert.equal(token.uaOS, 'baz', 'uaOS was updated')
           assert.equal(token.uaOSVersion, 'qux', 'uaOSVersion was updated')
           assert.equal(token.uaDeviceType, 'wibble', 'uaDeviceType was updated')
+          assert.equal(token.uaFormFactor, 'blee', 'uaFormFactor was updated')
           assert.equal(token.lastAccessTime, 'mnngh', 'lastAccessTime was updated')
         })
     }

--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -21,6 +21,8 @@ var userAgent = proxyquire('../../lib/userAgent', {
 })
 
 describe('userAgent', () => {
+  afterEach(() => uaParser.parse.reset())
+
   it(
     'exports function',
     () => {
@@ -54,14 +56,13 @@ describe('userAgent', () => {
       assert.ok(uaParser.parse.calledWithExactly('qux'))
 
       assert.equal(result, context)
-      assert.equal(Object.keys(result).length, 5)
+      assert.equal(Object.keys(result).length, 6)
       assert.equal(result.uaBrowser, 'foo')
       assert.equal(result.uaBrowserVersion, '1')
       assert.equal(result.uaOS, 'bar')
       assert.equal(result.uaOSVersion, '2')
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'baz')
     }
   )
 
@@ -90,12 +91,11 @@ describe('userAgent', () => {
       assert.ok(uaParser.parse.calledWithExactly('wibble'))
 
       assert.equal(result, context)
-      assert.equal(Object.keys(result).length, 5)
+      assert.equal(Object.keys(result).length, 6)
       assert.equal(result.uaBrowser, null)
       assert.equal(result.uaOS, null)
       assert.equal(result.uaDeviceType, null)
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, null)
     }
   )
 
@@ -122,8 +122,6 @@ describe('userAgent', () => {
 
       assert.equal(result.uaBrowserVersion, '1.1')
       assert.equal(result.uaOSVersion, '2.34567')
-
-      uaParser.parse.reset()
     }
   )
 
@@ -149,8 +147,7 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, null)
     }
   )
 
@@ -169,15 +166,13 @@ describe('userAgent', () => {
           minor: '0'
         },
         device: {
-          family: 'Other'
+          family: 'iPhone 7'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent.call({})
 
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'iPhone 7')
     }
   )
 
@@ -203,8 +198,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
     }
   )
 
@@ -230,8 +223,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
     }
   )
 
@@ -257,8 +248,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
     }
   )
 
@@ -284,8 +273,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, null)
-
-      uaParser.parse.reset()
     }
   )
 
@@ -311,8 +298,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, null)
-
-      uaParser.parse.reset()
     }
   )
 
@@ -338,8 +323,6 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, null)
-
-      uaParser.parse.reset()
     }
   )
 
@@ -359,18 +342,15 @@ describe('userAgent', () => {
           minor: '0'
         },
         device: {
-          family: 'iPad'
+          family: 'iPad Pro'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent.call({})
 
       assert.equal(result.uaDeviceType, 'tablet')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'iPad Pro')
     }
   )
-
 
   it(
     'recognises Android tablets as tablets',
@@ -395,10 +375,33 @@ describe('userAgent', () => {
       var result = userAgent.call(context)
 
       assert.equal(result.uaDeviceType, 'tablet')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'Nexus 7')
     }
   )
+
+  it('ignores form factor for generic devices', () => {
+    parserResult = {
+      userAgent: 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0',
+      ua: {
+        family: 'Firefox Mobile',
+        major: '41',
+        minor: '0'
+      },
+      os: {
+        family: 'Android',
+        major: '4',
+        minor: '4'
+      },
+      device: {
+        family: 'Generic Smartphone',
+        brand: 'Generic'
+      }
+    }
+    const result = userAgent.call({})
+
+    assert.equal(result.uaDeviceType, 'mobile')
+    assert.equal(result.uaFormFactor, null)
+  })
 
   it(
     'recognises old Firefox-iOS user agents',
@@ -412,8 +415,7 @@ describe('userAgent', () => {
       assert.equal(result.uaBrowserVersion, '5.3')
       assert.equal(result.uaOS, 'iOS')
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, null)
     }
   )
 
@@ -430,8 +432,7 @@ describe('userAgent', () => {
       assert.equal(result.uaOS, 'iOS')
       assert.equal(result.uaOSVersion, '10.3')
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'iPhone 6S')
     }
   )
 
@@ -448,8 +449,7 @@ describe('userAgent', () => {
       assert.equal(result.uaOS, 'iOS')
       assert.equal(result.uaOSVersion, '10.3')
       assert.equal(result.uaDeviceType, 'tablet')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, 'iPad Mini')
     }
   )
 
@@ -465,8 +465,7 @@ describe('userAgent', () => {
       assert.equal(result.uaBrowserVersion, '49.0.2')
       assert.equal(result.uaOS, 'Android')
       assert.equal(result.uaDeviceType, 'mobile')
-
-      uaParser.parse.reset()
+      assert.equal(result.uaFormFactor, null)
     }
   )
 
@@ -481,8 +480,7 @@ describe('userAgent', () => {
     assert.equal(result.uaOS, 'Android')
     assert.equal(result.uaOSVersion, '6.0')
     assert.equal(result.uaDeviceType, 'mobile')
-
-    uaParser.parse.reset()
+    assert.equal(result.uaFormFactor, 'Mobile')
   })
 
   it('recognises new mobile Sync library user agents on iOS', () => {
@@ -496,8 +494,7 @@ describe('userAgent', () => {
     assert.equal(result.uaOS, 'iOS')
     assert.equal(result.uaOSVersion, '10.3')
     assert.equal(result.uaDeviceType, 'tablet')
-
-    uaParser.parse.reset()
+    assert.equal(result.uaFormFactor, 'iPad Mini')
   })
 })
 

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -247,6 +247,8 @@ describe('remote db', function() {
           assert.equal(token.uaBrowserVersion, '41')
           assert.equal(token.uaOS, 'Mac OS X')
           assert.equal(token.uaOSVersion, '10.10')
+          assert.equal(token.uaDeviceType, null)
+          assert.equal(token.uaFormFactor, null)
           assert.equal(token.location.state, 'Mordor', 'state is correct')
           assert.equal(token.location.country, 'ME', 'country is correct')
           assert.ok(token.lastAccessTime)
@@ -274,7 +276,30 @@ describe('remote db', function() {
           assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct')
           assert.equal(sessions[0].uaOSVersion, '4.4', 'uaOSVersion property is correct')
           assert.equal(sessions[0].uaDeviceType, 'mobile', 'uaDeviceType property is correct')
+          assert.equal(sessions[0].uaFormFactor, null, 'uaFormFactor property is correct')
           assert.equal(sessions[0].location, null, 'location property is correct')
+
+          // Fetch the session token
+          return db.sessionToken(tokenId)
+        })
+        .then(sessionToken => {
+          // Update the session token
+          return db.updateSessionToken(sessionToken, 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', '1.1.1.1')
+        })
+        .then(tokens => {
+          redisGetSpy.returns(P.resolve(JSON.stringify(tokens)))
+
+          // Fetch all sessions for the account
+          return db.sessions(account.uid)
+        })
+        .then(sessions => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item')
+          assert.equal(sessions[0].uaBrowser, 'Firefox iOS', 'uaBrowser property is correct')
+          assert.equal(sessions[0].uaBrowserVersion, '1', 'uaBrowserVersion property is correct')
+          assert.equal(sessions[0].uaOS, 'iOS', 'uaOS property is correct')
+          assert.equal(sessions[0].uaOSVersion, '8.3', 'uaOSVersion property is correct')
+          assert.equal(sessions[0].uaDeviceType, 'tablet', 'uaDeviceType property is correct')
+          assert.equal(sessions[0].uaFormFactor, 'iPad', 'uaFormFactor property is correct')
 
           // Simulate an error on redis.get
           redisGetSpy.returns(P.reject({}))
@@ -433,6 +458,7 @@ describe('remote db', function() {
             assert.equal(device.uaOS, 'Android', 'device.uaOS is correct')
             assert.equal(device.uaOSVersion, '4.4', 'device.uaOSVersion is correct')
             assert.equal(device.uaDeviceType, 'mobile', 'device.uaDeviceType is correct')
+            assert.equal(device.uaFormFactor, null, 'device.uaFormFactor is correct')
             deviceInfo.id = device.id
             deviceInfo.name = 'wibble'
             deviceInfo.type = 'desktop'
@@ -496,6 +522,7 @@ describe('remote db', function() {
             assert.equal(device.uaOS, 'Mac OS X', 'device.uaOS is correct')
             assert.equal(device.uaOSVersion, '10.10', 'device.uaOSVersion is correct')
             assert.equal(device.uaDeviceType, null, 'device.uaDeviceType is correct')
+            assert.equal(device.uaFormFactor, null, 'device.uaFormFactor is correct')
             // Delete the devices
             return P.all([
               db.deleteDevice(account.uid, deviceInfo.id),


### PR DESCRIPTION
Fixes #1910.

Changes the behaviour of `devices.synthesizeName` so that it appends the form factor when we have one. If we don't have one, the synthesized name is as it was previously. If we do have one, form factor replaces OS version.

We won't always have the form factor; either because the user agent string didn't contain it or because the session token didn't come from redis. The attempt to add `uaFormFactor` to MySQL from mozilla/fxa-auth-db-mysql#259 was swiftly rolled back in mozilla/fxa-auth-db-mysql#262 because the migration caused problems in prod. In future, if we do add `uaFormFactor` to MySQL, it should just work for `devices.synthesizeName` too.

I also did a spot of refactoring to the `/account/devices` route because the way that it was implemented made it easy to fail response validation. Instead of deleting properties we know we don't want and hoping that nothing else is on the object, I changed it to explicitly return only the properties we care about. That's in a separate commit (460b3eb6) for easier review/rollback if it's not wanted.

@mozilla/fxa-devs r?