### PR TITLE
fix(docs): update dependencies for api doc generation

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,8 @@
   "exceptions": [
     // i18n-abide@0.0.25
     "https://nodesecurity.io/advisories/39",
-    "https://nodesecurity.io/advisories/48"
+    "https://nodesecurity.io/advisories/48",
+    // tough-cookie@2.3.2
+    "https://nodesecurity.io/advisories/525"
   ]
 }

--- a/grunttasks/doc.js
+++ b/grunttasks/doc.js
@@ -19,7 +19,10 @@ module.exports = function (grunt) {
     api: {
       // have a src and dest set allows grunt-newer to work
       src: [
+        'lib/devices.js',
         'lib/error.js',
+        'lib/features.js',
+        'lib/metrics/context.js',
         'lib/routes'
       ],
       dest: 'docs/api.md'


### PR DESCRIPTION
Although this doesn't fix the underlying issue for #2128, it does update the list of dependencies which was hitherto incomplete.

@mozilla/fxa-devs r?