### PR TITLE
refactor(mailer): automatically pass through args to mailer methods

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -330,15 +330,9 @@ module.exports = function (log) {
       templateName = 'verifySyncEmail'
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
-      subject: subject,
+    return this.send(Object.assign({}, message, {
+      headers,
+      subject,
       template: templateName,
       templateValues: {
         device: this._formatUserAgentInfo(message),
@@ -351,9 +345,8 @@ module.exports = function (log) {
         sync: message.service,
         supportUrl: links.supportUrl,
         supportLinkAttributes: links.supportLinkAttributes
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.unblockCodeEmail = function (message) {
@@ -377,15 +370,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Firefox Account authorization code'),
       template: templateName,
       templateValues: {
@@ -398,9 +384,8 @@ module.exports = function (log) {
         reportSignInLinkAttributes: links.reportSignInLinkAttributes,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage),
         unblockCode: message.unblockCode
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.verifyLoginEmail = function (message) {
@@ -427,15 +412,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Confirm new sign-in to Firefox'),
       template: templateName,
       templateValues: {
@@ -451,9 +429,8 @@ module.exports = function (log) {
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.verifySecondaryEmail = function (message) {
@@ -482,14 +459,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Verify email for Firefox Accounts'),
       template: templateName,
       templateValues: {
@@ -508,9 +479,8 @@ module.exports = function (log) {
         supportUrl: links.supportUrl,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage),
         primaryEmail: message.primaryEmail
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.recoveryEmail = function (message) {
@@ -536,15 +506,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Reset your Firefox Account password'),
       template: templateName,
       templateValues: {
@@ -558,9 +521,8 @@ module.exports = function (log) {
         supportUrl: links.supportUrl,
         supportLinkAttributes: links.supportLinkAttributes,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.passwordChangedEmail = function (message) {
@@ -576,15 +538,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Your Firefox Account password has been changed'),
       template: templateName,
       templateValues: {
@@ -597,9 +552,8 @@ module.exports = function (log) {
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.passwordResetEmail = function (message) {
@@ -614,15 +568,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Your Firefox Account password has been reset'),
       template: templateName,
       templateValues: {
@@ -631,9 +578,8 @@ module.exports = function (log) {
         resetLinkAttributes: links.resetLinkAttributes,
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.passwordResetRequiredEmail = function (message) {
@@ -648,23 +594,16 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Firefox Account password reset required'),
       template: templateName,
       templateValues: {
         passwordManagerInfoUrl: links.passwordManagerInfoUrl,
         privacyUrl: links.privacyUrl,
         resetLink: links.resetLink
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.newDeviceLoginEmail = function (message) {
@@ -680,15 +619,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('New sign-in to Firefox'),
       template: templateName,
       templateValues: {
@@ -701,9 +633,8 @@ module.exports = function (log) {
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         timestamp: this._constructLocalTimeString(message.timeZone, message.acceptLanguage)
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.postVerifyEmail = function (message) {
@@ -720,14 +651,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Firefox Account verified'),
       template: templateName,
       templateValues: {
@@ -739,9 +664,8 @@ module.exports = function (log) {
         privacyUrl: links.privacyUrl,
         supportUrl: links.supportUrl,
         supportLinkAttributes: links.supportLinkAttributes
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.postVerifySecondaryEmail = function (message) {
@@ -758,14 +682,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Secondary Firefox Account email added'),
       template: templateName,
       templateValues: {
@@ -776,9 +694,8 @@ module.exports = function (log) {
         supportUrl: links.supportUrl,
         secondaryEmail: message.secondaryEmail,
         supportLinkAttributes: links.supportLinkAttributes
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.postRemoveSecondaryEmail = function (message) {
@@ -795,15 +712,8 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
-      acceptLanguage: message.acceptLanguage,
-      ccEmails: message.ccEmails,
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      service: message.service,
+    return this.send(Object.assign({}, message, {
+      headers,
       subject: gettext('Secondary Firefox Account email removed'),
       template: templateName,
       templateValues: {
@@ -814,9 +724,8 @@ module.exports = function (log) {
         supportUrl: links.supportUrl,
         secondaryEmail: message.secondaryEmail,
         supportLinkAttributes: links.supportLinkAttributes
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype.verificationReminderEmail = function (message) {
@@ -854,15 +763,10 @@ module.exports = function (log) {
       headers[X_SES_MESSAGE_TAGS] = sesMessageTagsHeaderValue(templateName)
     }
 
-    return this.send({
+    return this.send(Object.assign({}, message, {
       acceptLanguage: message.acceptLanguage || 'en',
-      deviceId: message.deviceId,
-      email: message.email,
-      flowId: message.flowId,
-      flowBeginTime: message.flowBeginTime,
-      headers: headers,
-      subject: subject,
-      service: message.service,
+      headers,
+      subject,
       template: templateName,
       templateValues: {
         email: message.email,
@@ -871,9 +775,8 @@ module.exports = function (log) {
         privacyUrl: links.privacyUrl,
         supportUrl: links.supportUrl,
         supportLinkAttributes: links.supportLinkAttributes
-      },
-      uid: message.uid
-    })
+      }
+    }))
   }
 
   Mailer.prototype._generateUTMLink = function (link, query, templateName, content) {

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -107,23 +107,11 @@ module.exports = (log, config, error, bounces, translator, sender) => {
         const primaryEmail = account.email
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
-            return mailer.verifyEmail({
-              email: primaryEmail,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime,
-              uid: account.uid,
-              code: opts.code,
-              service: opts.service,
-              redirectTo: opts.redirectTo,
-              resume: opts.resume,
+            return mailer.verifyEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              ip: opts.ip,
-              location: opts.location,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion
-            })
+              email: primaryEmail,
+              uid: account.uid
+            }))
           })
       },
       sendVerifyLoginEmail: function (emails, account, opts) {
@@ -133,25 +121,12 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.verifyLoginEmail({
+            return mailer.verifyLoginEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              code: opts.code,
-              ccEmails: ccEmails,
+              ccEmails,
               email: primaryEmail,
-              ip: opts.ip,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime,
-              location: opts.location,
-              redirectTo: opts.redirectTo,
-              resume: opts.resume,
-              service: opts.service,
-              timeZone: opts.timeZone,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion,
               uid: account.uid
-            })
+            }))
           })
       },
       sendVerifySecondaryEmail: function (emails, account, opts) {
@@ -160,23 +135,12 @@ module.exports = (log, config, error, bounces, translator, sender) => {
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
-            return mailer.verifySecondaryEmail({
+            return mailer.verifySecondaryEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              code: opts.code,
               email: verifyEmailAddress,
-              ip: opts.ip,
-              location: opts.location,
-              redirectTo: opts.redirectTo,
-              resume: opts.resume,
-              service: opts.service,
-              timeZone: opts.timeZone,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion,
-              uid: account.uid,
-              primaryEmail: primaryEmail
-            })
+              primaryEmail,
+              uid: account.uid
+            }))
           })
       },
       sendRecoveryCode: function (emails, account, opts) {
@@ -186,26 +150,13 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.recoveryEmail({
-              ccEmails: ccEmails,
+            return mailer.recoveryEmail(Object.assign({}, opts, {
+              acceptLanguage: opts.acceptLanguage || defaultLanguage,
+              ccEmails,
               email: primaryEmail,
               emailToHashWith: account.email,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime,
-              token: opts.token.data,
-              code: opts.code,
-              service: opts.service,
-              redirectTo: opts.redirectTo,
-              resume: opts.resume,
-              acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              ip: opts.ip,
-              location: opts.location,
-              timeZone: opts.timeZone,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion
-            })
+              token: opts.token.data
+            }))
           })
       },
       sendPasswordChangedNotification: function (emails, account, opts) {
@@ -215,17 +166,11 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.passwordChangedEmail({
-              email: primaryEmail,
-              ccEmails: ccEmails,
+            return mailer.passwordChangedEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              ip: opts.ip,
-              location: opts.location,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion
-            })
+              ccEmails,
+              email: primaryEmail
+            }))
           })
       },
       sendPasswordResetNotification: function (emails, account, opts) {
@@ -235,13 +180,11 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.passwordResetEmail({
-              ccEmails: ccEmails,
-              email: primaryEmail,
+            return mailer.passwordResetEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime
-            })
+              ccEmails,
+              email: primaryEmail
+            }))
           })
       },
       sendNewDeviceLoginNotification: function (emails, account, opts) {
@@ -251,20 +194,11 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.newDeviceLoginEmail({
+            return mailer.newDeviceLoginEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime,
-              ccEmails: ccEmails,
-              email: primaryEmail,
-              ip: opts.ip,
-              location: opts.location,
-              timeZone: opts.timeZone,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion
-            })
+              ccEmails,
+              email: primaryEmail
+            }))
           })
       },
       sendPostVerifyEmail: function (emails, account, opts) {
@@ -272,10 +206,10 @@ module.exports = (log, config, error, bounces, translator, sender) => {
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
-            return mailer.postVerifyEmail({
-              email: primaryEmail,
-              acceptLanguage: opts.acceptLanguage || defaultLanguage
-            })
+            return mailer.postVerifyEmail(Object.assign({}, opts, {
+              acceptLanguage: opts.acceptLanguage || defaultLanguage,
+              email: primaryEmail
+            }))
           })
       },
       sendPostRemoveSecondaryEmail: function (emails, account, opts) {
@@ -285,12 +219,11 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.postRemoveSecondaryEmail({
-              email: primaryEmail,
-              ccEmails: ccEmails,
-              secondaryEmail: opts.secondaryEmail,
-              acceptLanguage: opts.acceptLanguage || defaultLanguage
-            })
+            return mailer.postRemoveSecondaryEmail(Object.assign({}, opts, {
+              acceptLanguage: opts.acceptLanguage || defaultLanguage,
+              ccEmails,
+              email: primaryEmail
+            }))
           })
       },
       sendPostVerifySecondaryEmail: function (emails, account, opts) {
@@ -298,11 +231,10 @@ module.exports = (log, config, error, bounces, translator, sender) => {
 
         return getSafeMailer(primaryEmail)
           .then(function (mailer) {
-            return mailer.postVerifySecondaryEmail({
-              email: primaryEmail,
-              secondaryEmail: opts.secondaryEmail,
-              acceptLanguage: opts.acceptLanguage || defaultLanguage
-            })
+            return mailer.postVerifySecondaryEmail(Object.assign({}, opts, {
+              acceptLanguage: opts.acceptLanguage || defaultLanguage,
+              email: primaryEmail
+            }))
           })
       },
       sendUnblockCode: function (emails, account, opts) {
@@ -312,22 +244,12 @@ module.exports = (log, config, error, bounces, translator, sender) => {
             const primaryEmail = result.ungatedPrimaryEmail
             const ccEmails = result.ungatedCcEmails
 
-            return mailer.unblockCodeEmail({
+            return mailer.unblockCodeEmail(Object.assign({}, opts, {
               acceptLanguage: opts.acceptLanguage || defaultLanguage,
-              flowId: opts.flowId,
-              flowBeginTime: opts.flowBeginTime,
-              ccEmails: ccEmails,
+              ccEmails,
               email: primaryEmail,
-              ip: opts.ip,
-              location: opts.location,
-              timeZone: opts.timeZone,
-              uaBrowser: opts.uaBrowser,
-              uaBrowserVersion: opts.uaBrowserVersion,
-              uaOS: opts.uaOS,
-              uaOSVersion: opts.uaOSVersion,
-              uid: account.uid,
-              unblockCode: opts.unblockCode
-            })
+              uid: account.uid
+            }))
           })
       },
       translator: function () {


### PR DESCRIPTION
This addresses a pain point I had when adding properties to the data passed to mailer methods in #2069. There are actually three levels of indirection before reaching the core `send` method, and each one independently sets properties on the options object. Adding common properties to all methods involved a load of tedious copy/paste and then for a long time I didn't even realise that I'd missed one of the layers.

That explicit filtering would make sense if the data was about to be exposed publicly or subjected to validation that could make something fail. But neither of those are happening here so it's just annoying.

Here, I've tweaked things slightly on the two innermost layers to lean on `Object.assign` and pass through all properties as they arrive, unless overridden by method-specific logic. In the future, this means setting any new data only has to happen at the original call site, which I think is an improvement.

@mozilla/fxa-devs r?