### PR TITLE
chore(logo): add new logo to email templates

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -102,13 +102,13 @@ module.exports = function (log) {
 
   function isFF57(message) {
     const uaBrowser = message.uaBrowser
-    const uaBrowserVersion = message.uaBrowserVersion
+    const uaBrowserVersion = message.uaBrowserVersion ? parseFloat(message.uaBrowserVersion) : 0
     const uaOS = message.uaOS
 
     // Display new FF57 logo from all FF57 originating browsers
-    return (uaBrowser === 'Firefox' && uaBrowserVersion >= '57') ||
-      (uaBrowser === 'Firefox Android' && uaBrowserVersion >= '57') ||
-      (uaBrowser === 'Firefox' && uaBrowserVersion >= '10.0' && uaOS === 'iOS')
+    return (uaBrowser === 'Firefox' && uaBrowserVersion >= 57) ||
+      (uaBrowser === 'Firefox Android' && uaBrowserVersion >= 57) ||
+      (uaBrowser === 'Firefox' && uaBrowserVersion >= 10.0 && uaOS === 'iOS')
   }
 
   function Mailer(translator, templates, config, sender) {

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -100,6 +100,17 @@ module.exports = function (log) {
     return 'messageType=fxa-' + templateName + ', app=fxa'
   }
 
+  function isFF57(message) {
+    const uaBrowser = message.uaBrowser
+    const uaBrowserVersion = message.uaBrowserVersion
+    const uaOS = message.uaOS
+
+    // Display new FF57 logo from all FF57 originating browsers
+    return (uaBrowser === 'Firefox' && uaBrowserVersion >= '57') ||
+      (uaBrowser === 'Firefox Android' && uaBrowserVersion >= '57') ||
+      (uaBrowser === 'Firefox' && uaBrowserVersion >= '10.0' && uaOS === 'iOS')
+  }
+
   function Mailer(translator, templates, config, sender) {
     var options = {
       host: config.host,
@@ -227,6 +238,10 @@ module.exports = function (log) {
 
   Mailer.prototype.send = function (message) {
     log.trace({ op: 'mailer.' + message.template, email: message.email, uid: message.uid })
+
+    if (message.templateValues) {
+      message.templateValues.isFF57 = isFF57(message)
+    }
 
     const localized = this.localize(message)
 

--- a/lib/senders/partials/base/base.html
+++ b/lib/senders/partials/base/base.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/partials/base/base.html
+++ b/lib/senders/partials/base/base.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/new_device_login.html
+++ b/lib/senders/templates/new_device_login.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/new_device_login.html
+++ b/lib/senders/templates/new_device_login.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/password_changed.html
+++ b/lib/senders/templates/password_changed.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/password_changed.html
+++ b/lib/senders/templates/password_changed.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/password_reset.html
+++ b/lib/senders/templates/password_reset.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/password_reset.html
+++ b/lib/senders/templates/password_reset.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/post_remove_secondary.html
+++ b/lib/senders/templates/post_remove_secondary.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/post_remove_secondary.html
+++ b/lib/senders/templates/post_remove_secondary.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/post_verify.html
+++ b/lib/senders/templates/post_verify.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/post_verify.html
+++ b/lib/senders/templates/post_verify.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/post_verify_secondary.html
+++ b/lib/senders/templates/post_verify_secondary.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/post_verify_secondary.html
+++ b/lib/senders/templates/post_verify_secondary.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/recovery.html
+++ b/lib/senders/templates/recovery.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/recovery.html
+++ b/lib/senders/templates/recovery.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/unblock_code.html
+++ b/lib/senders/templates/unblock_code.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/unblock_code.html
+++ b/lib/senders/templates/unblock_code.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verification_reminder_first.html
+++ b/lib/senders/templates/verification_reminder_first.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verification_reminder_first.html
+++ b/lib/senders/templates/verification_reminder_first.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verification_reminder_second.html
+++ b/lib/senders/templates/verification_reminder_second.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verification_reminder_second.html
+++ b/lib/senders/templates/verification_reminder_second.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verify.html
+++ b/lib/senders/templates/verify.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verify.html
+++ b/lib/senders/templates/verify.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verify_login.html
+++ b/lib/senders/templates/verify_login.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verify_login.html
+++ b/lib/senders/templates/verify_login.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verify_secondary.html
+++ b/lib/senders/templates/verify_secondary.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verify_secondary.html
+++ b/lib/senders/templates/verify_secondary.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/lib/senders/templates/verify_sync.html
+++ b/lib/senders/templates/verify_sync.html
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if isFF57 }}
-        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
       {{/if}}
 
     {{/if}}

--- a/lib/senders/templates/verify_sync.html
+++ b/lib/senders/templates/verify_sync.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -708,7 +708,7 @@ describe(
 
     describe('renders FF57 logo on FF57', () => {
       const oldLogoUrl = 'http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif'
-      const newLogoUrl = 'https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg'
+      const newLogoUrl = 'https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png'
       it('does not render for <FF57', () => {
         const message = {
           email: 'foo@example.com',

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -721,6 +721,19 @@ describe(
         mailer['newDeviceLoginEmail'](message)
       })
 
+      it('does not render for <10 on ios', () => {
+        const message = {
+          email: 'foo@example.com',
+          uaBrowser: 'Firefox',
+          uaOS: 'iOS',
+          uaBrowserVersion: '9.3'
+        }
+        mailer.mailer.sendMail = emailConfig => {
+          assert.equal(emailConfig.html.indexOf(oldLogoUrl) > 1, true, 'old logo')
+        }
+        mailer['newDeviceLoginEmail'](message)
+      })
+
       it('renders for >=FF57 desktop', () => {
         const message = {
           email: 'foo@example.com',
@@ -745,7 +758,7 @@ describe(
         mailer['newDeviceLoginEmail'](message)
       })
 
-      it('renders for >=10 FxiOS', () => {
+      it('renders for >=10 FxiOS on ios', () => {
         const message = {
           email: 'foo@example.com',
           uaBrowser: 'Firefox',

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -705,5 +705,58 @@ describe(
         })
       })
     })
+
+    describe('renders FF57 logo on FF57', () => {
+      const oldLogoUrl = 'http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif'
+      const newLogoUrl = 'https://accounts-static.cdn.mozilla.net/images/6c1e077e.firefox-logo.svg'
+      it('does not render for <FF57', () => {
+        const message = {
+          email: 'foo@example.com',
+          uaBrowser: 'Firefox',
+          uaBrowserVersion: '56'
+        }
+        mailer.mailer.sendMail = emailConfig => {
+          assert.equal(emailConfig.html.indexOf(oldLogoUrl) > 1, true, 'old logo')
+        }
+        mailer['newDeviceLoginEmail'](message)
+      })
+
+      it('renders for >=FF57 desktop', () => {
+        const message = {
+          email: 'foo@example.com',
+          uaBrowser: 'Firefox',
+          uaBrowserVersion: '57'
+        }
+        mailer.mailer.sendMail = emailConfig => {
+          assert.equal(emailConfig.html.indexOf(newLogoUrl) > 1, true, 'new logo')
+        }
+        mailer['newDeviceLoginEmail'](message)
+      })
+
+      it('renders for >=FF57 android', () => {
+        const message = {
+          email: 'foo@example.com',
+          uaBrowser: 'Firefox Android',
+          uaBrowserVersion: '57'
+        }
+        mailer.mailer.sendMail = emailConfig => {
+          assert.equal(emailConfig.html.indexOf(newLogoUrl) > 1, true, 'new logo')
+        }
+        mailer['newDeviceLoginEmail'](message)
+      })
+
+      it('renders for >=10 FxiOS', () => {
+        const message = {
+          email: 'foo@example.com',
+          uaBrowser: 'Firefox',
+          uaBrowserVersion: '10.0',
+          uaOS: 'iOS'
+        }
+        mailer.mailer.sendMail = emailConfig => {
+          assert.equal(emailConfig.html.indexOf(newLogoUrl) > 1, true, 'new logo')
+        }
+        mailer['newDeviceLoginEmail'](message)
+      })
+    })
   }
 )


### PR DESCRIPTION
WIP PR, using the content server logo to see how things rendered. Waiting for `e.mozilla.org` hosted logo.

Targeting train-98 in case we need to rollback.