### PR TITLE
fix(metrics): remove the forgot_sent amplitude event

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -61,14 +61,6 @@ const EVENTS = {
     group: (request, data, metricsContext) => GROUPS[metricsContext.flowType],
     event: 'complete'
   },
-  'password.forgot.resend_code.completed': {
-    group: GROUPS.login,
-    event: 'forgot_sent'
-  },
-  'password.forgot.send_code.completed': {
-    group: GROUPS.login,
-    event: 'forgot_sent'
-  },
   'sms.installFirefox.sent': {
     group: GROUPS.sms,
     event: 'sent'

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -316,38 +316,6 @@ describe('metrics/amplitude', () => {
       })
     })
 
-    describe('password.forgot.resend_code.completed', () => {
-      beforeEach(() => {
-        amplitude('password.forgot.resend_code.completed', mocks.mockRequest({}))
-      })
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0)
-      })
-
-      it('called log.amplitudeEvent correctly', () => {
-        assert.equal(log.amplitudeEvent.callCount, 1)
-        const args = log.amplitudeEvent.args[0]
-        assert.equal(args[0].event_type, 'fxa_login - forgot_sent')
-      })
-    })
-
-    describe('password.forgot.send_code.completed', () => {
-      beforeEach(() => {
-        amplitude('password.forgot.send_code.completed', mocks.mockRequest({}))
-      })
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0)
-      })
-
-      it('called log.amplitudeEvent correctly', () => {
-        assert.equal(log.amplitudeEvent.callCount, 1)
-        const args = log.amplitudeEvent.args[0]
-        assert.equal(args[0].event_type, 'fxa_login - forgot_sent')
-      })
-    })
-
     describe('sms.installFirefox.sent', () => {
       beforeEach(() => {
         amplitude('sms.installFirefox.sent', mocks.mockRequest({}))


### PR DESCRIPTION
It was agreed that this event is redundant because of the generic `fxa_email - sent` event and, as such, it's now crossed out in [the taxonomy](https://docs.google.com/spreadsheets/d/1G_8OJGOxeWXdGJ1Ugmykk33Zsl-qAQL05CONSeD4Uz4/edit#gid=879531055). Let's delete it from the code too.

@mozilla/fxa-devs r?