### PR TITLE
fix(push): return pushEndpointExpired as a boolean

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -455,7 +455,7 @@ module.exports = (
             pushCallback: device.callbackURL,
             pushPublicKey: device.callbackPublicKey,
             pushAuthKey: device.callbackAuthKey,
-            pushEndpointExpired: device.callbackIsExpired,
+            pushEndpointExpired: !! device.callbackIsExpired,
             uaBrowser: mergedInfo.uaBrowser,
             uaBrowserVersion: mergedInfo.uaBrowserVersion,
             uaOS: mergedInfo.uaOS,
@@ -617,7 +617,7 @@ module.exports = (
         callbackURL: deviceInfo.pushCallback,
         callbackPublicKey: deviceInfo.pushPublicKey,
         callbackAuthKey: deviceInfo.pushAuthKey,
-        callbackIsExpired: deviceInfo.pushEndpointExpired
+        callbackIsExpired: !! deviceInfo.pushEndpointExpired
       }
     )
     .then(

--- a/lib/routes/devices-sessions.js
+++ b/lib/routes/devices-sessions.js
@@ -365,7 +365,7 @@ module.exports = (log, db, config, customs, push, devices) => {
                 deviceCallbackURL: session.deviceCallbackURL,
                 deviceCallbackPublicKey: session.deviceCallbackPublicKey,
                 deviceCallbackAuthKey: session.deviceCallbackAuthKey,
-                deviceCallbackIsExpired: session.deviceCallbackIsExpired,
+                deviceCallbackIsExpired: !! session.deviceCallbackIsExpired,
                 id: session.tokenId,
                 isCurrentDevice: session.tokenId === sessionToken.tokenId,
                 isDevice,


### PR DESCRIPTION
I noticed that pushEndpointExpired is returned as a number in fxa responses. Oops.