### PR TITLE
feat(server): lazily get devices array on the request object

### DIFF
--- a/bin/profile_server_messaging.js
+++ b/bin/profile_server_messaging.js
@@ -28,6 +28,6 @@ var profileUpdatesQueue = new SQSReceiver(config.profileServerMessaging.region, 
 DB.connect(config[config.db.backend])
   .then(
     function (db) {
-      profileUpdates(profileUpdatesQueue, push(log, db, config))
+      profileUpdates(profileUpdatesQueue, push(log, db, config), db)
     }
   )

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -57,7 +57,9 @@ module.exports = (log, db, push) => {
             deviceName = synthesizeName(deviceInfo)
           }
           if (sessionToken.tokenVerified) {
-            push.notifyDeviceConnected(sessionToken.uid, deviceName, result.id)
+            request.app.devices.then(devices =>
+              push.notifyDeviceConnected(sessionToken.uid, devices, deviceName, result.id)
+            )
           }
           if (isPlaceholderDevice) {
             log.info({

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1343,10 +1343,10 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
       },
       handler: function accountReset(request, reply) {
         log.begin('Account.reset', request)
-        var accountResetToken = request.auth.credentials
-        var authPW = request.payload.authPW
-        var account, sessionToken, keyFetchToken, verifyHash, wrapKb, devicesToNotify
-        var hasSessionToken = request.payload.sessionToken
+        const accountResetToken = request.auth.credentials
+        const authPW = request.payload.authPW
+        const hasSessionToken = request.payload.sessionToken
+        let account, sessionToken, keyFetchToken, verifyHash, wrapKb
 
         request.validateMetricsContext()
 
@@ -1358,24 +1358,12 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
         }
         request.setMetricsFlowCompleteSignal(flowCompleteSignal)
 
-        return fetchDevicesToNotify()
-          .then(resetAccountData)
+        return resetAccountData()
           .then(createSessionToken)
           .then(createKeyFetchToken)
           .then(recordSecurityEvent)
           .then(createResponse)
           .then(reply, reply)
-
-        function fetchDevicesToNotify() {
-          // We fetch the devices to notify before resetAccountData() because
-          // db.resetAccount() deletes all the devices saved in the account.
-          return db.devices(accountResetToken.uid)
-            .then(
-              function(devices) {
-                devicesToNotify = devices
-              }
-            )
-        }
 
         function resetAccountData () {
           let authSalt, password, wrapWrapKb
@@ -1411,7 +1399,9 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             .then(
               function () {
                 // Notify the devices that the account has changed.
-                push.notifyPasswordReset(accountResetToken.uid, devicesToNotify)
+                request.app.devices.then(devices =>
+                  push.notifyPasswordReset(accountResetToken.uid, devices)
+                )
 
                 return db.account(accountResetToken.uid)
                   .then((accountData) => {
@@ -1567,7 +1557,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                     }
                     // We fetch the devices to notify before deleteAccount()
                     // because obviously we can't retrieve the devices list after!
-                    return db.devices(uid)
+                    return request.app.devices
                   }
                 )
                 .then(
@@ -1578,7 +1568,8 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                 )
                 .then(
                   function () {
-                    push.notifyAccountDestroyed(uid, devicesToNotify).catch(function () {})
+                    push.notifyAccountDestroyed(uid, devicesToNotify)
+                      .catch(() => {})
                     return P.all([
                       log.notifyAttachedServices('delete', request, {
                         uid: uid,

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1557,7 +1557,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
                     }
                     // We fetch the devices to notify before deleteAccount()
                     // because obviously we can't retrieve the devices list after!
-                    return request.app.devices
+                    return db.devices(uid)
                   }
                 )
                 .then(

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -413,7 +413,9 @@ module.exports = (log, db, mailer, config, customs, push) => {
                   request.emitMetricsEvent('account.confirmed', {
                     uid: uid
                   })
-                  push.notifyUpdate(uid, 'accountConfirm')
+                  request.app.devices.then(devices =>
+                    push.notifyUpdate(uid, devices, 'accountConfirm')
+                  )
                 }
               })
               .catch(err => {
@@ -432,7 +434,9 @@ module.exports = (log, db, mailer, config, customs, push) => {
               })
               .then(() => {
                 if (device) {
-                  push.notifyDeviceConnected(uid, device.name, device.id)
+                  request.app.devices.then(devices =>
+                    push.notifyDeviceConnected(uid, devices, device.name, device.id)
+                  )
                 }
               })
               .then(() => {
@@ -471,7 +475,9 @@ module.exports = (log, db, mailer, config, customs, push) => {
                   })
                   .then(() => {
                     // send a push notification to all devices that the account changed
-                    push.notifyUpdate(uid, 'accountVerify')
+                    request.app.devices.then(devices =>
+                      push.notifyUpdate(uid, devices, 'accountVerify')
+                    )
 
                     // remove verification reminders
                     verificationReminder.delete({
@@ -791,7 +797,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
               return db.setPrimaryEmail(uid, email.normalizedEmail)
             })
             .then(() => {
-              push.notifyProfileUpdated(uid)
+              request.app.devices.then(devices => push.notifyProfileUpdated(uid, devices))
               log.notifyAttachedServices('primaryEmailChanged', request, {
                 uid: account.uid,
                 email: email

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -184,18 +184,15 @@ module.exports = function (
         function fetchDevicesToNotify() {
           // We fetch the devices to notify before changePassword() because
           // db.resetAccount() deletes all the devices saved in the account.
-          return db.devices(passwordChangeToken.uid)
-            .then(
-              function(devices) {
-                devicesToNotify = devices
-                // If the originating sessionToken belongs to a device,
-                // do not send the notification to that device. It will
-                // get informed about the change via WebChannel message.
-                if (originatingDeviceId) {
-                  devicesToNotify = devicesToNotify.filter(d => (d.id !== originatingDeviceId))
-                }
-              }
-            )
+          return request.app.devices.then(devices => {
+            devicesToNotify = devices
+            // If the originating sessionToken belongs to a device,
+            // do not send the notification to that device. It will
+            // get informed about the change via WebChannel message.
+            if (originatingDeviceId) {
+              devicesToNotify = devicesToNotify.filter(d => (d.id !== originatingDeviceId))
+            }
+          })
         }
 
         function changePassword() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,6 @@
 
 const fs = require('fs')
 const Hapi = require('hapi')
-const P = require('./promise')
 const path = require('path')
 const url = require('url')
 const userAgent = require('./userAgent')
@@ -277,10 +276,15 @@ function create(log, error, config, routes, db, translator) {
       defineLazyGetter(request.app, 'ua', () => userAgent(request.headers['user-agent']))
       defineLazyGetter(request.app, 'geo', () => getGeoData(request.app.clientAddress))
       defineLazyGetter(request.app, 'devices', () => {
+        let uid
+
         if (request.auth && request.auth.credentials) {
-          return db.devices(request.auth.credentials.uid)
+          uid = request.auth.credentials.uid
+        } else if (request.payload && request.payload.uid) {
+          uid = request.payload.uid
         }
-        return P.resolve([])
+
+        return db.devices(uid)
       })
 
       if (request.headers.authorization) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const fs = require('fs')
+const Hapi = require('hapi')
+const P = require('./promise')
 const path = require('path')
 const url = require('url')
-const Hapi = require('hapi')
 const userAgent = require('./userAgent')
 
-const HEX_STRING = require('./routes/validators').HEX_STRING
+const { HEX_STRING } = require('./routes/validators')
 
 function trimLocale(header) {
   if (! header) {
@@ -275,6 +276,12 @@ function create(log, error, config, routes, db, translator) {
 
       defineLazyGetter(request.app, 'ua', () => userAgent(request.headers['user-agent']))
       defineLazyGetter(request.app, 'geo', () => getGeoData(request.app.clientAddress))
+      defineLazyGetter(request.app, 'devices', () => {
+        if (request.auth && request.auth.credentials) {
+          return db.devices(request.auth.credentials.uid)
+        }
+        return P.resolve([])
+      })
 
       if (request.headers.authorization) {
         // Log some helpful details for debugging authentication problems.

--- a/test/e2e/push_tests.js
+++ b/test/e2e/push_tests.js
@@ -5,18 +5,16 @@
 'use strict'
 
 const assert = require('insist')
-var proxyquire = require('proxyquire')
+const config = require('../../config').getProperties()
+const proxyquire = require('proxyquire')
+const { mockDB, spyLog } = require('../mocks')
+const { PushManager } = require('../push_helper')
 
-var P = require('../../lib/promise')
-var config = require('../../config').getProperties()
-var spyLog = require('../mocks').spyLog
-var mockUid = Buffer.from('foo')
-
-var PushManager = require('../push_helper').PushManager
+const mockUid = 'foo'
 
 describe('e2e/push', () => {
-
   let pushManager
+
   before(() => {
     pushManager = new PushManager({
       server: 'wss://push.services.mozilla.com/',
@@ -24,31 +22,9 @@ describe('e2e/push', () => {
     })
   })
 
-  it(
-    'pushToAllDevices sends notifications using a real push server',
-    () => {
-      return pushManager.getSubscription().then(function (subscription) { // eslint-disable-line no-unreachable
-        var mockDbResult = {
-          devices: function (/* uid */) {
-            return P.resolve([
-              {
-                'id': '0f7aa00356e5416e82b3bef7bc409eef',
-                'isCurrentDevice': true,
-                'lastAccessTime': 1449235471335,
-                'name': 'My Phone',
-                'type': 'mobile',
-                'pushCallback': subscription.endpoint,
-                'pushPublicKey': 'BBXOKjUb84pzws1wionFpfCBjDuCh4-s_1b52WA46K5wYL2gCWEOmFKWn_NkS5nmJwTBuO8qxxdjAIDtNeklvQc',
-                'pushAuthKey': 'GSsIiaD2Mr83iPqwFNK4rw',
-                'pushEndpointExpired': false
-              }
-            ])
-          },
-          updateDevice: function () {
-            return P.resolve()
-          }
-        }
-
+  it('notifyUpdate sends notifications using a real push server', () => {
+    return pushManager.getSubscription()
+      .then(subscription => {
         let count = 0
         var thisSpyLog = spyLog({
           info: function (log) {
@@ -58,15 +34,27 @@ describe('e2e/push', () => {
           }
         })
 
-        var push = proxyquire('../../lib/push', {})(thisSpyLog, mockDbResult, config)
+        var push = proxyquire('../../lib/push', {})(thisSpyLog, mockDB(), config)
         var options = {
           data: Buffer.from('foodata')
         }
-        return push.pushToAllDevices(mockUid, 'accountVerify', options).then(function() {
-          assert.equal(thisSpyLog.error.callCount, 0, 'No errors should have been logged')
-          assert.equal(count, 1)
-        })
+        return push.notifyUpdate(mockUid, [
+          {
+            id: '0f7aa00356e5416e82b3bef7bc409eef',
+            isCurrentDevice: true,
+            lastAccessTime: 1449235471335,
+            name: 'My Phone',
+            type: 'mobile',
+            pushCallback: subscription.endpoint,
+            pushPublicKey: 'BBXOKjUb84pzws1wionFpfCBjDuCh4-s_1b52WA46K5wYL2gCWEOmFKWn_NkS5nmJwTBuO8qxxdjAIDtNeklvQc',
+            pushAuthKey: 'GSsIiaD2Mr83iPqwFNK4rw',
+            pushEndpointExpired: false
+          }
+        ], 'accountVerify', options)
+          .then(() => {
+            assert.equal(thisSpyLog.error.callCount, 0, 'No errors should have been logged')
+            assert.equal(count, 1, 'log.info::push.account_verify.success was called once')
+          })
       })
-    }
-  )
+  })
 })

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -116,10 +116,11 @@ describe('devices', () => {
 
             assert.equal(push.notifyDeviceConnected.callCount, 1, 'push.notifyDeviceConnected was called once')
             args = push.notifyDeviceConnected.args[0]
-            assert.equal(args.length, 3, 'push.notifyDeviceConnected was passed three arguments')
+            assert.equal(args.length, 4, 'push.notifyDeviceConnected was passed four arguments')
             assert.equal(args[0], sessionToken.uid, 'first argument was uid')
-            assert.equal(args[1], device.name, 'second arguent was device name')
-            assert.equal(args[2], deviceId, 'third argument was device id')
+            assert.ok(Array.isArray(args[1]), 'second argument was devices array')
+            assert.equal(args[2], device.name, 'third arguent was device name')
+            assert.equal(args[3], deviceId, 'fourth argument was device id')
           })
       })
 
@@ -156,7 +157,7 @@ describe('devices', () => {
 
             assert.equal(push.notifyDeviceConnected.callCount, 1, 'push.notifyDeviceConnected was called once')
             assert.equal(push.notifyDeviceConnected.args[0][0], sessionToken.uid, 'uid was correct')
-            assert.equal(push.notifyDeviceConnected.args[0][1], 'Firefox', 'device name was included')
+            assert.equal(push.notifyDeviceConnected.args[0][2], 'Firefox', 'device name was included')
 
           })
       })

--- a/test/local/profile/updates.js
+++ b/test/local/profile/updates.js
@@ -6,7 +6,7 @@ const assert = require('insist')
 
 const EventEmitter = require('events').EventEmitter
 const sinon = require('sinon')
-const spyLog = require('../../mocks').spyLog
+const { mockDB, spyLog } = require('../../mocks')
 const profileUpdates = require('../../../lib/profile/updates')
 const P = require('../../../lib/promise')
 
@@ -30,7 +30,7 @@ const mockPush = {
 }
 
 function mockProfileUpdates(log) {
-  return profileUpdates(log)(mockDeliveryQueue, mockPush)
+  return profileUpdates(log)(mockDeliveryQueue, mockPush, mockDB())
 }
 
 describe('profile updates', () => {

--- a/test/local/routes/devices-sessions.js
+++ b/test/local/routes/devices-sessions.js
@@ -243,7 +243,7 @@ describe('/account/devices/notify', function () {
       assert(false, 'should have thrown')
     })
       .then(() => assert(false), function (err) {
-        assert.equal(mockPush.pushToDevices.callCount, 0, 'mockPush.pushToDevices was not called')
+        assert.equal(mockPush.notifyUpdate.callCount, 0, 'mockPush.notifyUpdate was not called')
         assert.equal(err.errno, 107, 'Correct errno for invalid push payload')
       })
   })
@@ -255,22 +255,23 @@ describe('/account/devices/notify', function () {
       TTL: 60,
       payload: pushPayload
     }
-    // We don't wait on pushToAllDevices in the request handler, that's why
+    // We don't wait on notifyUpdate in the request handler, that's why
     // we have to wait on it manually by spying.
-    var pushToAllDevicesPromise = P.defer()
-    mockPush.pushToAllDevices = sinon.spy(function () {
-      pushToAllDevicesPromise.resolve()
+    var notifyUpdatePromise = P.defer()
+    mockPush.notifyUpdate = sinon.spy(function () {
+      notifyUpdatePromise.resolve()
       return P.resolve()
     })
     return runTest(route, mockRequest, function (response) {
-      return pushToAllDevicesPromise.promise.then(function () {
+      return notifyUpdatePromise.promise.then(function () {
         assert.equal(mockCustoms.checkAuthenticated.callCount, 1, 'mockCustoms.checkAuthenticated was called once')
-        assert.equal(mockPush.pushToAllDevices.callCount, 1, 'mockPush.pushToAllDevices was called once')
-        var args = mockPush.pushToAllDevices.args[0]
-        assert.equal(args.length, 3, 'mockPush.pushToAllDevices was passed three arguments')
+        assert.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate was called once')
+        var args = mockPush.notifyUpdate.args[0]
+        assert.equal(args.length, 4, 'mockPush.notifyUpdate was passed four arguments')
         assert.equal(args[0], uid, 'first argument was the device uid')
-        assert.equal(args[1], 'devicesNotify', 'second argument was the devicesNotify reason')
-        assert.deepEqual(args[2], {
+        assert.ok(Array.isArray(args[1]), 'second argument was devices array')
+        assert.equal(args[2], 'devicesNotify', 'second argument was the devicesNotify reason')
+        assert.deepEqual(args[3], {
           data: Buffer.from(JSON.stringify(pushPayload)),
           excludedDeviceIds: ['bogusid'],
           TTL: 60
@@ -289,11 +290,11 @@ describe('/account/devices/notify', function () {
       TTL: 60,
       payload: extraPropsPayload
     }
-    // We don't wait on pushToAllDevices in the request handler, that's why
+    // We don't wait on notifyUpdate in the request handler, that's why
     // we have to wait on it manually by spying.
-    var pushToAllDevicesPromise = P.defer()
-    mockPush.pushToAllDevices = sinon.spy(function () {
-      pushToAllDevicesPromise.resolve()
+    var notifyUpdatePromise = P.defer()
+    mockPush.notifyUpdate = sinon.spy(function () {
+      notifyUpdatePromise.resolve()
       return Promise.resolve()
     })
     return runTest(route, mockRequest, function () {
@@ -314,25 +315,26 @@ describe('/account/devices/notify', function () {
       TTL: 60,
       payload: pushPayload
     }
-    // We don't wait on pushToDevices in the request handler, that's why
+    // We don't wait on notifyUpdate in the request handler, that's why
     // we have to wait on it manually by spying.
-    var pushToDevicesPromise = P.defer()
-    mockPush.pushToDevices = sinon.spy(function () {
-      pushToDevicesPromise.resolve()
+    var notifyUpdatePromise = P.defer()
+    mockPush.notifyUpdate = sinon.spy(function () {
+      notifyUpdatePromise.resolve()
       return P.resolve()
     })
     return runTest(route, mockRequest, function (response) {
-      return pushToDevicesPromise.promise.then(function () {
+      return notifyUpdatePromise.promise.then(function () {
         assert.equal(mockCustoms.checkAuthenticated.callCount, 1, 'mockCustoms.checkAuthenticated was called once')
-        assert.equal(mockPush.pushToDevices.callCount, 1, 'mockPush.pushToDevices was called once')
-        var args = mockPush.pushToDevices.args[0]
-        assert.equal(args.length, 4, 'mockPush.pushToDevices was passed four arguments')
+        assert.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate was called once')
+        var args = mockPush.notifyUpdate.args[0]
+        assert.equal(args.length, 4, 'mockPush.notifyUpdate was passed four arguments')
         assert.equal(args[0], uid, 'first argument was the device uid')
-        assert.deepEqual(args[1], ['bogusid1', 'bogusid2'], 'second argument was the list of device ids')
+        assert.ok(Array.isArray(args[1]), 'second argument was devices array')
         assert.equal(args[2], 'devicesNotify', 'third argument was the devicesNotify reason')
         assert.deepEqual(args[3], {
           data: Buffer.from(JSON.stringify(pushPayload)),
-          TTL: 60
+          TTL: 60,
+          includedDeviceIds: [ 'bogusid1', 'bogusid2' ]
         }, 'fourth argument was the push options')
         assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
         args = mockLog.activityEvent.args[0]
@@ -350,7 +352,7 @@ describe('/account/devices/notify', function () {
   })
 
   it('does not log activity event for non-send-tab-related messages', function () {
-    mockPush.pushToDevices.reset()
+    mockPush.notifyUpdate.reset()
     mockLog.activityEvent.reset()
     mockLog.error.reset()
     mockRequest.payload = {
@@ -362,7 +364,7 @@ describe('/account/devices/notify', function () {
       }
     }
     return runTest(route, mockRequest, function (response) {
-      assert.equal(mockPush.pushToDevices.callCount, 1, 'mockPush.pushToDevices was called once')
+      assert.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate was called once')
       assert.equal(mockLog.activityEvent.callCount, 0, 'log.activityEvent was not called')
       assert.equal(mockLog.error.callCount, 0, 'log.error was not called')
     })
@@ -418,7 +420,7 @@ describe('/account/devices/notify', function () {
 
     var mockLog = mocks.spyLog()
     var mockPush = mocks.mockPush({
-      pushToDevices: () => P.reject('Devices ids not found in devices')
+      notifyUpdate: () => P.reject('devices empty')
     })
     var mockCustoms = {
       checkAuthenticated: () => P.resolve()
@@ -464,7 +466,7 @@ describe('/account/device/destroy', function () {
       assert.ok(mockDB.deleteDevice.calledBefore(mockPush.notifyDeviceDisconnected))
       assert.equal(mockPush.notifyDeviceDisconnected.callCount, 1)
       assert.equal(mockPush.notifyDeviceDisconnected.firstCall.args[0], mockRequest.auth.credentials.uid)
-      assert.equal(mockPush.notifyDeviceDisconnected.firstCall.args[1], deviceId)
+      assert.equal(mockPush.notifyDeviceDisconnected.firstCall.args[2], deviceId)
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
       var args = mockLog.activityEvent.args[0]

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -509,9 +509,10 @@ describe('/recovery_email/verify_code', function () {
 
         assert.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate should have been called once')
         args = mockPush.notifyUpdate.args[0]
-        assert.equal(args.length, 2, 'mockPush.notifyUpdate should have been passed two arguments')
+        assert.equal(args.length, 3, 'mockPush.notifyUpdate should have been passed three arguments')
         assert.equal(args[0].toString('hex'), uid, 'first argument should have been uid')
-        assert.equal(args[1], 'accountVerify', 'second argument should have been reason')
+        assert.ok(Array.isArray(args[1]), 'second argument should have been devices array')
+        assert.equal(args[2], 'accountVerify', 'third argument should have been reason')
 
         assert.equal(JSON.stringify(response), '{}')
       })
@@ -639,9 +640,10 @@ describe('/recovery_email/verify_code', function () {
 
         assert.equal(mockPush.notifyUpdate.callCount, 1, 'mockPush.notifyUpdate should have been called once')
         args = mockPush.notifyUpdate.args[0]
-        assert.equal(args.length, 2, 'mockPush.notifyUpdate should have been passed two arguments')
+        assert.equal(args.length, 3, 'mockPush.notifyUpdate should have been passed three arguments')
         assert.equal(args[0].toString('hex'), uid, 'first argument should have been uid')
-        assert.equal(args[1], 'accountConfirm', 'second argument should have been reason')
+        assert.ok(Array.isArray(args[1]), 'second argument should have been devices array')
+        assert.equal(args[2], 'accountConfirm', 'third argument should have been reason')
       })
         .then(function () {
           mockDB.verifyTokens.reset()

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -276,8 +276,8 @@ describe('/password', () => {
         ]
         var mockDB = mocks.mockDB({
           email: TEST_EMAIL,
-          uid: uid,
-          devices: devices
+          uid,
+          devices
         })
         var mockPush = mocks.mockPush()
         var mockMailer = mocks.mockMailer()
@@ -286,6 +286,7 @@ describe('/password', () => {
           credentials: {
             uid: uid
           },
+          devices,
           payload: {
             authPW: crypto.randomBytes(32).toString('hex'),
             wrapKb: crypto.randomBytes(32).toString('hex'),

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -69,7 +69,9 @@ describe('lib/server', () => {
       log = mocks.spyLog()
       config = getConfig()
       routes = getRoutes()
-      db = mocks.mockDB()
+      db = mocks.mockDB({
+        devices: [ { id: 'fake device id' } ]
+      })
       translator = {
         getTranslator: sinon.spy(() => ({ en: { format: () => {}, language: 'en' } })),
         getLocale: sinon.spy(() => 'en')
@@ -99,6 +101,9 @@ describe('lib/server', () => {
         beforeEach(() => {
           response = 'ok'
           return instance.inject({
+            credentials: {
+              uid: 'fake uid'
+            },
             headers: {
               'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
               'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:57.0) Gecko/20100101 Firefox/57.0',
@@ -167,6 +172,17 @@ describe('lib/server', () => {
             assert.equal(geo.location.state, 'California')
             assert.equal(geo.location.stateCode, 'CA')
             assert.equal(geo.timeZone, 'America/Los_Angeles')
+          })
+        })
+
+        it('fetched devices correctly', () => {
+          assert.ok(request.app.devices)
+          assert.equal(typeof request.app.devices.then, 'function')
+          assert.equal(db.devices.callCount, 1)
+          assert.equal(db.devices.args[0].length, 1)
+          assert.equal(db.devices.args[0][0], 'fake uid')
+          return request.app.devices.then(devices => {
+            assert.deepEqual(devices, [ { id: 'fake device id' } ])
           })
         })
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -112,9 +112,7 @@ const PUSH_METHOD_NAMES = [
   'notifyPasswordReset',
   'notifyAccountDestroyed',
   'notifyProfileUpdated',
-  'notifyUpdate',
-  'pushToAllDevices',
-  'pushToDevices'
+  'notifyUpdate'
 ]
 
 module.exports = {
@@ -487,6 +485,7 @@ function mockRequest (data, errors) {
     app: {
       acceptLanguage: 'en-US',
       clientAddress: data.clientAddress || '63.245.221.32',
+      devices: P.resolve(data.devices || []),
       features: new Set(data.features),
       geo,
       locale: data.locale || 'en-US',

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -119,10 +119,9 @@ describe('remote push db', function() {
           .then(function () {
             return db.devices(ACCOUNT.uid)
           })
-
-          .then(function () {
-            var pushWithUnknown400 = proxyquire('../../lib/push', mocksUnknown400)(mockLog, db, {})
-            return pushWithUnknown400.pushToAllDevices(ACCOUNT.uid, 'accountVerify')
+          .then(devices => {
+            const pushWithUnknown400 = proxyquire('../../lib/push', mocksUnknown400)(mockLog, db, {})
+            return pushWithUnknown400.notifyUpdate(ACCOUNT.uid, devices, 'accountVerify')
           })
           .then(function () {
             return db.devices(ACCOUNT.uid)
@@ -134,11 +133,9 @@ describe('remote push db', function() {
             assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
             assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
             assert.equal(device.pushEndpointExpired, deviceInfo.pushEndpointExpired, 'device.pushEndpointExpired is correct')
-          })
 
-          .then(function () {
-            var pushWithKnown400 = proxyquire('../../lib/push', mocksKnown400)(mockLog, db, {})
-            return pushWithKnown400.pushToAllDevices(ACCOUNT.uid, 'accountVerify')
+            const pushWithKnown400 = proxyquire('../../lib/push', mocksKnown400)(mockLog, db, {})
+            return pushWithKnown400.notifyUpdate(ACCOUNT.uid, devices, 'accountVerify')
           })
           .then(function () {
             return db.devices(ACCOUNT.uid)


### PR DESCRIPTION
Fixes #2106.

Prevents us from accidentally calling `db.devices` more than once per request. I saw one definite case of this in `/recovery_email/verify_code` and it's possible there were others. I'll also be making use of this property heavily for the amplitude events, so it will get further usage imminently.

Making the change necessitated pulling calls to `db.devices` out of `lib/push`, which triggered some refactoring that almost got away from me. I'll add inline commentary to call out why things have changed the way they have, but most push methods now take an extra `devices` argument and a few other methods became redundant so I deleted them. I don't *think* I've broken anything.

@mozilla/fxa-devs r?