### PR TITLE
fix(logging): more clearly distinguish amplitude error messages

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -163,7 +163,7 @@ Lug.prototype.flowEvent = function (data) {
 
 Lug.prototype.amplitudeEvent = function (data) {
   if (! data || ! data.event_type || (! data.device_id && ! data.user_id)) {
-    this.error({ op: 'log.amplitudeEvent', data })
+    this.error({ op: 'amplitude.missingData', data })
     return
   }
 

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -120,7 +120,7 @@ module.exports = (log, config) => {
 
   function receiveEvent (event, request, data = {}, metricsContext = {}) {
     if (! event || ! request) {
-      log.error({ op: 'amplitudeMetrics', err: 'Bad argument', event, hasRequest: !! request })
+      log.error({ op: 'amplitude.badArgument', err: 'Bad argument', event, hasRequest: !! request })
       return P.resolve()
     }
 

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -371,9 +371,9 @@ describe('log', () => {
     assert.equal(logger.error.callCount, 1, 'logger.error was called once')
     const args = logger.error.args[0]
     assert.equal(args.length, 2, 'logger.error was passed two arguments')
-    assert.equal(args[0], 'log.amplitudeEvent', 'first argument was function name')
+    assert.equal(args[0], 'amplitude.missingData', 'first argument was error op')
     assert.deepEqual(args[1], {
-      op: 'log.amplitudeEvent',
+      op: 'amplitude.missingData',
       data: undefined
     }, 'second argument was correct')
 
@@ -391,9 +391,9 @@ describe('log', () => {
     assert.equal(logger.error.callCount, 1, 'logger.error was called once')
     const args = logger.error.args[0]
     assert.equal(args.length, 2, 'logger.error was passed two arguments')
-    assert.equal(args[0], 'log.amplitudeEvent', 'first argument was function name')
+    assert.equal(args[0], 'amplitude.missingData', 'first argument was error op')
     assert.deepEqual(args[1], {
-      op: 'log.amplitudeEvent',
+      op: 'amplitude.missingData',
       data: { device_id: 'foo', user_id: 'bar' }
     }, 'second argument was correct')
 
@@ -411,9 +411,9 @@ describe('log', () => {
     assert.equal(logger.error.callCount, 1, 'logger.error was called once')
     const args = logger.error.args[0]
     assert.equal(args.length, 2, 'logger.error was passed two arguments')
-    assert.equal(args[0], 'log.amplitudeEvent', 'first argument was function name')
+    assert.equal(args[0], 'amplitude.missingData', 'first argument was error op')
     assert.deepEqual(args[1], {
-      op: 'log.amplitudeEvent',
+      op: 'amplitude.missingData',
       data: { event_type: 'foo' }
     }, 'second argument was correct')
 

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -51,7 +51,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.error.callCount, 1)
         assert.equal(log.error.args[0].length, 1)
         assert.deepEqual(log.error.args[0][0], {
-          op: 'amplitudeMetrics',
+          op: 'amplitude.badArgument',
           err: 'Bad argument',
           event: '',
           hasRequest: true
@@ -72,7 +72,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.error.callCount, 1)
         assert.equal(log.error.args[0].length, 1)
         assert.deepEqual(log.error.args[0][0], {
-          op: 'amplitudeMetrics',
+          op: 'amplitude.badArgument',
           err: 'Bad argument',
           event: 'foo',
           hasRequest: false


### PR DESCRIPTION
It came up in the meeting just now that we should more clearly distinguish the amplitude error messages so that they're not accidentally mistaken for events in the logs. This PR does that.

@mozilla/fxa-devs r?