### PR TITLE
feat(sms): Enable SMS in Austria, Germany.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -728,7 +728,7 @@ var conf = convict({
     },
     countryCodes: {
       doc: 'Allow sending SMS to these ISO 3166-1 alpha-2 country codes',
-      default: ['CA', 'GB', 'US'],
+      default: ['AT', 'CA', 'DE', 'GB', 'US'],
       format: Array,
       env: 'SMS_COUNTRY_CODES'
     },

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -205,18 +205,6 @@ describe('/sms with the signinCodes feature included in the payload', () => {
           .then((_response) => response = _response)
       })
 
-      it('called log.begin once', () => {
-        assert.equal(log.begin.callCount, 1)
-      })
-
-      it('called request.validateMetricsContext once', () => {
-        assert.equal(request.validateMetricsContext.callCount, 1)
-      })
-
-      it('called db.createSigninCode once', () => {
-        assert.equal(db.createSigninCode.callCount, 1)
-      })
-
       it('called sms.send correctly', () => {
         assert.equal(sms.send.callCount, 1)
         const args = sms.send.args[0]
@@ -238,18 +226,6 @@ describe('/sms with the signinCodes feature included in the payload', () => {
         request.payload.phoneNumber = '+49015153563252'
         return runTest(route, request)
           .then((_response) => response = _response)
-      })
-
-      it('called log.begin once', () => {
-        assert.equal(log.begin.callCount, 1)
-      })
-
-      it('called request.validateMetricsContext once', () => {
-        assert.equal(request.validateMetricsContext.callCount, 1)
-      })
-
-      it('called db.createSigninCode once', () => {
-        assert.equal(db.createSigninCode.callCount, 1)
       })
 
       it('called sms.send correctly', () => {

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -42,7 +42,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
     config = {
       sms: {
         enabled: true,
-        countryCodes: [ 'CA', 'GB', 'US' ],
+        countryCodes: [ 'AT', 'CA', 'DE', 'GB', 'US' ],
         isStatusGeoEnabled: true
       }
     }
@@ -195,6 +195,76 @@ describe('/sms with the signinCodes feature included in the payload', () => {
 
       it('returns a formattedPhoneNumber', () => {
         assert.equal(response.formattedPhoneNumber, '20 7855 3000')
+      })
+    })
+
+    describe('AT phone number', () => {
+      beforeEach(() => {
+        request.payload.phoneNumber = '+43676641643'
+        return runTest(route, request)
+          .then((_response) => response = _response)
+      })
+
+      it('called log.begin once', () => {
+        assert.equal(log.begin.callCount, 1)
+      })
+
+      it('called request.validateMetricsContext once', () => {
+        assert.equal(request.validateMetricsContext.callCount, 1)
+      })
+
+      it('called db.createSigninCode once', () => {
+        assert.equal(db.createSigninCode.callCount, 1)
+      })
+
+      it('called sms.send correctly', () => {
+        assert.equal(sms.send.callCount, 1)
+        const args = sms.send.args[0]
+        assert.equal(args[0], '+43676641643')
+      })
+
+      it('called log.flowEvent correctly', () => {
+        assert.equal(log.flowEvent.callCount, 2)
+        assert.equal(log.flowEvent.args[0][0].event, 'sms.region.AT')
+      })
+
+      it('returns a formattedPhoneNumber', () => {
+        assert.equal(response.formattedPhoneNumber, '676 641643')
+      })
+    })
+
+    describe('DE phone number', () => {
+      beforeEach(() => {
+        request.payload.phoneNumber = '+49015153563252'
+        return runTest(route, request)
+          .then((_response) => response = _response)
+      })
+
+      it('called log.begin once', () => {
+        assert.equal(log.begin.callCount, 1)
+      })
+
+      it('called request.validateMetricsContext once', () => {
+        assert.equal(request.validateMetricsContext.callCount, 1)
+      })
+
+      it('called db.createSigninCode once', () => {
+        assert.equal(db.createSigninCode.callCount, 1)
+      })
+
+      it('called sms.send correctly', () => {
+        assert.equal(sms.send.callCount, 1)
+        const args = sms.send.args[0]
+        assert.equal(args[0], '+49015153563252')
+      })
+
+      it('called log.flowEvent correctly', () => {
+        assert.equal(log.flowEvent.callCount, 2)
+        assert.equal(log.flowEvent.args[0][0].event, 'sms.region.DE')
+      })
+
+      it('returns a formattedPhoneNumber', () => {
+        assert.equal(response.formattedPhoneNumber, '1515 3563252')
       })
     })
 


### PR DESCRIPTION
fixes #2177

@philbooth - I wasn't sure how far down the testing rabbit hole to go for each new country. It seems like most of the test is the same, the important parts are to ensure the sms.send is called correctly, logFlowEvent is called with the correct region, and that the formattedPhoneNumber is returned as expected. Do we need the other parts?

f? @philbooth