### PR TITLE
feat(devices): return approximateLastAccessTime for old devices

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -635,6 +635,12 @@ var conf = convict({
       format: Number,
       default: 0.3,
       env: 'LASTACCESSTIME_UPDATES_SAMPLE_RATE'
+    },
+    earliestSaneTimestamp: {
+      doc: 'timestamp used as the basis of the fallback value for lastAccessTimeFormatted, currently pinned to the deployment of 1.96.4 / a0940d7dc51e2ba20fa18aa3a830810e35c9a9d9',
+      format: 'timestamp',
+      default: 1507081020000,
+      env: 'LASTACCESSTIME_EARLIEST_SANE_TIMESTAMP'
     }
   },
   signinUnblock: {

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -5,22 +5,22 @@
 'use strict'
 
 const assert = require('insist')
-var TestServer = require('../test_server')
+const TestServer = require('../test_server')
 const Client = require('../client')()
-var config = require('../../config').getProperties()
-var crypto = require('crypto')
-var base64url = require('base64url')
-var P = require('../../lib/promise')
-var mocks = require('../mocks')
+const config = require('../../config').getProperties()
+const crypto = require('crypto')
+const base64url = require('base64url')
+const P = require('../../lib/promise')
+const mocks = require('../mocks')
 
-describe('remote device', function() {
+describe('remote device', function () {
   this.timeout(15000)
   let server
   before(() => {
     config.lastAccessTimeUpdates = {
       enabled: true,
-      enabledEmailAddresses: /.*/g,
-      sampleRate: 1
+      sampleRate: 1,
+      earliestSaneTimestamp: config.lastAccessTimeUpdates.earliestSaneTimestamp
     }
 
     return TestServer.start(config)


### PR DESCRIPTION
Related to mozilla/fxa-content-server#5599.

For the device manager OKR, we're replacing the first sync time with an approximate last sync time like "last sync over 2 months ago".

There are two parts to that change, one here and one in mozilla/fxa-content-server#5627. This PR does the auth server portion, implemented in such a way as to be deployable independently of the content server bit. It only adds new properties to the response, so doesn't break older content servers that receive the data.

The change is dependent on new config, the threshold timestamp before which all values should be treated as approximate. I've set that to the time at which auth server 96.4 was deployed (containing #2150). That seemed like the correct time to me, but let me know if it's wrong for whatever reason.

@mozilla/fxa-devs r?