### PR TITLE
chore(logs): log error if headers are missing in email notifications

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,8 @@
   "exceptions": [
     // i18n-abide@0.0.25
     "https://nodesecurity.io/advisories/39",
-    "https://nodesecurity.io/advisories/48"
+    "https://nodesecurity.io/advisories/48",
+    // tough-cookie@2.3.2
+    "https://nodesecurity.io/advisories/525"
   ]
 }

--- a/lib/email/bounces.js
+++ b/lib/email/bounces.js
@@ -40,7 +40,7 @@ module.exports = function (log, error) {
     }
 
     function handleBounce(message) {
-      utils.logErrorIfHeadersAreWeirdOrMissing(log, message)
+      utils.logErrorIfHeadersAreWeirdOrMissing(log, message, 'bounce')
 
       var recipients = []
       // According to the AWS SES docs, a notification will never

--- a/lib/email/bounces.js
+++ b/lib/email/bounces.js
@@ -40,6 +40,8 @@ module.exports = function (log, error) {
     }
 
     function handleBounce(message) {
+      utils.logErrorIfHeadersAreWeirdOrMissing(log, message)
+
       var recipients = []
       // According to the AWS SES docs, a notification will never
       // include multiple types, so it's fine for us to check for

--- a/lib/email/delivery.js
+++ b/lib/email/delivery.js
@@ -12,6 +12,7 @@ module.exports = function (log) {
   return function start(deliveryQueue) {
 
     function handleDelivery(message) {
+      utils.logErrorIfHeadersAreWeirdOrMissing(log, message)
 
       var recipients = []
       if (message.delivery && message.notificationType === 'Delivery') {

--- a/lib/email/delivery.js
+++ b/lib/email/delivery.js
@@ -12,7 +12,7 @@ module.exports = function (log) {
   return function start(deliveryQueue) {
 
     function handleDelivery(message) {
-      utils.logErrorIfHeadersAreWeirdOrMissing(log, message)
+      utils.logErrorIfHeadersAreWeirdOrMissing(log, message, 'delivery')
 
       var recipients = []
       if (message.delivery && message.notificationType === 'Delivery') {

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -42,13 +42,32 @@ function getInsensitiveHeaderValueFromObject(headerName, headers) {
 }
 
 function getHeaderValue(headerName, message){
-  var headers = message.mail && message.mail.headers || message.headers
+  const headers = getHeaders(message)
+
   if (Array.isArray(headers)) {
     return getInsensitiveHeaderValueFromArray(headerName, headers)
-  } else if (headers) {
+  }
+
+  if (headers) {
     return getInsensitiveHeaderValueFromObject(headerName, headers)
+  }
+
+  return ''
+}
+
+function getHeaders (message) {
+  return message.mail && message.mail.headers || message.headers
+}
+
+function logErrorIfHeadersAreWeirdOrMissing (log, message) {
+  const headers = getHeaders(message)
+  if (headers) {
+    const type = typeof headers
+    if (type !== 'object') {
+      log.error({ op: 'emailHeaders.weird', type })
+    }
   } else {
-    return ''
+    log.error({ op: 'emailHeaders.missing' })
   }
 }
 
@@ -175,9 +194,10 @@ function getAnonymizedEmailDomain(email) {
 }
 
 module.exports = {
-  logEmailEventSent: logEmailEventSent,
-  logEmailEventFromMessage: logEmailEventFromMessage,
-  logFlowEventFromMessage: logFlowEventFromMessage,
-  getHeaderValue: getHeaderValue,
-  getAnonymizedEmailDomain: getAnonymizedEmailDomain
+  logEmailEventSent,
+  logEmailEventFromMessage,
+  logErrorIfHeadersAreWeirdOrMissing,
+  logFlowEventFromMessage,
+  getHeaderValue,
+  getAnonymizedEmailDomain
 }

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -59,15 +59,15 @@ function getHeaders (message) {
   return message.mail && message.mail.headers || message.headers
 }
 
-function logErrorIfHeadersAreWeirdOrMissing (log, message) {
+function logErrorIfHeadersAreWeirdOrMissing (log, message, origin) {
   const headers = getHeaders(message)
   if (headers) {
     const type = typeof headers
     if (type !== 'object') {
-      log.error({ op: 'emailHeaders.weird', type })
+      log.error({ op: 'emailHeaders.weird', type, origin })
     }
   } else {
-    log.error({ op: 'emailHeaders.missing' })
+    log.error({ op: 'emailHeaders.missing', origin })
   }
 }
 

--- a/test/local/email/bounce.js
+++ b/test/local/email/bounce.js
@@ -18,6 +18,7 @@ mockBounceQueue.start = function start() {}
 
 function mockMessage(msg) {
   msg.del = sinon.spy()
+  msg.headers = {}
   return msg
 }
 
@@ -28,6 +29,24 @@ function mockedBounces(log, db) {
 describe('bounce messages', () => {
   afterEach(() => {
     mockBounceQueue.removeAllListeners()
+  })
+
+  it('should not log an error for headers', () => {
+    const log = spyLog()
+    return mockedBounces(log, {})
+      .handleBounce(mockMessage({ junk: 'message' }))
+      .then(() => assert.equal(log.error.callCount, 0))
+  })
+
+  it('should log an error for missing headers', () => {
+    const log = spyLog()
+    const message = mockMessage({
+      junk: 'message'
+    })
+    message.headers = undefined
+    return mockedBounces(log, {})
+      .handleBounce(message)
+      .then(() => assert.equal(log.error.callCount, 1))
   })
 
   it(

--- a/test/local/email/delivery.js
+++ b/test/local/email/delivery.js
@@ -17,6 +17,7 @@ mockDeliveryQueue.start = function start() {
 
 function mockMessage(msg) {
   msg.del = sinon.spy()
+  msg.headers = {}
   return msg
 }
 
@@ -25,6 +26,24 @@ function mockedDelivery(log) {
 }
 
 describe('delivery messages', () => {
+  it('should not log an error for headers', () => {
+    const log = spyLog()
+    return mockedDelivery(log)
+      .handleDelivery(mockMessage({ junk: 'message' }))
+      .then(() => assert.equal(log.error.callCount, 0))
+  })
+
+  it('should log an error for missing headers', () => {
+    const log = spyLog()
+    const message = mockMessage({
+      junk: 'message'
+    })
+    message.headers = undefined
+    return mockedDelivery(log)
+      .handleDelivery(message)
+      .then(() => assert.equal(log.error.callCount, 1))
+  })
+
   it(
     'should ignore unknown message types',
     () => {

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -159,4 +159,53 @@ describe('email utils helpers', () => {
     })
     assert.equal(args[3].flow_id, 'c')
   })
+
+  describe('logErrorIfHeadersAreWeirdOrMissing', () => {
+    let log
+
+    beforeEach(() => {
+      log = spyLog()
+    })
+
+    it('logs an error if message.mail is missing', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, {})
+      assert.equal(log.error.callCount, 1)
+      assert.equal(log.error.args[0].length, 1)
+      assert.deepEqual({ op: 'emailHeaders.missing' }, log.error.args[0][0])
+    })
+
+    it('logs an error if message.mail.headers is missing', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {} })
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual({ op: 'emailHeaders.missing' }, log.error.args[0][0])
+    })
+
+    it('does not log an error if message.mail.headers is object', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: { headers: {} } })
+      assert.equal(log.error.callCount, 0)
+    })
+
+    it('does not log an error if message.headers is object', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { headers: {} })
+      assert.equal(log.error.callCount, 0)
+    })
+
+    it('logs an error if message.mail.headers is non-object', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: { headers: 'foo' } })
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual({
+        op: 'emailHeaders.weird',
+        type: 'string'
+      }, log.error.args[0][0])
+    })
+
+    it('logs an error if message.headers is non-object', () => {
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {}, headers: 42 })
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual({
+        op: 'emailHeaders.weird',
+        type: 'number'
+      }, log.error.args[0][0])
+    })
+  })
 })

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -168,16 +168,22 @@ describe('email utils helpers', () => {
     })
 
     it('logs an error if message.mail is missing', () => {
-      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, {})
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, {}, 'wibble')
       assert.equal(log.error.callCount, 1)
       assert.equal(log.error.args[0].length, 1)
-      assert.deepEqual({ op: 'emailHeaders.missing' }, log.error.args[0][0])
+      assert.deepEqual({
+        op: 'emailHeaders.missing',
+        origin: 'wibble'
+      }, log.error.args[0][0])
     })
 
     it('logs an error if message.mail.headers is missing', () => {
-      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {} })
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {} }, 'blee')
       assert.equal(log.error.callCount, 1)
-      assert.deepEqual({ op: 'emailHeaders.missing' }, log.error.args[0][0])
+      assert.deepEqual({
+        op: 'emailHeaders.missing',
+        origin: 'blee'
+      }, log.error.args[0][0])
     })
 
     it('does not log an error if message.mail.headers is object', () => {
@@ -191,20 +197,22 @@ describe('email utils helpers', () => {
     })
 
     it('logs an error if message.mail.headers is non-object', () => {
-      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: { headers: 'foo' } })
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: { headers: 'foo' } }, 'wibble')
       assert.equal(log.error.callCount, 1)
       assert.deepEqual({
         op: 'emailHeaders.weird',
-        type: 'string'
+        type: 'string',
+        origin: 'wibble'
       }, log.error.args[0][0])
     })
 
     it('logs an error if message.headers is non-object', () => {
-      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {}, headers: 42 })
+      emailHelpers.logErrorIfHeadersAreWeirdOrMissing(log, { mail: {}, headers: 42 }, 'wibble')
       assert.equal(log.error.callCount, 1)
       assert.deepEqual({
         op: 'emailHeaders.weird',
-        type: 'number'
+        type: 'number',
+        origin: 'wibble'
       }, log.error.args[0][0])
     })
   })


### PR DESCRIPTION
Opening this for a proposed `96.2` auth server patch, to help debug #2133 in production. My suspicion is that we're expecting headers from AWS that it never provides us, but I'd like to know for sure.

@mozilla/fxa-devs r?