### PR TITLE
fix(server): enforce 'use strict' everywhere

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,3 +4,4 @@ extends: plugin:fxa/server
 
 rules:
   handle-callback-err: 0
+  strict: 2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt)
 

--- a/bin/email_notifications.js
+++ b/bin/email_notifications.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'fxa-email-bouncer')
 var error = require('../lib/error')

--- a/bin/mailer_server.js
+++ b/bin/mailer_server.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var restify = require('restify')
 var safeJsonFormatter = require('restify-safe-json-formatter')
 var config = require('../config')

--- a/bin/profile_server_messaging.js
+++ b/bin/profile_server_messaging.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'profile-server-messaging')
 var error = require('../lib/error')

--- a/config/index.js
+++ b/config/index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var fs = require('fs')
 var path = require('path')
 var url = require('url')

--- a/config/popular-email-domains.js
+++ b/config/popular-email-domains.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 // This is a list of popular email domains based on FxA users
 // Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1337932
 const domains = new Set([

--- a/config/supportedLanguages.js
+++ b/config/supportedLanguages.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 // The list below should be kept in sync with:
 // https://raw.githubusercontent.com/mozilla/fxa-content-server/master/server/config/production-locales.json
 

--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -4,9 +4,9 @@
 
 // takes care of bumping the version number in package.json
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.config('bump', {
     options: {
       files: ['package.json', 'npm-shrinkwrap.json'],

--- a/grunttasks/changelog.js
+++ b/grunttasks/changelog.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var fxaChangelog = require('fxa-conventional-changelog')()
 
 module.exports = function (grunt) {

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.config('copyright', {
     app: {
       options: {

--- a/grunttasks/doc.js
+++ b/grunttasks/doc.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.registerMultiTask('doc', function () {
     const done = this.async()
     const doc = require('../scripts/write-api-docs')

--- a/grunttasks/eslint.js
+++ b/grunttasks/eslint.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.config('eslint', {
     app: {
       src: [

--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -4,14 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const path = require('path')
 const extract = require('jsxgettext-recursive')
 
 const pkgroot = path.dirname(__dirname)
 
 module.exports = function (grunt) {
-  'use strict'
-
   grunt.config('copy', {
     strings: {
       files: [{

--- a/grunttasks/nsp.js
+++ b/grunttasks/nsp.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.config('nsp', {
     output: 'summary',
     package: grunt.file.readJSON('package.json'),

--- a/grunttasks/templates.js
+++ b/grunttasks/templates.js
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.config('nunjucks', {
     options: {
       paths: 'lib/senders/',

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -16,9 +16,9 @@
 // NOTE: This task will not push this commit for you.
 //
 
-module.exports = function (grunt) {
-  'use strict'
+'use strict'
 
+module.exports = function (grunt) {
   grunt.registerTask('version', [
     'bump-only:minor',
     'conventionalChangelog:release',

--- a/lib/crypto/hkdf.js
+++ b/lib/crypto/hkdf.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var HKDF = require('hkdf')
 var P = require('../promise')
 

--- a/lib/crypto/password.js
+++ b/lib/crypto/password.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('../promise')
 var hkdf = require('./hkdf')
 var butil = require('./butil')

--- a/lib/crypto/pbkdf2.js
+++ b/lib/crypto/pbkdf2.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var sjcl = require('sjcl')
 var P = require('../promise')
 

--- a/lib/crypto/scrypt.js
+++ b/lib/crypto/scrypt.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('../promise')
 var scrypt_hash = require('scrypt-hash')
 

--- a/lib/customs.js
+++ b/lib/customs.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('./promise')
 var Pool = require('./pool')
 var config = require('../config')

--- a/lib/email/delivery.js
+++ b/lib/email/delivery.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('./../promise')
 var utils = require('./utils/helpers')
 

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const emailDomains = require('../../../config/popular-email-domains')
 const P = require('../../promise')
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var inherits = require('util').inherits
 var messages = require('joi/lib/language').errors
 

--- a/lib/geodb.js
+++ b/lib/geodb.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var config = require('../config').get('geodb')
 var geodb = require('fxa-geodb')(config)
 var P = require('./promise')

--- a/lib/newrelic.js
+++ b/lib/newrelic.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 // To be enabled via the environment of stage or prod. NEW_RELIC_HIGH_SECURITY
 // and NEW_RELIC_LOG should be set in addition to NEW_RELIC_APP_NAME and
 // NEW_RELIC_LICENSE_KEY.

--- a/lib/push.js
+++ b/lib/push.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var crypto = require('crypto')
 var base64url = require('base64url')
 var webpush = require('web-push')

--- a/lib/routes/idp.js
+++ b/lib/routes/idp.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var jwtool = require('fxa-jwtool')
 
 function b64toDec(str) {

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const error = require('../error')
 const isA = require('joi')
 const P = require('../promise')

--- a/lib/routes/utils/password_check.js
+++ b/lib/routes/utils/password_check.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /**
  * Check if the password a user entered matches the one on
  * file for the account. If it does not, flag the account with

--- a/lib/routes/utils/request_helper.js
+++ b/lib/routes/utils/request_helper.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /**
  * Returns `true` if request has a keys=true query param.
  *

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var url = require('url')
 var punycode = require('punycode')
 var isA = require('joi')

--- a/lib/senders/db.js
+++ b/lib/senders/db.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var log = require('./log')('db')
 var P = require('../promise')
 var Pool = require('./pool')

--- a/lib/senders/db_connect.js
+++ b/lib/senders/db_connect.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('bluebird')
 var config = require('../../config')
 var log = require('./log')('db')

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var qs = require('querystring')
 var url = require('url')
 var P = require('bluebird')

--- a/lib/senders/legacy_log.js
+++ b/lib/senders/legacy_log.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /**
  * This module converts old logging messages to mozlog
  *

--- a/lib/senders/log.js
+++ b/lib/senders/log.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var mozlog = require('mozlog')
 
 var logConfig = require('../../config').get('log')

--- a/lib/senders/pool.js
+++ b/lib/senders/pool.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('../promise')
 var Poolee = require('poolee')
 

--- a/lib/senders/templates/index.js
+++ b/lib/senders/templates/index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var path = require('path')
 var P = require('bluebird')
 var handlebars = require('handlebars')

--- a/lib/senders/translator.js
+++ b/lib/senders/translator.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var path = require('path')
 var i18n = require('i18n-abide')
 var Jed = require('jed')

--- a/lib/senders/verification-reminders.js
+++ b/lib/senders/verification-reminders.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var logger = require('./log')('verification-reminders')
 var P = require('../promise')
 var config = require('../../config')

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var jwtool = require('fxa-jwtool')
 
 module.exports = function (secretKeyFile, domain) {

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var AWS = require('aws-sdk')
 var inherits = require('util').inherits
 var EventEmitter = require('events').EventEmitter

--- a/lib/tokens/account_reset_token.js
+++ b/lib/tokens/account_reset_token.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const inherits = require('util').inherits
 
 module.exports = function (log, Token, lifetime) {

--- a/lib/tokens/bundle.js
+++ b/lib/tokens/bundle.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 
 /*  Utility functions for working with encrypted data bundles.
  *

--- a/lib/tokens/key_fetch_token.js
+++ b/lib/tokens/key_fetch_token.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const inherits = require('util').inherits
 const P = require('../promise')
 

--- a/lib/tokens/token.js
+++ b/lib/tokens/token.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /*  Base class for handling various types of token.
  *
  *  This module provides the basic functionality for handling authentication
@@ -40,7 +42,6 @@ module.exports = (log, config) => {
     KEYS.forEach(name => {
       this[name] = keys[name] && keys[name].toString('hex')
     })
-    this.algorithm = 'sha256'
     this.uid = details.uid || null
     this.lifetime = details.lifetime || Infinity
     this.createdAt = details.createdAt || 0

--- a/lib/verification-reminders.js
+++ b/lib/verification-reminders.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var config = require('../config')
 var P = require('./promise')
 var reminderConfig = config.get('verificationReminders')

--- a/scripts/bulk-mailer.js
+++ b/scripts/bulk-mailer.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var commandLineOptions = require('commander')
 var config = require('../config').getProperties()
 var fs = require('fs')

--- a/scripts/bulk-mailer/nodemailer-mock.js
+++ b/scripts/bulk-mailer/nodemailer-mock.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var fs = require('fs')
 var path = require('path')
 

--- a/scripts/e2e-email/index.js
+++ b/scripts/e2e-email/index.js
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const crypto = require('crypto')
 const commander = require('commander')
 

--- a/scripts/e2e-email/localeQuirks.js
+++ b/scripts/e2e-email/localeQuirks.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 // Not all non-english locales have tranlated some things yet.
 // So there are these unfortunate bits of custom mappings that
 // will need to change over time.

--- a/scripts/e2e-email/validate-email.js
+++ b/scripts/e2e-email/validate-email.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const util = require('util')
 const url = require('url')
 

--- a/scripts/gen_keys.js
+++ b/scripts/gen_keys.js
@@ -20,6 +20,8 @@
    keypair.
 */
 
+'use strict'
+
 const fs = require('fs')
 const cp = require('child_process')
 const assert = require('assert')

--- a/scripts/gen_vapid_keys.js
+++ b/scripts/gen_vapid_keys.js
@@ -19,6 +19,8 @@
    keypair.
 */
 
+'use strict'
+
 const fs = require('fs')
 const config = require('../config')
 const webpush = require('web-push')

--- a/scripts/must-reset.js
+++ b/scripts/must-reset.js
@@ -15,6 +15,8 @@
 
  /*/
 
+'use strict'
+
 var butil = require('../lib/crypto/butil')
 var commandLineOptions = require('commander')
 var config = require('../config').getProperties()

--- a/scripts/reset-send-create-batches.js
+++ b/scripts/reset-send-create-batches.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var commandLineOptions = require('commander')
 var fs = require('fs')
 var P = require('../lib/promise')

--- a/scripts/rpm-version.js
+++ b/scripts/rpm-version.js
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var cp = require('child_process')
 var util = require('util')
 

--- a/scripts/test-remote-quick.js
+++ b/scripts/test-remote-quick.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var path = require('path')
 var spawn = require('child_process').spawn
 var config = require('../config').getProperties()

--- a/scripts/write-emails-to-disk.js
+++ b/scripts/write-emails-to-disk.js
@@ -28,6 +28,8 @@
  * to give a rough idea of how they would render in real life.
  */
 
+'use strict'
+
 var P = require('bluebird')
 const config = require('../config').getProperties()
 const error = require('../lib/error')

--- a/test/bench/bot.js
+++ b/test/bench/bot.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /* eslint-disable no-console */
 var Client = require('../client')()
 

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 /* eslint-disable no-console */
 var cp = require('child_process')
 var split = require('binary-split')

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 module.exports = config => {
   var P = require('../../lib/promise')
   const ClientApi = require('./api')(config)
@@ -467,7 +469,7 @@ module.exports = config => {
             headers,
             options
           )
-            .then(function (response) {
+            .then(response => {
               // Update to the new verified tokens
               this.sessionToken = response.sessionToken
               this.keyFetchToken = response.keyFetchToken

--- a/test/key_server_stub.js
+++ b/test/key_server_stub.js
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 require('../bin/key_server.js')

--- a/test/local/crypto/base32.js
+++ b/test/local/crypto/base32.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 const base32 = require('../../../lib/crypto/base32')
 

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const ROOT_DIR = '../..'
 
 const assert = require('insist')

--- a/test/local/email/delivery.js
+++ b/test/local/email/delivery.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 
 const EventEmitter = require('events').EventEmitter

--- a/test/local/error.js
+++ b/test/local/error.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 var messages = require('joi/lib/language')
 const AppError = require('../../lib/error')

--- a/test/local/password_check.js
+++ b/test/local/password_check.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 var sinon = require('sinon')
 

--- a/test/local/profile/updates.js
+++ b/test/local/profile/updates.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 
 const EventEmitter = require('events').EventEmitter

--- a/test/local/senders/db_connect.js
+++ b/test/local/senders/db_connect.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const ROOT_DIR = '../../..'
 
 const assert = require('insist')

--- a/test/local/senders/legacy_log.js
+++ b/test/local/senders/legacy_log.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 var sinon = require('sinon')
 const legacyLog = require('../../../lib/senders/legacy_log')

--- a/test/local/senders/pool.js
+++ b/test/local/senders/pool.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('insist')
 var sinon = require('sinon')
 var proxyquire = require('proxyquire')

--- a/test/local/senders/reminder.js
+++ b/test/local/senders/reminder.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const ROOT_DIR = '../../../'
 
 const assert = require('insist')

--- a/test/mailbox.js
+++ b/test/mailbox.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var P = require('../lib/promise')
 var request = require('request')
 const EventEmitter = require('events').EventEmitter

--- a/test/mailer_helper.js
+++ b/test/mailer_helper.js
@@ -4,6 +4,8 @@
 
 /*eslint no-console: 0*/
 
+'use strict'
+
 var uuid = require('uuid')
 
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex').toString('hex')

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -6,6 +6,8 @@
  * Shared helpers for mocking things out in the tests.
  */
 
+'use strict'
+
 const assert = require('assert')
 const sinon = require('sinon')
 const extend = require('util')._extend

--- a/test/push_helper.js
+++ b/test/push_helper.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var WebSocket = require('ws')
 var P = require('../lib/promise')
 

--- a/test/routes_helpers.js
+++ b/test/routes_helpers.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 exports.getRoute = function (routes, path) {
   var route = null
 

--- a/test/test_mailer_server.js
+++ b/test/test_mailer_server.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 var createDBServer = require('fxa-auth-db-mysql')
 
 function TestServer(config) {


### PR DESCRIPTION
Train 96 contains a few things that I expect to improve the performance of auth server routes. In order to maximise the improvement, and because non-strict code prohibits some V8 optimisations, I decided to add `'use strict'` directives everywhere and enforce their presence in `.eslintrc`.

As an added bonus, I found two bona fide issues in the code by enabling strict mode. Neither causes any problems in production (one was in test code, the other was harmless but logically insane), but it's a pertinent reminder of why strict mode is to be preferred. I'll call them out explicitly inline.

And sorry, I've ended up creating one of those PRs that I always moan about. I'll make a point of complaining about my own behaviour in next week's retro.

@mozilla/fxa-devs r?
