### PR TITLE
fix(devices): ditch OS in synthesized name if form factor is present

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -79,18 +79,16 @@ module.exports = (log, db, push) => {
       }
     }
 
+    if (uaFormFactor) {
+      return `${result}${uaFormFactor}`
+    }
+
     if (uaOS) {
       result += uaOS
 
-      if (uaFormFactor) {
-        result += ' '
-      } else if (uaOSVersion) {
+      if (uaOSVersion) {
         result += ` ${uaOSVersion}`
       }
-    }
-
-    if (uaFormFactor) {
-      result += uaFormFactor
     }
 
     return result

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -210,21 +210,21 @@ describe('devices', () => {
         uaOS: 'baz',
         uaOSVersion: 'qux',
         uaFormFactor: 'wibble'
-      }), 'foo bar, baz wibble', 'result is correct when all ua properties are set')
+      }), 'foo bar, wibble', 'result is correct when all ua properties are set')
 
       assert.equal(devices.synthesizeName({
         uaBrowserVersion: 'foo',
         uaOS: 'bar',
         uaOSVersion: 'baz',
         uaFormFactor: 'wibble'
-      }), 'bar wibble', 'result is correct when uaBrowser property is missing')
+      }), 'wibble', 'result is correct when uaBrowser property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
         uaOS: 'bar',
         uaOSVersion: 'baz',
         uaFormFactor: 'wibble'
-      }), 'foo, bar wibble', 'result is correct when uaBrowserVersion property is missing')
+      }), 'foo, wibble', 'result is correct when uaBrowserVersion property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
@@ -238,7 +238,7 @@ describe('devices', () => {
         uaBrowserVersion: 'bar',
         uaOS: 'baz',
         uaFormFactor: 'wibble'
-      }), 'foo bar, baz wibble', 'result is correct when uaOSVersion property is missing')
+      }), 'foo bar, wibble', 'result is correct when uaOSVersion property is missing')
 
       assert.equal(devices.synthesizeName({
         uaBrowser: 'foo',
@@ -248,9 +248,21 @@ describe('devices', () => {
       }), 'foo bar, baz qux', 'result is correct when uaFormFactor property is missing')
 
       assert.equal(devices.synthesizeName({
+        uaOS: 'bar',
+        uaFormFactor: 'wibble'
+      }), 'wibble', 'result is correct when uaBrowser and uaBrowserVersion properties are missing')
+
+      assert.equal(devices.synthesizeName({
         uaBrowser: 'wibble',
-        uaBrowserVersion: 'blee'
+        uaBrowserVersion: 'blee',
+        uaOSVersion: 'qux'
       }), 'wibble blee', 'result is correct when uaOS and uaFormFactor properties are missing')
+
+      assert.equal(devices.synthesizeName({
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz'
+      }), 'foo bar, baz', 'result is correct when uaOSVersion and uaFormFactor properties are missing')
 
       assert.equal(devices.synthesizeName({
         uaOS: 'foo'
@@ -259,6 +271,11 @@ describe('devices', () => {
       assert.equal(devices.synthesizeName({
         uaFormFactor: 'bar'
       }), 'bar', 'result is correct when only uaFormFactor property is present')
+
+      assert.equal(devices.synthesizeName({
+        uaOS: 'foo',
+        uaOSVersion: 'bar'
+      }), 'foo bar', 'result is correct when only uaOS and uaOSVersion properties are present')
 
       assert.equal(devices.synthesizeName({
         uaOSVersion: 'foo'


### PR DESCRIPTION
Fixes #2045.

Opened as a patch against train-93 because it's low-impact and that's where the related fix landed.

Before:

<img width="534" alt="screen shot 2017-08-10 at 16 47 17" src="https://user-images.githubusercontent.com/64367/29182626-8308ef08-7df7-11e7-9377-27e311ddd6fd.png" />
<img width="528" alt="screen shot 2017-08-10 at 16 48 45" src="https://user-images.githubusercontent.com/64367/29182630-88f4126c-7df7-11e7-9635-e3eb16e3e0cd.png" />

After:

<img width="522" alt="screen shot 2017-08-10 at 16 53 16" src="https://user-images.githubusercontent.com/64367/29182638-91bba978-7df7-11e7-845f-44778b88e395.png" />
<img width="522" alt="screen shot 2017-08-10 at 16 51 06" src="https://user-images.githubusercontent.com/64367/29182698-c8313806-7df7-11e7-8e5a-963d14074aac.png" />

@mozilla/fxa-devs r?
