### PR TITLE
feat(server): add parsed user agent info to the request object

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -7,7 +7,6 @@
 const error = require('./error')
 const P = require('./promise')
 const Pool = require('./pool')
-const userAgent = require('./userAgent')
 
 const random = require('./crypto/random')
 const redis = require('redis')
@@ -113,9 +112,9 @@ module.exports = (
     )
   }
 
-  DB.prototype.createSessionToken = function (authToken, userAgentString) {
+  DB.prototype.createSessionToken = function (authToken) {
     log.trace({ op: 'DB.createSessionToken', uid: authToken && authToken.uid })
-    return SessionToken.create(userAgent.call(authToken, userAgentString))
+    return SessionToken.create(authToken)
       .then(
         function (sessionToken) {
           return this.pool.put(
@@ -501,7 +500,7 @@ module.exports = (
     )
   }
 
-  DB.prototype.updateSessionToken = function (token, userAgentString, ip) {
+  DB.prototype.updateSessionToken = function (token, ip) {
     log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
 
     const uid = token.uid
@@ -509,9 +508,8 @@ module.exports = (
       return P.resolve()
     }
 
-    token.update(userAgentString)
     const newToken = {
-      tokenId: token.id,
+      tokenId: token.tokenId,
       uid: uid,
       uaBrowser: token.uaBrowser,
       uaBrowserVersion: token.uaBrowserVersion,
@@ -537,7 +535,7 @@ module.exports = (
     .then(res => {
       // update the hash with the new token
       sessionTokens = res ? JSON.parse(res) : {}
-      sessionTokens[token.id] = newToken
+      sessionTokens[token.tokenId] = newToken
       return sessionTokens
     })
     // add new updated token into array, and set the resulting array as the new value

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -10,7 +10,6 @@ const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema
 const P = require('../promise')
 const random = require('../crypto/random')
 const requestHelper = require('../routes/utils/request_helper')
-const userAgent = require('../userAgent')
 const uuid = require('uuid')
 const validators = require('./validators')
 
@@ -211,7 +210,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                   uid: account.uid,
                   email: account.email,
                   deviceCount: 1,
-                  userAgent: request.headers['user-agent']
+                  userAgent: userAgentString
                 })
               }
             }
@@ -231,8 +230,14 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             emailVerified: account.emailVerified,
             verifierSetAt: account.verifierSetAt,
             mustVerify: requestHelper.wantsKeys(request),
-            tokenVerificationId: tokenVerificationId
-          }, userAgentString)
+            tokenVerificationId: tokenVerificationId,
+            uaBrowser: request.app.uaBrowser,
+            uaBrowserVersion: request.app.uaBrowserVersion,
+            uaOS: request.app.uaOS,
+            uaOSVersion: request.app.uaOSVersion,
+            uaDeviceType: request.app.uaDeviceType,
+            uaFormFactor: request.app.uaFormFactor
+          })
             .then(
               function (result) {
                 sessionToken = result
@@ -761,10 +766,16 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                 emailVerified: accountRecord.primaryEmail.isVerified,
                 verifierSetAt: accountRecord.verifierSetAt,
                 mustVerify: mustVerifySession,
-                tokenVerificationId: tokenVerificationId
+                tokenVerificationId: tokenVerificationId,
+                uaBrowser: request.app.uaBrowser,
+                uaBrowserVersion: request.app.uaBrowserVersion,
+                uaOS: request.app.uaOS,
+                uaOSVersion: request.app.uaOSVersion,
+                uaDeviceType: request.app.uaDeviceType,
+                uaFormFactor: request.app.uaFormFactor
               }
 
-              return db.createSessionToken(sessionTokenOptions, request.headers['user-agent'])
+              return db.createSessionToken(sessionTokenOptions)
             })
             .then(
               function (result) {
@@ -1233,15 +1244,20 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
         function mailUnblockCode(code) {
           return P.all([getGeoData(ip), db.accountEmails(emailRecord.uid)])
             .spread((geoData, emails) => {
-              return mailer.sendUnblockCode(emails, emailRecord, userAgent.call({
+              return mailer.sendUnblockCode(emails, emailRecord, {
                 acceptLanguage: request.app.acceptLanguage,
                 unblockCode: code,
                 flowId: flowId,
                 flowBeginTime: flowBeginTime,
                 ip: ip,
                 location: geoData.location,
-                timeZone: geoData.timeZone
-              }, request.headers['user-agent']))
+                timeZone: geoData.timeZone,
+                uaBrowser: request.app.uaBrowser,
+                uaBrowserVersion: request.app.uaBrowserVersion,
+                uaOS: request.app.uaOS,
+                uaOSVersion: request.app.uaOSVersion,
+                uaDeviceType: request.app.uaDeviceType
+              })
             })
         }
       }
@@ -1399,15 +1415,21 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
           if (hasSessionToken) {
             // Since the only way to reach this point is clicking a
             // link from the user's email, we create a verified sessionToken
-            var sessionTokenOptions = {
+            const sessionTokenOptions = {
               uid: account.uid,
               email: account.primaryEmail.email,
               emailCode: account.primaryEmail.emailCode,
               emailVerified: account.primaryEmail.isVerified,
-              verifierSetAt: account.verifierSetAt
+              verifierSetAt: account.verifierSetAt,
+              uaBrowser: request.app.uaBrowser,
+              uaBrowserVersion: request.app.uaBrowserVersion,
+              uaOS: request.app.uaOS,
+              uaOSVersion: request.app.uaOSVersion,
+              uaDeviceType: request.app.uaDeviceType,
+              uaFormFactor: request.app.uaFormFactor
             }
 
-            return db.createSessionToken(sessionTokenOptions, request.headers['user-agent'])
+            return db.createSessionToken(sessionTokenOptions)
               .then(
                 function (result) {
                   sessionToken = result

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -223,6 +223,15 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             tokenVerificationId = undefined
           }
 
+          const {
+            browser: uaBrowser,
+            browserVersion: uaBrowserVersion,
+            os: uaOS,
+            osVersion: uaOSVersion,
+            deviceType: uaDeviceType,
+            formFactor: uaFormFactor
+          } = request.app.ua
+
           return db.createSessionToken({
             uid: account.uid,
             email: account.email,
@@ -231,12 +240,12 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             verifierSetAt: account.verifierSetAt,
             mustVerify: requestHelper.wantsKeys(request),
             tokenVerificationId: tokenVerificationId,
-            uaBrowser: request.app.uaBrowser,
-            uaBrowserVersion: request.app.uaBrowserVersion,
-            uaOS: request.app.uaOS,
-            uaOSVersion: request.app.uaOSVersion,
-            uaDeviceType: request.app.uaDeviceType,
-            uaFormFactor: request.app.uaFormFactor
+            uaBrowser,
+            uaBrowserVersion,
+            uaOS,
+            uaOSVersion,
+            uaDeviceType,
+            uaFormFactor
           })
             .then(
               function (result) {
@@ -759,6 +768,15 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
               }
             })
             .then(() => {
+              const {
+                browser: uaBrowser,
+                browserVersion: uaBrowserVersion,
+                os: uaOS,
+                osVersion: uaOSVersion,
+                deviceType: uaDeviceType,
+                formFactor: uaFormFactor
+              } = request.app.ua
+
               const sessionTokenOptions = {
                 uid: accountRecord.uid,
                 email: accountRecord.primaryEmail.email,
@@ -767,12 +785,12 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                 verifierSetAt: accountRecord.verifierSetAt,
                 mustVerify: mustVerifySession,
                 tokenVerificationId: tokenVerificationId,
-                uaBrowser: request.app.uaBrowser,
-                uaBrowserVersion: request.app.uaBrowserVersion,
-                uaOS: request.app.uaOS,
-                uaOSVersion: request.app.uaOSVersion,
-                uaDeviceType: request.app.uaDeviceType,
-                uaFormFactor: request.app.uaFormFactor
+                uaBrowser,
+                uaBrowserVersion,
+                uaOS,
+                uaOSVersion,
+                uaDeviceType,
+                uaFormFactor
               }
 
               return db.createSessionToken(sessionTokenOptions)
@@ -1244,6 +1262,14 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
         function mailUnblockCode(code) {
           return P.all([getGeoData(ip), db.accountEmails(emailRecord.uid)])
             .spread((geoData, emails) => {
+              const {
+                browser: uaBrowser,
+                browserVersion: uaBrowserVersion,
+                os: uaOS,
+                osVersion: uaOSVersion,
+                deviceType: uaDeviceType
+              } = request.app.ua
+
               return mailer.sendUnblockCode(emails, emailRecord, {
                 acceptLanguage: request.app.acceptLanguage,
                 unblockCode: code,
@@ -1252,11 +1278,11 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                 ip: ip,
                 location: geoData.location,
                 timeZone: geoData.timeZone,
-                uaBrowser: request.app.uaBrowser,
-                uaBrowserVersion: request.app.uaBrowserVersion,
-                uaOS: request.app.uaOS,
-                uaOSVersion: request.app.uaOSVersion,
-                uaDeviceType: request.app.uaDeviceType
+                uaBrowser,
+                uaBrowserVersion,
+                uaOS,
+                uaOSVersion,
+                uaDeviceType
               })
             })
         }
@@ -1413,6 +1439,15 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
 
         function createSessionToken () {
           if (hasSessionToken) {
+            const {
+              browser: uaBrowser,
+              browserVersion: uaBrowserVersion,
+              os: uaOS,
+              osVersion: uaOSVersion,
+              deviceType: uaDeviceType,
+              formFactor: uaFormFactor
+            } = request.app.ua
+
             // Since the only way to reach this point is clicking a
             // link from the user's email, we create a verified sessionToken
             const sessionTokenOptions = {
@@ -1421,12 +1456,12 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
               emailCode: account.primaryEmail.emailCode,
               emailVerified: account.primaryEmail.isVerified,
               verifierSetAt: account.verifierSetAt,
-              uaBrowser: request.app.uaBrowser,
-              uaBrowserVersion: request.app.uaBrowserVersion,
-              uaOS: request.app.uaOS,
-              uaOSVersion: request.app.uaOSVersion,
-              uaDeviceType: request.app.uaDeviceType,
-              uaFormFactor: request.app.uaFormFactor
+              uaBrowser,
+              uaBrowserVersion,
+              uaOS,
+              uaOSVersion,
+              uaDeviceType,
+              uaFormFactor
             }
 
             return db.createSessionToken(sessionTokenOptions)

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -11,7 +11,6 @@ const butil = require('../crypto/butil')
 const error = require('../error')
 const isA = require('joi')
 const P = require('../promise')
-const userAgent = require('../userAgent')
 const random = require('../crypto/random')
 const requestHelper = require('../routes/utils/request_helper')
 
@@ -266,16 +265,17 @@ module.exports = function (
                 return getGeoData(ip)
                   .then(
                     function (geoData) {
-                      return mailer.sendPasswordChangedNotification(
-                        emails,
-                        account,
-                        userAgent.call({
-                          acceptLanguage: request.app.acceptLanguage,
-                          ip: ip,
-                          location: geoData.location,
-                          timeZone: geoData.timeZone
-                        }, request.headers['user-agent'])
-                      )
+                      return mailer.sendPasswordChangedNotification(emails, account, {
+                        acceptLanguage: request.app.acceptLanguage,
+                        ip: ip,
+                        location: geoData.location,
+                        timeZone: geoData.timeZone,
+                        uaBrowser: request.app.uaBrowser,
+                        uaBrowserVersion: request.app.uaBrowserVersion,
+                        uaOS: request.app.uaOS,
+                        uaOSVersion: request.app.uaOSVersion,
+                        uaDeviceType: request.app.uaDeviceType
+                      })
                       .catch(e => {
                         // If we couldn't email them, no big deal. Log
                         // and pretend everything worked.
@@ -306,10 +306,16 @@ module.exports = function (
                 emailVerified: account.emailVerified,
                 verifierSetAt: account.verifierSetAt,
                 mustVerify: wantsKeys,
-                tokenVerificationId: maybeToken
+                tokenVerificationId: maybeToken,
+                uaBrowser: request.app.uaBrowser,
+                uaBrowserVersion: request.app.uaBrowserVersion,
+                uaOS: request.app.uaOS,
+                uaOSVersion: request.app.uaOSVersion,
+                uaDeviceType: request.app.uaDeviceType,
+                uaFormFactor: request.app.uaFormFactor
               }
 
-              return db.createSessionToken(sessionTokenOptions, request.headers['user-agent'])
+              return db.createSessionToken(sessionTokenOptions)
             })
             .then(
               function (result) {
@@ -419,23 +425,24 @@ module.exports = function (
             function (passwordForgotToken) {
               return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
-                  return mailer.sendRecoveryCode(
-                    emails,
-                    passwordForgotToken,
-                    userAgent.call({
-                      token: passwordForgotToken,
-                      code: passwordForgotToken.passCode,
-                      service: service,
-                      redirectTo: request.payload.redirectTo,
-                      resume: request.payload.resume,
-                      acceptLanguage: request.app.acceptLanguage,
-                      flowId: flowId,
-                      flowBeginTime: flowBeginTime,
-                      ip: ip,
-                      location: geoData.location,
-                      timeZone: geoData.timeZone
-                    }, request.headers['user-agent'])
-                  )
+                  return mailer.sendRecoveryCode(emails, passwordForgotToken, {
+                    token: passwordForgotToken,
+                    code: passwordForgotToken.passCode,
+                    service: service,
+                    redirectTo: request.payload.redirectTo,
+                    resume: request.payload.resume,
+                    acceptLanguage: request.app.acceptLanguage,
+                    flowId: flowId,
+                    flowBeginTime: flowBeginTime,
+                    ip: ip,
+                    location: geoData.location,
+                    timeZone: geoData.timeZone,
+                    uaBrowser: request.app.uaBrowser,
+                    uaBrowserVersion: request.app.uaBrowserVersion,
+                    uaOS: request.app.uaOS,
+                    uaOSVersion: request.app.uaOSVersion,
+                    uaDeviceType: request.app.uaDeviceType
+                  })
                 })
                 .then(
                   function () {
@@ -515,23 +522,24 @@ module.exports = function (
             function () {
               return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
-                  return mailer.sendRecoveryCode(
-                    emails,
-                    passwordForgotToken,
-                    userAgent.call({
-                      code: passwordForgotToken.passCode,
-                      token: passwordForgotToken,
-                      service: service,
-                      redirectTo: request.payload.redirectTo,
-                      resume: request.payload.resume,
-                      acceptLanguage: request.app.acceptLanguage,
-                      flowId: flowId,
-                      flowBeginTime: flowBeginTime,
-                      ip: ip,
-                      location: geoData.location,
-                      timeZone: geoData.timeZone
-                    }, request.headers['user-agent'])
-                  )
+                  return mailer.sendRecoveryCode(emails, passwordForgotToken, {
+                    code: passwordForgotToken.passCode,
+                    token: passwordForgotToken,
+                    service: service,
+                    redirectTo: request.payload.redirectTo,
+                    resume: request.payload.resume,
+                    acceptLanguage: request.app.acceptLanguage,
+                    flowId: flowId,
+                    flowBeginTime: flowBeginTime,
+                    ip: ip,
+                    location: geoData.location,
+                    timeZone: geoData.timeZone,
+                    uaBrowser: request.app.uaBrowser,
+                    uaBrowserVersion: request.app.uaBrowserVersion,
+                    uaOS: request.app.uaOS,
+                    uaOSVersion: request.app.uaOSVersion,
+                    uaDeviceType: request.app.uaDeviceType
+                  })
                 })
             }
           )

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -265,16 +265,24 @@ module.exports = function (
                 return getGeoData(ip)
                   .then(
                     function (geoData) {
+                      const {
+                        browser: uaBrowser,
+                        browserVersion: uaBrowserVersion,
+                        os: uaOS,
+                        osVersion: uaOSVersion,
+                        deviceType: uaDeviceType
+                      } = request.app.ua
+
                       return mailer.sendPasswordChangedNotification(emails, account, {
                         acceptLanguage: request.app.acceptLanguage,
                         ip: ip,
                         location: geoData.location,
                         timeZone: geoData.timeZone,
-                        uaBrowser: request.app.uaBrowser,
-                        uaBrowserVersion: request.app.uaBrowserVersion,
-                        uaOS: request.app.uaOS,
-                        uaOSVersion: request.app.uaOSVersion,
-                        uaDeviceType: request.app.uaDeviceType
+                        uaBrowser,
+                        uaBrowserVersion,
+                        uaOS,
+                        uaOSVersion,
+                        uaDeviceType
                       })
                       .catch(e => {
                         // If we couldn't email them, no big deal. Log
@@ -298,6 +306,15 @@ module.exports = function (
               }
             })
             .then(maybeToken => {
+              const {
+                browser: uaBrowser,
+                browserVersion: uaBrowserVersion,
+                os: uaOS,
+                osVersion: uaOSVersion,
+                deviceType: uaDeviceType,
+                formFactor: uaFormFactor
+              } = request.app.ua
+
               // Create a sessionToken with the verification status of the current session
               const sessionTokenOptions = {
                 uid: account.uid,
@@ -307,12 +324,12 @@ module.exports = function (
                 verifierSetAt: account.verifierSetAt,
                 mustVerify: wantsKeys,
                 tokenVerificationId: maybeToken,
-                uaBrowser: request.app.uaBrowser,
-                uaBrowserVersion: request.app.uaBrowserVersion,
-                uaOS: request.app.uaOS,
-                uaOSVersion: request.app.uaOSVersion,
-                uaDeviceType: request.app.uaDeviceType,
-                uaFormFactor: request.app.uaFormFactor
+                uaBrowser,
+                uaBrowserVersion,
+                uaOS,
+                uaOSVersion,
+                uaDeviceType,
+                uaFormFactor
               }
 
               return db.createSessionToken(sessionTokenOptions)
@@ -425,6 +442,14 @@ module.exports = function (
             function (passwordForgotToken) {
               return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
+                  const {
+                    browser: uaBrowser,
+                    browserVersion: uaBrowserVersion,
+                    os: uaOS,
+                    osVersion: uaOSVersion,
+                    deviceType: uaDeviceType
+                  } = request.app.ua
+
                   return mailer.sendRecoveryCode(emails, passwordForgotToken, {
                     token: passwordForgotToken,
                     code: passwordForgotToken.passCode,
@@ -437,11 +462,11 @@ module.exports = function (
                     ip: ip,
                     location: geoData.location,
                     timeZone: geoData.timeZone,
-                    uaBrowser: request.app.uaBrowser,
-                    uaBrowserVersion: request.app.uaBrowserVersion,
-                    uaOS: request.app.uaOS,
-                    uaOSVersion: request.app.uaOSVersion,
-                    uaDeviceType: request.app.uaDeviceType
+                    uaBrowser,
+                    uaBrowserVersion,
+                    uaOS,
+                    uaOSVersion,
+                    uaDeviceType
                   })
                 })
                 .then(
@@ -522,6 +547,14 @@ module.exports = function (
             function () {
               return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
+                  const {
+                    browser: uaBrowser,
+                    browserVersion: uaBrowserVersion,
+                    os: uaOS,
+                    osVersion: uaOSVersion,
+                    deviceType: uaDeviceType
+                  } = request.app.ua
+
                   return mailer.sendRecoveryCode(emails, passwordForgotToken, {
                     code: passwordForgotToken.passCode,
                     token: passwordForgotToken,
@@ -534,11 +567,11 @@ module.exports = function (
                     ip: ip,
                     location: geoData.location,
                     timeZone: geoData.timeZone,
-                    uaBrowser: request.app.uaBrowser,
-                    uaBrowserVersion: request.app.uaBrowserVersion,
-                    uaOS: request.app.uaOS,
-                    uaOSVersion: request.app.uaOSVersion,
-                    uaDeviceType: request.app.uaDeviceType
+                    uaBrowser,
+                    uaBrowserVersion,
+                    uaOS,
+                    uaOSVersion,
+                    uaDeviceType
                   })
                 })
             }

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -51,7 +51,8 @@ module.exports = (log, signer, db, domain, devices) => {
         var deviceId, uid, certResult
         // No need to wait for a response, update in the background.
         if (request.headers['user-agent']) {
-          db.updateSessionToken(sessionToken, request.headers['user-agent'], clientIp)
+          sessionToken.setUserAgentInfo(request.app)
+          db.updateSessionToken(sessionToken, clientIp)
         } else {
           log.warn({
             op: 'signer.updateSessionToken', message: 'no user agent string, session token not updated'

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -49,9 +49,24 @@ module.exports = (log, signer, db, domain, devices) => {
         var service = request.query.service
         var clientIp = request.app.clientAddress
         var deviceId, uid, certResult
-        // No need to wait for a response, update in the background.
         if (request.headers['user-agent']) {
-          sessionToken.setUserAgentInfo(request.app)
+          const {
+            browser: uaBrowser,
+            browserVersion: uaBrowserVersion,
+            os: uaOS,
+            osVersion: uaOSVersion,
+            deviceType: uaDeviceType,
+            formFactor: uaFormFactor
+          } = request.app.ua
+          sessionToken.setUserAgentInfo({
+            uaBrowser,
+            uaBrowserVersion,
+            uaOS,
+            uaOSVersion,
+            uaDeviceType,
+            uaFormFactor
+          })
+          // No need to wait for a response, update in the background.
           db.updateSessionToken(sessionToken, clientIp)
         } else {
           log.warn({

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var fs = require('fs')
-var path = require('path')
-var url = require('url')
-var Hapi = require('hapi')
+const fs = require('fs')
+const path = require('path')
+const url = require('url')
+const Hapi = require('hapi')
+const userAgent = require('./userAgent')
 
-var HEX_STRING = require('./routes/validators').HEX_STRING
+const HEX_STRING = require('./routes/validators').HEX_STRING
 
 function trimLocale(header) {
   if (! header) {
@@ -270,6 +271,7 @@ function create(log, error, config, routes, db, translator) {
       const acceptLanguage = trimLocale(request.headers['accept-language'])
       request.app.acceptLanguage = acceptLanguage
       request.app.locale = translator.getLocale(acceptLanguage)
+      userAgent.call(request.app, request.headers['user-agent'])
 
       if (request.headers.authorization) {
         // Log some helpful details for debugging authentication problems.

--- a/lib/server.js
+++ b/lib/server.js
@@ -271,7 +271,17 @@ function create(log, error, config, routes, db, translator) {
       const acceptLanguage = trimLocale(request.headers['accept-language'])
       request.app.acceptLanguage = acceptLanguage
       request.app.locale = translator.getLocale(acceptLanguage)
-      userAgent.call(request.app, request.headers['user-agent'])
+
+      let ua
+      Object.defineProperty(request.app, 'ua', {
+        get () {
+          if (! ua) {
+            ua = userAgent(request.headers['user-agent'])
+          }
+
+          return ua
+        }
+      })
 
       if (request.headers.authorization) {
         // Log some helpful details for debugging authentication problems.

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -4,8 +4,6 @@
 
 'use strict'
 
-const userAgent = require('../userAgent')
-
 module.exports = (log, Token, config) => {
   const MAX_AGE_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
 
@@ -55,20 +53,6 @@ module.exports = (log, Token, config) => {
       }
     }
 
-    // Parse the user agent string, then update properties on this
-    // It is the caller's responsibility to update the database.
-    update(userAgentString) {
-      log.trace({ op: 'SessionToken.update', uid: this.uid })
-
-      var freshData = userAgent.call({
-        lastAccessTime: Date.now()
-      }, userAgentString)
-
-      this.setUserAgentInfo(freshData)
-
-      return true
-    }
-
     setUserAgentInfo(data) {
       this.uaBrowser = data.uaBrowser
       this.uaBrowserVersion = data.uaBrowserVersion
@@ -76,7 +60,9 @@ module.exports = (log, Token, config) => {
       this.uaOSVersion = data.uaOSVersion
       this.uaDeviceType = data.uaDeviceType
       this.uaFormFactor = data.uaFormFactor
-      this.lastAccessTime = data.lastAccessTime
+      if (data.lastAccessTime) {
+        this.lastAccessTime = data.lastAccessTime
+      }
     }
 
     setDeviceInfo(data) {

--- a/lib/userAgent.js
+++ b/lib/userAgent.js
@@ -39,24 +39,25 @@ module.exports = function (userAgentString) {
   if (matches && matches.length > 2) {
     // Always parse known Sync user-agents ourselves,
     // because node-uap makes a pig's ear of it.
-    this.uaBrowser = matches[6] || matches[1]
-    this.uaBrowserVersion = matches[3] || null
-    this.uaOS = matches[2]
-    this.uaOSVersion = matches[5]
-    this.uaDeviceType = marshallDeviceType(matches[4])
-    this.uaFormFactor = matches[4] || null
-  } else {
-    const userAgentData = ua.parse(userAgentString)
-
-    this.uaBrowser = getFamily(userAgentData.ua) || null
-    this.uaBrowserVersion = getVersion(userAgentData.ua) || null
-    this.uaOS = getFamily(userAgentData.os) || null
-    this.uaOSVersion = getVersion(userAgentData.os) || null
-    this.uaDeviceType = getDeviceType(userAgentData) || null
-    this.uaFormFactor = getFormFactor(userAgentData) || null
+    return {
+      browser: matches[6] || matches[1],
+      browserVersion: matches[3] || null,
+      os: matches[2],
+      osVersion: matches[5],
+      deviceType: marshallDeviceType(matches[4]),
+      formFactor: matches[4] || null
+    }
   }
 
-  return this
+  const userAgentData = ua.parse(userAgentString)
+  return {
+    browser: getFamily(userAgentData.ua) || null,
+    browserVersion: getVersion(userAgentData.ua) || null,
+    os: getFamily(userAgentData.os) || null,
+    osVersion: getVersion(userAgentData.os) || null,
+    deviceType: getDeviceType(userAgentData) || null,
+    formFactor: getFormFactor(userAgentData) || null
+  }
 }
 
 function getFamily (data) {

--- a/test/local/ip_profiling.js
+++ b/test/local/ip_profiling.js
@@ -351,7 +351,8 @@ describe('IP Profiling', () => {
 
       mockRequest.app = {
         clientAddress: '63.245.221.32',
-        isSuspiciousRequest: true
+        isSuspiciousRequest: true,
+        ua: {}
       }
 
       route = getRoute(accountRoutes, '/account/login')

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -94,7 +94,11 @@ describe('/account/reset', function () {
       },
       query: {
         keys: 'true'
-      }
+      },
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '57',
+      uaOS: 'Mac OS X',
+      uaOSVersion: '10.11'
     })
     const keyFetchTokenId = hexString(16)
     const sessionTokenId = hexString(16)
@@ -168,6 +172,16 @@ describe('/account/reset', function () {
       assert.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
       assert.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
+
+      assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called once')
+      args = mockDB.createSessionToken.args[0]
+      assert.equal(args.length, 1, 'db.createSessionToken was passed one argument')
+      assert.equal(args[0].uaBrowser, 'Firefox', 'db.createSessionToken was passed correct browser')
+      assert.equal(args[0].uaBrowserVersion, '57', 'db.createSessionToken was passed correct browser version')
+      assert.equal(args[0].uaOS, 'Mac OS X', 'db.createSessionToken was passed correct os')
+      assert.equal(args[0].uaOSVersion, '10.11', 'db.createSessionToken was passed correct os version')
+      assert.equal(args[0].uaDeviceType, null, 'db.createSessionToken was passed correct device type')
+      assert.equal(args[0].uaFormFactor, null, 'db.createSessionToken was passed correct form factor')
     })
   })
 })
@@ -201,7 +215,13 @@ describe('/account/create', () => {
       },
       query: {
         keys: 'true'
-      }
+      },
+      uaBrowser: 'Firefox Mobile',
+      uaBrowserVersion: '9',
+      uaOS: 'iOS',
+      uaOSVersion: '11',
+      uaDeviceType: 'tablet',
+      uaFormFactor: 'iPad'
     })
     const clientAddress = mockRequest.app.clientAddress
     const emailCode = hexString(16)
@@ -285,6 +305,16 @@ describe('/account/create', () => {
     return runTest(route, mockRequest, () => {
       assert.equal(mockDB.createAccount.callCount, 1, 'createAccount was called')
 
+      assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called once')
+      let args = mockDB.createSessionToken.args[0]
+      assert.equal(args.length, 1, 'db.createSessionToken was passed one argument')
+      assert.equal(args[0].uaBrowser, 'Firefox Mobile', 'db.createSessionToken was passed correct browser')
+      assert.equal(args[0].uaBrowserVersion, '9', 'db.createSessionToken was passed correct browser version')
+      assert.equal(args[0].uaOS, 'iOS', 'db.createSessionToken was passed correct os')
+      assert.equal(args[0].uaOSVersion, '11', 'db.createSessionToken was passed correct os version')
+      assert.equal(args[0].uaDeviceType, 'tablet', 'db.createSessionToken was passed correct device type')
+      assert.equal(args[0].uaFormFactor, 'iPad', 'db.createSessionToken was passed correct form factor')
+
       assert.equal(mockLog.notifier.send.callCount, 1, 'an sqs event was logged')
       var eventData = mockLog.notifier.send.getCall(0).args[0]
       assert.equal(eventData.event, 'login', 'it was a login event')
@@ -298,7 +328,7 @@ describe('/account/create', () => {
       }, 'it contained the correct metrics context metadata')
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
-      var args = mockLog.activityEvent.args[0]
+      args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
         event: 'account.created',
@@ -407,7 +437,12 @@ describe('/account/login', function () {
     },
     query: {
       keys: 'true'
-    }
+    },
+    uaBrowser: 'Firefox',
+    uaBrowserVersion: '50',
+    uaOS: 'Android',
+    uaOSVersion: '6',
+    uaDeviceType: 'mobile'
   })
   const mockRequestNoKeys = mocks.mockRequest({
     log: mockLog,
@@ -504,10 +539,19 @@ describe('/account/login', function () {
 
     return runTest(route, mockRequest, function (response) {
       assert.equal(mockDB.accountRecord.callCount, 1, 'db.emailRecord was called')
-      assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called')
+
+      assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called once')
+      let args = mockDB.createSessionToken.args[0]
+      assert.equal(args.length, 1, 'db.createSessionToken was passed one argument')
+      assert.equal(args[0].uaBrowser, 'Firefox', 'db.createSessionToken was passed correct browser')
+      assert.equal(args[0].uaBrowserVersion, '50', 'db.createSessionToken was passed correct browser version')
+      assert.equal(args[0].uaOS, 'Android', 'db.createSessionToken was passed correct os')
+      assert.equal(args[0].uaOSVersion, '6', 'db.createSessionToken was passed correct os version')
+      assert.equal(args[0].uaDeviceType, 'mobile', 'db.createSessionToken was passed correct device type')
+      assert.equal(args[0].uaFormFactor, null, 'db.createSessionToken was passed correct form factor')
 
       assert.equal(mockLog.notifier.send.callCount, 1, 'an sqs event was logged')
-      var eventData = mockLog.notifier.send.getCall(0).args[0]
+      const eventData = mockLog.notifier.send.getCall(0).args[0]
       assert.equal(eventData.event, 'login', 'it was a login event')
       assert.equal(eventData.data.service, 'sync', 'it was for sync')
       assert.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email')
@@ -519,7 +563,7 @@ describe('/account/login', function () {
       }, 'metrics context was correct')
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
-      let args = mockLog.activityEvent.args[0]
+      args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
         event: 'account.login',

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -289,7 +289,11 @@ describe('/password', () => {
           query: {
             keys: 'true'
           },
-          log: mockLog
+          log: mockLog,
+          uaBrowser: 'Firefox',
+          uaBrowserVersion: '57',
+          uaOS: 'Mac OS X',
+          uaOSVersion: '10.11'
         })
         var passwordRoutes = makeRoutes({
           db: mockDB,
@@ -323,6 +327,16 @@ describe('/password', () => {
             uid: uid.toString('hex'),
             userAgent: 'test user-agent'
           }, 'argument was event data')
+
+          assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called once')
+          args = mockDB.createSessionToken.args[0]
+          assert.equal(args.length, 1, 'db.createSessionToken was passed one argument')
+          assert.equal(args[0].uaBrowser, 'Firefox', 'db.createSessionToken was passed correct browser')
+          assert.equal(args[0].uaBrowserVersion, '57', 'db.createSessionToken was passed correct browser version')
+          assert.equal(args[0].uaOS, 'Mac OS X', 'db.createSessionToken was passed correct os')
+          assert.equal(args[0].uaOSVersion, '10.11', 'db.createSessionToken was passed correct os version')
+          assert.equal(args[0].uaDeviceType, null, 'db.createSessionToken was passed correct device type')
+          assert.equal(args[0].uaFormFactor, null, 'db.createSessionToken was passed correct form factor')
         })
       }
     )

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -119,12 +119,6 @@ describe('lib/server', () => {
           assert.ok(args[1])
           assert.equal(args[1].path, '/account/create')
           assert.equal(args[1].app.locale, 'en')
-          assert.equal(args[1].app.uaBrowser, 'Firefox')
-          assert.equal(args[1].app.uaBrowserVersion, '57')
-          assert.equal(args[1].app.uaOS, 'Mac OS X')
-          assert.equal(args[1].app.uaOSVersion, '10.11')
-          assert.equal(args[1].app.uaDeviceType, null)
-          assert.equal(args[1].app.uaFormFactor, null)
         })
 
         it('called log.summary correctly', () => {
@@ -149,6 +143,46 @@ describe('lib/server', () => {
           assert.equal(typeof request.app.features.has, 'function')
           assert.equal(request.app.features.has('signinCodes'), true)
         })
+
+        it('parsed user agent correctly', () => {
+          assert.ok(request.app.ua)
+          assert.equal(request.app.ua.browser, 'Firefox')
+          assert.equal(request.app.ua.browserVersion, '57')
+          assert.equal(request.app.ua.os, 'Mac OS X')
+          assert.equal(request.app.ua.osVersion, '10.11')
+          assert.equal(request.app.ua.deviceType, null)
+          assert.equal(request.app.ua.formFactor, null)
+        })
+
+        describe('another request:', () => {
+          let secondRequest
+
+          beforeEach(() => {
+            response = 'ok'
+            return instance.inject({
+              headers: {
+                'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
+                'user-agent': 'Firefox-Android-FxAccounts/34.0a1 (Nightly)'
+              },
+              method: 'POST',
+              url: '/account/create',
+              payload: {
+                features: [ 'signinCodes' ]
+              }
+            }).then(response => secondRequest = response.request)
+          })
+
+          it('second request has its own user agent info', () => {
+            assert.notEqual(request, secondRequest)
+            assert.notEqual(request.app.ua, secondRequest.app.ua)
+            assert.equal(secondRequest.app.ua.browser, 'Nightly')
+            assert.equal(secondRequest.app.ua.browserVersion, '34.0a1')
+            assert.equal(secondRequest.app.ua.os, 'Android')
+            assert.equal(secondRequest.app.ua.osVersion, null)
+            assert.equal(secondRequest.app.ua.deviceType, 'mobile')
+            assert.equal(secondRequest.app.ua.formFactor, null)
+          })
+        })
       })
 
       describe('successful request, unacceptable locale, no features enabled:', () => {
@@ -171,12 +205,12 @@ describe('lib/server', () => {
           assert.equal(log.begin.callCount, 1)
           const args = log.begin.args[0]
           assert.equal(args[1].app.locale, 'en')
-          assert.equal(args[1].app.uaBrowser, 'Chrome Mobile iOS')
-          assert.equal(args[1].app.uaBrowserVersion, '56')
-          assert.equal(args[1].app.uaOS, 'iOS')
-          assert.equal(args[1].app.uaOSVersion, '10.3')
-          assert.equal(args[1].app.uaDeviceType, 'mobile')
-          assert.equal(args[1].app.uaFormFactor, 'iPhone')
+          assert.equal(args[1].app.ua.browser, 'Chrome Mobile iOS')
+          assert.equal(args[1].app.ua.browserVersion, '56')
+          assert.equal(args[1].app.ua.os, 'iOS')
+          assert.equal(args[1].app.ua.osVersion, '10.3')
+          assert.equal(args[1].app.ua.deviceType, 'mobile')
+          assert.equal(args[1].app.ua.formFactor, 'iPhone')
         })
 
         it('called log.summary once', () => {

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -100,7 +100,8 @@ describe('lib/server', () => {
           response = 'ok'
           return instance.inject({
             headers: {
-              'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5'
+              'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
+              'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:57.0) Gecko/20100101 Firefox/57.0'
             },
             method: 'POST',
             url: '/account/create',
@@ -118,6 +119,12 @@ describe('lib/server', () => {
           assert.ok(args[1])
           assert.equal(args[1].path, '/account/create')
           assert.equal(args[1].app.locale, 'en')
+          assert.equal(args[1].app.uaBrowser, 'Firefox')
+          assert.equal(args[1].app.uaBrowserVersion, '57')
+          assert.equal(args[1].app.uaOS, 'Mac OS X')
+          assert.equal(args[1].app.uaOSVersion, '10.11')
+          assert.equal(args[1].app.uaDeviceType, null)
+          assert.equal(args[1].app.uaFormFactor, null)
         })
 
         it('called log.summary correctly', () => {
@@ -151,7 +158,8 @@ describe('lib/server', () => {
           response = 'ok'
           return instance.inject({
             headers: {
-              'accept-language': 'fr-CH, fr;q=0.9'
+              'accept-language': 'fr-CH, fr;q=0.9',
+              'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1'
             },
             method: 'POST',
             url: '/account/create',
@@ -163,6 +171,12 @@ describe('lib/server', () => {
           assert.equal(log.begin.callCount, 1)
           const args = log.begin.args[0]
           assert.equal(args[1].app.locale, 'en')
+          assert.equal(args[1].app.uaBrowser, 'Chrome Mobile iOS')
+          assert.equal(args[1].app.uaBrowserVersion, '56')
+          assert.equal(args[1].app.uaOS, 'iOS')
+          assert.equal(args[1].app.uaOSVersion, '10.3')
+          assert.equal(args[1].app.uaDeviceType, 'mobile')
+          assert.equal(args[1].app.uaFormFactor, 'iPhone')
         })
 
         it('called log.summary once', () => {

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -39,7 +39,6 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
       return SessionToken.create(TOKEN)
         .then(token => {
           assert.equal(typeof token.lastAuthAt, 'function', 'lastAuthAt method is defined')
-          assert.equal(typeof token.update, 'function', 'update method is defined')
           assert.equal(typeof token.setUserAgentInfo, 'function', 'setUserAgentInfo method is defined')
           assert.equal(Object.getOwnPropertyDescriptor(token, 'state'), undefined, 'state property is undefined')
           assert.equal(
@@ -209,25 +208,20 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
   )
 
   it(
-    'SessionToken.update on a token',
+    'SessionToken.setUserAgentInfo without lastAccessTime',
     () => {
-      return SessionToken.create()
+      return SessionToken.create(TOKEN)
         .then(function (token) {
-          sinon.spy(SessionToken.prototype, 'setUserAgentInfo')
-
-          assert.equal(
-            token.update(
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0'
-            ), true, 'returns true'
-          )
-
-          assert.equal(SessionToken.prototype.setUserAgentInfo.callCount, 1, 'setUserAgentInfo called once')
-          assert.equal(SessionToken.prototype.setUserAgentInfo.thisValues[0], token, 'setUserAgentInfo context was token')
-          var setUserAgentInfoArgs = SessionToken.prototype.setUserAgentInfo.args[0]
-          assert.equal(setUserAgentInfoArgs.length, 1, 'setUserAgentInfo was passed one argument')
-        })
-        .finally(function () {
-          SessionToken.prototype.setUserAgentInfo.restore()
+          token.lastAccessTime = 'foo'
+          token.setUserAgentInfo({
+            uaBrowser: 'foo',
+            uaBrowserVersion: 'bar',
+            uaOS: 'baz',
+            uaOSVersion: 'qux',
+            uaDeviceType: 'wibble',
+            uaFormFactor: 'blee'
+          })
+          assert.notEqual(token.lastAccessTime, undefined, 'lastAccessTime was not clobbered')
         })
     }
   )

--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -49,20 +49,18 @@ describe('userAgent', () => {
           family: 'baz'
         }
       }
-      var context = {}
-      var result = userAgent.call(context, 'qux')
+      const result = userAgent('qux')
 
       assert.equal(uaParser.parse.callCount, 1)
       assert.ok(uaParser.parse.calledWithExactly('qux'))
 
-      assert.equal(result, context)
       assert.equal(Object.keys(result).length, 6)
-      assert.equal(result.uaBrowser, 'foo')
-      assert.equal(result.uaBrowserVersion, '1')
-      assert.equal(result.uaOS, 'bar')
-      assert.equal(result.uaOSVersion, '2')
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, 'baz')
+      assert.equal(result.browser, 'foo')
+      assert.equal(result.browserVersion, '1')
+      assert.equal(result.os, 'bar')
+      assert.equal(result.osVersion, '2')
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, 'baz')
     }
   )
 
@@ -84,18 +82,16 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context, 'wibble')
+      const result = userAgent('wibble')
 
       assert.equal(uaParser.parse.callCount, 1)
       assert.ok(uaParser.parse.calledWithExactly('wibble'))
 
-      assert.equal(result, context)
       assert.equal(Object.keys(result).length, 6)
-      assert.equal(result.uaBrowser, null)
-      assert.equal(result.uaOS, null)
-      assert.equal(result.uaDeviceType, null)
-      assert.equal(result.uaFormFactor, null)
+      assert.equal(result.browser, null)
+      assert.equal(result.os, null)
+      assert.equal(result.deviceType, null)
+      assert.equal(result.formFactor, null)
     }
   )
 
@@ -117,11 +113,10 @@ describe('userAgent', () => {
           family: 'baz'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaBrowserVersion, '1.1')
-      assert.equal(result.uaOSVersion, '2.34567')
+      assert.equal(result.browserVersion, '1.1')
+      assert.equal(result.osVersion, '2.34567')
     }
   )
 
@@ -144,11 +139,10 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, null)
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, null)
     }
   )
 
@@ -170,10 +164,10 @@ describe('userAgent', () => {
           family: 'iPhone 7'
         }
       }
-      const result = userAgent.call({})
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, 'iPhone 7')
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, 'iPhone 7')
     }
   )
 
@@ -195,10 +189,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'mobile')
+      assert.equal(result.deviceType, 'mobile')
     }
   )
 
@@ -220,10 +213,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'mobile')
+      assert.equal(result.deviceType, 'mobile')
     }
   )
 
@@ -245,10 +237,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'mobile')
+      assert.equal(result.deviceType, 'mobile')
     }
   )
 
@@ -270,10 +261,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, null)
+      assert.equal(result.deviceType, null)
     }
   )
 
@@ -295,10 +285,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, null)
+      assert.equal(result.deviceType, null)
     }
   )
 
@@ -320,10 +309,9 @@ describe('userAgent', () => {
           family: 'Other'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, null)
+      assert.equal(result.deviceType, null)
     }
   )
 
@@ -346,10 +334,10 @@ describe('userAgent', () => {
           family: 'iPad Pro'
         }
       }
-      const result = userAgent.call({})
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'tablet')
-      assert.equal(result.uaFormFactor, 'iPad Pro')
+      assert.equal(result.deviceType, 'tablet')
+      assert.equal(result.formFactor, 'iPad Pro')
     }
   )
 
@@ -372,11 +360,10 @@ describe('userAgent', () => {
           family: 'Nexus 7'
         }
       }
-      var context = {}
-      var result = userAgent.call(context)
+      const result = userAgent()
 
-      assert.equal(result.uaDeviceType, 'tablet')
-      assert.equal(result.uaFormFactor, 'Nexus 7')
+      assert.equal(result.deviceType, 'tablet')
+      assert.equal(result.formFactor, 'Nexus 7')
     }
   )
 
@@ -399,9 +386,9 @@ describe('userAgent', () => {
         model: 'Smartphone'
       }
     }
-    const result = userAgent.call({})
+    const result = userAgent()
 
-    assert.equal(result.uaDeviceType, 'mobile')
+    assert.equal(result.deviceType, 'mobile')
   })
 
   it('recognises FirefoxOS tablets as tablets', () => {
@@ -423,9 +410,9 @@ describe('userAgent', () => {
         model: 'Tablet'
       }
     }
-    const result = userAgent.call({})
+    const result = userAgent()
 
-    assert.equal(result.uaDeviceType, 'tablet')
+    assert.equal(result.deviceType, 'tablet')
   })
 
   it('ignores form factor for generic devices', () => {
@@ -446,25 +433,23 @@ describe('userAgent', () => {
         brand: 'Generic'
       }
     }
-    const result = userAgent.call({})
+    const result = userAgent()
 
-    assert.equal(result.uaDeviceType, 'mobile')
-    assert.equal(result.uaFormFactor, null)
+    assert.equal(result.deviceType, 'mobile')
+    assert.equal(result.formFactor, null)
   })
 
   it(
     'recognises old Firefox-iOS user agents',
     () => {
       parserResult = null
-      const context = {}
-      const userAgentString = 'Firefox-iOS-FxA/5.3 (Firefox)'
-      const result = userAgent.call(context, userAgentString)
+      const result = userAgent('Firefox-iOS-FxA/5.3 (Firefox)')
 
-      assert.equal(result.uaBrowser, 'Firefox')
-      assert.equal(result.uaBrowserVersion, '5.3')
-      assert.equal(result.uaOS, 'iOS')
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, null)
+      assert.equal(result.browser, 'Firefox')
+      assert.equal(result.browserVersion, '5.3')
+      assert.equal(result.os, 'iOS')
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, null)
     }
   )
 
@@ -472,16 +457,14 @@ describe('userAgent', () => {
     'recognises new Firefox-iOS user agents',
     () => {
       parserResult = null
-      const context = {}
-      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Nightly)'
-      const result = userAgent.call(context, userAgentString)
+      const result = userAgent('Firefox-iOS-FxA/6.0b42 (iPhone 6S; iPhone OS 10.3) (Nightly)')
 
-      assert.equal(result.uaBrowser, 'Nightly')
-      assert.equal(result.uaBrowserVersion, '6.0')
-      assert.equal(result.uaOS, 'iOS')
-      assert.equal(result.uaOSVersion, '10.3')
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, 'iPhone 6S')
+      assert.equal(result.browser, 'Nightly')
+      assert.equal(result.browserVersion, '6.0')
+      assert.equal(result.os, 'iOS')
+      assert.equal(result.osVersion, '10.3')
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, 'iPhone 6S')
     }
   )
 
@@ -489,16 +472,14 @@ describe('userAgent', () => {
     'recognises new Firefox-iOS user agent on iPads',
     () => {
       parserResult = null
-      const context = {}
-      const userAgentString = 'Firefox-iOS-FxA/6.0b42 (iPad Mini; iPhone OS 10.3) (Nightly)'
-      const result = userAgent.call(context, userAgentString)
+      const result = userAgent('Firefox-iOS-FxA/6.0b42 (iPad Mini; iPhone OS 10.3) (Nightly)')
 
-      assert.equal(result.uaBrowser, 'Nightly')
-      assert.equal(result.uaBrowserVersion, '6.0')
-      assert.equal(result.uaOS, 'iOS')
-      assert.equal(result.uaOSVersion, '10.3')
-      assert.equal(result.uaDeviceType, 'tablet')
-      assert.equal(result.uaFormFactor, 'iPad Mini')
+      assert.equal(result.browser, 'Nightly')
+      assert.equal(result.browserVersion, '6.0')
+      assert.equal(result.os, 'iOS')
+      assert.equal(result.osVersion, '10.3')
+      assert.equal(result.deviceType, 'tablet')
+      assert.equal(result.formFactor, 'iPad Mini')
     }
   )
 
@@ -506,15 +487,13 @@ describe('userAgent', () => {
     'recognises Firefox-Android user agents',
     () => {
       parserResult = null
-      const context = {}
-      const userAgentString = 'Firefox-Android-FxAccounts/49.0.2 (Firefox)'
-      const result = userAgent.call(context, userAgentString)
+      const result = userAgent('Firefox-Android-FxAccounts/49.0.2 (Firefox)')
 
-      assert.equal(result.uaBrowser, 'Firefox')
-      assert.equal(result.uaBrowserVersion, '49.0.2')
-      assert.equal(result.uaOS, 'Android')
-      assert.equal(result.uaDeviceType, 'mobile')
-      assert.equal(result.uaFormFactor, null)
+      assert.equal(result.browser, 'Firefox')
+      assert.equal(result.browserVersion, '49.0.2')
+      assert.equal(result.os, 'Android')
+      assert.equal(result.deviceType, 'mobile')
+      assert.equal(result.formFactor, null)
     }
   )
 
@@ -533,41 +512,37 @@ describe('userAgent', () => {
         model: 'Smartphone'
       }
     }
-    const result = userAgent.call({}, 'Firefox AndroidSync 1.51.0.0 (Firefox)')
+    const result = userAgent('Firefox AndroidSync 1.51.0.0 (Firefox)')
 
-    assert.equal(result.uaBrowser, null)
-    assert.equal(result.uaBrowserVersion, null)
-    assert.equal(result.uaOS, 'Android')
-    assert.equal(result.uaDeviceType, 'mobile')
-    assert.equal(result.uaFormFactor, null)
+    assert.equal(result.browser, null)
+    assert.equal(result.browserVersion, null)
+    assert.equal(result.os, 'Android')
+    assert.equal(result.deviceType, 'mobile')
+    assert.equal(result.formFactor, null)
   })
 
   it('recognises new mobile Sync library user agents on Android', () => {
     parserResult = null
-    const context = {}
-    const userAgentString = 'Mobile-Android-Sync/(Mobile; Android 6.0) (foo() bar)'
-    const result = userAgent.call(context, userAgentString)
+    const result = userAgent('Mobile-Android-Sync/(Mobile; Android 6.0) (foo() bar)')
 
-    assert.equal(result.uaBrowser, 'foo() bar')
-    assert.equal(result.uaBrowserVersion, null)
-    assert.equal(result.uaOS, 'Android')
-    assert.equal(result.uaOSVersion, '6.0')
-    assert.equal(result.uaDeviceType, 'mobile')
-    assert.equal(result.uaFormFactor, 'Mobile')
+    assert.equal(result.browser, 'foo() bar')
+    assert.equal(result.browserVersion, null)
+    assert.equal(result.os, 'Android')
+    assert.equal(result.osVersion, '6.0')
+    assert.equal(result.deviceType, 'mobile')
+    assert.equal(result.formFactor, 'Mobile')
   })
 
   it('recognises new mobile Sync library user agents on iOS', () => {
     parserResult = null
-    const context = {}
-    const userAgentString = 'Mobile-iOS-Sync/(iPad Mini; iOS 10.3) (wibble)'
-    const result = userAgent.call(context, userAgentString)
+    const result = userAgent('Mobile-iOS-Sync/(iPad Mini; iOS 10.3) (wibble)')
 
-    assert.equal(result.uaBrowser, 'wibble')
-    assert.equal(result.uaBrowserVersion, null)
-    assert.equal(result.uaOS, 'iOS')
-    assert.equal(result.uaOSVersion, '10.3')
-    assert.equal(result.uaDeviceType, 'tablet')
-    assert.equal(result.uaFormFactor, 'iPad Mini')
+    assert.equal(result.browser, 'wibble')
+    assert.equal(result.browserVersion, null)
+    assert.equal(result.os, 'iOS')
+    assert.equal(result.osVersion, '10.3')
+    assert.equal(result.deviceType, 'tablet')
+    assert.equal(result.formFactor, 'iPad Mini')
   })
 
   it('recognises old Kindle user agents', () => {
@@ -585,13 +560,13 @@ describe('userAgent', () => {
         model: 'Kindle 3.0'
       }
     }
-    const result = userAgent.call({})
+    const result = userAgent()
 
-    assert.equal(result.uaBrowser, 'Kindle')
-    assert.equal(result.uaBrowserVersion, null)
-    assert.equal(result.uaOS, 'Kindle')
-    assert.equal(result.uaDeviceType, 'tablet')
-    assert.equal(result.uaFormFactor, 'Kindle')
+    assert.equal(result.browser, 'Kindle')
+    assert.equal(result.browserVersion, null)
+    assert.equal(result.os, 'Kindle')
+    assert.equal(result.deviceType, 'tablet')
+    assert.equal(result.formFactor, 'Kindle')
   })
 
   it('recognises Kindle Fire user agents', () => {
@@ -615,13 +590,13 @@ describe('userAgent', () => {
         model: 'Kindle Fire'
       }
     }
-    const result = userAgent.call({})
+    const result = userAgent()
 
-    assert.equal(result.uaBrowser, 'Android')
-    assert.equal(result.uaBrowserVersion, '2.3')
-    assert.equal(result.uaOS, 'Android')
-    assert.equal(result.uaDeviceType, 'tablet')
-    assert.equal(result.uaFormFactor, 'Kindle')
+    assert.equal(result.browser, 'Android')
+    assert.equal(result.browserVersion, '2.3')
+    assert.equal(result.os, 'Android')
+    assert.equal(result.deviceType, 'tablet')
+    assert.equal(result.formFactor, 'Kindle')
   })
 })
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -460,7 +460,13 @@ function mockRequest (data) {
       acceptLanguage: 'en-US',
       clientAddress: data.clientAddress || '63.245.221.32',
       locale: data.locale || 'en-US',
-      features: new Set(data.features)
+      features: new Set(data.features),
+      uaBrowser: data.uaBrowser || 'Firefox',
+      uaBrowserVersion: data.uaBrowserVersion || '57.0',
+      uaOS: data.uaOS || 'Mac OS X',
+      uaOSVersion: data.uaOSVersion || '10.13',
+      uaDeviceType: data.uaDeviceType || null,
+      uaFormFactor: data.uaFormFactor || null
     },
     auth: {
       credentials: data.credentials

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -461,12 +461,14 @@ function mockRequest (data) {
       clientAddress: data.clientAddress || '63.245.221.32',
       locale: data.locale || 'en-US',
       features: new Set(data.features),
-      uaBrowser: data.uaBrowser || 'Firefox',
-      uaBrowserVersion: data.uaBrowserVersion || '57.0',
-      uaOS: data.uaOS || 'Mac OS X',
-      uaOSVersion: data.uaOSVersion || '10.13',
-      uaDeviceType: data.uaDeviceType || null,
-      uaFormFactor: data.uaFormFactor || null
+      ua: {
+        browser: data.uaBrowser || 'Firefox',
+        browserVersion: data.uaBrowserVersion || '57.0',
+        os: data.uaOS || 'Mac OS X',
+        osVersion: data.uaOSVersion || '10.13',
+        deviceType: data.uaDeviceType || null,
+        formFactor: data.uaFormFactor || null
+      }
     },
     auth: {
       credentials: data.credentials


### PR DESCRIPTION
For the amplitude events, I want access to parsed user agent info before we have a session token object. To that end, I figured it makes sense to move parsing into the `onPreAuth` handler and expose the properties on `request.app`.

This has the side-effect of removing the need for any explicit calls to `lib/userAgent` in the main body of our request-handling code, which should eliminate the possibility of ever calling it multiple times per request again. The other side-effect is that now every request must pay the cost of user-agent parsing, however it feels like useful info to have around and we can keep an eye on the performance charts to make sure that median request times aren't negatively impacted.

@mozilla/fxa-devs r?
