### PR TITLE
fix(server): make geo data lazily available on the request

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -10,7 +10,6 @@ const Pool = require('./pool')
 
 const random = require('./crypto/random')
 const redis = require('redis')
-const geodb = require('../lib/geodb')
 
 P.promisifyAll(redis.RedisClient.prototype)
 P.promisifyAll(redis.Multi.prototype)
@@ -28,7 +27,6 @@ module.exports = (
   const AccountResetToken = Token.AccountResetToken
   const PasswordForgotToken = Token.PasswordForgotToken
   const PasswordChangeToken = Token.PasswordChangeToken
-  const getGeoData = geodb(log)
   const MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
 
   function setAccountEmails(account) {
@@ -501,7 +499,7 @@ module.exports = (
     )
   }
 
-  DB.prototype.updateSessionToken = function (token, ip) {
+  DB.prototype.updateSessionToken = function (token, ip, geo) {
     log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
 
     const uid = token.uid
@@ -522,7 +520,7 @@ module.exports = (
       createdAt: token.createdAt
     }
     let sessionTokens
-    return getGeoData(ip)
+    return geo
     .then((res) => {
       const state = res.location && res.location.state
       const country = res.location && res.location.country

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -25,7 +25,6 @@ const MS_ONE_WEEK = MS_ONE_DAY * 7
 const MS_ONE_MONTH = MS_ONE_DAY * 30
 
 module.exports = (log, db, mailer, Password, config, customs, checkPassword, push) => {
-  const getGeoData = require('../geodb')(log)
   const verificationReminder = require('../verification-reminders')(log, db)
 
   const unblockCodeLifetime = config.signinUnblock && config.signinUnblock.codeLifetime || 0
@@ -267,7 +266,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
 
         function sendVerifyCode () {
           if (! account.emailVerified) {
-            return getGeoData(ip)
+            return request.app.geo
               .then(function (geoData) {
                 mailer.sendVerifyCode([], account, {
                   code: account.emailCode,
@@ -870,7 +869,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             // This covers the cases where sign-in confirmation is disabled or not needed.
             var emailCode = tokenVerificationId ? tokenVerificationId : accountRecord.primaryEmail.emailCode
 
-            return getGeoData(ip)
+            return request.app.geo
               .then(
                 function (geoData) {
                   return mailer.sendVerifyCode([], accountRecord, {
@@ -907,7 +906,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             && ! doSigninConfirmation
             && accountRecord.primaryEmail.isVerified
           if (shouldSendNewDeviceLoginEmail) {
-            return P.all([getGeoData(ip), db.accountEmails(sessionToken.uid)])
+            return P.all([request.app.geo, db.accountEmails(sessionToken.uid)])
               .spread((geoData, emails) => {
                 // New device notifications are always sent to the primary account email (emailRecord.email)
                 // and CCed to all secondary email if enabled.
@@ -950,7 +949,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
               tokenVerificationId: tokenVerificationId
             })
 
-            return P.all([getGeoData(ip), db.accountEmails(sessionToken.uid)])
+            return P.all([request.app.geo, db.accountEmails(sessionToken.uid)])
               .spread((geoData, emails) => {
                 return mailer.sendVerifyLoginEmail(
                   emails,
@@ -1265,7 +1264,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
         }
 
         function mailUnblockCode(code) {
-          return P.all([getGeoData(ip), db.accountEmails(emailRecord.uid)])
+          return P.all([request.app.geo, db.accountEmails(emailRecord.uid)])
             .spread((geoData, emails) => {
               const {
                 browser: uaBrowser,

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -15,7 +15,6 @@ const validators = require('./validators')
 const HEX_STRING = validators.HEX_STRING
 
 module.exports = (log, db, mailer, config, customs, push) => {
-  const getGeoData = require('../geodb')(log)
   const features = require('../features')(config)
   const verificationReminder = require('../verification-reminders')(log, db)
 
@@ -644,7 +643,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
         }
 
         function sendEmailVerification () {
-          return getGeoData(ip)
+          return request.app.geo
             .then((geoData) => {
               return mailer.sendVerifySecondaryEmail([emailData], sessionToken, {
                 code: emailData.emailCode,

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -29,8 +29,6 @@ module.exports = function (
   config
   ) {
 
-  const getGeoData = require('../geodb')(log)
-
   function failVerifyAttempt(passwordForgotToken) {
     return (passwordForgotToken.failAttempt()) ?
       db.deletePasswordForgotToken(passwordForgotToken) :
@@ -262,7 +260,7 @@ module.exports = function (
             )
             .then(
               function (emails) {
-                return getGeoData(ip)
+                return request.app.geo
                   .then(
                     function (geoData) {
                       const {
@@ -441,7 +439,7 @@ module.exports = function (
           )
           .then(
             function (passwordForgotToken) {
-              return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
+              return P.all([request.app.geo, db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
                   const {
                     browser: uaBrowser,
@@ -547,7 +545,7 @@ module.exports = function (
         ])
           .then(
             function () {
-              return P.all([getGeoData(ip), db.accountEmails(passwordForgotToken.uid)])
+              return P.all([request.app.geo, db.accountEmails(passwordForgotToken.uid)])
                 .spread((geoData, emails) => {
                   const {
                     browser: uaBrowser,

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -67,7 +67,7 @@ module.exports = (log, signer, db, domain, devices) => {
             uaFormFactor
           })
           // No need to wait for a response, update in the background.
-          db.updateSessionToken(sessionToken, clientIp)
+          db.updateSessionToken(sessionToken, clientIp, request.app.geo)
         } else {
           log.warn({
             op: 'signer.updateSessionToken', message: 'no user agent string, session token not updated'

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -21,7 +21,6 @@ module.exports = (log, db, config, customs, sms) => {
     return []
   }
 
-  const getGeoData = require('../geodb')(log)
   const REGIONS = new Set(config.sms.countryCodes)
   const IS_STATUS_GEO_ENABLED = config.sms.isStatusGeoEnabled
 
@@ -139,7 +138,7 @@ module.exports = (log, db, config, customs, sms) => {
                 return forcedCountry
               }
 
-              return getGeoData(request.app.clientAddress)
+              return request.app.geo
                 .then(result => result.location && result.location.countryCode)
             })
             .then(result => {

--- a/test/local/ip_profiling.js
+++ b/test/local/ip_profiling.js
@@ -349,11 +349,8 @@ describe('IP Profiling', () => {
         push: mockPush
       })
 
-      mockRequest.app = {
-        clientAddress: '63.245.221.32',
-        isSuspiciousRequest: true,
-        ua: {}
-      }
+      mockRequest.app.clientAddress = '63.245.221.32'
+      mockRequest.app.isSuspiciousRequest = true
 
       route = getRoute(accountRoutes, '/account/login')
 

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -159,7 +159,7 @@ describe('/recovery_email/status', function () {
       mockRequest.auth.credentials.uaBrowserVersion = '57'
 
       return runTest(route, mockRequest).then(() => assert.ok(false), function (response) {
-        const args = log.info.secondCall.args[0]
+        const args = log.info.firstCall.args[0]
         assert.equal(args.op, 'recovery_email.status.stale')
         assert.equal(args.email, TEST_EMAIL_INVALID)
         assert.equal(args.createdAt, date.getTime())

--- a/test/local/routes/sign.js
+++ b/test/local/routes/sign.js
@@ -74,7 +74,7 @@ describe('/certificate/sign', () => {
     }, mockRequest, function () {
       assert.equal(db.updateSessionToken.callCount, 1, 'db.updateSessionToken was called once')
       let args = db.updateSessionToken.args[0]
-      assert.equal(args.length, 2, 'db.updateSessionToken was passed one argument')
+      assert.equal(args.length, 3, 'db.updateSessionToken was passed three arguments')
       assert.equal(args[0].uid, sessionToken.uid, 'first argument uid property was correct')
       assert.equal(args[0].email, sessionToken.email, 'first argument email property was correct')
       assert.equal(args[0].uaBrowser, 'Firefox', 'first argument uaBrowser property was correct')
@@ -83,7 +83,8 @@ describe('/certificate/sign', () => {
       assert.equal(args[0].uaOSVersion, '10', 'first argument uaOSVersion property was correct')
       assert.equal(args[0].uaDeviceType, null, 'first argument uaDeviceType property was null')
       assert.equal(args[0].uaFormFactor, null, 'first argument uaFormFactor property was null')
-      assert.equal(args[1], mockRequest.app.clientAddress, 'second argument was correct')
+      assert.equal(args[1], mockRequest.app.clientAddress, 'second argument was client IP address')
+      assert.equal(args[2], mockRequest.app.geo, 'third argument was getGeoData result')
 
       assert.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
       args = mockDevices.upsert.args[0]

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -463,16 +463,33 @@ function generateMetricsContext(){
   }
 }
 
-function mockRequest (data) {
+function mockRequest (data, errors) {
   const events = require('../lib/metrics/events')(data.log || module.exports.mockLog())
   const metricsContext = data.metricsContext || module.exports.mockMetricsContext()
+
+  let geo
+  if (errors && errors.geo) {
+    geo = P.reject(errors.geo)
+  } else {
+    geo = P.resolve(data.geo || {
+      timeZone: 'America/Los_Angeles',
+      location: {
+        city: 'Mountain View',
+        country: 'United States',
+        countryCode: 'US',
+        state: 'California',
+        stateCode: 'CA'
+      }
+    })
+  }
 
   return {
     app: {
       acceptLanguage: 'en-US',
       clientAddress: data.clientAddress || '63.245.221.32',
-      locale: data.locale || 'en-US',
       features: new Set(data.features),
+      geo,
+      locale: data.locale || 'en-US',
       ua: {
         browser: data.uaBrowser || 'Firefox',
         browserVersion: data.uaBrowserVersion || '57.0',


### PR DESCRIPTION
Fixes #2015.

This didn't turn out quite as nicely as the user-agent stuff because `getGeoData` is an async call, so we need to consider what to do if it is accessed before the promise has resolved. Ultimately I decided to expose the raw promise as `request.app.geo` because that places the least burden on consuming code.

Some alternatives I discounted were:

* Make the property non-lazy and set it in `lib/server` as soon as `getGeoData` resolves. This would force consuming code to check the value before use and take appropriate action itself if unset, possibly including a duplicate call to `getGeoData`.

* Expose dual `request.app.geo.value` and `request.app.geo.promise` properties. Again it forces consumers to include ugly checks, for the limited benefit of eliminating a call to `.then`.

All told it's both simpler and more idiomatic for consuming code to just always use `request.app.geo.then()` and let promises handle the complexity of waiting until data is available. It's what they're designed for, after all.

@mozilla/fxa-devs r?