### PR TITLE
fix(links): use a custom url when verifying primary email

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -806,6 +806,7 @@ conf.set('smtp.initiatePasswordResetUrl', conf.get('contentServer.url') + '/rese
 conf.set('smtp.initiatePasswordChangeUrl', conf.get('contentServer.url') + '/settings/change_password')
 conf.set('smtp.verifyLoginUrl', conf.get('contentServer.url') + '/complete_signin')
 conf.set('smtp.reportSignInUrl', conf.get('contentServer.url') + '/report_signin')
+conf.set('smtp.verifyPrimaryEmailUrl', conf.get('contentServer.url') + '/verify_primary_email')
 conf.set('smtp.verifySecondaryEmailUrl', conf.get('contentServer.url') + '/verify_secondary_email')
 
 conf.set('isProduction', conf.get('env') === 'prod')

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -148,6 +148,7 @@ module.exports = function (log) {
     this.verificationUrl = config.verificationUrl
     this.verifyLoginUrl = config.verifyLoginUrl
     this.verifySecondaryEmailUrl = config.verifySecondaryEmailUrl
+    this.verifyPrimaryEmailUrl = config.verifyPrimaryEmailUrl
   }
 
   Mailer.prototype.stop = function () {
@@ -470,14 +471,16 @@ module.exports = function (log) {
     const templateName = 'verifyPrimaryEmail'
     const query = {
       code: message.code,
-      uid: message.uid
+      uid: message.uid,
+      type: 'primary',
+      primary_email_verified: message.email
     }
 
     if (message.service) { query.service = message.service }
     if (message.redirectTo) { query.redirectTo = message.redirectTo }
     if (message.resume) { query.resume = message.resume }
 
-    const links = this._generateLinks(this.verifyLoginUrl, message.email, query, templateName)
+    const links = this._generateLinks(this.verifyPrimaryEmailUrl, message.email, query, templateName)
 
     const headers = {
       'X-Link': links.link,

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -548,6 +548,15 @@ describe(
               mailer[type](reminderMessage)
             }
           )
+        } else if (type === 'verifyPrimaryEmail') {
+          it('test verify token email', () => {
+            mailer.mailer.sendMail = (emailConfig) => {
+              const verifyPrimaryEmailUrl = config.get('smtp').verifyPrimaryEmailUrl
+              assert.ok(emailConfig.html.indexOf(verifyPrimaryEmailUrl) > 0)
+              assert.ok(emailConfig.text.indexOf(verifyPrimaryEmailUrl) > 0)
+            }
+            mailer[type](message)
+          })
         }
       }
     )


### PR DESCRIPTION
To help keep our metrics sane, use a different url for verifying your primary email. https://github.com/mozilla/fxa-content-server/pull/5626 adds support for this view.