### PR TITLE
fix(push): Target `Firefox Beta` for account verification messages

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -191,6 +191,10 @@ module.exports = function (log, db, config) {
       canSendToIOSVersion = () => payload.data.reason !== 'firstsync'
       break
     case null: // In the null case this is an account verification push message
+      canSendToIOSVersion = (deviceVersion, deviceBrowser) => {
+        return deviceVersion >= 10.0 && deviceBrowser === 'Firefox Beta'
+      }
+      break
     case 'fxaccounts:device_connected':
     case 'fxaccounts:device_disconnected':
       canSendToIOSVersion = deviceVersion => deviceVersion >= 10.0
@@ -202,7 +206,8 @@ module.exports = function (log, db, config) {
       const deviceOS = device.uaOS && device.uaOS.toLowerCase()
       if (deviceOS === 'ios') {
         const deviceVersion = device.uaBrowserVersion ? parseFloat(device.uaBrowserVersion) : 0
-        if (! canSendToIOSVersion(deviceVersion)) {
+        const deviceBrowserName = device.uaBrowser
+        if (! canSendToIOSVersion(deviceVersion, deviceBrowserName)) {
           log.info({
             op: 'push.filteredUnsupportedDevice',
             command: command,


### PR DESCRIPTION
This updates device filtering for iOS. We will only send account verification messages for `Firefox Beta` devices. 

From debugger, ios beta devices show up as `Firefox Beta` for browser name. It doesn't appear that we filter down to build number if that would ever be needed.

![screen shot 2017-10-13 at 2 52 00 pm](https://user-images.githubusercontent.com/1295288/31562823-dead4c68-b02a-11e7-802a-f15342a25ab9.png)

@rfk When you get a chance r? Hoping to land this as a point for 97.

Fixes https://github.com/mozilla/fxa-auth-server/issues/2156
