### PR TITLE
fix(profile): Handling incoming uids as strings, not buffers.

### DIFF
--- a/lib/profile/updates.js
+++ b/lib/profile/updates.js
@@ -10,8 +10,7 @@ module.exports = function (log) {
 
     function handleProfileUpdated(message) {
       return new P(resolve => {
-        const uid = Buffer.from(message.uid, 'hex')
-        resolve(push.notifyProfileUpdated(uid))
+        resolve(push.notifyProfileUpdated(message.uid))
       })
       .catch(function(err) {
         log.error({ op: 'handleProfileUpdated', err: err })

--- a/lib/push.js
+++ b/lib/push.js
@@ -128,7 +128,7 @@ module.exports = function (log, db, config) {
    * Reports push errors to logs
    *
    * @param {Error} err
-   * @param {Buffer} uid
+   * @param {String} uid
    * @param {String} deviceId
    */
   function reportPushError(err, uid, deviceId) {
@@ -216,7 +216,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices that there was an update to the account
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String} reason
      * @promise
      */
@@ -228,7 +228,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices (except the one who joined) that a new device joined the account
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String} deviceName
      * @param {String} currentDeviceId
      * @promise
@@ -248,7 +248,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a device that it is now disconnected from the account
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String} idToDisconnect
      * @promise
      */
@@ -267,7 +267,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies all devices that a the profile attached to the account was updated
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @promise
      */
     notifyProfileUpdated: function notifyProfileUpdated(uid) {
@@ -282,7 +282,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a set of devices that the password was changed
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {Device[]} devices
      * @promise
      */
@@ -298,7 +298,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a set of devices that the password was reset
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {Device[]} devices
      * @promise
      */
@@ -314,7 +314,7 @@ module.exports = function (log, db, config) {
     /**
      * Notifies a set of devices that the account no longer exists
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {Device[]} devices
      * @promise
      */
@@ -333,7 +333,7 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to all the devices in the account (except the ones in the excludedDeviceIds)
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String} reason
      * @param {Object} options
      * @param {String} options.excludedDeviceIds
@@ -359,7 +359,7 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to a set of devices in the account
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String[]} ids
      * @param {String} reason
      * @param {Object} options
@@ -385,7 +385,7 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to one device in the account
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {String} id
      * @param {String} reason
      * @param {Object} options
@@ -400,7 +400,7 @@ module.exports = function (log, db, config) {
     /**
      * Send a push notification with or without data to a list of devices
      *
-     * @param {Buffer} uid
+     * @param {String} uid
      * @param {Device[]} devices
      * @param {String} reason
      * @param {Object} options

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -63,7 +63,7 @@ describe('devices', () => {
         })
         sessionToken = {
           tokenId: crypto.randomBytes(16).toString('hex'),
-          uid: uuid.v4('binary'),
+          uid: uuid.v4('binary').toString('hex'),
           tokenVerified: true
         }
       })

--- a/test/local/ip_profiling.js
+++ b/test/local/ip_profiling.js
@@ -120,7 +120,7 @@ const mockRequest = mocks.mockRequest({
 })
 var keyFetchTokenId = crypto.randomBytes(16)
 var sessionTokenId = crypto.randomBytes(16)
-var uid = uuid.v4('binary')
+var uid = uuid.v4('binary').toString('hex')
 var mockDB = mocks.mockDB({
   email: TEST_EMAIL,
   emailVerified: true,

--- a/test/local/profile/updates.js
+++ b/test/local/profile/updates.js
@@ -20,7 +20,8 @@ function mockMessage(msg) {
 
 var pushShouldThrow = false
 const mockPush = {
-  notifyProfileUpdated: sinon.spy(() => {
+  notifyProfileUpdated: sinon.spy((uid) => {
+    assert.ok(typeof uid === 'string')
     if (pushShouldThrow) {
       throw new Error('oops')
     }
@@ -60,7 +61,7 @@ describe('profile updates', () => {
         assert.equal(mockLog.messages.length, 0)
         assert.equal(mockPush.notifyProfileUpdated.callCount, 2)
         var args = mockPush.notifyProfileUpdated.getCall(1).args
-        assert.deepEqual(args[0], Buffer.from(uid, 'hex'))
+        assert.equal(args[0], uid)
       })
     }
   )

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -75,7 +75,7 @@ function runTest (route, request, assertions) {
 
 describe('/account/reset', function () {
   it('should do things', () => {
-    var uid = uuid.v4('binary')
+    var uid = uuid.v4('binary').toString('hex')
     const mockLog = mocks.spyLog()
     const mockMetricsContext = mocks.mockMetricsContext()
     const mockRequest = mocks.mockRequest({
@@ -227,7 +227,7 @@ describe('/account/create', () => {
     const emailCode = hexString(16)
     const keyFetchTokenId = hexString(16)
     const sessionTokenId = hexString(16)
-    const uid = uuid.v4('binary')
+    const uid = uuid.v4('binary').toString('hex')
     const mockDB = mocks.mockDB({
       email: TEST_EMAIL,
       emailCode: emailCode,
@@ -485,7 +485,7 @@ describe('/account/login', function () {
   })
   var keyFetchTokenId = hexString(16)
   var sessionTokenId = hexString(16)
-  var uid = uuid.v4('binary')
+  var uid = uuid.v4('binary').toString('hex')
   var mockDB = mocks.mockDB({
     email: TEST_EMAIL,
     emailVerified: true,
@@ -1173,7 +1173,7 @@ describe('/account/login', function () {
 
 describe('/account/keys', function () {
   var keyFetchTokenId = hexString(16)
-  var uid = uuid.v4('binary')
+  var uid = uuid.v4('binary').toString('hex')
   const mockLog = mocks.spyLog()
   const mockRequest = mocks.mockRequest({
     credentials: {
@@ -1235,7 +1235,7 @@ describe('/account/keys', function () {
 describe('/account/destroy', function () {
   it('should delete the account', () => {
     var email = 'foo@example.com'
-    var uid = uuid.v4('binary')
+    var uid = uuid.v4('binary').toString('hex')
     var mockDB = mocks.mockDB({
       email: email,
       uid: uid

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -6,6 +6,7 @@
  * Shared helpers for mocking things out in the tests.
  */
 
+const assert = require('assert')
 const sinon = require('sinon')
 const extend = require('util')._extend
 const P = require('../lib/promise')
@@ -154,7 +155,8 @@ function mockDB (data, errors) {
   errors = errors || {}
 
   return mockObject(DB_METHOD_NAMES)({
-    account: sinon.spy(() => {
+    account: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve({
         email: data.email,
         emailCode: data.emailCode,
@@ -166,7 +168,8 @@ function mockDB (data, errors) {
         wrapWrapKb: data.wrapWrapKb
       })
     }),
-    accountEmails: sinon.spy(() => {
+    accountEmails: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve([
         {
           email: data.email || 'primary@email.com',
@@ -223,7 +226,8 @@ function mockDB (data, errors) {
         wrapWrapKb: data.wrapWrapKb
       })
     }),
-    createDevice: sinon.spy(() => {
+    createDevice: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve(Object.keys(data.device).reduce((result, key) => {
         result[key] = data.device[key]
         return result
@@ -269,10 +273,13 @@ function mockDB (data, errors) {
         uid: data.uid
       })
     }),
-    createSigninCode: sinon.spy(() => {
+    createSigninCode: sinon.spy((uid, flowId) => {
+      assert.ok(typeof uid === 'string')
+      assert.ok(typeof flowId === 'string')
       return P.resolve(data.signinCode || [])
     }),
-    devices: sinon.spy(() => {
+    devices: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve(data.devices || [])
     }),
     deleteSessionToken: sinon.spy(() => {
@@ -307,10 +314,12 @@ function mockDB (data, errors) {
     securityEvents: sinon.spy(() => {
       return P.resolve([])
     }),
-    sessions: sinon.spy(() => {
+    sessions: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve(data.sessions || [])
     }),
     updateDevice: sinon.spy((uid, sessionTokenId, device) => {
+      assert.ok(typeof uid === 'string')
       return P.resolve(device)
     }),
     sessionToken: sinon.spy(() => {


### PR DESCRIPTION
Connects to #2085 

After an epic PR by @seanmonstar we now uniformly prefer strings over buffers for passing data around internally.  Unfortunately the profile-update-handling code was still bufferizing the uid before passing it around.  This fixes it to be consistent with what the called code expects, updates the docs to report the correct types, and adds some sanity-checking asserts in our testsuite that might help us avoid this in other places in future.

@mozilla/fxa-devs r?