### PR TITLE
fix(metrics): prefer standard amplitude properties

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -174,9 +174,9 @@ module.exports = (log, config) => {
           language: getLocale(request),
           country: getLocationProperty(data, 'country'),
           region: getLocationProperty(data, 'state'),
-          os_name: os,
-          os_version: osVersion,
-          device_model: formFactor
+          os_name: safeGet(os),
+          os_version: safeGet(osVersion),
+          device_model: safeGet(formFactor)
         })
       })
     }
@@ -206,17 +206,23 @@ module.exports = (log, config) => {
     return Object.assign({
       flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
       sync_device_count: data.devices && data.devices.length,
-      ua_browser: browser,
-      ua_version: browserVersion
+      ua_browser: safeGet(browser),
+      ua_version: safeGet(browserVersion)
     }, getService(request))
   }
 
+  function safeGet (value) {
+    // Prevent null or the empty string from accidentally nuking
+    // properties in Amplitude (undefined is not serialised).
+    return value || undefined
+  }
+
   function getLocale (request) {
-    return request.app.locale || undefined
+    return safeGet(request.app.locale)
   }
 
   function getLocationProperty (data, key) {
-    return (data.location && data.location[key]) || undefined
+    return safeGet(data.location && data.location[key])
   }
 
   function getService (request) {

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -166,7 +166,9 @@ module.exports = (log, config) => {
           event_properties: mapEventProperties(group, request, data, metricsContext),
           user_properties: mapUserProperties(group, request, data, metricsContext),
           app_version: APP_VERSION,
-          language: getLocale(request)
+          language: getLocale(request),
+          country: getLocationProperty(data, 'country'),
+          region: getLocationProperty(data, 'state')
         })
       })
     }
@@ -199,9 +201,6 @@ module.exports = (log, config) => {
       ua_browser: browser,
       ua_version: browserVersion,
       ua_os: os,
-      user_country: getLocationProperty(data, 'country'),
-      user_locale: getLocale(request),
-      user_state: getLocationProperty(data, 'state'),
     }, getService(request))
   }
 

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -148,15 +148,20 @@ module.exports = (log, config) => {
           return P.resolve()
         }
       }
+
       if (mapping.eventCategory) {
         data.eventCategory = mapping.eventCategory
       }
+
       return P.all([
         request.app.geo,
         request.app.devices.catch(() => {})
       ]).spread((geo, devices) => {
+        const { os, osVersion, formFactor } = request.app.ua
+
         data.location = geo.location
         data.devices = devices
+
         log.amplitudeEvent({
           time: metricsContext.time || Date.now(),
           user_id: data.uid || getFromToken(request, 'uid'),
@@ -168,7 +173,10 @@ module.exports = (log, config) => {
           app_version: APP_VERSION,
           language: getLocale(request),
           country: getLocationProperty(data, 'country'),
-          region: getLocationProperty(data, 'state')
+          region: getLocationProperty(data, 'state'),
+          os_name: os,
+          os_version: osVersion,
+          device_model: formFactor
         })
       })
     }
@@ -194,13 +202,12 @@ module.exports = (log, config) => {
   }
 
   function mapUserProperties (group, request, data, metricsContext) {
-    const { browser, browserVersion, os } = request.app.ua
+    const { browser, browserVersion } = request.app.ua
     return Object.assign({
       flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
       sync_device_count: data.devices && data.devices.length,
       ua_browser: browser,
-      ua_version: browserVersion,
-      ua_os: os,
+      ua_version: browserVersion
     }, getService(request))
   }
 

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -91,8 +91,8 @@ describe('metrics/amplitude', () => {
           uaBrowserVersion: 'bar',
           uaOS: 'baz',
           uaOSVersion: 'qux',
-          uaDeviceType: 'qux',
-          uaFormFactor: 'qux',
+          uaDeviceType: 'pawk',
+          uaFormFactor: 'melm',
           locale: 'wibble',
           credentials: {
             uid: 'blee'
@@ -132,6 +132,9 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].language, 'wibble')
         assert.equal(args[0].country, 'United Kingdom')
         assert.equal(args[0].region, 'England')
+        assert.equal(args[0].os_name, 'baz')
+        assert.equal(args[0].os_version, 'qux')
+        assert.equal(args[0].device_model, 'melm')
         assert.deepEqual(args[0].event_properties, {
           service: '0'
         })
@@ -140,7 +143,6 @@ describe('metrics/amplitude', () => {
           sync_device_count: 3,
           ua_browser: 'foo',
           ua_version: 'bar',
-          ua_os: 'baz',
           '$append': {
             fxa_services_used: 'amo'
           }
@@ -157,11 +159,11 @@ describe('metrics/amplitude', () => {
           uaBrowserVersion: 'b',
           uaOS: 'c',
           uaOSVersion: 'd',
-          uaDeviceType: 'd',
-          uaFormFactor: 'd',
-          locale: 'e',
+          uaDeviceType: 'e',
+          uaFormFactor: 'f',
+          locale: 'g',
           credentials: {
-            uid: 'f'
+            uid: 'h'
           },
           devices: [],
           query: {
@@ -181,12 +183,15 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].device_id, undefined)
-        assert.equal(args[0].user_id, 'f')
+        assert.equal(args[0].user_id, 'h')
         assert.equal(args[0].event_type, 'fxa_reg - created')
         assert.equal(args[0].session_id, undefined)
-        assert.equal(args[0].language, 'e')
+        assert.equal(args[0].language, 'g')
         assert.equal(args[0].country, 'United States')
         assert.equal(args[0].region, 'California')
+        assert.equal(args[0].os_name, 'c')
+        assert.equal(args[0].os_version, 'd')
+        assert.equal(args[0].device_model, 'f')
         assert.deepEqual(args[0].event_properties, {
           service: '1'
         })
@@ -195,7 +200,6 @@ describe('metrics/amplitude', () => {
           sync_device_count: 0,
           ua_browser: 'a',
           ua_version: 'b',
-          ua_os: 'c',
           '$append': {
             fxa_services_used: 'pocket'
           }

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -130,6 +130,8 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].event_type, 'fxa_login - email_confirmed')
         assert.equal(args[0].session_id, 'kwop')
         assert.equal(args[0].language, 'wibble')
+        assert.equal(args[0].country, 'United Kingdom')
+        assert.equal(args[0].region, 'England')
         assert.deepEqual(args[0].event_properties, {
           service: '0'
         })
@@ -139,9 +141,6 @@ describe('metrics/amplitude', () => {
           ua_browser: 'foo',
           ua_version: 'bar',
           ua_os: 'baz',
-          user_country: 'United Kingdom',
-          user_locale: 'wibble',
-          user_state: 'England',
           '$append': {
             fxa_services_used: 'amo'
           }
@@ -186,6 +185,8 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].event_type, 'fxa_reg - created')
         assert.equal(args[0].session_id, undefined)
         assert.equal(args[0].language, 'e')
+        assert.equal(args[0].country, 'United States')
+        assert.equal(args[0].region, 'California')
         assert.deepEqual(args[0].event_properties, {
           service: '1'
         })
@@ -195,9 +196,6 @@ describe('metrics/amplitude', () => {
           ua_browser: 'a',
           ua_version: 'b',
           ua_os: 'c',
-          user_country: 'United States',
-          user_locale: 'e',
-          user_state: 'California',
           '$append': {
             fxa_services_used: 'pocket'
           }

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -628,10 +628,7 @@ describe('metrics/events', () => {
           sync_device_count: 0,
           ua_browser: request.app.ua.browser,
           ua_version: request.app.ua.browserVersion,
-          ua_os: request.app.ua.os,
-          user_country: 'United States',
-          user_locale: 'en-US',
-          user_state: 'California'
+          ua_os: request.app.ua.os
         }, 'log.amplitudeEvent was passed correct user properties')
 
         assert.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -627,8 +627,7 @@ describe('metrics/events', () => {
           flow_id: 'bar',
           sync_device_count: 0,
           ua_browser: request.app.ua.browser,
-          ua_version: request.app.ua.browserVersion,
-          ua_os: request.app.ua.os
+          ua_version: request.app.ua.browserVersion
         }, 'log.amplitudeEvent was passed correct user properties')
 
         assert.equal(metricsContext.gather.callCount, 0, 'metricsContext.gather was not called')


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#6. Proposed for a `96.3` patch release.

The taxonomy document has been updated to use standard event properties where available. This PR implements some of the suggested changes and also proposes a couple of others:

* `user_properties.user_country` => `country`
* `user_properties.user_state` => `region`
* Removed: `user_properties.user_locale`
* `user_properties.ua_os` => `os_name`
* Added: `os_version`
* Added: `device_model`

@davismtl @jbuck r?