### PR TITLE
fix(basket): reinstate utm params to the metrics context bundle

### DIFF
--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -19,7 +19,12 @@ const SCHEMA = isA.object({
   // only Sync creates records in the devices table.
   deviceId: isA.string().length(32).regex(HEX_STRING).optional(),
   flowId: isA.string().length(64).regex(HEX_STRING).optional(),
-  flowBeginTime: isA.number().integer().positive().optional()
+  flowBeginTime: isA.number().integer().positive().optional(),
+  utmCampaign: isA.string().optional(),
+  utmContent: isA.string().optional(),
+  utmMedium: isA.string().optional(),
+  utmSource: isA.string().optional(),
+  utmTerm: isA.string().optional()
 })
   .unknown(false)
   .and('flowId', 'flowBeginTime')
@@ -96,6 +101,15 @@ module.exports = function (log, config) {
           data.flowBeginTime = metadata.flowBeginTime
           data.flowCompleteSignal = metadata.flowCompleteSignal
           data.flowType = metadata.flowType
+
+          const doNotTrack = this.headers && this.headers.dnt === '1'
+          if (! doNotTrack) {
+            data.utm_campaign = metadata.utmCampaign
+            data.utm_content = metadata.utmContent
+            data.utm_medium = metadata.utmMedium
+            data.utm_source = metadata.utmSource
+            data.utm_term = metadata.utmTerm
+          }
         }
       })
       .catch(err => log.error({

--- a/test/local/metrics/context.js
+++ b/test/local/metrics/context.js
@@ -207,7 +207,7 @@ describe('metricsContext', () => {
       }, {}).then(function (result) {
         assert.equal(typeof result, 'object', 'result is object')
         assert.notEqual(result, null, 'result is not null')
-        assert.equal(Object.keys(result).length, 7, 'result has 7 properties')
+        assert.equal(Object.keys(result).length, 12, 'result has 12 properties')
         assert.ok(result.time > time, 'result.time seems correct')
         assert.equal(result.device_id, 'mock device id', 'result.device_id is correct')
         assert.equal(result.flow_id, 'mock flow id', 'result.flow_id is correct')
@@ -216,8 +216,52 @@ describe('metricsContext', () => {
         assert.equal(result.flowBeginTime, time, 'result.flowBeginTime is correct')
         assert.equal(result.flowCompleteSignal, 'mock flow complete signal', 'result.flowCompleteSignal is correct')
         assert.equal(result.flowType, 'mock flow type', 'result.flowType is correct')
+        assert.equal(result.utm_campaign, 'mock utm_campaign', 'result.utm_campaign is correct')
+        assert.equal(result.utm_content, 'mock utm_content', 'result.utm_content is correct')
+        assert.equal(result.utm_medium, 'mock utm_medium', 'result.utm_medium is correct')
+        assert.equal(result.utm_source, 'mock utm_source', 'result.utm_source is correct')
+        assert.equal(result.utm_term, 'mock utm_term', 'result.utm_term is correct')
 
         assert.equal(cache.get.callCount, 0, 'cache.get was not called')
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      })
+    }
+  )
+
+  it(
+    'metricsContext.gather with DNT header',
+    () => {
+      return metricsContext.gather.call({
+        headers: {
+          dnt: '1'
+        },
+        payload: {
+          metricsContext: {
+            deviceId: 'mock device id',
+            flowId: 'mock flow id',
+            flowBeginTime: Date.now(),
+            flowCompleteSignal: 'mock flow complete signal',
+            flowType: 'mock flow type',
+            context: 'mock context',
+            entrypoint: 'mock entry point',
+            migration: 'mock migration',
+            service: 'mock service',
+            utmCampaign: 'mock utm_campaign',
+            utmContent: 'mock utm_content',
+            utmMedium: 'mock utm_medium',
+            utmSource: 'mock utm_source',
+            utmTerm: 'mock utm_term',
+            ignore: 'mock ignorable property'
+          }
+        }
+      }, {}).then(function (result) {
+        assert.equal(Object.keys(result).length, 7, 'result has 7 properties')
+        assert.equal(result.utm_campaign, undefined, 'result.utm_campaign is undefined')
+        assert.equal(result.utm_content, undefined, 'result.utm_content is undefined')
+        assert.equal(result.utm_medium, undefined, 'result.utm_medium is undefined')
+        assert.equal(result.utm_source, undefined, 'result.utm_source is undefined')
+        assert.equal(result.utm_term, undefined, 'result.utm_term is undefined')
+
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
     }
@@ -256,7 +300,12 @@ describe('metricsContext', () => {
         flowId: 'flowId',
         flowBeginTime: time,
         flowCompleteSignal: 'flowCompleteSignal',
-        flowType: 'flowType'
+        flowType: 'flowType',
+        utmCampaign: 'utmCampaign',
+        utmContent: 'utmContent',
+        utmMedium: 'utmMedium',
+        utmSource: 'utmSource',
+        utmTerm: 'utmTerm'
       })
       return metricsContext.gather.call({
         auth: {
@@ -269,7 +318,7 @@ describe('metricsContext', () => {
 
         assert.equal(typeof result, 'object', 'result is object')
         assert.notEqual(result, null, 'result is not null')
-        assert.equal(Object.keys(result).length, 7, 'result has 7 properties')
+        assert.equal(Object.keys(result).length, 12, 'result has 12 properties')
         assert.ok(result.time > time, 'result.time seems correct')
         assert.equal(result.device_id, 'deviceId', 'result.device_id is correct')
         assert.equal(result.flow_id, 'flowId', 'result.flow_id is correct')
@@ -278,6 +327,11 @@ describe('metricsContext', () => {
         assert.equal(result.flowBeginTime, time, 'result.flowBeginTime is correct')
         assert.equal(result.flowCompleteSignal, 'flowCompleteSignal', 'result.flowCompleteSignal is correct')
         assert.equal(result.flowType, 'flowType', 'result.flowType is correct')
+        assert.equal(result.utm_campaign, 'utmCampaign', 'result.utm_campaign is correct')
+        assert.equal(result.utm_content, 'utmContent', 'result.utm_content is correct')
+        assert.equal(result.utm_medium, 'utmMedium', 'result.utm_medium is correct')
+        assert.equal(result.utm_source, 'utmSource', 'result.utm_source is correct')
+        assert.equal(result.utm_term, 'utmTerm', 'result.utm_term is correct')
 
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
@@ -306,7 +360,7 @@ describe('metricsContext', () => {
 
         assert.equal(typeof result, 'object', 'result is object')
         assert.notEqual(result, null, 'result is not null')
-        assert.equal(Object.keys(result).length, 7, 'result has 7 properties')
+        assert.equal(Object.keys(result).length, 12, 'result has 12 properties')
         assert.ok(result.time > time, 'result.time seems correct')
         assert.equal(result.flow_id, 'flowId', 'result.flow_id is correct')
         assert.ok(result.flow_time > 0, 'result.flow_time is greater than zero')

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -155,7 +155,12 @@ describe('metrics/events', () => {
         metricsContext: {
           flowId: 'bar',
           flowBeginTime: time - 1000,
-          flowCompleteSignal: 'account.signed'
+          flowCompleteSignal: 'account.signed',
+          utmCampaign: 'utm campaign',
+          utmContent: 'utm content',
+          utmMedium: 'utm medium',
+          utmSource: 'utm source',
+          utmTerm: 'utm term'
         },
         service: 'baz'
       }
@@ -177,7 +182,12 @@ describe('metrics/events', () => {
           locale: 'en-US',
           time,
           uid: 'deadbeef',
-          userAgent: 'test user-agent'
+          userAgent: 'test user-agent',
+          utm_campaign: 'utm campaign',
+          utm_content: 'utm content',
+          utm_medium: 'utm medium',
+          utm_source: 'utm source',
+          utm_term: 'utm term'
         }, 'argument was event data')
 
         assert.equal(log.activityEvent.callCount, 0, 'log.activityEvent was not called')
@@ -201,6 +211,7 @@ describe('metrics/events', () => {
       clearMetricsContext: metricsContext.clear,
       gatherMetricsContext: metricsContext.gather,
       headers: {
+        dnt: '1',
         'user-agent': 'foo'
       },
       payload: {
@@ -244,6 +255,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       payload: {
         metricsContext: {
@@ -287,6 +302,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       payload: {
         metricsContext: {
@@ -330,6 +349,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       payload: {
         metricsContext: {
@@ -372,6 +395,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       locale: 'fr',
       metricsContext,
       payload: {
@@ -491,6 +518,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       payload: {
         metricsContext: {
@@ -639,6 +670,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       path: '/v1/account/create',
       payload: {
@@ -696,6 +731,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       path: '/v1/account/login',
       payload: {
@@ -735,6 +774,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       path: '/v1/recovery_email/resend_code',
       payload: {
@@ -774,6 +817,10 @@ describe('metrics/events', () => {
     sinon.stub(Date, 'now', () => time)
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
+      headers: {
+        dnt: '1',
+        'user-agent': 'test user-agent'
+      },
       metricsContext,
       path: '/v1/account/destroy',
       payload: {

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -210,7 +210,12 @@ describe('/account/create', () => {
         service: 'sync',
         metricsContext: {
           flowBeginTime: Date.now(),
-          flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103'
+          flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+          utmCampaign: 'utm campaign',
+          utmContent: 'utm content',
+          utmMedium: 'utm medium',
+          utmSource: 'utm source',
+          utmTerm: 'utm term'
         }
       },
       query: {
@@ -326,7 +331,12 @@ describe('/account/create', () => {
         flowType: undefined,
         flow_id: mockRequest.payload.metricsContext.flowId,
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
-        time: now
+        time: now,
+        utm_campaign: 'utm campaign',
+        utm_content: 'utm content',
+        utm_medium: 'utm medium',
+        utm_source: 'utm source',
+        utm_term: 'utm term'
       }, 'it contained the correct metrics context metadata')
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once')
@@ -352,7 +362,12 @@ describe('/account/create', () => {
         locale: 'en-GB',
         time: now,
         uid: uid,
-        userAgent: 'test user-agent'
+        userAgent: 'test user-agent',
+        utm_campaign: 'utm campaign',
+        utm_content: 'utm content',
+        utm_medium: 'utm medium',
+        utm_source: 'utm source',
+        utm_term: 'utm term'
       }, 'flow event data was correct')
 
       assert.equal(mockMetricsContext.validate.callCount, 1, 'metricsContext.validate was called')
@@ -433,6 +448,10 @@ describe('/account/login', function () {
 
   const mockRequest = mocks.mockRequest({
     log: mockLog,
+    headers: {
+      dnt: '1',
+      'user-agent': 'test user-agent'
+    },
     metricsContext: mockMetricsContext,
     payload: {
       authPW: hexString(32),
@@ -441,7 +460,12 @@ describe('/account/login', function () {
       reason: 'signin',
       metricsContext: {
         flowBeginTime: Date.now(),
-        flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103'
+        flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+        utmCampaign: 'utm campaign',
+        utmContent: 'utm content',
+        utmMedium: 'utm medium',
+        utmSource: 'utm source',
+        utmTerm: 'utm term'
       }
     },
     query: {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -426,6 +426,12 @@ function mockMetricsContext (methods) {
               flowBeginTime: this.payload.metricsContext.flowBeginTime,
               flowCompleteSignal: this.payload.metricsContext.flowCompleteSignal,
               flowType: this.payload.metricsContext.flowType
+            }, this.headers && this.headers.dnt === '1' ? {} : {
+              utm_campaign: this.payload.metricsContext.utmCampaign,
+              utm_content: this.payload.metricsContext.utmContent,
+              utm_medium: this.payload.metricsContext.utmMedium,
+              utm_source: this.payload.metricsContext.utmSource,
+              utm_term: this.payload.metricsContext.utmTerm
             })
           }
 


### PR DESCRIPTION
Related to mozilla/fxa-content-server#5487.

We dropped `utm_*` in #1585. Turns out they were being depended on by basket. This PR reinstates them.

@mozilla/fxa-devs r?