### PR TITLE
feat(sms): Return the `formattedPhoneNumber` in the POST /sms response.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -255,6 +255,8 @@ for `code` and `errno` are:
   This email can not currently be used to login
 * `code: 400, errno: 150`:
   Can not resend email code to an email that does not belong to this account
+* `code: 400, errno: 151`:
+  Failed to send email
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -1008,6 +1010,12 @@ and display the tab in a timely manner.
   containing the relevant device ids.
   <!--end-request-body-post-accountdevicesnotify-to-->
 
+* `_endpointAction`: *string, valid('accountVerify'), optional*
+
+  <!--begin-request-body-post-accountdevicesnotify-_endpointAction-->
+  
+  <!--end-request-body-post-accountdevicesnotify-_endpointAction-->
+
 * `excluded`: *array, items(string, length(32), regex(HEX_STRING)), optional*
 
   <!--begin-request-body-post-accountdevicesnotify-excluded-->
@@ -1016,7 +1024,7 @@ and display the tab in a timely manner.
   Ignored unless `to:"all"` is specified.
   <!--end-request-body-post-accountdevicesnotify-excluded-->
 
-* `payload`: *object, required*
+* `payload`: *object, when('_endpointAction', { is: 'accountVerify', then: required, otherwise: required })*
 
   <!--begin-request-body-post-accountdevicesnotify-payload-->
   Push payload,
@@ -1566,6 +1574,9 @@ by the following errors
 
 * `code: 400, errno: 141`:
   Email already exists
+
+* `code: 400, errno: 151`:
+  Failed to send email
 
 
 #### POST /recovery_email/destroy

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,8 +255,6 @@ for `code` and `errno` are:
   This email can not currently be used to login
 * `code: 400, errno: 150`:
   Can not resend email code to an email that does not belong to this account
-* `code: 400, errno: 151`:
-  Failed to send email
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -1010,12 +1008,6 @@ and display the tab in a timely manner.
   containing the relevant device ids.
   <!--end-request-body-post-accountdevicesnotify-to-->
 
-* `_endpointAction`: *string, valid('accountVerify'), optional*
-
-  <!--begin-request-body-post-accountdevicesnotify-_endpointAction-->
-  
-  <!--end-request-body-post-accountdevicesnotify-_endpointAction-->
-
 * `excluded`: *array, items(string, length(32), regex(HEX_STRING)), optional*
 
   <!--begin-request-body-post-accountdevicesnotify-excluded-->
@@ -1024,7 +1016,7 @@ and display the tab in a timely manner.
   Ignored unless `to:"all"` is specified.
   <!--end-request-body-post-accountdevicesnotify-excluded-->
 
-* `payload`: *object, when('_endpointAction', { is: 'accountVerify', then: required, otherwise: required })*
+* `payload`: *object, required*
 
   <!--begin-request-body-post-accountdevicesnotify-payload-->
   Push payload,
@@ -1574,9 +1566,6 @@ by the following errors
 
 * `code: 400, errno: 141`:
   Email already exists
-
-* `code: 400, errno: 151`:
-  Failed to send email
 
 
 #### POST /recovery_email/destroy

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -50,7 +50,7 @@ module.exports = (log, db, config, customs, sms) => {
         const templateName = TEMPLATE_NAMES.get(request.payload.messageId)
         const acceptLanguage = request.app.acceptLanguage
 
-        let phoneNumberUtil, parsedPhoneNumber, region
+        let phoneNumberUtil, parsedPhoneNumber
 
         customs.check(request, sessionToken.email, 'connectDeviceSms')
           .then(parsePhoneNumber)
@@ -74,7 +74,7 @@ module.exports = (log, db, config, customs, sms) => {
         }
 
         function validateRegion () {
-          region = phoneNumberUtil.getRegionCodeForNumber(parsedPhoneNumber)
+          const region = phoneNumberUtil.getRegionCodeForNumber(parsedPhoneNumber)
           request.emitMetricsEvent(`sms.region.${region}`)
 
           if (! REGIONS.has(region)) {

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -50,7 +50,7 @@ module.exports = (log, db, config, customs, sms) => {
         const templateName = TEMPLATE_NAMES.get(request.payload.messageId)
         const acceptLanguage = request.app.acceptLanguage
 
-        let phoneNumberUtil, parsedPhoneNumber
+        let phoneNumberUtil, parsedPhoneNumber, region
 
         customs.check(request, sessionToken.email, 'connectDeviceSms')
           .then(parsePhoneNumber)
@@ -74,7 +74,7 @@ module.exports = (log, db, config, customs, sms) => {
         }
 
         function validateRegion () {
-          const region = phoneNumberUtil.getRegionCodeForNumber(parsedPhoneNumber)
+          region = phoneNumberUtil.getRegionCodeForNumber(parsedPhoneNumber)
           request.emitMetricsEvent(`sms.region.${region}`)
 
           if (! REGIONS.has(region)) {
@@ -98,7 +98,9 @@ module.exports = (log, db, config, customs, sms) => {
         }
 
         function createResponse () {
-          return {}
+          return {
+            formattedPhoneNumber: phoneNumberUtil.format(parsedPhoneNumber, 'international')
+          }
         }
       }
     },

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -33,7 +33,7 @@ function runTest (route, request) {
 }
 
 describe('/sms with the signinCodes feature included in the payload', () => {
-  let log, signinCode, db, config, routes, route, request
+  let log, signinCode, db, config, routes, route, request, response
 
   beforeEach(() => {
     log = mocks.mockLog()
@@ -74,6 +74,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
       beforeEach(() => {
         request.payload.phoneNumber = '+18885083401'
         return runTest(route, request)
+          .then((_response) => response = _response)
       })
 
       it('called log.begin correctly', () => {
@@ -121,12 +122,17 @@ describe('/sms with the signinCodes feature included in the payload', () => {
         assert.equal(args[0].event, 'sms.installFirefox.sent')
         assert.equal(args[0].flow_id, request.payload.metricsContext.flowId)
       })
+
+      it('returns a formattedPhoneNumber', () => {
+        assert.equal(response.formattedPhoneNumber, '888-508-3401')
+      })
     })
 
     describe('Canada phone number', () => {
       beforeEach(() => {
         request.payload.phoneNumber = '+14168483114'
         return runTest(route, request)
+          .then((_response) => response = _response)
       })
 
       it('called log.begin once', () => {
@@ -151,12 +157,17 @@ describe('/sms with the signinCodes feature included in the payload', () => {
         assert.equal(log.flowEvent.callCount, 2)
         assert.equal(log.flowEvent.args[0][0].event, 'sms.region.CA')
       })
+
+      it('returns a formattedPhoneNumber', () => {
+        assert.equal(response.formattedPhoneNumber, '416-848-3114')
+      })
     })
 
     describe('UK phone number', () => {
       beforeEach(() => {
         request.payload.phoneNumber = '+442078553000'
         return runTest(route, request)
+          .then((_response) => response = _response)
       })
 
       it('called log.begin once', () => {
@@ -180,6 +191,10 @@ describe('/sms with the signinCodes feature included in the payload', () => {
       it('called log.flowEvent correctly', () => {
         assert.equal(log.flowEvent.callCount, 2)
         assert.equal(log.flowEvent.args[0][0].event, 'sms.region.GB')
+      })
+
+      it('returns a formattedPhoneNumber', () => {
+        assert.equal(response.formattedPhoneNumber, '20 7855 3000')
       })
     })
 


### PR DESCRIPTION
formattedPhoneNumber is used by the content server to display the
telephone number the SMS was sent to, formatted for the user's country.

fixes #2176

@philbooth - r?