### PR TITLE
chore(git): remove prepush git hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - COVERALLS_REPO_TOKEN=vKN3jjhAOwxkv9HG0VBX4EYIlWLPwiJ9d npm run test-ci
   - npm run test-e2e
   # Test fxa-auth-mailer
-  - grunt templates
+  - grunt templates && git status -s | (! grep 'M lib/senders/templates/')
   - grunt l10n-extract
   # NSP check
   - grunt nsp

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "precommit": "grunt newer:doc && git add docs/api.md",
-    "prepush": "grunt quicklint && grunt templates && git status -s | (! grep 'M lib/senders/templates/')",
     "postinstall": "scripts/download_l10n.sh",
     "shrinkwrap": "npmshrink && npm run postinstall",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",


### PR DESCRIPTION
The prepush hook is slow, and annoying, and leads to people eventually just using `--no-verify` (at least @philbooth  and myself). This removes that hook, since CI will test for this stuff anyways.

Updates CI to do the same template check the prepush hook was doing.