### PR TITLE
fix(tests): unify the mock log implementations

### DIFF
--- a/test/e2e/push_tests.js
+++ b/test/e2e/push_tests.js
@@ -6,8 +6,7 @@
 
 const assert = require('insist')
 const config = require('../../config').getProperties()
-const proxyquire = require('proxyquire')
-const { mockDB, spyLog } = require('../mocks')
+const { mockDB, mockLog } = require('../mocks')
 const { PushManager } = require('../push_helper')
 
 const mockUid = 'foo'
@@ -26,16 +25,16 @@ describe('e2e/push', () => {
     return pushManager.getSubscription()
       .then(subscription => {
         let count = 0
-        var thisSpyLog = spyLog({
-          info: function (log) {
+        const thisSpyLog = mockLog({
+          info (log) {
             if (log.name === 'push.account_verify.success') {
               count++
             }
           }
         })
 
-        var push = proxyquire('../../lib/push', {})(thisSpyLog, mockDB(), config)
-        var options = {
+        const push = require('../../lib/push')(thisSpyLog, mockDB(), config)
+        const options = {
           data: Buffer.from('foodata')
         }
         return push.notifyUpdate(mockUid, [

--- a/test/local/cache.js
+++ b/test/local/cache.js
@@ -20,7 +20,7 @@ describe('cache:', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create()
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     cache = require(modulePath)(log, {
       memcached: {
         address: '127.0.0.1:1121',
@@ -173,7 +173,7 @@ describe('null cache:', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create()
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     cache = require(modulePath)(log, {
       memcached: {
         address: 'none',

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -30,7 +30,7 @@ describe('db, session tokens expire:', () => {
       getAsync: sinon.spy(() => P.resolve(results.redis)),
       setAsync: sinon.spy(() => P.resolve())
     }
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     tokens = require(`${LIB_DIR}/tokens`)(log, { tokenLifetimes })
     const DB = proxyquire(`${LIB_DIR}/db`, {
       './pool': function () { return pool },
@@ -84,7 +84,7 @@ describe('db, session tokens do not expire:', () => {
       getAsync: sinon.spy(() => P.resolve(results.redis)),
       setAsync: sinon.spy(() => P.resolve())
     }
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     tokens = require(`${LIB_DIR}/tokens`)(log, { tokenLifetimes })
     const DB = proxyquire(`${LIB_DIR}/db`, {
       './pool': function () { return pool },
@@ -142,7 +142,7 @@ describe('db with redis disabled', () => {
       del: sinon.spy(() => P.resolve())
     }
 
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     tokens = require(`${LIB_DIR}/tokens`)(log, { tokenLifetimes })
     const DB = proxyquire(`${LIB_DIR}/db`, {
       './pool': function () { return pool },

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -24,7 +24,7 @@ describe('devices', () => {
     var log, deviceCreatedAt, deviceId, device, db, push, devices
 
     beforeEach(() => {
-      log = mocks.spyLog()
+      log = mocks.mockLog()
       deviceCreatedAt = Date.now()
       deviceId = crypto.randomBytes(16).toString('hex')
       device = {

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -8,9 +8,9 @@ const ROOT_DIR = '../../..'
 
 const assert = require('insist')
 const P = require(`${ROOT_DIR}/lib/promise`)
+const { mockLog } = require('../../mocks')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const spyLog = require('../../mocks').spyLog
 
 const amplitude = sinon.spy()
 const emailHelpers = proxyquire(`${ROOT_DIR}/lib/email/utils/helpers`, {
@@ -53,7 +53,7 @@ describe('email utils helpers', () => {
 
   describe('logEmailEventSent', () => {
     it('should check headers case-insensitively', () => {
-      const mockLog = spyLog()
+      const log = mockLog()
       const message = {
         email: 'user@example.domain',
         template: 'verifyEmail',
@@ -61,28 +61,28 @@ describe('email utils helpers', () => {
           'cOnTeNt-LaNgUaGe': 'ru'
         }
       }
-      emailHelpers.logEmailEventSent(mockLog, message)
-      assert.equal(mockLog.info.callCount, 1)
-      assert.equal(mockLog.info.args[0][0].locale, 'ru')
+      emailHelpers.logEmailEventSent(log, message)
+      assert.equal(log.info.callCount, 1)
+      assert.equal(log.info.args[0][0].locale, 'ru')
     })
 
     it('should log an event per CC email', () => {
-      const mockLog = spyLog()
+      const log = mockLog()
       const message = {
         email: 'user@example.domain',
         ccEmails: ['noreply@gmail.com', 'noreply@yahoo.com'],
         template: 'verifyEmail'
       }
-      emailHelpers.logEmailEventSent(mockLog, message)
-      assert.equal(mockLog.info.callCount, 3)
-      assert.equal(mockLog.info.args[0][0].domain, 'other')
-      assert.equal(mockLog.info.args[1][0].domain, 'gmail.com')
-      assert.equal(mockLog.info.args[2][0].domain, 'yahoo.com')
+      emailHelpers.logEmailEventSent(log, message)
+      assert.equal(log.info.callCount, 3)
+      assert.equal(log.info.args[0][0].domain, 'other')
+      assert.equal(log.info.args[1][0].domain, 'gmail.com')
+      assert.equal(log.info.args[2][0].domain, 'yahoo.com')
     })
   })
 
   it('logEmailEventSent should call amplitude correctly', () => {
-    emailHelpers.logEmailEventSent(spyLog(), {
+    emailHelpers.logEmailEventSent(mockLog(), {
       email: 'foo@example.com',
       ccEmails: [ 'bar@example.com', 'baz@example.com' ],
       template: 'verifyEmail',
@@ -126,7 +126,7 @@ describe('email utils helpers', () => {
   })
 
   it('logEmailEventFromMessage should call amplitude correctly', () => {
-    emailHelpers.logEmailEventFromMessage(spyLog(), {
+    emailHelpers.logEmailEventFromMessage(mockLog(), {
       email: 'foo@example.com',
       ccEmails: [ 'bar@example.com', 'baz@example.com' ],
       headers: [
@@ -172,7 +172,7 @@ describe('email utils helpers', () => {
     let log
 
     beforeEach(() => {
-      log = spyLog()
+      log = mockLog()
     })
 
     it('logs an error if message.mail is missing', () => {

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -26,7 +26,7 @@ describe('metrics/amplitude', () => {
     let log, amplitude
 
     beforeEach(() => {
-      log = mocks.spyLog()
+      log = mocks.mockLog()
       amplitude = amplitudeModule(log, {
         oauth: {
           clientIds: {

--- a/test/local/metrics/context.js
+++ b/test/local/metrics/context.js
@@ -39,7 +39,7 @@ describe('metricsContext', () => {
       set: sinon.spy(() => results.set)
     }
     cacheFactory = sinon.spy(() => cache)
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {}
     metricsContext = proxyquire(modulePath, { '../cache': cacheFactory })(log, config)
   })
@@ -548,7 +548,7 @@ describe('metricsContext', () => {
       sinon.stub(Date, 'now', function() {
         return flowBeginTime + 59999
       })
-      const mockLog = mocks.spyLog()
+      const mockLog = mocks.mockLog()
       const mockConfig = {
         memcached: {},
         metrics: {
@@ -589,7 +589,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with missing payload',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -621,7 +621,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with missing data bundle',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -657,7 +657,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with missing flowId',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -695,7 +695,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with missing flowBeginTime',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -733,7 +733,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with flowBeginTime that is too old',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -772,7 +772,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.validate with an invalid flow signature',
     () => {
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -814,7 +814,7 @@ describe('metricsContext', () => {
       var expectedTime = 1451566800000
       var expectedSalt = '4d6f7a696c6c6146697265666f782121'
       var expectedHmac = 'c89d56556d22039fbbf54d34e0baf206'
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -863,7 +863,7 @@ describe('metricsContext', () => {
       var expectedTime = 1451566800000
       var expectedSalt = '4d6f7a696c6c6146697265666f782121'
       var expectedHmac = 'c89d56556d22039fbbf54d34e0baf206'
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {
@@ -912,7 +912,7 @@ describe('metricsContext', () => {
       var expectedTime = 1451566800000
       var expectedSalt = '4d6f7a696c6c6146697265666f782121'
       var expectedHmac = 'c89d56556d22039fbbf54d34e0baf206'
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockConfig = {
         memcached: {},
         metrics: {

--- a/test/local/profile/updates.js
+++ b/test/local/profile/updates.js
@@ -8,7 +8,7 @@ const assert = require('insist')
 
 const EventEmitter = require('events').EventEmitter
 const sinon = require('sinon')
-const { mockDB, spyLog } = require('../../mocks')
+const { mockDB, mockLog } = require('../../mocks')
 const profileUpdates = require('../../../lib/profile/updates')
 const P = require('../../../lib/promise')
 
@@ -40,12 +40,12 @@ describe('profile updates', () => {
     'should log errors',
     () => {
       pushShouldThrow = true
-      const mockLog = spyLog()
-      return mockProfileUpdates(mockLog).handleProfileUpdated(mockMessage({
+      const log = mockLog()
+      return mockProfileUpdates(log).handleProfileUpdated(mockMessage({
         uid: 'bogusuid'
       })).then(() => {
         assert.equal(mockPush.notifyProfileUpdated.callCount, 1)
-        assert.equal(mockLog.messages.length, 3)
+        assert.equal(log.error.callCount, 1)
         pushShouldThrow = false
       })
     }
@@ -54,13 +54,13 @@ describe('profile updates', () => {
   it(
     'should send push notifications',
     () => {
-      const mockLog = spyLog()
+      const log = mockLog()
       const uid = '1e2122ba'
 
-      return mockProfileUpdates(mockLog).handleProfileUpdated(mockMessage({
+      return mockProfileUpdates(log).handleProfileUpdated(mockMessage({
         uid: uid
       })).then(function () {
-        assert.equal(mockLog.messages.length, 2)
+        assert.equal(log.error.callCount, 0)
         assert.equal(mockPush.notifyProfileUpdated.callCount, 2)
         var args = mockPush.notifyProfileUpdated.getCall(1).args
         assert.equal(args[0], uid)

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -76,7 +76,7 @@ function runTest (route, request, assertions) {
 describe('/account/reset', function () {
   it('should do things', () => {
     var uid = uuid.v4('binary').toString('hex')
-    const mockLog = mocks.spyLog()
+    const mockLog = mocks.mockLog()
     const mockMetricsContext = mocks.mockMetricsContext()
     const mockRequest = mocks.mockRequest({
       credentials: {
@@ -1196,7 +1196,7 @@ describe('/account/login', function () {
 describe('/account/keys', function () {
   var keyFetchTokenId = hexString(16)
   var uid = uuid.v4('binary').toString('hex')
-  const mockLog = mocks.spyLog()
+  const mockLog = mocks.mockLog()
   const mockRequest = mocks.mockRequest({
     credentials: {
       emailVerified: true,
@@ -1261,7 +1261,7 @@ describe('/account/destroy', function () {
       email: email,
       uid: uid
     })
-    const mockLog = mocks.spyLog()
+    const mockLog = mocks.mockLog()
     const mockRequest = mocks.mockRequest({
       log: mockLog,
       payload: {

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -85,7 +85,7 @@ describe('/account/device', function () {
     }
   })
   var mockDevices = mocks.mockDevices()
-  var mockLog = mocks.spyLog()
+  var mockLog = mocks.mockLog()
   var accountRoutes = makeRoutes({
     config: config,
     devices: mockDevices,
@@ -209,7 +209,7 @@ describe('/account/devices/notify', function () {
   var config = {}
   var uid = uuid.v4('binary').toString('hex')
   var deviceId = crypto.randomBytes(16).toString('hex')
-  var mockLog = mocks.spyLog()
+  var mockLog = mocks.mockLog()
   var mockRequest = mocks.mockRequest({
     log: mockLog,
     credentials: {
@@ -419,7 +419,7 @@ describe('/account/devices/notify', function () {
       payload: pushPayload
     }
 
-    var mockLog = mocks.spyLog()
+    var mockLog = mocks.mockLog()
     var mockPush = mocks.mockPush({
       notifyUpdate: () => P.reject('devices empty')
     })
@@ -443,7 +443,7 @@ describe('/account/device/destroy', function () {
   it('should work', () => {
     var uid = uuid.v4('binary').toString('hex')
     var deviceId = crypto.randomBytes(16).toString('hex')
-    var mockLog = mocks.spyLog()
+    var mockLog = mocks.mockLog()
     var mockDB = mocks.mockDB()
     var mockRequest = mocks.mockRequest({
       credentials: {

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -413,7 +413,7 @@ describe('/recovery_email/resend_code', () => {
 
 describe('/recovery_email/verify_code', function () {
   const uid = uuid.v4('binary').toString('hex')
-  const mockLog = mocks.spyLog()
+  const mockLog = mocks.mockLog()
   const mockRequest = mocks.mockRequest({
     log: mockLog,
     metricsContext: mocks.mockMetricsContext({
@@ -670,7 +670,7 @@ describe('/recovery_email/verify_code', function () {
 
 describe('/recovery_email', () => {
   const uid = uuid.v4('binary').toString('hex')
-  const mockLog = mocks.spyLog()
+  const mockLog = mocks.mockLog()
   let dbData, accountRoutes, mockDB, mockRequest, route
   const mockMailer = mocks.mockMailer()
   const mockPush = mocks.mockPush()

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -281,7 +281,7 @@ describe('/password', () => {
         })
         var mockPush = mocks.mockPush()
         var mockMailer = mocks.mockMailer()
-        var mockLog = mocks.spyLog()
+        var mockLog = mocks.mockLog()
         var mockRequest = mocks.mockRequest({
           credentials: {
             uid: uid
@@ -362,7 +362,7 @@ describe('/password', () => {
             return P.reject(error.emailBouncedHard())
           })
         }
-        var mockLog = mocks.spyLog()
+        var mockLog = mocks.mockLog()
         var mockRequest = mocks.mockRequest({
           credentials: {
             uid: uid

--- a/test/local/routes/session.js
+++ b/test/local/routes/session.js
@@ -30,7 +30,7 @@ function runTest (route, request) {
 }
 
 describe('/session/status', () => {
-  const log = mocks.spyLog()
+  const log = mocks.mockLog()
   const config = {}
   const routes = makeRoutes({ log, config })
   const route = getRoute(routes, '/session/status')
@@ -61,7 +61,7 @@ describe('/session/destroy', () => {
 
   beforeEach(() => {
     db = mocks.mockDB()
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     const config = {}
     const routes = makeRoutes({ log, config, db})
     route = getRoute(routes, '/session/destroy')

--- a/test/local/routes/sign.js
+++ b/test/local/routes/sign.js
@@ -22,7 +22,7 @@ describe('/certificate/sign', () => {
     mockDevices = mocks.mockDevices({
       deviceId: deviceId
     })
-    mockLog = mocks.spyLog()
+    mockLog = mocks.mockLog()
     const Token = require(`${ROOT_DIR}/lib/tokens/token`)(mockLog)
     const SessionToken = require(`${ROOT_DIR}/lib/tokens/session_token`)(mockLog, Token, {
       tokenLifetimes: {

--- a/test/local/routes/signin-codes.js
+++ b/test/local/routes/signin-codes.js
@@ -148,7 +148,7 @@ describe('/signinCodes/consume:', () => {
     results = results || {}
     errors = errors || {}
 
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     db = mocks.mockDB(results.db, errors.db)
     customs = mocks.mockCustoms(errors.customs)
     routes = makeRoutes({ log, db, customs })

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -36,7 +36,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
   let log, signinCode, db, config, routes, route, request
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     signinCode = Buffer.from('++//ff0=', 'base64')
     db = mocks.mockDB({ signinCode })
     config = {
@@ -308,7 +308,7 @@ describe('/sms without the signinCodes feature included in the payload', () => {
   let log, signinCode, db, config, routes, route, request
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     signinCode = Buffer.from('++//ff0=', 'base64')
     db = mocks.mockDB({ signinCode })
     config = {
@@ -365,7 +365,7 @@ describe('/sms disabled', () => {
   let log, config, routes
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {
       sms: {
         enabled: false,
@@ -385,7 +385,7 @@ describe('/sms/status', () => {
   let log, config, routes, route
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {
       sms: {
         enabled: true,
@@ -537,7 +537,7 @@ describe('/sms/status with disabled geo-ip lookup', () => {
   let log, config, routes, route, request, response
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {
       sms: {
         enabled: true,
@@ -586,7 +586,7 @@ describe('/sms/status with query param and enabled geo-ip lookup', () => {
   let log, config, routes, route, request, response
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {
       sms: {
         enabled: true,
@@ -631,7 +631,7 @@ describe('/sms/status with query param and disabled geo-ip lookup', () => {
   let log, config, routes, route, request, response
 
   beforeEach(() => {
-    log = mocks.spyLog()
+    log = mocks.mockLog()
     config = {
       sms: {
         enabled: true,

--- a/test/local/routes/unblock-codes.js
+++ b/test/local/routes/unblock-codes.js
@@ -42,7 +42,7 @@ function runTest (route, request, assertions) {
 describe('/account/login/send_unblock_code', function () {
   var uid = uuid.v4('binary').toString('hex')
   var email = 'unblock@example.com'
-  const mockLog = mocks.spyLog()
+  const mockLog = mocks.mockLog()
   var mockRequest = mocks.mockRequest({
     log: mockLog,
     payload: {

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -242,7 +242,7 @@ describe('lib/senders/index', () => {
       const code = crypto.randomBytes(8).toString('hex')
 
       it('errors if bounce check fails', () => {
-        const log = mocks.spyLog()
+        const log = mocks.mockLog()
         const DATE = Date.now() - 10000
         const errorBounces =  {
           check: sinon.spy(() => P.reject(error.emailComplaint(DATE)))
@@ -267,7 +267,7 @@ describe('lib/senders/index', () => {
       })
 
       it('on gated primary email + verified secondary, sends to secondary', () => {
-        const log = mocks.spyLog()
+        const log = mocks.mockLog()
         const DATE = Date.now() - 10000
         let email
         const errorBounces = {
@@ -293,7 +293,7 @@ describe('lib/senders/index', () => {
       })
 
       it('on gated primary email + unverified secondary, blocks the send', () => {
-        const log = mocks.spyLog()
+        const log = mocks.mockLog()
         const DATE = Date.now() - 10000
         let email
         const errorBounces = {

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -66,7 +66,7 @@ describe('lib/server', () => {
     let log, config, routes, db, instance, response, locale, translator
 
     beforeEach(() => {
-      log = mocks.spyLog()
+      log = mocks.mockLog()
       config = getConfig()
       routes = getRoutes()
       db = mocks.mockDB({

--- a/test/local/tokens/token.js
+++ b/test/local/tokens/token.js
@@ -16,7 +16,7 @@ var Bundle = {
   bundle: sinon.spy(),
   unbundle: sinon.spy()
 }
-var log = mocks.spyLog()
+var log = mocks.mockLog()
 var modulePath = '../../../lib/tokens/token'
 
 describe('Token', () => {

--- a/test/local/verification_reminder.js
+++ b/test/local/verification_reminder.js
@@ -45,7 +45,7 @@ describe('verification reminders', () => {
         }
       }
 
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockDB = mocks.mockDB()
 
       var verificationReminder = proxyquire(verificationModulePath, moduleMocks)(mockLog, mockDB)
@@ -100,7 +100,7 @@ describe('verification reminders', () => {
           }
         }
       }
-      var mockLog = mocks.spyLog()
+      var mockLog = mocks.mockLog()
       var mockDB = mocks.mockDB({
         deleteVerificationReminder: function (reminderData) {
           assert.ok(reminderData.email)
@@ -120,11 +120,11 @@ describe('verification reminders', () => {
   it(
     'deletes reminders can catch errors',
     () => {
-      var mockLog = mocks.spyLog({
-        error: function (logErr) {
+      var mockLog = mocks.mockLog({
+        error: sinon.spy(logErr => {
           assert.equal(logErr.op, 'verification-reminder.delete')
           assert.ok(logErr.err.message)
-        }
+        })
       })
       var mockDB = {
         deleteVerificationReminder: sinon.spy(function () {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -121,15 +121,14 @@ module.exports = {
   MOCK_PUSH_KEY: 'BDLugiRzQCANNj5KI1fAqui8ELrE7qboxzfa5K_R0wnUoJ89xY1D_SOXI_QJKNmellykaW_7U2BZ7hnrPW3A3LM',
   generateMetricsContext: generateMetricsContext,
   mockBounces: mockObject(['check']),
-  mockCustoms: mockCustoms,
-  mockDB: mockDB,
-  mockDevices: mockDevices,
-  mockLog: mockLog,
-  spyLog: spyLog,
+  mockCustoms,
+  mockDB,
+  mockDevices,
+  mockLog: mockObject(LOG_METHOD_NAMES),
   mockMailer: mockObject(MAILER_METHOD_NAMES),
-  mockMetricsContext: mockMetricsContext,
-  mockPush: mockPush,
-  mockRequest: mockRequest
+  mockMetricsContext,
+  mockPush,
+  mockRequest
 }
 
 function mockCustoms (errors) {
@@ -378,39 +377,6 @@ function mockDevices (data) {
       return data.deviceName || null
     })
   }
-}
-
-// A logging mock that doesn't capture anything.
-// You can pass in an object of custom logging methods
-// if you need to e.g. make assertions about logged values.
-function mockLog (methods) {
-  const log = extend({}, methods)
-  LOG_METHOD_NAMES.forEach((name) => {
-    if (! log[name]) {
-      log[name] = function() {}
-    }
-  })
-  return log
-}
-
-// A logging mock where all logging methods are sinon spys,
-// and we capture a log of all their calls in order.
-function spyLog (methods) {
-  methods = extend({}, methods)
-  methods.messages = methods.messages || []
-  LOG_METHOD_NAMES.forEach(name => {
-    if (! methods[name]) {
-      // arrow function would alter `this` inside the method
-      methods[name] = function() {
-        this.messages.push({
-          level: name,
-          args: Array.prototype.slice.call(arguments)
-        })
-      }
-    }
-    methods[name] = sinon.spy(methods[name])
-  })
-  return mockLog(methods)
 }
 
 function mockMetricsContext (methods) {


### PR DESCRIPTION
Fixes #1655.

We had two implementations of a mock log object, this PR reduces that to one. It also replaces the home-baked spy functionality with the stuff provided by sinon.

@mozilla/fxa-devs r?