### PR TITLE
fix(metrics): add missing device_id and user_id amplitude properties

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -159,7 +159,7 @@ Lug.prototype.flowEvent = function (data) {
 }
 
 Lug.prototype.amplitudeEvent = function (data) {
-  if (! data || ! data.event_type) {
+  if (! data || ! data.event_type || (! data.device_id && ! data.user_id)) {
     this.error({ op: 'log.amplitudeEvent', data })
     return
   }

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -345,13 +345,17 @@ describe('log', () => {
   )
 
   it('.amplitudeEvent', () => {
-    log.amplitudeEvent({ event_type: 'foo' })
+    log.amplitudeEvent({ event_type: 'foo', device_id: 'bar', user_id: 'baz' })
 
     assert.equal(logger.info.callCount, 1, 'logger.info was called once')
     const args = logger.info.args[0]
     assert.equal(args.length, 2, 'logger.info was passed two arguments')
     assert.equal(args[0], 'amplitudeEvent', 'first argument was correct')
-    assert.deepEqual(args[1], { event_type: 'foo' }, 'second argument was event data')
+    assert.deepEqual(args[1], {
+      event_type: 'foo',
+      device_id: 'bar',
+      user_id: 'baz'
+    }, 'second argument was event data')
 
     assert.equal(logger.debug.callCount, 0, 'logger.debug was not called')
     assert.equal(logger.error.callCount, 0, 'logger.error was not called')
@@ -382,7 +386,7 @@ describe('log', () => {
   })
 
   it('.amplitudeEvent with missing event_type', () => {
-    log.amplitudeEvent({})
+    log.amplitudeEvent({ device_id: 'foo', user_id: 'bar' })
 
     assert.equal(logger.error.callCount, 1, 'logger.error was called once')
     const args = logger.error.args[0]
@@ -390,7 +394,7 @@ describe('log', () => {
     assert.equal(args[0], 'log.amplitudeEvent', 'first argument was function name')
     assert.deepEqual(args[1], {
       op: 'log.amplitudeEvent',
-      data: {}
+      data: { device_id: 'foo', user_id: 'bar' }
     }, 'second argument was correct')
 
     assert.equal(logger.info.callCount, 0, 'logger.info was not called')
@@ -399,6 +403,66 @@ describe('log', () => {
     assert.equal(logger.warn.callCount, 0, 'logger.warn was not called')
 
     logger.error.reset()
+  })
+
+  it('.amplitudeEvent with missing device_id and user_id', () => {
+    log.amplitudeEvent({ event_type: 'foo' })
+
+    assert.equal(logger.error.callCount, 1, 'logger.error was called once')
+    const args = logger.error.args[0]
+    assert.equal(args.length, 2, 'logger.error was passed two arguments')
+    assert.equal(args[0], 'log.amplitudeEvent', 'first argument was function name')
+    assert.deepEqual(args[1], {
+      op: 'log.amplitudeEvent',
+      data: { event_type: 'foo' }
+    }, 'second argument was correct')
+
+    assert.equal(logger.info.callCount, 0, 'logger.info was not called')
+    assert.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    assert.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    assert.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.error.reset()
+  })
+
+  it('.amplitudeEvent with missing device_id', () => {
+    log.amplitudeEvent({ event_type: 'wibble', user_id: 'blee' })
+
+    assert.equal(logger.info.callCount, 1, 'logger.info was called once')
+    const args = logger.info.args[0]
+    assert.equal(args.length, 2, 'logger.info was passed two arguments')
+    assert.equal(args[0], 'amplitudeEvent', 'first argument was correct')
+    assert.deepEqual(args[1], {
+      event_type: 'wibble',
+      user_id: 'blee'
+    }, 'second argument was event data')
+
+    assert.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    assert.equal(logger.error.callCount, 0, 'logger.error was not called')
+    assert.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    assert.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.info.reset()
+  })
+
+  it('.amplitudeEvent with missing user_id', () => {
+    log.amplitudeEvent({ event_type: 'foo', device_id: 'bar' })
+
+    assert.equal(logger.info.callCount, 1, 'logger.info was called once')
+    const args = logger.info.args[0]
+    assert.equal(args.length, 2, 'logger.info was passed two arguments')
+    assert.equal(args[0], 'amplitudeEvent', 'first argument was correct')
+    assert.deepEqual(args[1], {
+      event_type: 'foo',
+      device_id: 'bar'
+    }, 'second argument was event data')
+
+    assert.equal(logger.debug.callCount, 0, 'logger.debug was not called')
+    assert.equal(logger.error.callCount, 0, 'logger.error was not called')
+    assert.equal(logger.critical.callCount, 0, 'logger.critical was not called')
+    assert.equal(logger.warn.callCount, 0, 'logger.warn was not called')
+
+    logger.info.reset()
   })
 
   it(

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -108,11 +108,13 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args.length, 1)
+        assert.equal(args[0].device_id, 'juff')
+        assert.equal(args[0].user_id, 'blee')
         assert.equal(args[0].event_type, 'fxa_login - email_confirmed')
         assert.equal(args[0].session_id, 'kwop')
         assert.equal(args[0].language, 'wibble')
         assert.deepEqual(args[0].event_properties, {
-          device_id: 'juff',
+          device_id: args[0].device_id,
           service: 'melm'
         })
         assert.deepEqual(args[0].user_properties, {
@@ -120,7 +122,7 @@ describe('metrics/amplitude', () => {
           ua_browser: 'foo',
           ua_version: 'bar',
           ua_os: 'baz',
-          fxa_uid: 'blee'
+          fxa_uid: args[0].user_id
         })
         assert.ok(args[0].time > Date.now() - 1000)
         assert.ok(/^[1-9][0-9]+$/.test(args[0].app_version))
@@ -153,6 +155,8 @@ describe('metrics/amplitude', () => {
       it('called log.amplitudeEvent correctly', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
+        assert.equal(args[0].device_id, undefined)
+        assert.equal(args[0].user_id, 'f')
         assert.equal(args[0].event_type, 'fxa_reg - created')
         assert.equal(args[0].session_id, undefined)
         assert.equal(args[0].language, 'e')
@@ -165,7 +169,7 @@ describe('metrics/amplitude', () => {
           ua_browser: 'a',
           ua_version: 'b',
           ua_os: 'c',
-          fxa_uid: 'f'
+          fxa_uid: args[0].user_id
         })
       })
     })
@@ -939,8 +943,9 @@ describe('metrics/amplitude', () => {
       it('data properties were set', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
+        assert.equal(args[0].user_id, 'frip')
         assert.equal(args[0].event_properties.service, 'zang')
-        assert.equal(args[0].user_properties.fxa_uid, 'frip')
+        assert.equal(args[0].user_properties.fxa_uid, args[0].user_id)
       })
     })
 
@@ -965,7 +970,8 @@ describe('metrics/amplitude', () => {
       it('metricsContext properties were set', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
-        assert.equal(args[0].event_properties.device_id, 'plin')
+        assert.equal(args[0].device_id, 'plin')
+        assert.equal(args[0].event_properties.device_id, args[0].device_id)
         assert.equal(args[0].user_properties.flow_id, 'gorb')
         assert.equal(args[0].session_id, 'yerx')
         assert.equal(args[0].time, 'wenf')


### PR DESCRIPTION
While working on mozilla/fxa-content-server#5412, I realised that I'd forgotten to include the top-level `device_id` and `user_id` properties in the amplitude data. This is a quick & dirty PR to add them, which I'd like to slip into train 95 if nobody minds.

@mozilla/fxa-devs r?