### PR TITLE
fix(push): send push notification after a device is deleted

### DIFF
--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -416,11 +416,14 @@ module.exports = (log, db, config, customs, push, devices) => {
         const id = request.payload.id
         let result
 
-        return push.notifyDeviceDisconnected(uid, id)
-          .catch(() => {})
-          .then(() => db.deleteDevice(uid, id))
+        return db.deleteDevice(uid, id)
           .then(res => {
             result = res
+          })
+          .then(() => push.notifyDeviceDisconnected(uid, id)
+                          .catch(() => {})
+          )
+          .then(() => {
             return P.all([
               request.emitMetricsEvent('device.deleted', {
                 uid: uid,

--- a/test/local/routes/devices-sessions.js
+++ b/test/local/routes/devices-sessions.js
@@ -461,7 +461,7 @@ describe('/account/device/destroy', function () {
 
     return runTest(route, mockRequest, function () {
       assert.equal(mockDB.deleteDevice.callCount, 1)
-
+      assert.ok(mockDB.deleteDevice.calledBefore(mockPush.notifyDeviceDisconnected))
       assert.equal(mockPush.notifyDeviceDisconnected.callCount, 1)
       assert.equal(mockPush.notifyDeviceDisconnected.firstCall.args[0], mockRequest.auth.credentials.uid)
       assert.equal(mockPush.notifyDeviceDisconnected.firstCall.args[1], deviceId)


### PR DESCRIPTION
I noticed that sometimes Firefox didn't detect a disconnected device, which might be caused by a race in this part of the code.