### PR TITLE
feat(push): add a pushEndpointExpired flag for devices that need to re-register their push endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -342,6 +342,7 @@ those common validations are defined here.
     * `pushCallback`: isA.string.uri({ scheme: 'https' }).regex(PUSH_SERVER_REGEX).max(255).allow('')
     * `pushPublicKey`: isA.string.max(88).regex(URL_SAFE_BASE_64).allow('')
     * `pushAuthKey`: isA.string.max(24).regex(URL_SAFE_BASE_64).allow('')
+    * `pushEndpointExpired`: isA.boolean
 
   }
 
@@ -905,6 +906,9 @@ without the pair `{ pushPublicKey, pushAuthKey }`,
 both of those keys will be reset
 to the empty string.
 
+`pushEndpointExpired` will be reset to false on update if the tuple
+`{ pushCallback, pushPublicKey, pushAuthKey }` is specified.
+
 Devices should register with this endpoint
 before attempting to obtain a signed certificate
 and perform their first sync,
@@ -993,6 +997,12 @@ can be made available to other connected devices.
   <!--begin-response-body-post-accountdevice-pushAuthKey-->
   
   <!--end-response-body-post-accountdevice-pushAuthKey-->
+
+* `pushEndpointExpired`: *boolean, required*
+
+  <!--begin-response-body-post-accountdevice-pushEndpointExpired-->
+  
+  <!--end-response-body-post-accountdevice-pushEndpointExpired-->
 
 ##### Error responses
 
@@ -1131,6 +1141,12 @@ for the authenticated user.
   
   <!--end-response-body-get-accountdevices-pushAuthKey-->
 
+* `pushEndpointExpired`: *boolean, required*
+
+  <!--begin-response-body-get-accountdevices-pushEndpointExpired-->
+  
+  <!--end-response-body-get-accountdevices-pushEndpointExpired-->
+
 
 #### GET /account/sessions
 
@@ -1226,6 +1242,12 @@ for the authenticated user.
   <!--begin-response-body-get-accountsessions-deviceCallbackAuthKey-->
   
   <!--end-response-body-get-accountsessions-deviceCallbackAuthKey-->
+
+* `deviceCallbackIsExpired`: *boolean, required*
+
+  <!--begin-response-body-get-accountsessions-deviceCallbackIsExpired-->
+  
+  <!--end-response-body-get-accountsessions-deviceCallbackIsExpired-->
 
 * `isDevice`: *boolean, required*
 

--- a/docs/endpoint_data.md
+++ b/docs/endpoint_data.md
@@ -446,6 +446,7 @@
   * pushCallback
   * pushPublicKey
   * pushAuthKey
+  * pushEndpointExpired
 * db-write
   * Devices
 
@@ -460,6 +461,7 @@
     * pushCallback
     * pushPublicKey
     * pushAuthKey
+    * pushEndpointExpired
 
 ## /account/device
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -96,4 +96,5 @@
 * pushCallback
 * pushPublicKey
 * pushAuthKey
+* pushEndpointExpired
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -457,6 +457,7 @@ module.exports = (
             pushCallback: device.callbackURL,
             pushPublicKey: device.callbackPublicKey,
             pushAuthKey: device.callbackAuthKey,
+            pushEndpointExpired: device.callbackIsExpired,
             uaBrowser: mergedInfo.uaBrowser,
             uaBrowserVersion: mergedInfo.uaBrowserVersion,
             uaOS: mergedInfo.uaOS,
@@ -567,7 +568,10 @@ module.exports = (
         )
       })
       .then(
-        () => deviceInfo,
+        () => {
+          deviceInfo.pushEndpointExpired = false
+          return deviceInfo
+        },
         err => {
           if (isRecordAlreadyExistsError(err)) {
             return this.devices(uid)
@@ -614,7 +618,8 @@ module.exports = (
         type: deviceInfo.type,
         callbackURL: deviceInfo.pushCallback,
         callbackPublicKey: deviceInfo.pushPublicKey,
-        callbackAuthKey: deviceInfo.pushAuthKey
+        callbackAuthKey: deviceInfo.pushAuthKey,
+        callbackIsExpired: deviceInfo.pushEndpointExpired
       }
     )
     .then(

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -21,7 +21,8 @@ const SCHEMA = {
   type: isA.string().max(16),
   pushCallback: isA.string().uri({ scheme: 'https' }).regex(PUSH_SERVER_REGEX).max(255).allow(''),
   pushPublicKey: isA.string().max(88).regex(URL_SAFE_BASE_64).allow(''),
-  pushAuthKey: isA.string().max(24).regex(URL_SAFE_BASE_64).allow('')
+  pushAuthKey: isA.string().max(24).regex(URL_SAFE_BASE_64).allow(''),
+  pushEndpointExpired: isA.boolean()
 }
 
 module.exports = (log, db, push) => {

--- a/lib/push.js
+++ b/lib/push.js
@@ -444,7 +444,7 @@ module.exports = function (log, db, config) {
           pushCallback: device.pushCallback
         })
 
-        if (device.pushCallback) {
+        if (device.pushCallback && ! device.pushEndpointExpired) {
           // send the push notification
           incrementPushAction(events.send)
           var pushSubscription = { endpoint: device.pushCallback }
@@ -484,11 +484,9 @@ module.exports = function (log, db, config) {
               // the push settings need to be reset.
               // the clients will check this and re-register push endpoints
               if (err.statusCode === 404 || err.statusCode === 410 || keyWasInvalid) {
-                // reset device push configuration
+                // set the push endpoint expired flag
                 // Warning: this method is called without any session tokens or auth validation.
-                device.pushCallback = ''
-                device.pushPublicKey = ''
-                device.pushAuthKey = ''
+                device.pushEndpointExpired = true
                 return db.updateDevice(uid, null, device).catch(function (err) {
                   reportPushError(err, uid, deviceId)
                 }).then(function() {

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -73,6 +73,7 @@ module.exports = (log, Token, config) => {
       this.callbackURL = data.callbackURL
       this.callbackPublicKey = data.callbackPublicKey
       this.callbackAuthKey = data.callbackAuthKey
+      this.callbackIsExpired = data.callbackIsExpired
     }
   }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -330,7 +330,7 @@
     "fxa-auth-db-mysql": {
       "version": "1.94.1",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#f1e21529c7ebcf22a724c6c48df09429335e0cf7",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#d8e93c42b5e2207f7f3c3005e08a12ce7c7934c5",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",

--- a/test/e2e/push_tests.js
+++ b/test/e2e/push_tests.js
@@ -39,7 +39,8 @@ describe('e2e/push', () => {
                 'type': 'mobile',
                 'pushCallback': subscription.endpoint,
                 'pushPublicKey': 'BBXOKjUb84pzws1wionFpfCBjDuCh4-s_1b52WA46K5wYL2gCWEOmFKWn_NkS5nmJwTBuO8qxxdjAIDtNeklvQc',
-                'pushAuthKey': 'GSsIiaD2Mr83iPqwFNK4rw'
+                'pushAuthKey': 'GSsIiaD2Mr83iPqwFNK4rw',
+                'pushEndpointExpired': false
               }
             ])
           },

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -38,7 +38,8 @@ var mockDevices = [
     'type': 'mobile',
     'pushCallback': 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
     'pushPublicKey': mocks.MOCK_PUSH_KEY,
-    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong=='
+    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong==',
+    'pushEndpointExpired': false
   },
   {
     'id': '3a45e6d0dae543qqdKyqjuvAiEupsnOd',
@@ -48,7 +49,8 @@ var mockDevices = [
     'type': null,
     'pushCallback': 'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
     'pushPublicKey': mocks.MOCK_PUSH_KEY,
-    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong=='
+    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong==',
+    'pushEndpointExpired': false
   },
   {
     'id': '50973923bc3e4507a0aa4e285513194a',
@@ -59,7 +61,8 @@ var mockDevices = [
     'uaOS': 'iOS',
     'pushCallback': 'https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a',
     'pushPublicKey': mocks.MOCK_PUSH_KEY,
-    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong=='
+    'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong==',
+    'pushEndpointExpired': false
   }
 ]
 
@@ -329,7 +332,8 @@ describe('push', () => {
         'id': 'foo',
         'name': 'My Phone',
         'pushCallback': 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
-        'pushAuthKey': 'bogus'
+        'pushAuthKey': 'bogus',
+        'pushEndpointExpired': false
       }]
 
       var push = require(pushModulePath)(thisMockLog, mockDbResult, mockConfig)

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -174,7 +174,7 @@ describe('remote db', function() {
         })
         .then(sessions => {
           assert.equal(sessions.length, 1, 'sessions contains one item')
-          assert.equal(Object.keys(sessions[0]).length, 17, 'session has correct number of properties')
+          assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct number of properties')
           assert.equal(typeof sessions[0].tokenId, 'string', 'tokenId property is not a buffer')
           assert.equal(sessions[0].uid, account.uid, 'uid property is correct')
           assert.ok(sessions[0].createdAt >= account.createdAt, 'createdAt property seems correct')
@@ -421,6 +421,7 @@ describe('remote db', function() {
             assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
             assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
             assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
+            assert.equal(device.pushEndpointExpired, false, 'device.pushEndpointExpired is correct')
             // Fetch the session token
             return db.sessionToken(sessionToken.tokenId)
           })
@@ -451,6 +452,7 @@ describe('remote db', function() {
             assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
             assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
             assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
+            assert.equal(device.pushEndpointExpired, false, 'device.pushEndpointExpired is correct')
             assert.equal(device.uaBrowser, 'Firefox Mobile', 'device.uaBrowser is correct')
             assert.equal(device.uaBrowserVersion, '41', 'device.uaBrowserVersion is correct')
             assert.equal(device.uaOS, 'Android', 'device.uaOS is correct')
@@ -520,6 +522,7 @@ describe('remote db', function() {
             assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
             assert.equal(device.pushPublicKey, '', 'device.pushPublicKey is correct')
             assert.equal(device.pushAuthKey, '', 'device.pushAuthKey is correct')
+            assert.equal(device.pushEndpointExpired, false, 'device.pushEndpointExpired is correct')
             assert.equal(device.uaBrowser, 'Firefox', 'device.uaBrowser is correct')
             assert.equal(device.uaBrowserVersion, '44', 'device.uaBrowserVersion is correct')
             assert.equal(device.uaOS, 'Mac OS X', 'device.uaOS is correct')

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -60,6 +60,7 @@ describe('remote device', function() {
                   assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
                   assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
                   assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
+                  assert.equal(device.pushEndpointExpired, false, 'device.pushEndpointExpired is correct')
                 }
               )
               .then(
@@ -75,6 +76,7 @@ describe('remote device', function() {
                   assert.equal(devices[0].pushCallback, '', 'devices returned empty pushCallback')
                   assert.equal(devices[0].pushPublicKey, '', 'devices returned correct pushPublicKey')
                   assert.equal(devices[0].pushAuthKey, '', 'devices returned correct pushAuthKey')
+                  assert.equal(devices[0].pushEndpointExpired, '', 'devices returned correct pushEndpointExpired')
                   return client.destroyDevice(devices[0].id)
                 }
               )
@@ -111,6 +113,7 @@ describe('remote device', function() {
                   assert.equal(device.pushCallback, undefined, 'device.pushCallback is undefined')
                   assert.equal(device.pushPublicKey, undefined, 'device.pushPublicKey is undefined')
                   assert.equal(device.pushAuthKey, undefined, 'device.pushAuthKey is undefined')
+                  assert.equal(device.pushEndpointExpired, false, 'device.pushEndpointExpired is false')
                 }
               )
               .then(
@@ -126,6 +129,7 @@ describe('remote device', function() {
                   assert.equal(devices[0].pushCallback, null, 'devices returned undefined pushCallback')
                   assert.equal(devices[0].pushPublicKey, null, 'devices returned undefined pushPublicKey')
                   assert.equal(devices[0].pushAuthKey, null, 'devices returned undefined pushAuthKey')
+                  assert.equal(devices[0].pushEndpointExpired, false, 'devices returned false pushEndpointExpired')
                   return client.destroyDevice(devices[0].id)
                 }
               )
@@ -494,6 +498,7 @@ describe('remote device', function() {
                 assert.equal(devices[0].pushCallback, deviceInfo.pushCallback, 'devices returned correct pushCallback')
                 assert.equal(devices[0].pushPublicKey, deviceInfo.pushPublicKey, 'devices returned correct pushPublicKey')
                 assert.equal(devices[0].pushAuthKey, deviceInfo.pushAuthKey, 'devices returned correct pushAuthKey')
+                assert.equal(devices[0].pushEndpointExpired, false, 'devices returned correct pushEndpointExpired')
                 return client.updateDevice({
                   id: client.device.id,
                   pushCallback: 'https://updates.push.services.mozilla.com/foo'
@@ -510,6 +515,7 @@ describe('remote device', function() {
                 assert.equal(devices[0].pushCallback, 'https://updates.push.services.mozilla.com/foo', 'devices returned correct pushCallback')
                 assert.equal(devices[0].pushPublicKey, '', 'devices returned newly empty pushPublicKey')
                 assert.equal(devices[0].pushAuthKey, '', 'devices returned newly empty pushAuthKey')
+                assert.equal(devices[0].pushEndpointExpired, false, 'devices returned false pushEndpointExpired')
               }
             )
         }

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -73,7 +73,8 @@ describe('remote push db', function() {
         type: 'mobile',
         pushCallback: 'https://foo/bar',
         pushPublicKey: base64url(Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])),
-        pushAuthKey: base64url(crypto.randomBytes(16))
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+        pushEndpointExpired: false
       }
       // two tests below, first for unknown 400 level error the device push info will stay the same
       // second, for a known 400 error we reset the device
@@ -132,6 +133,7 @@ describe('remote push db', function() {
             assert.equal(device.pushCallback, deviceInfo.pushCallback)
             assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
             assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
+            assert.equal(device.pushEndpointExpired, deviceInfo.pushEndpointExpired, 'device.pushEndpointExpired is correct')
           })
 
           .then(function () {
@@ -144,9 +146,7 @@ describe('remote push db', function() {
           .then(function (devices) {
             var device = devices[0]
             assert.equal(device.name, deviceInfo.name)
-            assert.equal(device.pushCallback, '')
-            assert.equal(device.pushPublicKey, '', 'device.pushPublicKey is correct')
-            assert.equal(device.pushAuthKey, '', 'device.pushAuthKey is correct')
+            assert.equal(device.pushEndpointExpired, true, 'device.pushEndpointExpired is correct')
           })
     }
   )


### PR DESCRIPTION
Fixes #1873.
Connects to mozilla/fxa-auth-db-mysql#272

(Duplicate of #2073 which was hosted on my repo, CircleCI wouldn't start)