### PR TITLE
chore(eslint): fix eslint task config so newer works

### DIFF
--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
         pattern: 'This Source Code Form is subject to the terms of the Mozilla'
       },
       src: [
-        '<%= eslint.files %>'
+        '<%= eslint.app.src %>'
       ]
     }
   })

--- a/grunttasks/eslint.js
+++ b/grunttasks/eslint.js
@@ -6,12 +6,11 @@ module.exports = function (grunt) {
   'use strict'
 
   grunt.config('eslint', {
-    options: {
-      eslintrc: '.eslintrc'
-    },
-    files: [
-      '{,bin/,config/,grunttasks/,lib/**/,scripts/**/,test/**/}*.js'
-    ]
+    app: {
+      src: [
+        '{,bin/,config/,grunttasks/,lib/**/,scripts/**/,test/**/}*.js'
+      ]
+    }
   })
   grunt.registerTask('quicklint', 'lint the modified files', 'newer:eslint')
 }


### PR DESCRIPTION
I noticed the prepush hook seemed to eslint all the files always. Some searching around shows that we need to configure a target for eslint in order for eslint to save a proper timestamp of last run.

Easy way to compare the difference: run `grunt quicklint` with and without this change. Without, it always runs the full thing. With, after the first run, subsequent runs will print out immediately "No newer files to process."