### PR TITLE
feat(metrics): implement email_version amplitude property

### DIFF
--- a/bin/mailer_server.js
+++ b/bin/mailer_server.js
@@ -26,7 +26,7 @@ var dbConnect = require('../lib/senders/db_connect')()
 P.all(
   [
     require('../lib/senders/translator')(config.get('i18n.supportedLanguages'), config.get('i18n.defaultLanguage')),
-    require('../lib/senders/templates')()
+    require('../lib/senders/templates').init()
   ]
 )
 .spread(

--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -75,6 +75,7 @@ function logEmailEventSent(log, message) {
   const emailEventInfo = {
     op: 'emailEvent',
     template: message.template,
+    templateVersion: message.templateVersion,
     type: 'sent',
     flow_id: message.flowId
   }
@@ -115,6 +116,7 @@ function logAmplitudeEvent (log, message, eventInfo) {
     device_id: message.deviceId || getHeaderValue('X-Device-Id', message),
     email_domain: eventInfo.domain,
     service: message.service || getHeaderValue('X-Service-Id', message),
+    templateVersion: eventInfo.templateVersion,
     uid: message.uid || getHeaderValue('X-Uid', message)
   }, {
     flowBeginTime: message.flowBeginTime || getHeaderValue('X-Flow-Begin-Time', message),
@@ -125,15 +127,17 @@ function logAmplitudeEvent (log, message, eventInfo) {
 
 function logEmailEventFromMessage(log, message, type, emailDomain) {
   const templateName = getHeaderValue('X-Template-Name', message)
+  const templateVersion = getHeaderValue('X-Template-Version', message)
   const flowId = getHeaderValue('X-Flow-Id', message)
   const locale = getHeaderValue('Content-Language', message)
 
   const emailEventInfo = {
     domain: emailDomain,
-    locale: locale,
+    locale,
     op: 'emailEvent',
     template: templateName,
-    type: type
+    templateVersion,
+    type
   }
 
   if (flowId) {

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -241,8 +241,10 @@ function mapEmailEventProperties (request, data) {
   const emailType = EMAIL_TYPES[data.eventCategory]
   if (emailType) {
     return {
+      email_provider: data.email_domain,
+      email_template: data.eventCategory,
       email_type: emailType,
-      email_provider: data.email_domain
+      email_version: data.templateVersion
     }
   }
 }

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -13,7 +13,7 @@ module.exports = (log, config, error, bounces, translator, sender) => {
 
   function createSenders() {
     const Mailer = createMailer(log)
-    return require('./templates')()
+    return require('./templates').init()
       .then(function (templates) {
         return {
           email: new Mailer(translator, templates, config.smtp, sender),

--- a/lib/senders/templates/_versions.json
+++ b/lib/senders/templates/_versions.json
@@ -1,0 +1,18 @@
+{
+  "newDeviceLoginEmail": 1,
+  "passwordChangedEmail": 1,
+  "passwordResetEmail": 1,
+  "passwordResetRequiredEmail": 1,
+  "postRemoveSecondaryEmail": 1,
+  "postVerifyEmail": 1,
+  "postVerifySecondaryEmail": 1,
+  "recoveryEmail": 1,
+  "sms.installFirefox": 1,
+  "unblockCodeEmail": 1,
+  "verificationReminderFirstEmail": 1,
+  "verificationReminderSecondEmail": 1,
+  "verifyEmail": 1,
+  "verifyLoginEmail": 1,
+  "verifySecondaryEmail": 1,
+  "verifySyncEmail": 1
+}

--- a/lib/senders/templates/index.js
+++ b/lib/senders/templates/index.js
@@ -55,8 +55,9 @@ function loadTemplates(name) {
   )
 }
 
-module.exports = function () {
-  return P.all(
+module.exports = {
+  generateTemplateName,
+  init: () => P.all(
     [
       'new_device_login',
       'password_changed',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "test"
   },
   "scripts": {
-    "precommit": "grunt newer:doc && git add docs/api.md",
+    "bump-template-versions": "node scripts/template-version-bump && git add lib/senders/templates/_versions.json",
+    "update-api-docs": "grunt newer:doc && git add docs/api.md",
+    "precommit": "npm run bump-template-versions && npm run update-api-docs",
     "postinstall": "scripts/download_l10n.sh",
     "shrink": "npmshrink && npm run postinstall",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",

--- a/scripts/template-version-bump.js
+++ b/scripts/template-version-bump.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Checks git status for template changes and bumps version numbers
+// accordingly. Note that deletions do not cause version numbers to
+// be deleted, to ensure that we have sane metrics in the cases where
+// a deleted template is reinstated by some later commit or only one
+// format of a template is deleted.
+
+'use strict'
+
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const ROOT_DIR = path.join(__dirname, '..')
+const TEMPLATE_DIR = 'lib/senders/templates'
+const VERSIONS_FILE = '_versions.json'
+const IGNORE = new Set([ VERSIONS_FILE, '_pending.txt', 'index.js', 'README.md' ])
+const DEDUP = {}
+
+const templates = require(`../${TEMPLATE_DIR}`)
+const versions = require(`../${TEMPLATE_DIR}/${VERSIONS_FILE}`)
+
+cp.execSync('git status --porcelain', { cwd: ROOT_DIR, encoding: 'utf8' })
+  .split('\n')
+  .filter(line => line.match(`^[AM]. ${TEMPLATE_DIR}/\\w+`))
+  .map(line => {
+    const parts = line.split(' ')
+    return parts[2] || parts[1]
+  })
+  .map(templatePath => templatePath.split('/')[3])
+  .filter(fileName => ! IGNORE.has(fileName))
+  .map(fileName => templates.generateTemplateName(fileName.substr(0, fileName.lastIndexOf('.'))))
+  .filter(templateName => {
+    if (DEDUP[templateName]) {
+      return false
+    }
+
+    DEDUP[templateName] = true
+    return true
+  })
+  .forEach(templateName => {
+    const version = versions[templateName]
+    if (version) {
+      const type = typeof version
+      if (type !== 'number' || isNaN(version)) {
+        console.log(`Bad version "${version}" {${type}} for template "${templateName}"`)
+        process.exit(1)
+      }
+      versions[templateName] = version + 1
+    } else {
+      versions[templateName] = 1
+    }
+  })
+
+fs.writeFileSync(
+  path.join(`${ROOT_DIR}/${TEMPLATE_DIR}/${VERSIONS_FILE}`),
+  JSON.stringify(versions, null, '  ')
+)
+

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -93,7 +93,8 @@ describe('email utils helpers', () => {
       flowBeginTime: 42,
       flowId: 'ccc',
       service: 'ddd',
-      uid: 'eee'
+      templateVersion: 'eee',
+      uid: 'fff'
     })
     assert.equal(amplitude.callCount, 1)
     const args = amplitude.args[0]
@@ -116,7 +117,8 @@ describe('email utils helpers', () => {
       device_id: 'bbb',
       email_domain: 'other',
       service: 'ddd',
-      uid: 'eee'
+      templateVersion: 'eee',
+      uid: 'fff'
     })
     assert.equal(args[3].flow_id, 'ccc')
     assert.equal(args[3].flowBeginTime, 42)
@@ -134,6 +136,7 @@ describe('email utils helpers', () => {
         { name: 'X-Flow-Id', value: 'c' },
         { name: 'X-Service-Id', value: 'd' },
         { name: 'X-Template-Name', value: 'verifyLoginEmail' },
+        { name: 'X-Template-Version', value: 42 },
         { name: 'X-Uid', value: 'e' }
       ]
     }, 'bounced', 'gmail')
@@ -158,6 +161,7 @@ describe('email utils helpers', () => {
       device_id: 'b',
       email_domain: 'gmail',
       service: 'd',
+      templateVersion: 42,
       uid: 'e'
     })
     assert.equal(args[3].flow_id, 'c')

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -401,7 +401,8 @@ describe('metrics/amplitude', () => {
     describe('email.newDeviceLoginEmail.bounced', () => {
       beforeEach(() => {
         return amplitude('email.newDeviceLoginEmail.bounced', mocks.mockRequest({}), {
-          email_domain: 'gmail'
+          email_domain: 'gmail',
+          templateVersion: 'wibble'
         })
       })
 
@@ -415,6 +416,8 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].event_type, 'fxa_email - bounced')
         assert.equal(args[0].event_properties.email_type, 'login')
         assert.equal(args[0].event_properties.email_provider, 'gmail')
+        assert.equal(args[0].event_properties.email_template, 'newDeviceLoginEmail')
+        assert.equal(args[0].event_properties.email_version, 'wibble')
       })
     })
 

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -678,6 +678,32 @@ describe(
       }
     )
 
+    describe('delete template versions', () => {
+      before(() => {
+        Object.keys(TEMPLATE_VERSIONS).forEach(key => TEMPLATE_VERSIONS[key] = undefined)
+      })
 
+      messageTypes.forEach(type => {
+        const message = {
+          code: 'code',
+          deviceId: 'deviceId',
+          email: 'foo@example.com',
+          locations: [],
+          service: 'sync',
+          uid: 'uid',
+          unblockCode: 'unblockCode',
+          type: 'secondary',
+          flowId: 'flowId',
+          flowBeginTime: Date.now()
+        }
+
+        it(`uses default template version for ${type}`, () => {
+          mailer.mailer.sendMail = emailConfig => {
+            assert.equal(emailConfig.headers['X-Template-Version'], 1, 'template version defaults to 1')
+          }
+          mailer[type](message)
+        })
+      })
+    })
   }
 )

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -7,21 +7,23 @@
 const ROOT_DIR = '../../..'
 
 const assert = require('insist')
-var extend = require('util')._extend
-var sinon = require('sinon')
-var P = require('bluebird')
+const extend = require('util')._extend
+const sinon = require('sinon')
+const P = require('bluebird')
 
-var mockLog = {
+const mockLog = {
   amplitudeEvent () {},
   trace () {},
   info: sinon.spy(),
   error () {}
 }
 
-var config = require(`${ROOT_DIR}/config`)
-var Mailer = require(`${ROOT_DIR}/lib/senders/email`)(mockLog)
+const config = require(`${ROOT_DIR}/config`)
+const Mailer = require(`${ROOT_DIR}/lib/senders/email`)(mockLog)
 
-var messageTypes = [
+const TEMPLATE_VERSIONS = require(`${ROOT_DIR}/lib/senders/templates/_versions.json`)
+
+const messageTypes = [
   'newDeviceLoginEmail',
   'passwordChangedEmail',
   'passwordResetEmail',
@@ -36,7 +38,7 @@ var messageTypes = [
   'verifySecondaryEmail'
 ]
 
-var typesContainSupportLinks = [
+const typesContainSupportLinks = [
   'newDeviceLoginEmail',
   'passwordChangedEmail',
   'passwordResetEmail',
@@ -48,35 +50,35 @@ var typesContainSupportLinks = [
   'verifySecondaryEmail'
 ]
 
-var typesContainPasswordResetLinks = [
+const typesContainPasswordResetLinks = [
   'passwordChangedEmail',
   'passwordResetEmail',
   'passwordResetRequiredEmail'
 ]
 
-var typesContainPasswordChangeLinks = [
+const typesContainPasswordChangeLinks = [
   'newDeviceLoginEmail',
   'verifyLoginEmail',
   'postVerifySecondaryEmail'
 ]
 
-var typesContainUnblockCode = [
+const typesContainUnblockCode = [
   'unblockCodeEmail'
 ]
 
-var typesContainReportSignInLinks = [
+const typesContainReportSignInLinks = [
   'unblockCodeEmail'
 ]
 
-var typesContainAndroidStoreLinks = [
+const typesContainAndroidStoreLinks = [
   'postVerifyEmail'
 ]
 
-var typesContainIOSStoreLinks = [
+const typesContainIOSStoreLinks = [
   'postVerifyEmail'
 ]
 
-var typesContainLocationData = [
+const typesContainLocationData = [
   'newDeviceLoginEmail',
   'passwordChangedEmail',
   'unblockCodeEmail',
@@ -86,7 +88,7 @@ var typesContainLocationData = [
   'verifySecondaryEmail'
 ]
 
-var typesContainPasswordManagerInfoLinks = [
+const typesContainPasswordManagerInfoLinks = [
   'passwordResetRequiredEmail',
 ]
 
@@ -116,7 +118,7 @@ describe(
     before(() => {
       return P.all([
         require(`${ROOT_DIR}/lib/senders/translator`)(['en'], 'en'),
-        require(`${ROOT_DIR}/lib/senders/templates`)()
+        require(`${ROOT_DIR}/lib/senders/templates`).init()
       ]).spread((translator, templates) => {
         mailer = new Mailer(translator, templates, config.get('smtp'))
       })
@@ -147,7 +149,8 @@ describe(
             mailer.mailer.sendMail = function (emailConfig) {
               assert.equal(emailConfig.from, config.get('smtp.sender'), 'from header is correct')
               assert.equal(emailConfig.sender, config.get('smtp.sender'), 'sender header is correct')
-              var templateName = emailConfig.headers['X-Template-Name']
+              const templateName = emailConfig.headers['X-Template-Name']
+              const templateVersion = emailConfig.headers['X-Template-Version']
 
               if (type === 'verificationReminderEmail') {
                 // Handle special case for verification reminders
@@ -159,6 +162,8 @@ describe(
               } else {
                 assert.equal(templateName, type)
               }
+
+              assert.equal(templateVersion, TEMPLATE_VERSIONS[templateName], 'template version is correct')
             }
             mailer[type](message)
           }

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -38,7 +38,7 @@ describe('lib/senders/sms:', () => {
   before(() => {
     return P.all([
       require(`${ROOT_DIR}/lib/senders/translator`)(['en'], 'en'),
-      require(`${ROOT_DIR}/lib/senders/templates`)()
+      require(`${ROOT_DIR}/lib/senders/templates`).init()
     ]).spread((translator, templates) => {
       sms = proxyquire(`${ROOT_DIR}/lib/senders/sms`, {
         'aws-sdk': { SNS }
@@ -176,7 +176,7 @@ describe('lib/senders/sms:', () => {
   it('uses the MockSNS constructor if `useMock: true`', () => {
     return P.all([
       require(`${ROOT_DIR}/lib/senders/translator`)(['en'], 'en'),
-      require(`${ROOT_DIR}/lib/senders/templates`)()
+      require(`${ROOT_DIR}/lib/senders/templates`).init()
     ]).spread((translator, templates) => {
       sms = proxyquire(`${ROOT_DIR}/lib/senders/sms`, {
         'aws-sdk': { SNS },

--- a/test/local/senders/templates.js
+++ b/test/local/senders/templates.js
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const ROOT_DIR = '../../..'
+
+const assert = require('insist')
+
+describe('lib/senders/templates/index:', () => {
+  let templates
+
+  before(() => {
+    templates = require(`${ROOT_DIR}/lib/senders/templates`)
+  })
+
+  it('interface is correct', () => {
+    assert.equal(typeof templates, 'object')
+    assert.equal(Object.keys(templates).length, 2)
+    assert.equal(typeof templates.generateTemplateName, 'function')
+    assert.equal(templates.generateTemplateName.length, 1)
+    assert.equal(typeof templates.init, 'function')
+    assert.equal(templates.init.length, 0)
+  })
+
+  it('templates.generateTemplateName converts from snake case to camel case', () =>
+    assert.equal(templates.generateTemplateName('this_is-a_Test'), 'thisIs-aTestEmail')
+  )
+
+  it('templates.generateTemplateName does not alter SMS template names', () =>
+    assert.equal(templates.generateTemplateName('sms.another_test'), 'sms.another_test')
+  )
+
+  describe('templates.init:', () => {
+    let result
+
+    before(() => templates.init().then(r => result = r))
+
+    it('result is correct', () => {
+      assert.equal(typeof result, 'object')
+      const keys = Object.keys(result)
+      assert.equal(keys.length, 16)
+      keys.forEach(key => {
+        const fn = result[key]
+        assert.equal(typeof fn, 'function')
+        assert.equal(fn.length, 1)
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
Fixes #2097.

Adds an `email_version` property to the amplitude events, which represents a numerical, automatically-incrementing version number for the relevant template. The automatically-incrementing part is handled by a new pre-commit hook. Version numbers are stored in a json file inside the `templates` directory.

Also adds an `email_template` property to the events, because `email_version` on its own makes no sense and may be misleading.

Here is a sample event demonstrating the new properties:

```
{"time":1506606961905,"user_id":"d849bbc4bee44f2592fae62816c002a5","event_type":"fxa_email - sent","session_id":1506606950658,"event_properties":{"email_provider":"gmail.com","email_template":"verifyEmail","email_type":"registration","email_version":1},"user_properties":{"flow_id":"89729796c85775f815b4b1f75e62f10041a72b71b1a5f2b0db28f679b41a628a","sync_device_count":0},"app_version":"96"}
```

@mozilla/fxa-devs r?