### PR TITLE
refactor(secondary-email): Remove "add secondary email" feature flag.

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -25,9 +25,6 @@
       "allowedRecency": 0
     }
   },
-  "secondaryEmail": {
-    "enabled": true
-  },
   "lastAccessTimeUpdates": {
     "enabled": true,
     "sampleRate": 1

--- a/config/index.js
+++ b/config/index.js
@@ -741,18 +741,6 @@ var conf = convict({
     }
   },
   secondaryEmail: {
-    enabled: {
-      doc: 'Indicates whether secondary email APIs are enabled',
-      default: true,
-      format: Boolean,
-      env: 'SECONDARY_EMAIL_ENABLED'
-    },
-    enabledEmailAddresses: {
-      doc: 'Only enable for email addresses matching this regex.',
-      format: RegExp,
-      default: /.+@mozilla\.com$|.+@restmail\.net$|.+@softvisioninc\.eu$|.+@softvision\.(com|ro)$/,
-      env: 'SECONDARY_EMAIL_ENABLE_REGEX'
-    },
     minUnverifiedAccountTime: {
       doc: 'The minimum amount of time an account can be unverified before another account can use it for secondary email',
       default: '1 day',

--- a/docs/api.md
+++ b/docs/api.md
@@ -324,6 +324,11 @@ those common validations are defined here.
     * `deviceId`: string, length(32), regex(HEX_STRING), optional
     * `flowId`: string, length(64), regex(HEX_STRING), optional
     * `flowBeginTime`: number, integer, positive, optional
+    * `utmCampaign`: string, optional
+    * `utmContent`: string, optional
+    * `utmMedium`: string, optional
+    * `utmSource`: string, optional
+    * `utmTerm`: string, optional
 
   }), unknown(false), and('flowId', 'flowBeginTime')
 * `schema`: SCHEMA.optional
@@ -1552,15 +1557,6 @@ from the `accounts` table.
   
   <!--end-response-body-get-recovery_emails-email-->
 
-##### Error responses
-
-Failing requests may be caused
-by the following errors
-(this is not an exhaustive list):
-
-* `code: 503, errno: 202`:
-  Feature not enabled
-
 
 #### POST /recovery_email
 
@@ -1585,9 +1581,6 @@ and will not replace the primary email address.
 Failing requests may be caused
 by the following errors
 (this is not an exhaustive list):
-
-* `code: 503, errno: 202`:
-  Feature not enabled
 
 * `code: 400, errno: 104`:
   Unverified account
@@ -1627,9 +1620,6 @@ Failing requests may be caused
 by the following errors
 (this is not an exhaustive list):
 
-* `code: 503, errno: 202`:
-  Feature not enabled
-
 * `code: 400, errno: 138`:
   Unverified session
 
@@ -1655,9 +1645,6 @@ belong to the user and be verified.
 Failing requests may be caused
 by the following errors
 (this is not an exhaustive list):
-
-* `code: 503, errno: 202`:
-  Feature not enabled
 
 * `code: 400, errno: 138`:
   Unverified session

--- a/lib/features.js
+++ b/lib/features.js
@@ -11,7 +11,6 @@ const SCHEMA = isA.array().items(isA.string()).optional()
 
 module.exports = config => {
   const lastAccessTimeUpdates = config.lastAccessTimeUpdates
-  const secondaryEmail = config.secondaryEmail
 
   return {
     /**
@@ -24,19 +23,6 @@ module.exports = config => {
     isLastAccessTimeEnabledForUser (uid) {
       return lastAccessTimeUpdates.enabled &&
         isSampledUser(lastAccessTimeUpdates.sampleRate, uid, 'lastAccessTimeUpdates')
-    },
-
-    /**
-     * Return whether or not secondary email support is enabled.
-     *
-     * @returns {boolean}
-     */
-    isSecondaryEmailEnabled(email) {
-      if (secondaryEmail && secondaryEmail.enabled && secondaryEmail.enabledEmailAddresses) {
-        return secondaryEmail.enabledEmailAddresses.test(email)
-      }
-
-      return false
     },
 
     /**

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -15,7 +15,6 @@ const validators = require('./validators')
 const HEX_STRING = validators.HEX_STRING
 
 module.exports = (log, db, mailer, config, customs, push) => {
-  const features = require('../features')(config)
   const verificationReminder = require('../verification-reminders')(log, db)
 
   return [
@@ -31,16 +30,11 @@ module.exports = (log, db, mailer, config, customs, push) => {
         log.begin('Account.RecoveryEmailEnabled', request)
 
         const sessionToken = request.auth.credentials
-        let isEnabled = false
 
         return db.account(sessionToken.uid)
           .then((account) =>{
-            // Secondary emails are enabled if email address matches config and the session is verified
-            if (features.isSecondaryEmailEnabled(account.email) && sessionToken.tokenVerified) {
-              isEnabled = true
-            }
-
-            return reply({ ok: isEnabled })
+            // Secondary emails are enabled if the session is verified
+            return reply({ ok: sessionToken.tokenVerified })
           })
       }
     },
@@ -319,7 +313,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
           .then((account) => {
             // Check if param `type` is specified and equal to `secondary`
             // If so, verify the secondary email and respond
-            if (type && type === 'secondary' && features.isSecondaryEmailEnabled(account.email)) {
+            if (type && type === 'secondary') {
               let matchedEmail
               return db.accountEmails(account.uid)
                 .then((emails) => {
@@ -529,11 +523,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
 
         return db.account(uid)
           .then((account) => {
-
-            if (! features.isSecondaryEmailEnabled(account.email)) {
-              throw error.featureNotEnabled()
-            }
-
             return createResponse(account.emails)
           })
           .done(reply, reply)
@@ -582,10 +571,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
             return db.account(uid)
           })
           .then((account) => {
-            if (! features.isSecondaryEmailEnabled(account.email)) {
-              return reply(error.featureNotEnabled())
-            }
-
             if (! sessionToken.emailVerified) {
               throw error.unverifiedAccount()
             }
@@ -700,10 +685,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
           .then((result) => {
             account = result
 
-            if (! features.isSecondaryEmailEnabled(account.email)) {
-              throw error.featureNotEnabled()
-            }
-
             if (sessionToken.tokenVerificationId) {
               throw error.unverifiedSession()
             }
@@ -762,13 +743,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
           })
           .then((result) => {
             account = result
-
-            // If a user changes their primary email, then they will still
-            // have access to secondary emails because we check against the original
-            // account email.
-            if (! features.isSecondaryEmailEnabled(account.email)) {
-              throw error.featureNotEnabled()
-            }
 
             if (sessionToken.tokenVerificationId) {
               throw error.unverifiedSession()

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -31,11 +31,8 @@ module.exports = (log, db, mailer, config, customs, push) => {
 
         const sessionToken = request.auth.credentials
 
-        return db.account(sessionToken.uid)
-          .then((account) =>{
-            // Secondary emails are enabled if the session is verified
-            return reply({ ok: sessionToken.tokenVerified })
-          })
+        // Secondary emails are enabled if the session is verified
+        return reply({ ok: sessionToken.tokenVerified })
       }
     },
     {
@@ -568,9 +565,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
 
         customs.check(request, primaryEmail, 'createEmail')
           .then(() => {
-            return db.account(uid)
-          })
-          .then((account) => {
             if (! sessionToken.emailVerified) {
               throw error.unverifiedAccount()
             }
@@ -733,17 +727,11 @@ module.exports = (log, db, mailer, config, customs, push) => {
         const uid = sessionToken.uid
         const primaryEmail = sessionToken.email
         const email = request.payload.email
-        let account
 
         log.begin('Account.RecoveryEmailSetPrimary', request)
 
         customs.check(request, primaryEmail, 'setPrimaryEmail')
           .then(() => {
-            return db.account(uid)
-          })
-          .then((result) => {
-            account = result
-
             if (sessionToken.tokenVerificationId) {
               throw error.unverifiedSession()
             }
@@ -773,7 +761,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
             .then(() => {
               request.app.devices.then(devices => push.notifyProfileUpdated(uid, devices))
               log.notifyAttachedServices('primaryEmailChanged', request, {
-                uid: account.uid,
+                uid,
                 email: email
               })
             })

--- a/test/local/features.js
+++ b/test/local/features.js
@@ -21,8 +21,7 @@ const config = {
   lastAccessTimeUpdates: {},
   signinConfirmation: {},
   signinUnblock: {},
-  securityHistory: {},
-  secondaryEmail: {}
+  securityHistory: {}
 }
 
 const MODULE_PATH = '../../lib/features'
@@ -39,10 +38,9 @@ describe('features', () => {
       assert.notEqual(require(MODULE_PATH).schema, null, 'features.schema is not null')
 
       assert.equal(typeof features, 'object', 'object type should be exported')
-      assert.equal(Object.keys(features).length, 3, 'object should have correct number of properties')
+      assert.equal(Object.keys(features).length, 2, 'object should have correct number of properties')
       assert.equal(typeof features.isSampledUser, 'function', 'isSampledUser should be function')
       assert.equal(typeof features.isLastAccessTimeEnabledForUser, 'function', 'isLastAccessTimeEnabledForUser should be function')
-      assert.equal(typeof features.isSecondaryEmailEnabled, 'function', 'isSecondaryEmailEnabled should be function')
 
       assert.equal(crypto.createHash.callCount, 1, 'crypto.createHash should have been called once on require')
       let args = crypto.createHash.args[0]
@@ -177,21 +175,6 @@ describe('features', () => {
       config.lastAccessTimeUpdates.enabled = false
       config.lastAccessTimeUpdates.sampleRate = 0.03
       assert.equal(features.isLastAccessTimeEnabledForUser(uid, email), false, 'should return false when feature is disabled')
-    }
-  )
-
-  it(
-    'isSecondaryEmailEnabled',
-    () => {
-      config.secondaryEmail.enabled = true
-      assert.equal(features.isSecondaryEmailEnabled('asdf@mozilla.com'), false, 'should return false if no enabled regex address specified')
-
-      config.secondaryEmail.enabledEmailAddresses = /.+@mozilla\.com$/
-      assert.equal(features.isSecondaryEmailEnabled('asdf@mozilla.com'), true, 'should return true when email matches regex')
-      assert.equal(features.isSecondaryEmailEnabled('asdf@notmozilla.com'), false, 'should return false when email does not match regex')
-
-      config.secondaryEmail.enabled = false
-      assert.equal(features.isSecondaryEmailEnabled(), false, 'should return false when secondary email is disabled in config')
     }
   )
 })

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1181,8 +1181,6 @@ describe('/account/login', function () {
 
   it('fails login with non primary email', function () {
     const email = 'foo@mail.com'
-    config.secondaryEmail.enabled = true
-    config.secondaryEmail.enabledEmailAddresses = /\w/
     mockDB.accountRecord = sinon.spy(function () {
       return P.resolve({
         primaryEmail: {normalizedEmail: email.toLowerCase(), email: email, isVerified: true, isPrimary: false},

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -853,7 +853,7 @@ describe('/recovery_email', () => {
         assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments')
         assert.equal(args[0], 'primaryEmailChanged', 'first argument was event name')
         assert.equal(args[1], mockRequest, 'second argument was request object')
-        assert.equal(args[2].uid, uid, 'third argument was event data with a uid')
+        assert.equal(args[2].uid, mockRequest.auth.credentials.uid, 'third argument was event data with a uid')
         assert.equal(args[2].email, TEST_EMAIL_ADDITIONAL, 'third argument was event data with new email')
       })
         .then(function () {

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -76,12 +76,7 @@ function runTest (route, request, assertions) {
 }
 
 describe('/recovery_email/status', function () {
-  var config = {
-    secondaryEmail: {
-      enabled: true,
-      enabledEmailAddresses: /\w/
-    }
-  }
+  var config = {}
   var mockDB = mocks.mockDB()
   var pushCalled
   var mockLog = mocks.mockLog({
@@ -260,12 +255,7 @@ describe('/recovery_email/status', function () {
 })
 
 describe('/recovery_email/resend_code', () => {
-  const config = {
-    secondaryEmail: {
-      enabled: true,
-      enabledEmailAddresses: /\w/
-    }
-  }
+  const config = {}
   const secondEmailCode = crypto.randomBytes(16)
   const mockDB = mocks.mockDB({secondEmailCode: secondEmailCode})
   const mockLog = mocks.mockLog()
@@ -462,12 +452,7 @@ describe('/recovery_email/verify_code', function () {
     checkPassword: function () {
       return P.resolve(true)
     },
-    config: {
-      secondaryEmail: {
-        enabled: true,
-        enabledEmailAddresses: /\w/
-      }
-    },
+    config: {},
     customs: mockCustoms,
     db: mockDB,
     log: mockLog,
@@ -717,8 +702,6 @@ describe('/recovery_email', () => {
       },
       config: {
         secondaryEmail: {
-          enabled: true,
-          enabledEmailAddresses: /\w/,
           minUnverifiedAccountTime: MS_IN_DAY
         }
       },
@@ -910,48 +893,6 @@ describe('/recovery_email', () => {
     })
   })
 
-  describe('can disable feature', () => {
-    beforeEach(() => {
-      accountRoutes = makeRoutes({
-        checkPassword: function () {
-          return P.resolve(true)
-        },
-        config: {
-          secondaryEmail: {
-            enabled: false,
-            enabledEmailAddresses: /\w/
-          }
-        },
-        customs: mockCustoms,
-        db: mockDB,
-        log: mockLog,
-        mailer: mockMailer,
-        push: mockPush
-      })
-    })
-
-    it('/recovery_email/destroy disabled', () => {
-      route = getRoute(accountRoutes, '/recovery_email/destroy')
-      return runTest(route, mockRequest).then(
-        () => assert.fail('Should have failed accessing endpoint'),
-        err => assert.equal(err.errno, 202, 'correct errno feature disabled'))
-    })
-
-    it('/recovery_email disabled', () => {
-      route = getRoute(accountRoutes, '/recovery_email')
-      return runTest(route, mockRequest).then(
-        () => assert.fail('Should have failed accessing endpoint'),
-        err => assert.equal(err.errno, 202, 'correct errno feature disabled'))
-    })
-
-    it('/recovery_emails disabled', () => {
-      route = getRoute(accountRoutes, '/recovery_emails')
-      return runTest(route, mockRequest).then(
-        () => assert.fail('Should have failed accessing endpoint'),
-        err => assert.equal(err.errno, 202, 'correct errno feature disabled'))
-    })
-  })
-
   describe('can check feature enable flag', () => {
     function setupTest(options) {
       dbData = {
@@ -964,12 +905,7 @@ describe('/recovery_email', () => {
         checkPassword: function () {
           return P.resolve(true)
         },
-        config: {
-          secondaryEmail: {
-            enabled: true,
-            enabledEmailAddresses: /@mozilla\.com/
-          }
-        },
+        config: {},
         customs: mockCustoms,
         db: mockDB,
         log: mockLog,
@@ -982,14 +918,6 @@ describe('/recovery_email', () => {
     it('/recovery_email/check_can_add_secondary_address disabled with unverified session', () => {
       setupTest({email: 'asdf@mozilla.com'})
       mockRequest.auth.credentials.tokenVerified = false
-      return runTest(route, mockRequest, (res) => {
-        assert.equal(res.ok, false, 'return ok `false` when feature is not enabled for user')
-      })
-    })
-
-    it('/recovery_email/check_can_add_secondary_address disabled with invalid email', () => {
-      setupTest({email: 'email@notvalid.com'})
-      mockRequest.auth.credentials.tokenVerified = true
       return runTest(route, mockRequest, (res) => {
         assert.equal(res.ok, false, 'return ok `false` when feature is not enabled for user')
       })

--- a/test/remote/recovery_email_change_email.js
+++ b/test/remote/recovery_email_change_email.js
@@ -16,10 +16,6 @@ describe('remote change email', function () {
 
   before(() => {
     config = require('../../config').getProperties()
-    config.secondaryEmail = {
-      enabled: true,
-      enabledEmailAddresses: /@restmail.net/
-    }
     config.securityHistory.ipProfiling = {}
     return TestServer.start(config)
       .then(s => {

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -20,10 +20,6 @@ describe('remote emails', function () {
 
   before(() => {
     config = require('../../config').getProperties()
-    config.secondaryEmail = {
-      enabled: true,
-      enabledEmailAddresses: /\w/
-    }
     config.securityHistory.ipProfiling = {}
     config.signinConfirmation.skipForNewAccounts.enabled = false
 


### PR DESCRIPTION
This removes features.isSecondaryEmailEnabled, but does not remove
the `/recovery_email/check_can_add_secondary_address` check which
checks to ensure the token is verified. I'm unsure whether that call
is necessary because the front-end will not allow a user to visit
/settings if their session is unverified.

fixes #2099 

@vbudhram - r?