### PR TITLE
fix(metrics): include missing user_properties on amplitude events

### DIFF
--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const emailDomains = require('../../../config/popular-email-domains')
+const P = require('../../promise')
+
 let amplitude
 
 function getInsensitiveHeaderValueFromArray(headerName, headers) {
@@ -63,7 +65,9 @@ function logEmailEventSent(log, message) {
     log.info(msg)
   })
 
-  logAmplitudeEvent(log, message, emailEventInfo)
+  logAmplitudeEvent(log, message, Object.assign({
+    domain: getAnonymizedEmailDomain(message.email)
+  }, emailEventInfo))
 }
 
 function logAmplitudeEvent (log, message, eventInfo) {
@@ -73,6 +77,9 @@ function logAmplitudeEvent (log, message, eventInfo) {
 
   amplitude(`email.${eventInfo.template}.${eventInfo.type}`, {
     app: {
+      geo: P.resolve({
+        location: {}
+      }),
       locale: eventInfo.locale,
       ua: {}
     },
@@ -81,6 +88,7 @@ function logAmplitudeEvent (log, message, eventInfo) {
     payload: {}
   }, {
     device_id: getHeaderValue('X-Device-Id', message),
+    email_domain: eventInfo.domain,
     service: getHeaderValue('X-Service-Id', message),
     uid: getHeaderValue('X-Uid', message)
   }, {

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -77,6 +77,7 @@ function logAmplitudeEvent (log, message, eventInfo) {
 
   amplitude(`email.${eventInfo.template}.${eventInfo.type}`, {
     app: {
+      devices: P.resolve([]),
       geo: P.resolve({
         location: {}
       }),

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -151,7 +151,7 @@ module.exports = log => {
         data.devices = devices
         log.amplitudeEvent({
           time: metricsContext.time || Date.now(),
-          user_id: getUid(request, data),
+          user_id: data.uid || getFromToken(request, 'uid'),
           device_id: getDeviceId(request, metricsContext),
           event_type: `${group} - ${mapping.event}`,
           session_id: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
@@ -165,10 +165,6 @@ module.exports = log => {
 
     return P.resolve()
   }
-}
-
-function getUid (request, data) {
-  return data.uid || getFromToken(request, 'uid')
 }
 
 function getFromToken (request, key) {
@@ -207,7 +203,6 @@ function mapUserProperties (group, request, data, metricsContext) {
   const { browser, browserVersion, os } = request.app.ua
   return {
     flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
-    fxa_uid: getUid(request, data),
     sync_device_count: data.devices && data.devices.length,
     ua_browser: browser,
     ua_version: browserVersion,

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -18,6 +18,8 @@
 
 'use strict'
 
+const P = require('../promise')
+
 const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1]
 
 const GROUPS = {
@@ -97,17 +99,9 @@ const NOP = () => {}
 
 const EVENT_PROPERTIES = {
   [GROUPS.activity]: NOP,
-  [GROUPS.email]: mapEmailType,
+  [GROUPS.email]: mapEmailEventProperties,
   [GROUPS.login]: NOP,
   [GROUPS.registration]: NOP,
-  [GROUPS.sms]: NOP
-}
-
-const USER_PROPERTIES = {
-  [GROUPS.activity]: mapUid,
-  [GROUPS.email]: mapUid,
-  [GROUPS.login]: mapUid,
-  [GROUPS.registration]: mapUid,
   [GROUPS.sms]: NOP
 }
 
@@ -119,7 +113,7 @@ module.exports = log => {
   function receiveEvent (event, request, data = {}, metricsContext = {}) {
     if (! event || ! request) {
       log.error({ op: 'amplitudeMetrics', err: 'Bad argument', event, hasRequest: !! request })
-      return
+      return P.resolve()
     }
 
     let mapping = EVENTS[event]
@@ -143,24 +137,29 @@ module.exports = log => {
       if (mapping.isDynamicGroup) {
         group = group(request, data, metricsContext)
         if (! group) {
-          return
+          return P.resolve()
         }
       }
       if (mapping.eventCategory) {
         data.eventCategory = mapping.eventCategory
       }
-      log.amplitudeEvent({
-        time: metricsContext.time || Date.now(),
-        user_id: getUid(request, data),
-        device_id: getDeviceId(request, metricsContext),
-        event_type: `${group} - ${mapping.event}`,
-        session_id: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
-        event_properties: mapEventProperties(group, request, data, metricsContext),
-        user_properties: mapUserProperties(group, request, data, metricsContext),
-        app_version: APP_VERSION,
-        language: request.app.locale || undefined
+      return request.app.geo.then(geo => {
+        data.location = geo.location
+        log.amplitudeEvent({
+          time: metricsContext.time || Date.now(),
+          user_id: getUid(request, data),
+          device_id: getDeviceId(request, metricsContext),
+          event_type: `${group} - ${mapping.event}`,
+          session_id: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
+          event_properties: mapEventProperties(group, request, data, metricsContext),
+          user_properties: mapUserProperties(group, request, data, metricsContext),
+          app_version: APP_VERSION,
+          language: getLocale(request)
+        })
       })
     }
+
+    return P.resolve()
   }
 }
 
@@ -190,28 +189,35 @@ function mapEventProperties (group, request, data, metricsContext) {
   }, EVENT_PROPERTIES[group](request, data, metricsContext))
 }
 
-function mapEmailType (request, data) {
+function mapEmailEventProperties (request, data) {
   const emailType = EMAIL_TYPES[data.eventCategory]
   if (emailType) {
     return {
-      email_type: emailType
+      email_type: emailType,
+      email_provider: data.email_domain
     }
   }
 }
 
 function mapUserProperties (group, request, data, metricsContext) {
   const { browser, browserVersion, os } = request.app.ua
-  return Object.assign({
+  return {
     flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
+    fxa_uid: getUid(request, data),
     ua_browser: browser,
     ua_version: browserVersion,
-    ua_os: os
-  }, USER_PROPERTIES[group](request, data, metricsContext))
+    ua_os: os,
+    user_country: getLocationProperty(data, 'country'),
+    user_locale: getLocale(request),
+    user_state: getLocationProperty(data, 'state'),
+  }
 }
 
-function mapUid (request, data) {
-  return {
-    fxa_uid: getUid(request, data)
-  }
+function getLocale (request) {
+  return request.app.locale || undefined
+}
+
+function getLocationProperty (data, key) {
+  return (data.location && data.location[key]) || undefined
 }
 

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -152,7 +152,7 @@ module.exports = log => {
         log.amplitudeEvent({
           time: metricsContext.time || Date.now(),
           user_id: data.uid || getFromToken(request, 'uid'),
-          device_id: getDeviceId(request, metricsContext),
+          device_id: getFromMetricsContext(metricsContext, 'device_id', request, 'deviceId'),
           event_type: `${group} - ${mapping.event}`,
           session_id: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
           event_properties: mapEventProperties(group, request, data, metricsContext),
@@ -173,10 +173,6 @@ function getFromToken (request, key) {
   }
 }
 
-function getDeviceId (request, metricsContext) {
-  return getFromMetricsContext(metricsContext, 'device_id', request, 'deviceId')
-}
-
 function getFromMetricsContext (metricsContext, key, request, payloadKey) {
   return metricsContext[key] ||
     (request.payload.metricsContext && request.payload.metricsContext[payloadKey])
@@ -184,7 +180,6 @@ function getFromMetricsContext (metricsContext, key, request, payloadKey) {
 
 function mapEventProperties (group, request, data, metricsContext) {
   return Object.assign({
-    device_id: getDeviceId(request, metricsContext),
     service: data.service || request.query.service || request.payload.service
   }, EVENT_PROPERTIES[group](request, data, metricsContext))
 }

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -143,8 +143,12 @@ module.exports = log => {
       if (mapping.eventCategory) {
         data.eventCategory = mapping.eventCategory
       }
-      return request.app.geo.then(geo => {
+      return P.all([
+        request.app.geo,
+        request.app.devices.catch(() => {})
+      ]).spread((geo, devices) => {
         data.location = geo.location
+        data.devices = devices
         log.amplitudeEvent({
           time: metricsContext.time || Date.now(),
           user_id: getUid(request, data),
@@ -204,6 +208,7 @@ function mapUserProperties (group, request, data, metricsContext) {
   return {
     flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
     fxa_uid: getUid(request, data),
+    sync_device_count: data.devices && data.devices.length,
     ua_browser: browser,
     ua_version: browserVersion,
     ua_os: os,

--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -102,13 +102,14 @@ module.exports = log => {
         return emitFlowEvent(event, request, data)
       })
       .then(metricsContext => {
-        amplitude(event, request, data, metricsContext)
-
-        if (metricsContext && event === metricsContext.flowCompleteSignal) {
-          log.flowEvent(Object.assign({}, metricsContext, { event: 'flow.complete' }))
-          amplitude('flow.complete', request, data, metricsContext)
-          request.clearMetricsContext()
-        }
+        return amplitude(event, request, data, metricsContext)
+          .then(() => {
+            if (metricsContext && event === metricsContext.flowCompleteSignal) {
+              log.flowEvent(Object.assign({}, metricsContext, { event: 'flow.complete' }))
+              return amplitude('flow.complete', request, data, metricsContext)
+                .then(() => request.clearMetricsContext())
+            }
+          })
       })
     },
 

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -100,6 +100,7 @@ describe('email utils helpers', () => {
     assert.equal(args[0], 'email.verifyEmail.sent')
     assert.deepEqual(args[1], {
       app: {
+        devices: P.resolve([]),
         geo: P.resolve({
           location: {}
         }),
@@ -139,6 +140,7 @@ describe('email utils helpers', () => {
     assert.equal(args[0], 'email.verifyLoginEmail.bounced')
     assert.deepEqual(args[1], {
       app: {
+        devices: P.resolve([]),
         geo: P.resolve({
           location: {}
         }),

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -4,13 +4,16 @@
 
 'use strict'
 
+const ROOT_DIR = '../../..'
+
 const assert = require('insist')
+const P = require(`${ROOT_DIR}/lib/promise`)
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const spyLog = require('../../mocks').spyLog
 
 const amplitude = sinon.spy()
-const emailHelpers = proxyquire('../../../lib/email/utils/helpers', {
+const emailHelpers = proxyquire(`${ROOT_DIR}/lib/email/utils/helpers`, {
   '../../metrics/amplitude': () => amplitude
 })
 
@@ -97,6 +100,9 @@ describe('email utils helpers', () => {
     assert.equal(args[0], 'email.verifyEmail.sent')
     assert.deepEqual(args[1], {
       app: {
+        geo: P.resolve({
+          location: {}
+        }),
         locale: 'aaa',
         ua: {}
       },
@@ -106,6 +112,7 @@ describe('email utils helpers', () => {
     })
     assert.deepEqual(args[2], {
       device_id: 'bbb',
+      email_domain: 'other',
       service: 'ddd',
       uid: 'eee'
     })
@@ -125,13 +132,16 @@ describe('email utils helpers', () => {
         { name: 'X-Template-Name', value: 'verifyLoginEmail' },
         { name: 'X-Uid', value: 'e' }
       ]
-    }, 'bounced', 'gmail.com')
+    }, 'bounced', 'gmail')
     assert.equal(amplitude.callCount, 1)
     const args = amplitude.args[0]
     assert.equal(args.length, 4)
     assert.equal(args[0], 'email.verifyLoginEmail.bounced')
     assert.deepEqual(args[1], {
       app: {
+        geo: P.resolve({
+          location: {}
+        }),
         locale: 'a',
         ua: {}
       },
@@ -141,6 +151,7 @@ describe('email utils helpers', () => {
     })
     assert.deepEqual(args[2], {
       device_id: 'b',
+      email_domain: 'gmail',
       service: 'd',
       uid: 'e'
     })

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -86,6 +86,7 @@ describe('metrics/amplitude', () => {
           credentials: {
             uid: 'blee'
           },
+          devices: [ {}, {}, {} ],
           geo: {
             location: {
               country: 'United Kingdom',
@@ -125,6 +126,7 @@ describe('metrics/amplitude', () => {
         })
         assert.deepEqual(args[0].user_properties, {
           flow_id: 'udge',
+          sync_device_count: 3,
           ua_browser: 'foo',
           ua_version: 'bar',
           ua_os: 'baz',
@@ -151,6 +153,7 @@ describe('metrics/amplitude', () => {
           credentials: {
             uid: 'f'
           },
+          devices: [],
           payload: {
             service: 'g'
           }
@@ -175,6 +178,7 @@ describe('metrics/amplitude', () => {
         })
         assert.deepEqual(args[0].user_properties, {
           flow_id: undefined,
+          sync_device_count: 0,
           ua_browser: 'a',
           ua_version: 'b',
           ua_os: 'c',
@@ -188,7 +192,9 @@ describe('metrics/amplitude', () => {
 
     describe('account.login', () => {
       beforeEach(() => {
-        return amplitude('account.login', mocks.mockRequest({}))
+        return amplitude('account.login', mocks.mockRequest({}, {
+          devices: {}
+        }))
       })
 
       it('did not call log.error', () => {
@@ -199,6 +205,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_login - success')
+        assert.equal(args[0].user_properties.sync_device_count, undefined)
       })
     })
 

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -33,7 +33,7 @@ describe('metrics/amplitude', () => {
 
     describe('empty event argument', () => {
       beforeEach(() => {
-        amplitude('', mocks.mockRequest({}))
+        return amplitude('', mocks.mockRequest({}))
       })
 
       it('called log.error correctly', () => {
@@ -54,7 +54,7 @@ describe('metrics/amplitude', () => {
 
     describe('missing request argument', () => {
       beforeEach(() => {
-        amplitude('foo')
+        return amplitude('foo')
       })
 
       it('called log.error correctly', () => {
@@ -75,7 +75,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.confirmed', () => {
       beforeEach(() => {
-        amplitude('account.confirmed', mocks.mockRequest({
+        return amplitude('account.confirmed', mocks.mockRequest({
           uaBrowser: 'foo',
           uaBrowserVersion: 'bar',
           uaOS: 'baz',
@@ -85,6 +85,12 @@ describe('metrics/amplitude', () => {
           locale: 'wibble',
           credentials: {
             uid: 'blee'
+          },
+          geo: {
+            location: {
+              country: 'United Kingdom',
+              state: 'England',
+            }
           },
           query: {
             service: 'melm'
@@ -122,6 +128,9 @@ describe('metrics/amplitude', () => {
           ua_browser: 'foo',
           ua_version: 'bar',
           ua_os: 'baz',
+          user_country: 'United Kingdom',
+          user_locale: 'wibble',
+          user_state: 'England',
           fxa_uid: args[0].user_id
         })
         assert.ok(args[0].time > Date.now() - 1000)
@@ -131,7 +140,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.created', () => {
       beforeEach(() => {
-        amplitude('account.created', mocks.mockRequest({
+        return amplitude('account.created', mocks.mockRequest({
           uaBrowser: 'a',
           uaBrowserVersion: 'b',
           uaOS: 'c',
@@ -169,6 +178,9 @@ describe('metrics/amplitude', () => {
           ua_browser: 'a',
           ua_version: 'b',
           ua_os: 'c',
+          user_country: 'United States',
+          user_locale: 'e',
+          user_state: 'California',
           fxa_uid: args[0].user_id
         })
       })
@@ -176,7 +188,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.login', () => {
       beforeEach(() => {
-        amplitude('account.login', mocks.mockRequest({}))
+        return amplitude('account.login', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -192,7 +204,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.login.blocked', () => {
       beforeEach(() => {
-        amplitude('account.login.blocked', mocks.mockRequest({}))
+        return amplitude('account.login.blocked', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -208,7 +220,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.login.confirmedUnblockCode', () => {
       beforeEach(() => {
-        amplitude('account.login.confirmedUnblockCode', mocks.mockRequest({}))
+        return amplitude('account.login.confirmedUnblockCode', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -224,7 +236,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.reset', () => {
       beforeEach(() => {
-        amplitude('account.reset', mocks.mockRequest({}))
+        return amplitude('account.reset', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -240,7 +252,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.signed', () => {
       beforeEach(() => {
-        amplitude('account.signed', mocks.mockRequest({}))
+        return amplitude('account.signed', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -256,7 +268,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.verified', () => {
       beforeEach(() => {
-        amplitude('account.verified', mocks.mockRequest({}))
+        return amplitude('account.verified', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -272,7 +284,7 @@ describe('metrics/amplitude', () => {
 
     describe('flow.complete (sign-up)', () => {
       beforeEach(() => {
-        amplitude('flow.complete', mocks.mockRequest({}), {}, {
+        return amplitude('flow.complete', mocks.mockRequest({}), {}, {
           flowType: 'registration'
         })
       })
@@ -290,7 +302,7 @@ describe('metrics/amplitude', () => {
 
     describe('flow.complete (sign-in)', () => {
       beforeEach(() => {
-        amplitude('flow.complete', mocks.mockRequest({}), {}, {
+        return amplitude('flow.complete', mocks.mockRequest({}), {}, {
           flowType: 'login'
         })
       })
@@ -308,7 +320,7 @@ describe('metrics/amplitude', () => {
 
     describe('flow.complete (reset)', () => {
       beforeEach(() => {
-        amplitude('flow.complete', mocks.mockRequest({}))
+        return amplitude('flow.complete', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -322,7 +334,7 @@ describe('metrics/amplitude', () => {
 
     describe('sms.installFirefox.sent', () => {
       beforeEach(() => {
-        amplitude('sms.installFirefox.sent', mocks.mockRequest({}))
+        return amplitude('sms.installFirefox.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -338,7 +350,7 @@ describe('metrics/amplitude', () => {
 
     describe('device.created', () => {
       beforeEach(() => {
-        amplitude('device.created', mocks.mockRequest({}))
+        return amplitude('device.created', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -352,7 +364,9 @@ describe('metrics/amplitude', () => {
 
     describe('email.newDeviceLoginEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.newDeviceLoginEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.newDeviceLoginEmail.bounced', mocks.mockRequest({}), {
+          email_domain: 'gmail'
+        })
       })
 
       it('did not call log.error', () => {
@@ -364,12 +378,13 @@ describe('metrics/amplitude', () => {
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_email - bounced')
         assert.equal(args[0].event_properties.email_type, 'login')
+        assert.equal(args[0].event_properties.email_provider, 'gmail')
       })
     })
 
     describe('email.newDeviceLoginEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.newDeviceLoginEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.newDeviceLoginEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -381,12 +396,13 @@ describe('metrics/amplitude', () => {
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_email - sent')
         assert.equal(args[0].event_properties.email_type, 'login')
+        assert.equal(args[0].event_properties.email_provider, undefined)
       })
     })
 
     describe('email.passwordChangedEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.passwordChangedEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.passwordChangedEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -403,7 +419,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.passwordChangedEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.passwordChangedEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.passwordChangedEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -420,7 +436,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.passwordResetEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.passwordResetEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.passwordResetEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -437,7 +453,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.passwordResetEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.passwordResetEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.passwordResetEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -454,7 +470,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.passwordResetRequiredEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.passwordResetRequiredEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.passwordResetRequiredEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -471,7 +487,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.passwordResetRequiredEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.passwordResetRequiredEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.passwordResetRequiredEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -488,7 +504,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postRemoveSecondaryEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.postRemoveSecondaryEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.postRemoveSecondaryEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -505,7 +521,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postRemoveSecondaryEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.postRemoveSecondaryEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.postRemoveSecondaryEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -522,7 +538,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postVerifyEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.postVerifyEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.postVerifyEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -539,7 +555,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postVerifyEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.postVerifyEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.postVerifyEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -556,7 +572,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postVerifySecondaryEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.postVerifySecondaryEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.postVerifySecondaryEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -573,7 +589,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.postVerifySecondaryEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.postVerifySecondaryEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.postVerifySecondaryEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -590,7 +606,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.recoveryEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.recoveryEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.recoveryEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -607,7 +623,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.recoveryEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.recoveryEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.recoveryEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -624,7 +640,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.unblockCode.bounced', () => {
       beforeEach(() => {
-        amplitude('email.unblockCode.bounced', mocks.mockRequest({}))
+        return amplitude('email.unblockCode.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -641,7 +657,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.unblockCode.sent', () => {
       beforeEach(() => {
-        amplitude('email.unblockCode.sent', mocks.mockRequest({}))
+        return amplitude('email.unblockCode.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -658,7 +674,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderFirstEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderFirstEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderFirstEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -675,7 +691,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderFirstEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderFirstEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderFirstEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -692,7 +708,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderSecondEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderSecondEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderSecondEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -709,7 +725,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderSecondEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderSecondEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderSecondEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -726,7 +742,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -743,7 +759,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verificationReminderEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verificationReminderEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verificationReminderEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -760,7 +776,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifyEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verifyEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verifyEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -777,7 +793,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifyEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verifyEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verifyEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -794,7 +810,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifyLoginEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verifyLoginEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verifyLoginEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -811,7 +827,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifyLoginEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verifyLoginEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verifyLoginEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -828,7 +844,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifySyncEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verifySyncEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verifySyncEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -845,7 +861,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifySyncEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verifySyncEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verifySyncEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -862,7 +878,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifySecondaryEmail.bounced', () => {
       beforeEach(() => {
-        amplitude('email.verifySecondaryEmail.bounced', mocks.mockRequest({}))
+        return amplitude('email.verifySecondaryEmail.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -879,7 +895,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.verifySecondaryEmail.sent', () => {
       beforeEach(() => {
-        amplitude('email.verifySecondaryEmail.sent', mocks.mockRequest({}))
+        return amplitude('email.verifySecondaryEmail.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -896,7 +912,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.wibble.bounced', () => {
       beforeEach(() => {
-        amplitude('email.wibble.bounced', mocks.mockRequest({}))
+        return amplitude('email.wibble.bounced', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -910,7 +926,7 @@ describe('metrics/amplitude', () => {
 
     describe('email.wibble.sent', () => {
       beforeEach(() => {
-        amplitude('email.wibble.sent', mocks.mockRequest({}))
+        return amplitude('email.wibble.sent', mocks.mockRequest({}))
       })
 
       it('did not call log.error', () => {
@@ -924,7 +940,7 @@ describe('metrics/amplitude', () => {
 
     describe('with data', () => {
       beforeEach(() => {
-        amplitude('account.signed', mocks.mockRequest({
+        return amplitude('account.signed', mocks.mockRequest({
           credentials: {
             uid: 'foo'
           },
@@ -951,7 +967,7 @@ describe('metrics/amplitude', () => {
 
     describe('with metricsContext', () => {
       beforeEach(() => {
-        amplitude('sms.installFirefox.sent', mocks.mockRequest({
+        return amplitude('sms.installFirefox.sent', mocks.mockRequest({
           payload: {
             metricsContext: {
               deviceId: 'foo',

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -121,7 +121,6 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].session_id, 'kwop')
         assert.equal(args[0].language, 'wibble')
         assert.deepEqual(args[0].event_properties, {
-          device_id: args[0].device_id,
           service: 'melm'
         })
         assert.deepEqual(args[0].user_properties, {
@@ -172,7 +171,6 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].session_id, undefined)
         assert.equal(args[0].language, 'e')
         assert.deepEqual(args[0].event_properties, {
-          device_id: undefined,
           service: 'g'
         })
         assert.deepEqual(args[0].user_properties, {
@@ -991,7 +989,6 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].device_id, 'plin')
-        assert.equal(args[0].event_properties.device_id, args[0].device_id)
         assert.equal(args[0].user_properties.flow_id, 'gorb')
         assert.equal(args[0].session_id, 'yerx')
         assert.equal(args[0].time, 'wenf')

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -132,8 +132,7 @@ describe('metrics/amplitude', () => {
           ua_os: 'baz',
           user_country: 'United Kingdom',
           user_locale: 'wibble',
-          user_state: 'England',
-          fxa_uid: args[0].user_id
+          user_state: 'England'
         })
         assert.ok(args[0].time > Date.now() - 1000)
         assert.ok(/^[1-9][0-9]+$/.test(args[0].app_version))
@@ -184,8 +183,7 @@ describe('metrics/amplitude', () => {
           ua_os: 'c',
           user_country: 'United States',
           user_locale: 'e',
-          user_state: 'California',
-          fxa_uid: args[0].user_id
+          user_state: 'California'
         })
       })
     })
@@ -968,7 +966,6 @@ describe('metrics/amplitude', () => {
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].user_id, 'frip')
         assert.equal(args[0].event_properties.service, 'zang')
-        assert.equal(args[0].user_properties.fxa_uid, args[0].user_id)
       })
     })
 

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -594,8 +594,11 @@ describe('metrics/events', () => {
           ua_browser: request.app.ua.browser,
           ua_version: request.app.ua.browserVersion,
           ua_os: request.app.ua.os,
+          user_country: 'United States',
+          user_locale: 'en-US',
+          user_state: 'California',
           fxa_uid: 'baz'
-        }, 'log.amplitudeEvent was passed correct event properties')
+        }, 'log.amplitudeEvent was passed correct user properties')
 
         assert.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')
         assert.equal(log.flowEvent.callCount, 0, 'log.flowEvent was not called')

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -597,8 +597,7 @@ describe('metrics/events', () => {
           ua_os: request.app.ua.os,
           user_country: 'United States',
           user_locale: 'en-US',
-          user_state: 'California',
-          fxa_uid: 'baz'
+          user_state: 'California'
         }, 'log.amplitudeEvent was passed correct user properties')
 
         assert.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -591,6 +591,7 @@ describe('metrics/events', () => {
         }, 'log.amplitudeEvent was passed correct event properties')
         assert.deepEqual(log.amplitudeEvent.args[0][0].user_properties, {
           flow_id: 'bar',
+          sync_device_count: 0,
           ua_browser: request.app.ua.browser,
           ua_version: request.app.ua.browserVersion,
           ua_os: request.app.ua.os,

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -586,7 +586,6 @@ describe('metrics/events', () => {
         assert.equal(log.amplitudeEvent.args[0].length, 1, 'log.amplitudeEvent was passed one argument')
         assert.equal(log.amplitudeEvent.args[0][0].event_type, 'fxa_activity - cert_signed', 'log.amplitudeEvent was passed correct event_type')
         assert.deepEqual(log.amplitudeEvent.args[0][0].event_properties, {
-          device_id: undefined,
           service: 'content-server'
         }, 'log.amplitudeEvent was passed correct event properties')
         assert.deepEqual(log.amplitudeEvent.args[0][0].user_properties, {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -481,11 +481,18 @@ function mockRequest (data, errors) {
     })
   }
 
+  let devices
+  if (errors && errors.devices) {
+    devices = P.reject(errors.devices)
+  } else {
+    devices = P.resolve(data.devices || [])
+  }
+
   return {
     app: {
       acceptLanguage: 'en-US',
       clientAddress: data.clientAddress || '63.245.221.32',
-      devices: P.resolve(data.devices || []),
+      devices,
       features: new Set(data.features),
       geo,
       locale: data.locale || 'en-US',


### PR DESCRIPTION
Fixes #2076.

This mops up some user properties that I forgot about because they were on a separate tab in the taxonomy doc. There's still a couple of outstanding properties not included here, which I've opened standalone issues for because jiggery-pokery was involved.

The properties added are:

* `email_provider`
* `sync_device_count`
* `user_country`
* `user_locale`
* `user_state`

As it stands, it also ditches the duplicate `device_id` and `fxa_uid` properties, although there are still outstanding question marks over those two so best not merge this just yet. I'll confirm back here if/when they get the green light.

@mozilla/fxa-devs r?

