### PR TITLE
fix(metrics): don't emit os_version if os_name is unset

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -157,12 +157,12 @@ module.exports = (log, config) => {
         request.app.geo,
         request.app.devices.catch(() => {})
       ]).spread((geo, devices) => {
-        const { os, osVersion, formFactor } = request.app.ua
+        const { formFactor } = request.app.ua
 
         data.location = geo.location
         data.devices = devices
 
-        log.amplitudeEvent({
+        log.amplitudeEvent(Object.assign({
           time: metricsContext.time || Date.now(),
           user_id: data.uid || getFromToken(request, 'uid'),
           device_id: getFromMetricsContext(metricsContext, 'device_id', request, 'deviceId'),
@@ -174,14 +174,23 @@ module.exports = (log, config) => {
           language: getLocale(request),
           country: getLocationProperty(data, 'country'),
           region: getLocationProperty(data, 'state'),
-          os_name: safeGet(os),
-          os_version: safeGet(osVersion),
           device_model: safeGet(formFactor)
-        })
+        }, mapOs(request)))
       })
     }
 
     return P.resolve()
+  }
+
+  function mapOs (request) {
+    const { os, osVersion } = request.app.ua
+
+    if (os) {
+      return {
+        os_name: safeGet(os),
+        os_version: safeGet(osVersion)
+      }
+    }
   }
 
   function getFromToken (request, key) {

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -154,10 +154,9 @@ describe('metrics/amplitude', () => {
 
     describe('account.created', () => {
       beforeEach(() => {
-        return amplitude('account.created', mocks.mockRequest({
+        const request = mocks.mockRequest({
           uaBrowser: 'a',
           uaBrowserVersion: 'b',
-          uaOS: 'c',
           uaOSVersion: 'd',
           uaDeviceType: 'e',
           uaFormFactor: 'f',
@@ -172,7 +171,10 @@ describe('metrics/amplitude', () => {
           payload: {
             service: '1'
           }
-        }))
+        })
+        // mockRequest forces uaOS if it's not set
+        request.app.ua.os = ''
+        return amplitude('account.created', request)
       })
 
       it('did not call log.error', () => {
@@ -189,8 +191,8 @@ describe('metrics/amplitude', () => {
         assert.equal(args[0].language, 'g')
         assert.equal(args[0].country, 'United States')
         assert.equal(args[0].region, 'California')
-        assert.equal(args[0].os_name, 'c')
-        assert.equal(args[0].os_version, 'd')
+        assert.equal(args[0].os_name, undefined)
+        assert.equal(args[0].os_version, undefined)
         assert.equal(args[0].device_model, 'f')
         assert.deepEqual(args[0].event_properties, {
           service: 'pocket'


### PR DESCRIPTION
Tangentially related to mozilla/fxa-amplitude-send#19.

Omits the `os_version` Amplitude property if we have no value for `os_name`, which is the same behaviour that I've implemented for the content server in mozilla/fxa-content-server#5587.

@davismtl does that seem like the right thing to do?

@mozilla/fxa-devs r?