### PR TITLE
fix(emailVerify):Added secondary to subject line

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -475,7 +475,7 @@ module.exports = function (log) {
 
     return this.send(Object.assign({}, message, {
       headers,
-      subject: gettext('Verify email for Firefox Accounts'),
+      subject: gettext('Verify secondary email'),
       template: templateName,
       templateValues: {
         device: this._formatUserAgentInfo(message),


### PR DESCRIPTION
Added word "secondary" to subject line to pave the way for primary