### PR TITLE
fix(push): send push notification after a device is deleted

### DIFF
--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -403,11 +403,12 @@ module.exports = (log, db, config, customs, push, devices) => {
         const id = request.payload.id
         let result
 
-        return push.notifyDeviceDisconnected(uid, id)
-          .catch(() => {})
-          .then(() => db.deleteDevice(uid, id))
+        return db.deleteDevice(uid, id)
           .then(res => {
             result = res
+          })
+          .then(() => push.notifyDeviceDisconnected(uid, id).catch(() => {}))
+          .then(() => {
             return P.all([
               request.emitMetricsEvent('device.deleted', {
                 uid: uid,


### PR DESCRIPTION
I noticed that sometimes Firefox didn't detect a disconnected device, which might be caused by a race in this part of the code.