### PR TITLE
fix(push): Allow device connection push messages for Firefox iOS >= 9.0

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -182,25 +182,33 @@ module.exports = function (log, db, config) {
    * The list of devices to which to send the push.
    */
   function filterSupportedDevices(command, devices) {
-    var minVersion
+    let requiredIOSVersion
     switch (command) {
     case 'sync:collection_changed':
       // Everything supports this message, short-circuit.
       return devices
     case 'fxaccounts:device_connected':
     case 'fxaccounts:device_disconnected':
-      minVersion = 9.0
+      requiredIOSVersion = 9.0
       break
     default:
-      minVersion = Infinity
+      requiredIOSVersion = Infinity
     }
     return devices.filter(function(device) {
-      var deviceOS = device.uaOS && device.uaOS.toLowerCase()
-      if (deviceOS !== 'ios') {
-        return true
+      const deviceOS = device.uaOS && device.uaOS.toLowerCase()
+      if (deviceOS === 'ios') {
+        const deviceVersion = device.uaBrowserVersion ? parseFloat(device.uaBrowserVersion) : 0
+        if (deviceVersion < requiredIOSVersion) {
+          log.info({
+            op: 'push.filteredUnsupportedDevice',
+            command: command,
+            uaOS: device.uaOS,
+            uaBrowserVersion: device.uaBrowserVersion
+          })
+          return false
+        }
       }
-      var deviceVersion = device.uaBrowserVersion ? parseFloat(device.uaBrowserVersion) : 0
-      return deviceVersion >= minVersion
+      return true
     })
   }
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -171,6 +171,40 @@ module.exports = function (log, db, config) {
   }
 
   /**
+   * iOS clients don't yet support all commands types, and due to
+   * platform limitations they have to show some bad fallback UX
+   * if they receive an unsupported message type.  Filter out
+   * devices that we know won't respond well to the given command.
+   *
+   * @param {String} command
+   * The command from the push message payload
+   * @param {Device[]} devices
+   * The list of devices to which to send the push.
+   */
+  function filterSupportedDevices(command, devices) {
+    var minVersion
+    switch (command) {
+    case 'sync:collection_changed':
+      // Everything supports this message, short-circuit.
+      return devices
+    case 'fxaccounts:device_connected':
+    case 'fxaccounts:device_disconnected':
+      minVersion = 9.0
+      break
+    default:
+      minVersion = Infinity
+    }
+    return devices.filter(function(device) {
+      var deviceOS = device.uaOS && device.uaOS.toLowerCase()
+      if (deviceOS !== 'ios') {
+        return true
+      }
+      var deviceVersion = device.uaBrowserVersion ? parseFloat(device.uaBrowserVersion) : 0
+      return deviceVersion >= minVersion
+    })
+  }
+
+  /**
    * Checks whether the given string is a valid public key for push.
    * This is a little tricky because we need to work around a bug in nodejs
    * where using an invalid ECDH key can cause a later (unrelated) attempt
@@ -416,15 +450,7 @@ module.exports = function (log, db, config) {
       } catch (e) {
         command = false
       }
-      // Only non collection_changed events are allowed to be sent to ios
-      // devices due to empty notifications. TODO: Remove.
-      if (command !== 'sync:collection_changed') {
-        devices = devices.filter(function(device) {
-          var deviceOS = device.uaOS && device.uaOS.toLowerCase()
-          return deviceOS !== 'ios'
-        })
-      }
-
+      devices = filterSupportedDevices(command, devices)
       var events = reasonToEvents[reason]
       if (! events) {
         return P.reject('Unknown push reason: ' + reason)

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -267,9 +267,9 @@ describe('push', () => {
   it(
     'sendPush doesn\'t push to ios devices if it is triggered with an unsupported command',
     () => {
-      var data = Buffer.from(JSON.stringify({command: 'fxaccounts:non_existent_command'}))
-      var endPoints = []
-      var mocks = {
+      const data = Buffer.from(JSON.stringify({command: 'fxaccounts:non_existent_command'}))
+      const endPoints = []
+      const mocks = {
         'web-push': {
           sendNotification: function (sub, payload, options) {
             endPoints.push(sub.endpoint)
@@ -278,8 +278,8 @@ describe('push', () => {
         }
       }
 
-      var push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
-      var options = { data: data }
+      const push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
+      const options = { data: data }
       return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
         .then(() => {
           assert.equal(endPoints.length, 2)
@@ -292,9 +292,9 @@ describe('push', () => {
   it(
     'sendPush pushes to all ios devices if it is triggered with a "collection changed" command',
     () => {
-      var data = Buffer.from(JSON.stringify({command: 'sync:collection_changed'}))
-      var endPoints = []
-      var mocks = {
+      const data = Buffer.from(JSON.stringify({command: 'sync:collection_changed'}))
+      const endPoints = []
+      const mocks = {
         'web-push': {
           sendNotification: function (sub, payload, options) {
             endPoints.push(sub.endpoint)
@@ -303,8 +303,8 @@ describe('push', () => {
         }
       }
 
-      var push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
-      var options = { data: data }
+      const push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
+      const options = { data: data }
       return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
         .then(() => {
           assert.equal(endPoints.length, 3)
@@ -318,9 +318,9 @@ describe('push', () => {
   it(
     'sendPush pushes to ios >=9.0 devices if it is triggered with a "device connected" command',
     () => {
-      var data = Buffer.from(JSON.stringify({command: 'fxaccounts:device_connected'}))
-      var endPoints = []
-      var mocks = {
+      const data = Buffer.from(JSON.stringify({command: 'fxaccounts:device_connected'}))
+      let endPoints = []
+      const mocks = {
         'web-push': {
           sendNotification: function (sub, payload, options) {
             endPoints.push(sub.endpoint)
@@ -329,8 +329,8 @@ describe('push', () => {
         }
       }
 
-      var push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
-      var options = { data: data }
+      const push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
+      const options = { data: data }
       return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
         .then(() => {
           assert.equal(endPoints.length, 2)

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -265,9 +265,9 @@ describe('push', () => {
   )
 
   it(
-    'sendPush doesn\'t push to ios devices if it is triggered with a non collection changed command',
+    'sendPush doesn\'t push to ios devices if it is triggered with an unsupported command',
     () => {
-      var data = Buffer.from(JSON.stringify({command: 'randomCommand'}))
+      var data = Buffer.from(JSON.stringify({command: 'fxaccounts:non_existent_command'}))
       var endPoints = []
       var mocks = {
         'web-push': {
@@ -290,7 +290,7 @@ describe('push', () => {
   )
 
   it(
-    'sendPush pushes to ios devices if it is triggered with a collection changed command',
+    'sendPush pushes to all ios devices if it is triggered with a "collection changed" command',
     () => {
       var data = Buffer.from(JSON.stringify({command: 'sync:collection_changed'}))
       var endPoints = []
@@ -311,6 +311,70 @@ describe('push', () => {
           assert.equal(endPoints[0], mockDevices[0].pushCallback)
           assert.equal(endPoints[1], mockDevices[1].pushCallback)
           assert.equal(endPoints[2], mockDevices[2].pushCallback)
+        })
+    }
+  )
+
+  it(
+    'sendPush pushes to ios >=9.0 devices if it is triggered with a "device connected" command',
+    () => {
+      var data = Buffer.from(JSON.stringify({command: 'fxaccounts:device_connected'}))
+      var endPoints = []
+      var mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            endPoints.push(sub.endpoint)
+            return P.resolve()
+          }
+        }
+      }
+
+      var push = proxyquire(pushModulePath, mocks)(mockLog(), mockDbResult, mockConfig)
+      var options = { data: data }
+      return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        .then(() => {
+          assert.equal(endPoints.length, 2)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          // iOS not notified due to unknown browser version
+        }).then(() => {
+          endPoints = []
+          mockDevices[2].uaBrowserVersion = '8.2'
+          return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        }).then(() => {
+          assert.equal(endPoints.length, 2)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          // iOS not notified due to unsupported browser version
+        }).then(() => {
+          endPoints = []
+          mockDevices[2].uaBrowserVersion = '9.0'
+          return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        }).then(() => {
+          assert.equal(endPoints.length, 3)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          assert.equal(endPoints[2], mockDevices[2].pushCallback)
+        }).then(() => {
+          endPoints = []
+          mockDevices[2].uaBrowserVersion = '9.1'
+          return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        }).then(() => {
+          assert.equal(endPoints.length, 3)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          assert.equal(endPoints[2], mockDevices[2].pushCallback)
+        }).then(() => {
+          endPoints = []
+          mockDevices[2].uaBrowserVersion = '10.2'
+          return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        }).then(() => {
+          assert.equal(endPoints.length, 3)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          assert.equal(endPoints[2], mockDevices[2].pushCallback)
+        }).finally(() => {
+          delete mockDevices[2].uaBrowserVersion
         })
     }
   )


### PR DESCRIPTION
Fixes #2083, but WIP while I do a bit of mucking around with it