### PR TITLE
Always report a name and type in device registration response

### DIFF
--- a/test/client/api.js
+++ b/test/client/api.js
@@ -344,9 +344,13 @@ module.exports = config => {
     return tokens.SessionToken.fromHex(sessionTokenHex)
       .then(
         function (token) {
+          let url = this.baseURL + '/certificate/sign'
+          if (options.service) {
+            url += '?service=' + options.service
+          }
           return this.doRequest(
             'POST',
-            this.baseURL + '/certificate/sign',
+            url,
             token,
             {
               publicKey: publicKey,


### PR DESCRIPTION
Fixes #2130.

The response from `POST /account/device` must always include "name" and "type" fields, otherwise it fails validation.  As seen in #2130 and [1], a small number of clients are somehow attempting to update a device record that doesn't have a "type" value specified, meaning we don't include a "type" field in the response, meaning we throw a response validation error.

This fixes it by applying the same logic for default "name" and "type" fields as the `GET /account/devices` route.  @eoger could you please sanity-check this as a follow-on to #2130?  @philbooth r?

[1] https://sentry.prod.mozaws.net/operations/auth-prod/issues/668478/