### PR TITLE
fix(logging): silence annoying redis log noise

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -431,6 +431,11 @@ module.exports = (
 
   DB.prototype.devices = function (uid) {
     log.trace({ op: 'DB.devices', uid: uid })
+
+    if (! uid) {
+      return P.reject(error.unknownAccount())
+    }
+
     const promises = [
       this.pool.get('/account/' + uid + '/devices')
     ]


### PR DESCRIPTION
Fixes #2163.

We were passing `undefined` to `redis.get` because the Amplitude metrics make an indiscriminate attempt to use `request.app.devices`.

Changing the logic in the Amplitude code was a bit messier, so I chose to shortcut the call inside `db.devices` instead. If `uid` is `undefined` we know that the request is going to fail, so fail early.

@mozilla/fxa-devs r?