### PR TITLE
[deploy only] feat(devices): Allow devices to send each other empty notifications.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1025,7 +1025,7 @@ and display the tab in a timely manner.
   Ignored unless `to:"all"` is specified.
   <!--end-request-body-post-accountdevicesnotify-excluded-->
 
-* `payload`: *object, required*
+* `payload`: *object, optional*
 
   <!--begin-request-body-post-accountdevicesnotify-payload-->
   Push payload,

--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -148,12 +148,12 @@ module.exports = (log, db, config, customs, push, devices) => {
             isA.object({
               to: isA.string().valid('all').required(),
               excluded: isA.array().items(isA.string().length(32).regex(HEX_STRING)).optional(),
-              payload: isA.object().required(),
+              payload: isA.object().optional(),
               TTL: isA.number().integer().min(0).optional()
             }),
             isA.object({
               to: isA.array().items(isA.string().length(32).regex(HEX_STRING)).required(),
-              payload: isA.object().required(),
+              payload: isA.object().optional(),
               TTL: isA.number().integer().min(0).optional()
             })
           )
@@ -177,12 +177,13 @@ module.exports = (log, db, config, customs, push, devices) => {
         const ip = request.app.clientAddress
         const payload = body.payload
 
-        if (! validatePushPayload(payload)) {
-          throw error.invalidRequestParameter('invalid payload')
-        }
+        const pushOptions = {}
 
-        const pushOptions = {
-          data: Buffer.from(JSON.stringify(payload))
+        if (payload) {
+          if (! validatePushPayload(payload)) {
+            throw error.invalidRequestParameter('invalid payload')
+          }
+          pushOptions.data = Buffer.from(JSON.stringify(payload))
         }
 
         if (body.excluded) {


### PR DESCRIPTION
@vbudhram what do you think about doing something like this to help the iOS team with testing the "account verified" notification?  Obviously it needs tests if we want to deploy to production, but it might be useful even if just deployed on a dev box for now.