### PR TITLE
fix(email): Show proper error and delete email if postfix fails to send

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -60,6 +60,7 @@ var ERRNO = {
   CHANGE_EMAIL_TO_UNOWNED_EMAIL: 148,
   LOGIN_WITH_INVALID_EMAIL: 149,
   RESEND_EMAIL_CODE_TO_UNOWNED_EMAIL: 150,
+  FAILED_TO_SEND_EMAIL: 151,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -712,6 +713,15 @@ AppError.cannotResendEmailCodeToUnownedEmail = function () {
     error: 'Bad Request',
     errno: ERRNO.RESEND_EMAIL_CODE_TO_UNOWNED_EMAIL,
     message: 'Can not resend email code to an email that does not belong to this account'
+  })
+}
+
+AppError.cannotSendEmail = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.FAILED_TO_SEND_EMAIL,
+    message: 'Failed to send email'
   })
 }
 

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -632,7 +632,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
           return db.createEmail(uid, emailData)
         }
 
-        function sendEmailVerification () {
+        function sendEmailVerification() {
           return request.app.geo
             .then((geoData) => {
               return mailer.sendVerifySecondaryEmail([emailData], sessionToken, {
@@ -650,6 +650,13 @@ module.exports = (log, db, mailer, config, customs, push) => {
                 uaOSVersion: sessionToken.uaOSVersion,
                 uid
               })
+                .catch((err) => {
+                  log.error({op: 'mailer.sendVerifySecondaryEmail', err: err})
+                  return db.deleteEmail(emailData.uid, emailData.normalizedEmail)
+                    .then(() => {
+                      throw error.cannotSendEmail()
+                    })
+                })
             })
         }
       }


### PR DESCRIPTION
Thinking about it a little more, I convinced myself this was the best thing to do if postfix fails to send a secondary email verification email.

  * Show `Failed to send email.` instead of unexpected error
  * Delete secondary email

Fixes #2101 
