### PR TITLE
feat(metrics): add newsletter_state property to amplitude events

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -247,8 +247,8 @@ module.exports = (log, config) => {
   }
 
   function getNewsletterState (data) {
-    if (data.marketingOptIn === true) {
-      return { newsletter_state: 'subscribed' }
+    if (data.marketingOptIn === true || data.marketingOptIn === false) {
+      return { newsletter_state: data.marketingOptIn ? 'subscribed' : 'unsubscribed' }
     }
   }
 }

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -218,7 +218,7 @@ module.exports = (log, config) => {
       sync_device_count: data.devices && data.devices.length,
       ua_browser: safeGet(browser),
       ua_version: safeGet(browserVersion)
-    }, getService(request))
+    }, getService(request), getNewsletterState(data))
   }
 
   function safeGet (value) {
@@ -243,6 +243,12 @@ module.exports = (log, config) => {
           fxa_services_used: service
         }
       }
+    }
+  }
+
+  function getNewsletterState (data) {
+    if (data.marketingOptIn === true) {
+      return { newsletter_state: 'subscribed' }
     }
   }
 }

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -454,7 +454,8 @@ module.exports = (log, db, mailer, config, customs, push) => {
                         marketingOptIn: marketingOptIn ? true : undefined
                       }),
                       request.emitMetricsEvent('account.verified', {
-                        uid: uid
+                        marketingOptIn,
+                        uid
                       })
                     ])
                   })

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -454,7 +454,9 @@ module.exports = (log, db, mailer, config, customs, push) => {
                         marketingOptIn: marketingOptIn ? true : undefined
                       }),
                       request.emitMetricsEvent('account.verified', {
-                        marketingOptIn,
+                        // The content server omits marketingOptIn in the false case.
+                        // Force it so that we emit the appropriate newsletter state.
+                        marketingOptIn: marketingOptIn || false,
                         uid
                       })
                     ])

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -318,6 +318,45 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_reg - email_confirmed')
+        assert.equal(args[0].user_properties.newsletter_state, undefined)
+      })
+    })
+
+    describe('account.verified, marketingOptIn=true', () => {
+      beforeEach(() => {
+        return amplitude('account.verified', mocks.mockRequest({}), {
+          marketingOptIn: true
+        })
+      })
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0)
+      })
+
+      it('called log.amplitudeEvent correctly', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1)
+        const args = log.amplitudeEvent.args[0]
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed')
+        assert.equal(args[0].user_properties.newsletter_state, 'subscribed')
+      })
+    })
+
+    describe('account.verified, marketingOptIn=false', () => {
+      beforeEach(() => {
+        return amplitude('account.verified', mocks.mockRequest({}), {
+          marketingOptIn: false
+        })
+      })
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0)
+      })
+
+      it('called log.amplitudeEvent correctly', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1)
+        const args = log.amplitudeEvent.args[0]
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed')
+        assert.equal(args[0].user_properties.newsletter_state, undefined)
       })
     })
 

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -356,7 +356,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_reg - email_confirmed')
-        assert.equal(args[0].user_properties.newsletter_state, undefined)
+        assert.equal(args[0].user_properties.newsletter_state, 'unsubscribed')
       })
     })
 

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -428,9 +428,10 @@ describe('/recovery_email/verify_code', function () {
     }),
     query: {},
     payload: {
-      uid: uid,
       code: 'e3c5b0e3f5391e134596c27519979b93',
-      service: 'sync'
+      marketingOptIn: false,
+      service: 'sync',
+      uid: uid
     }
   })
   var dbData = {
@@ -483,10 +484,16 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
           event: 'account.verified',
+          marketingOptIn: false,
           service: 'sync',
-          userAgent: 'test user-agent',
-          uid: uid.toString('hex')
+          uid: uid.toString('hex'),
+          userAgent: 'test user-agent'
         }, 'event data was correct')
+
+        assert.equal(mockLog.amplitudeEvent.callCount, 1, 'amplitudeEvent was called once')
+        args = mockLog.amplitudeEvent.args[0]
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed', 'first call to amplitudeEvent was email_confirmed event')
+        assert.equal(args[0].user_properties.newsletter_state, undefined, 'newsletter_state was correct')
 
         assert.equal(mockLog.flowEvent.callCount, 2, 'flowEvent was called twice')
         assert.equal(mockLog.flowEvent.args[0][0].event, 'email.verify_code.clicked', 'first event was email.verify_code.clicked')
@@ -516,10 +523,15 @@ describe('/recovery_email/verify_code', function () {
       mockRequest.payload.marketingOptIn = true
       return runTest(route, mockRequest, function (response) {
         assert.equal(mockLog.notifyAttachedServices.callCount, 1, 'logs verified')
-        const args = mockLog.notifyAttachedServices.args[0]
+        let args = mockLog.notifyAttachedServices.args[0]
         assert.equal(args[0], 'verified')
         assert.equal(args[2].uid, uid)
         assert.equal(args[2].marketingOptIn, true)
+
+        assert.equal(mockLog.amplitudeEvent.callCount, 2, 'amplitudeEvent was called twice')
+        args = mockLog.amplitudeEvent.args[1]
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed', 'second call to amplitudeEvent was email_confirmed event')
+        assert.equal(args[0].user_properties.newsletter_state, 'subscribed', 'newsletter_state was correct')
 
         assert.equal(JSON.stringify(response), '{}')
       })

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -429,7 +429,6 @@ describe('/recovery_email/verify_code', function () {
     query: {},
     payload: {
       code: 'e3c5b0e3f5391e134596c27519979b93',
-      marketingOptIn: false,
       service: 'sync',
       uid: uid
     }
@@ -493,7 +492,7 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(mockLog.amplitudeEvent.callCount, 1, 'amplitudeEvent was called once')
         args = mockLog.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_reg - email_confirmed', 'first call to amplitudeEvent was email_confirmed event')
-        assert.equal(args[0].user_properties.newsletter_state, undefined, 'newsletter_state was correct')
+        assert.equal(args[0].user_properties.newsletter_state, 'unsubscribed', 'newsletter_state was correct')
 
         assert.equal(mockLog.flowEvent.callCount, 2, 'flowEvent was called twice')
         assert.equal(mockLog.flowEvent.args[0][0].event, 'email.verify_code.clicked', 'first event was email.verify_code.clicked')


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#23.

~~I have an outstanding question for @davismtl on that issue about how I've implemented this, so don't merge just yet.~~

Here's a sample event when the newsletter checkbox was selected:

```
amplitudeEvent {"time":1508752234911,"user_id":"c1aec827141f4fabb1e1cb0d61215d53","device_id":"b98eac7fca63420c94e6a9453ad85c0e","event_type":"fxa_reg - email_confirmed","session_id":1508752189176,"event_properties":{"service":"sync"},"user_properties":{"flow_id":"66965668fd4ee50518fbd72c19c02490da5a2a541b730237c042187c64b5e2dc","sync_device_count":1,"ua_browser":"Firefox","ua_version":"58","$append":{"fxa_services_used":"sync"},"newsletter_state":"subscribed"},"app_version":"98","language":"en","os_name":"Mac OS X","os_version":"10.11"}
```

And here's one when it wasn't:

```
amplitudeEvent {"time":1508752136634,"user_id":"f30e1106c40747e98607b810af320184","device_id":"fbcea403f104446883749546acd522d8","event_type":"fxa_reg - email_confirmed","session_id":1508752090183,"event_properties":{"service":"sync"},"user_properties":{"flow_id":"b946dfcb39c92abfb4dd63ebb11e703b110a17045404c9f3cb446cec1ab544d2","sync_device_count":1,"ua_browser":"Firefox","ua_version":"58","$append":{"fxa_services_used":"sync"},"newsletter_state":"unsubscribed"},"app_version":"98","language":"en","os_name":"Mac OS X","os_version":"10.11"}
```

@mozilla/fxa-devs r?