### PR TITLE
refactor(tokens): prefer token.id to token.tokenId

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -118,7 +118,7 @@ module.exports = (
           return this.pool.put(
             '/sessionToken/' + sessionToken.id,
             {
-              tokenId: sessionToken.tokenId,
+              tokenId: sessionToken.id,
               data: sessionToken.data,
               uid: sessionToken.uid,
               createdAt: sessionToken.createdAt,
@@ -148,7 +148,7 @@ module.exports = (
           return this.pool.put(
             '/keyFetchToken/' + keyFetchToken.id,
             {
-              tokenId: keyFetchToken.tokenId,
+              tokenId: keyFetchToken.id,
               authKey: keyFetchToken.authKey,
               uid: keyFetchToken.uid,
               keyBundle: keyFetchToken.keyBundle,
@@ -173,7 +173,7 @@ module.exports = (
           return this.pool.put(
             '/passwordForgotToken/' + passwordForgotToken.id,
             {
-              tokenId: passwordForgotToken.tokenId,
+              tokenId: passwordForgotToken.id,
               data: passwordForgotToken.data,
               uid: passwordForgotToken.uid,
               passCode: passwordForgotToken.passCode,
@@ -198,7 +198,7 @@ module.exports = (
           return this.pool.put(
             '/passwordChangeToken/' + passwordChangeToken.id,
             {
-              tokenId: passwordChangeToken.tokenId,
+              tokenId: passwordChangeToken.id,
               data: passwordChangeToken.data,
               uid: passwordChangeToken.uid,
               createdAt: passwordChangeToken.createdAt
@@ -276,8 +276,13 @@ module.exports = (
         // overwrite the properties of the db token with the redis token values
         const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : {}
         const sessions = mysqlSessionTokens.map((sessionToken) => {
-          const redisToken = redisSessionTokens[sessionToken.tokenId]
-          const mergedToken = Object.assign({}, sessionToken, redisToken)
+          const id = sessionToken.tokenId
+          const redisToken = redisSessionTokens[id]
+          const mergedToken = Object.assign({}, sessionToken, redisToken, {
+            // Map from the db's tokenId property to this repo's id property
+            id
+          })
+          delete mergedToken.tokenId
           return mergedToken
         })
         log.info({
@@ -508,7 +513,7 @@ module.exports = (
     }
 
     const newToken = {
-      tokenId: token.tokenId,
+      tokenId: token.id,
       uid: uid,
       uaBrowser: token.uaBrowser,
       uaBrowserVersion: token.uaBrowserVersion,
@@ -534,7 +539,7 @@ module.exports = (
     .then(res => {
       // update the hash with the new token
       sessionTokens = res ? JSON.parse(res) : {}
-      sessionTokens[token.tokenId] = newToken
+      sessionTokens[token.id] = newToken
       return sessionTokens
     })
     // add new updated token into array, and set the resulting array as the new value
@@ -818,7 +823,7 @@ module.exports = (
           return this.pool.post(
             '/passwordForgotToken/' + passwordForgotToken.id + '/verified',
             {
-              tokenId: accountResetToken.tokenId,
+              tokenId: accountResetToken.id,
               data: accountResetToken.data,
               uid: accountResetToken.uid,
               createdAt: accountResetToken.createdAt

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -39,7 +39,7 @@ module.exports = (log, db, push) => {
     }
     const isPlaceholderDevice = ! deviceInfo.id && ! deviceInfo.name && ! deviceInfo.type
 
-    return db[operation](sessionToken.uid, sessionToken.tokenId, deviceInfo)
+    return db[operation](sessionToken.uid, sessionToken.id, deviceInfo)
       .then(device => {
         result = device
         return request.emitMetricsEvent(event, {

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -347,7 +347,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             name: 'account.create',
             uid: account.uid,
             ipAddr: request.app.clientAddress,
-            tokenId: sessionToken.tokenId
+            tokenId: sessionToken.id
           })
         }
 
@@ -983,7 +983,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             name: 'account.login',
             uid: accountRecord.uid,
             ipAddr: request.app.clientAddress,
-            tokenId: sessionToken && sessionToken.tokenId
+            tokenId: sessionToken && sessionToken.id
           })
         }
 
@@ -1389,7 +1389,7 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
             name: 'account.reset',
             uid: account.uid,
             ipAddr: request.app.clientAddress,
-            tokenId: sessionToken && sessionToken.tokenId
+            tokenId: sessionToken && sessionToken.id
           })
         }
 

--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -291,7 +291,7 @@ module.exports = (log, db, config, customs, push, devices) => {
             reply(deviceArray.map(device => {
               return {
                 id: device.id,
-                isCurrentDevice: device.sessionToken === sessionToken.tokenId,
+                isCurrentDevice: device.sessionToken === sessionToken.id,
                 lastAccessTime: device.lastAccessTime,
                 lastAccessTimeFormatted: localizeTimestamp.format(
                   device.lastAccessTime,
@@ -376,8 +376,8 @@ module.exports = (log, db, config, customs, push, devices) => {
                 deviceCallbackPublicKey: session.deviceCallbackPublicKey,
                 deviceCallbackAuthKey: session.deviceCallbackAuthKey,
                 deviceCallbackIsExpired: !! session.deviceCallbackIsExpired,
-                id: session.tokenId,
-                isCurrentDevice: session.tokenId === sessionToken.tokenId,
+                id: session.id,
+                isCurrentDevice: session.id === sessionToken.id,
                 isDevice,
                 location: {
                   state: session.location && session.location.state,

--- a/lib/tokens/key_fetch_token.js
+++ b/lib/tokens/key_fetch_token.js
@@ -40,7 +40,7 @@ module.exports = function (log, Token) {
 
   KeyFetchToken.fromId = function (id, details) {
     log.trace({ op: 'KeyFetchToken.fromId' })
-    return P.resolve(new KeyFetchToken({ tokenId: id, authKey: details.authKey }, details))
+    return P.resolve(new KeyFetchToken({ id, authKey: details.authKey }, details))
   }
 
   KeyFetchToken.fromHex = function (string, details) {

--- a/lib/tokens/token.js
+++ b/lib/tokens/token.js
@@ -12,10 +12,10 @@
  *
  *    - Each token is created from an initial data seed of 32 random bytes.
  *
- *    - From the seed data we HKDF-derive three 32-byte values: a tokenId,
+ *    - From the seed data we HKDF-derive three 32-byte values: an id,
  *      an authKey and a bundleKey.
  *
- *    - The tokenId/authKey pair can be used as part of a request-signing
+ *    - The id/authKey pair can be used as part of a request-signing
  *      authentication scheme.
  *
  *    - The bundleKey can be used to encrypt data as part of the request.
@@ -29,7 +29,7 @@ const Bundle = require('./bundle')
 const hkdf = require('../crypto/hkdf')
 const random = require('../crypto/random')
 
-const KEYS = ['data', 'tokenId', 'authKey', 'bundleKey']
+const KEYS = ['data', 'id', 'authKey', 'bundleKey']
 
 module.exports = (log, config) => {
 
@@ -70,7 +70,7 @@ module.exports = (log, config) => {
   }
 
 
-  // Derive tokenId, authKey and bundleKey from token seed data.
+  // Derive id, authKey and bundleKey from token seed data.
   //
   Token.deriveTokenKeys = function (TokenType, data) {
     return hkdf(data, TokenType.tokenTypeID, null, 3 * 32)
@@ -78,7 +78,7 @@ module.exports = (log, config) => {
         function (keyMaterial) {
           return {
             data: data,
-            tokenId: keyMaterial.slice(0, 32),
+            id: keyMaterial.slice(0, 32),
             authKey: keyMaterial.slice(32, 64),
             bundleKey: keyMaterial.slice(64, 96)
           }
@@ -116,9 +116,6 @@ module.exports = (log, config) => {
   Object.defineProperties(
     Token.prototype,
     {
-      id: {
-        get: function () { return this.tokenId }
-      },
       key: {
         get: function () { return Buffer.from(this.authKey, 'hex') }
       },

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -59,9 +59,9 @@ describe('db, session tokens expire:', () => {
     it('returned the correct result', () => {
       assert(Array.isArray(sessions))
       assert.equal(sessions.length, 3)
-      assert.equal(sessions[0].tokenId, 'foo')
-      assert.equal(sessions[1].tokenId, 'baz')
-      assert.equal(sessions[2].tokenId, 'qux')
+      assert.equal(sessions[0].id, 'foo')
+      assert.equal(sessions[1].id, 'baz')
+      assert.equal(sessions[2].id, 'qux')
     })
   })
 })
@@ -112,10 +112,10 @@ describe('db, session tokens do not expire:', () => {
 
     it('returned the correct result', () => {
       assert.equal(sessions.length, 4)
-      assert.equal(sessions[0].tokenId, 'foo')
-      assert.equal(sessions[1].tokenId, 'bar')
-      assert.equal(sessions[2].tokenId, 'baz')
-      assert.equal(sessions[3].tokenId, 'qux')
+      assert.equal(sessions[0].id, 'foo')
+      assert.equal(sessions[1].id, 'bar')
+      assert.equal(sessions[2].id, 'baz')
+      assert.equal(sessions[3].id, 'qux')
     })
   })
 })

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -62,7 +62,7 @@ describe('devices', () => {
           log: log
         })
         sessionToken = {
-          tokenId: crypto.randomBytes(16).toString('hex'),
+          id: crypto.randomBytes(16).toString('hex'),
           uid: uuid.v4('binary').toString('hex'),
           tokenVerified: true
         }
@@ -84,7 +84,7 @@ describe('devices', () => {
             var args = db.createDevice.args[0]
             assert.equal(args.length, 3, 'db.createDevice was passed three arguments')
             assert.deepEqual(args[0], sessionToken.uid, 'first argument was uid')
-            assert.deepEqual(args[1], sessionToken.tokenId, 'second argument was sessionTokenId')
+            assert.deepEqual(args[1], sessionToken.id, 'second argument was sessionTokenId')
             assert.equal(args[2], device, 'third argument was device')
 
             assert.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
@@ -178,7 +178,7 @@ describe('devices', () => {
             var args = db.updateDevice.args[0]
             assert.equal(args.length, 3, 'db.createDevice was passed three arguments')
             assert.deepEqual(args[0], sessionToken.uid, 'first argument was uid')
-            assert.deepEqual(args[1], sessionToken.tokenId, 'second argument was sessionTokenId')
+            assert.deepEqual(args[1], sessionToken.id, 'second argument was sessionTokenId')
             assert.deepEqual(args[2], {
               id: deviceId,
               name: device.name,

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -163,13 +163,13 @@ describe('/account/reset', function () {
 
       args = mockMetricsContext.stash.args[0]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
-      assert.deepEqual(args[0].tokenId, sessionTokenId, 'argument was session token')
+      assert.deepEqual(args[0].id, sessionTokenId, 'argument was session token')
       assert.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
 
       args = mockMetricsContext.stash.args[1]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument second time')
-      assert.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
+      assert.deepEqual(args[0].id, keyFetchTokenId, 'argument was key fetch token')
       assert.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
@@ -377,7 +377,7 @@ describe('/account/create', () => {
 
       args = mockMetricsContext.stash.args[0]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
-      assert.deepEqual(args[0].tokenId, sessionTokenId, 'argument was session token')
+      assert.deepEqual(args[0].id, sessionTokenId, 'argument was session token')
       assert.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
 
@@ -389,7 +389,7 @@ describe('/account/create', () => {
 
       args = mockMetricsContext.stash.args[2]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument third time')
-      assert.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
+      assert.deepEqual(args[0].id, keyFetchTokenId, 'argument was key fetch token')
       assert.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[2], mockRequest, 'this was request')
 
@@ -641,7 +641,7 @@ describe('/account/login', function () {
 
       args = mockMetricsContext.stash.args[0]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
-      assert.deepEqual(args[0].tokenId, sessionTokenId, 'argument was session token')
+      assert.deepEqual(args[0].id, sessionTokenId, 'argument was session token')
       assert.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
 
@@ -653,7 +653,7 @@ describe('/account/login', function () {
 
       args = mockMetricsContext.stash.args[2]
       assert.equal(args.length, 1, 'metricsContext.stash was passed one argument third time')
-      assert.deepEqual(args[0].tokenId, keyFetchTokenId, 'argument was key fetch token')
+      assert.deepEqual(args[0].id, keyFetchTokenId, 'argument was key fetch token')
       assert.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
       assert.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
 
@@ -1202,7 +1202,6 @@ describe('/account/keys', function () {
       emailVerified: true,
       id: keyFetchTokenId,
       keyBundle: hexString(16),
-      tokenId: keyFetchTokenId,
       tokenVerificationId: undefined,
       tokenVerified: true,
       uid: uid

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -76,7 +76,7 @@ describe('/account/device', function () {
       deviceId: deviceId,
       deviceName: mockDeviceName,
       deviceType: 'desktop',
-      tokenId: crypto.randomBytes(16).toString('hex'),
+      id: crypto.randomBytes(16).toString('hex'),
       uid: uid
     },
     payload: {
@@ -116,7 +116,7 @@ describe('/account/device', function () {
       var args = mockDevices.upsert.args[0]
       assert.equal(args.length, 3, 'devices.upsert was passed three arguments')
       assert.equal(args[0], mockRequest, 'first argument was request object')
-      assert.deepEqual(args[1].tokenId, mockRequest.auth.credentials.tokenId, 'second argument was session token')
+      assert.deepEqual(args[1].id, mockRequest.auth.credentials.id, 'second argument was session token')
       assert.deepEqual(args[1].uid, uid, 'sessionToken.uid was correct')
       assert.deepEqual(args[2], mockRequest.payload, 'third argument was payload')
     })
@@ -162,7 +162,7 @@ describe('/account/device', function () {
         deviceId: deviceId,
         deviceName: mockDeviceName,
         deviceType: 'desktop',
-        tokenId: crypto.randomBytes(16).toString('hex'),
+        id: crypto.randomBytes(16).toString('hex'),
         uid: uid
       },
       payload: {
@@ -189,7 +189,7 @@ describe('/account/device', function () {
         deviceId: deviceId,
         deviceName: mockDeviceName,
         deviceType: 'desktop',
-        tokenId: crypto.randomBytes(16).toString('hex'),
+        id: crypto.randomBytes(16).toString('hex'),
         uid: uid
       },
       payload: {
@@ -498,14 +498,14 @@ describe('/account/devices', function () {
     var mockRequest = mocks.mockRequest({
       credentials: {
         uid: crypto.randomBytes(16).toString('hex'),
-        tokenId: crypto.randomBytes(16).toString('hex')
+        id: crypto.randomBytes(16).toString('hex')
       },
       payload: {}
     })
     var unnamedDevice = { sessionToken: crypto.randomBytes(16).toString('hex') }
     var mockDB = mocks.mockDB({
       devices: [
-        { name: 'current session', type: 'mobile', sessionToken: mockRequest.auth.credentials.tokenId },
+        { name: 'current session', type: 'mobile', sessionToken: mockRequest.auth.credentials.id },
         { name: 'has no type', sessionToken: crypto.randomBytes(16).toString('hex' )},
         { name: 'has device type', sessionToken: crypto.randomBytes(16).toString('hex'), uaDeviceType: 'wibble' },
         unnamedDevice
@@ -570,7 +570,7 @@ describe('/account/sessions', () => {
   const tokenIds = [ 'foo', 'bar', 'baz' ]
   const sessions = [
     {
-      tokenId: tokenIds[0], uid: 'qux', createdAt: times[0], lastAccessTime: times[1],
+      id: tokenIds[0], uid: 'qux', createdAt: times[0], lastAccessTime: times[1],
       uaBrowser: 'Firefox', uaBrowserVersion: '50', uaOS: 'Windows', uaOSVersion: '10',
       uaDeviceType: null, deviceId: null, deviceCreatedAt: times[2],
       deviceCallbackURL: 'callback', deviceCallbackPublicKey: 'publicKey', deviceCallbackAuthKey: 'authKey',
@@ -578,7 +578,7 @@ describe('/account/sessions', () => {
       location: { country: 'Canada', state: 'ON' }
     },
     {
-      tokenId: tokenIds[1], uid: 'wibble', createdAt: times[3], lastAccessTime: times[4],
+      id: tokenIds[1], uid: 'wibble', createdAt: times[3], lastAccessTime: times[4],
       uaBrowser: 'Nightly', uaBrowserVersion: null, uaOS: 'Android', uaOSVersion: '6',
       uaDeviceType: 'mobile', deviceId: 'deviceId', deviceCreatedAt: times[5],
       deviceCallbackURL: null, deviceCallbackPublicKey: null, deviceCallbackAuthKey: null,
@@ -586,7 +586,7 @@ describe('/account/sessions', () => {
       location: { country: 'England', state: 'AB' }
     },
     {
-      tokenId: tokenIds[2], uid: 'blee', createdAt: times[6], lastAccessTime: times[7],
+      id: tokenIds[2], uid: 'blee', createdAt: times[6], lastAccessTime: times[7],
       uaBrowser: null, uaBrowserVersion: '50', uaOS: null, uaOSVersion: '10',
       uaDeviceType: 'tablet', deviceId: 'deviceId', deviceCreatedAt: times[8],
       deviceCallbackURL: 'callback', deviceCallbackPublicKey: 'publicKey', deviceCallbackAuthKey: 'authKey',
@@ -598,7 +598,7 @@ describe('/account/sessions', () => {
   const accountRoutes = makeRoutes({ db })
   const request = mocks.mockRequest({
     credentials: {
-      tokenId: tokenIds[0],
+      id: tokenIds[0],
       uid: hexString(16)
     },
     payload: {}

--- a/test/local/tokens/account_reset_token.js
+++ b/test/local/tokens/account_reset_token.js
@@ -51,7 +51,7 @@ describe('account reset tokens', () => {
           (x) => {
             token = x
             assert.equal(token.data.toString('hex'), tokenData)
-            assert.equal(token.id.toString('hex'), '46ec557e56e531a058620e9344ca9c75afac0d0bcbdd6f8c3c2f36055d9540cf')
+            assert.equal(token.id, '46ec557e56e531a058620e9344ca9c75afac0d0bcbdd6f8c3c2f36055d9540cf')
             assert.equal(token.authKey.toString('hex'), '716ebc28f5122ef48670a48209190a1605263c3188dfe45256265929d1c45e48')
             assert.equal(token.bundleKey.toString('hex'), 'aa5906d2318c6e54ecebfa52f10df4c036165c230cc78ee859f546c66ea3c126')
           }

--- a/test/local/tokens/key_fetch_token.js
+++ b/test/local/tokens/key_fetch_token.js
@@ -59,12 +59,12 @@ describe('KeyFetchToken', () => {
         .then(
           function (x) {
             token = x
-            return KeyFetchToken.fromId(token.tokenId, token)
+            return KeyFetchToken.fromId(token.id, token)
           }
         )
         .then(
           function (x) {
-            assert.equal(x.tokenId, token.tokenId, 'should have same id')
+            assert.equal(x.id, token.id, 'should have same id')
             assert.equal(x.authKey, token.authKey, 'should have same authKey')
           }
         )

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -150,7 +150,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
           function (x) {
             token = x
             assert.equal(token.data.toString('hex'), tokenData)
-            assert.equal(token.id.toString('hex'), 'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab')
+            assert.equal(token.id, 'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab')
             assert.equal(token.authKey.toString('hex'), '9d8f22998ee7f5798b887042466b72d53e56ab0c094388bf65831f702d2febc0')
           }
         )
@@ -164,7 +164,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
         .then(function (token) {
           token.setUserAgentInfo({
             data: 'foo',
-            tokenId: 'foo',
+            id: 'foo',
             authKey: 'foo',
             bundleKey: 'foo',
             algorithm: 'foo',
@@ -185,7 +185,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
             lastAccessTime: 'mnngh'
           })
           assert.notEqual(token.data, 'foo', 'data was not updated')
-          assert.notEqual(token.tokenId, 'foo', 'tokenId was not updated')
+          assert.notEqual(token.id, 'foo', 'id was not updated')
           assert.notEqual(token.authKey, 'foo', 'authKey was not updated')
           assert.notEqual(token.bundleKey, 'foo', 'bundleKey was not updated')
           assert.notEqual(token.algorithm, 'foo', 'algorithm was not updated')

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -239,7 +239,7 @@ function mockDB (data, errors) {
     createKeyFetchToken: sinon.spy(() => {
       return P.resolve({
         data: crypto.randomBytes(32).toString('hex'),
-        tokenId: data.keyFetchTokenId,
+        id: data.keyFetchTokenId,
         uid: data.uid
       })
     }),
@@ -247,7 +247,7 @@ function mockDB (data, errors) {
       return P.resolve({
         data: crypto.randomBytes(32).toString('hex'),
         passCode: data.passCode,
-        tokenId: data.passwordForgotTokenId,
+        id: data.passwordForgotTokenId,
         uid: data.uid,
         ttl: function () {
           return data.passwordForgotTokenTTL || 100
@@ -262,7 +262,7 @@ function mockDB (data, errors) {
         lastAuthAt: () => {
           return Date.now()
         },
-        tokenId: data.sessionTokenId,
+        id: data.sessionTokenId,
         tokenVerificationId: data.tokenVerificationId,
         tokenVerified: ! data.tokenVerificationId,
         uaBrowser: data.uaBrowser,

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -107,7 +107,7 @@ describe('remote push db', function() {
           })
 
           .then(function (sessionToken) {
-            sessionTokenId = sessionToken.tokenId
+            sessionTokenId = sessionToken.id
             return db.createDevice(ACCOUNT.uid, sessionTokenId, deviceInfo)
           })
           .then(function (device) {


### PR DESCRIPTION
Fixes #1981.

Removes the `tokenId` property from all token objects and uses `id` instead. Obviously the db schema still contains `tokenId` columns so there's a bit of marshalling in `lib/db.js`. Other than that, `id` is used everywhere.

This means we eliminate some duplication and avoid the stuttering pointed out by @seanmonstar in https://github.com/mozilla/fxa-auth-server/issues/1981#issuecomment-314138217 (may he rest in peace 😞).

@mozilla/fxa-devs r?