### PR TITLE
fix(metrics): fix the data on email sent events

### DIFF
--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -75,10 +75,10 @@ function logEmailEventSent(log, message) {
   const emailEventInfo = {
     op: 'emailEvent',
     template: message.template,
-    type: 'sent'
+    type: 'sent',
+    flow_id: message.flowId
   }
 
-  emailEventInfo['flow_id'] = getHeaderValue('X-Flow-Id', message)
   emailEventInfo.locale = getHeaderValue('Content-Language', message)
 
   const addrs = [message.email].concat(message.ccEmails || [])
@@ -112,11 +112,12 @@ function logAmplitudeEvent (log, message, eventInfo) {
     query: {},
     payload: {}
   }, {
-    device_id: getHeaderValue('X-Device-Id', message),
+    device_id: message.deviceId || getHeaderValue('X-Device-Id', message),
     email_domain: eventInfo.domain,
-    service: getHeaderValue('X-Service-Id', message),
-    uid: getHeaderValue('X-Uid', message)
+    service: message.service || getHeaderValue('X-Service-Id', message),
+    uid: message.uid || getHeaderValue('X-Uid', message)
   }, {
+    flowBeginTime: message.flowBeginTime || getHeaderValue('X-Flow-Begin-Time', message),
     flow_id: eventInfo.flow_id,
     time: Date.now()
   })

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -87,12 +87,13 @@ describe('email utils helpers', () => {
       ccEmails: [ 'bar@example.com', 'baz@example.com' ],
       template: 'verifyEmail',
       headers: [
-        { name: 'Content-Language', value: 'aaa' },
-        { name: 'X-Device-Id', value: 'bbb' },
-        { name: 'X-Flow-Id', value: 'ccc' },
-        { name: 'X-Service-Id', value: 'ddd' },
-        { name: 'X-Uid', value: 'eee' }
-      ]
+        { name: 'Content-Language', value: 'aaa' }
+      ],
+      deviceId: 'bbb',
+      flowBeginTime: 42,
+      flowId: 'ccc',
+      service: 'ddd',
+      uid: 'eee'
     })
     assert.equal(amplitude.callCount, 1)
     const args = amplitude.args[0]
@@ -118,6 +119,7 @@ describe('email utils helpers', () => {
       uid: 'eee'
     })
     assert.equal(args[3].flow_id, 'ccc')
+    assert.equal(args[3].flowBeginTime, 42)
     assert.ok(args[3].time > Date.now() - 1000)
   })
 
@@ -128,6 +130,7 @@ describe('email utils helpers', () => {
       headers: [
         { name: 'Content-Language', value: 'a' },
         { name: 'X-Device-Id', value: 'b' },
+        { name: 'X-Flow-Begin-Time', value: 1 },
         { name: 'X-Flow-Id', value: 'c' },
         { name: 'X-Service-Id', value: 'd' },
         { name: 'X-Template-Name', value: 'verifyLoginEmail' },
@@ -158,6 +161,7 @@ describe('email utils helpers', () => {
       uid: 'e'
     })
     assert.equal(args[3].flow_id, 'c')
+    assert.equal(args[3].flowBeginTime, 1)
   })
 
   describe('logErrorIfHeadersAreWeirdOrMissing', () => {

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -122,6 +122,10 @@ describe(
       })
     })
 
+    afterEach(() => {
+      mockLog.info.reset()
+    })
+
     messageTypes.forEach(
       function (type) {
         var message = {
@@ -631,10 +635,9 @@ describe(
     it(
       'logs emailEvent on send',
       function () {
-        mockLog.info.reset()
-
         var message = {
           email: 'test@restmail.net',
+          flowId: 'wibble',
           subject: 'subject',
           template: 'verifyLoginEmail',
           uid: 'foo'
@@ -646,6 +649,7 @@ describe(
             const emailEventLog = mockLog.info.getCalls()[2]
             assert.equal(emailEventLog.args[0].op, 'emailEvent', 'logs emailEvent')
             assert.equal(emailEventLog.args[0].domain, 'other', 'logs domain')
+            assert.equal(emailEventLog.args[0].flow_id, 'wibble', 'logs flow id')
             assert.equal(emailEventLog.args[0].template, 'verifyLoginEmail', 'logs correct template')
             assert.equal(emailEventLog.args[0].type, 'sent', 'logs correct type')
           })
@@ -655,8 +659,6 @@ describe(
     it(
       'rejects sendMail status',
       function () {
-        mailer.mailer.sendMail.reset()
-
         var message = {
           email: 'test@restmail.net',
           subject: 'subject',


### PR DESCRIPTION
Related to #2133. Supercedes #2138. Opened for a prospective auth server `96.3` patch because it's affecting the amplitude metrics (sorry).

`logEmailEventSent` is not passed the full email headers that are created in `Mailer.prototype.send`. It *is* passed the `message` object that those headers are built from. This change makes it work using that `message` object instead.

The alternative fix would have been to pass in the headers and leave `logEmailEventSent` and `logAmplitudeEvent` untouched. I opted against that because the code to read from the headers is (a little bit) more work than dereferencing `message` directly. But I can still do it that way if it's preferred for reasons of conceptual purity.

Here is an amplitude event showing the correct properties:

```
amplitudeEvent {"time":1506156664455,"user_id":"eac6a27493ad4fffb458b2dfeccc7311","event_type":"fxa_email - sent","session_id":1506156647690,"event_properties":{"email_type":"registration","email_provider":"gmail.com"},"user_properties":{"flow_id":"a5d47dceed90c23e27188adf366b40499cba72ebac90f3e459fe05b0270f96d0","sync_device_count":0},"app_version":"96"}
```

Without the changes here, `user_id`, `session_id` and `flow_id` are missing.

This will also fix the big spike in [this chart](https://sql.telemetry.mozilla.org/queries/41382/source#111444):


![Chart showing an increase in the number of email sent events without a flow id](https://user-images.githubusercontent.com/64367/30771461-38202aa4-a040-11e7-9c6c-f4dace383759.png)

@mozilla/fxa-devs r?