### PR TITLE
fix(strings): change "to" to "for" for verify secondary email

### DIFF
--- a/lib/senders/partials/post_verify_secondary.html
+++ b/lib/senders/partials/post_verify_secondary.html
@@ -5,7 +5,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email added" }}</h1>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
     </td>
 </tr>
 

--- a/lib/senders/templates/post_verify_secondary.html
+++ b/lib/senders/templates/post_verify_secondary.html
@@ -25,7 +25,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email added" }}</h1>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
     </td>
 </tr>
 

--- a/lib/senders/templates/post_verify_secondary.txt
+++ b/lib/senders/templates/post_verify_secondary.txt
@@ -1,6 +1,6 @@
 {{t "Secondary email added" }}
 
-{{{t "You have successfully verified %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}
+{{{t "You have successfully verified %(secondaryEmail)s as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}
 
 {{t "Manage account:"}} {{{ link }}}
 

--- a/lib/senders/templates/post_verify_secondary_email.html
+++ b/lib/senders/templates/post_verify_secondary_email.html
@@ -25,7 +25,7 @@
 <tr style="page-break-before: always">
     <td valign="top">
         <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Secondary email added" }}</h1>
-        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email to your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
+        <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "You have successfully verified %(secondaryEmail)s as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses." }}}</p>
     </td>
 </tr>
 


### PR DESCRIPTION
As discussed in the meeting just now, update the verify secondary email strings to use "for" instead of "to". Related to #2040.

@mozilla/fxa-devs r?