### PR TITLE
chore(email): regenerate templates from partials

### DIFF
--- a/lib/senders/templates/verify_primary.html
+++ b/lib/senders/templates/verify_primary.html
@@ -12,8 +12,17 @@
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
     {{^if sync}}
-      <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+
+      {{^if isFF57 }}
+        <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
+      {{#if isFF57 }}
+        <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+      {{/if}}
+
     {{/if}}
+
     {{#if sync}}
       <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
     {{/if}}


### PR DESCRIPTION
Because #2190 was made against the `train-98` branch, it obviously didn't update the new `verifyPrimaryEmail` template (which doesn't exist there). So when I merged `train-98` to `master`, bustage was created. This unbusts it.

@vbudhram r?