### PR TITLE
fix(logging): don't log errors if location is not set

### DIFF
--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -68,6 +68,11 @@ module.exports = (log, db, config, customs, push, devices) => {
   function marshallLocation (location, request) {
     let language
 
+    if (! location) {
+      // Shortcut the error logging if location isn't set
+      return {}
+    }
+
     try {
       const languages = i18n.parseAcceptLanguage(request.app.acceptLanguage)
       language = i18n.bestLanguage(languages, supportedLanguages, defaultLanguage)

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -597,9 +597,11 @@ describe('/account/devices', () => {
       ]
     })
     const mockDevices = mocks.mockDevices()
+    const log = mocks.mockLog()
     const accountRoutes = makeRoutes({
       db: mockDB,
-      devices: mockDevices
+      devices: mockDevices,
+      log
     })
     const route = getRoute(accountRoutes, '/account/devices')
 
@@ -645,6 +647,8 @@ describe('/account/devices', () => {
       assert.equal(response[3].lastAccessTimeFormatted, moment(EARLIEST_SANE_TIMESTAMP).locale('fr').fromNow())
       assert.equal(response[3].approximateLastAccessTime, undefined)
       assert.equal(response[3].approximateLastAccessTimeFormatted, undefined)
+
+      assert.equal(log.error.callCount, 0, 'log.error was not called')
 
       assert.equal(mockDB.devices.callCount, 1, 'db.devices was called once')
       assert.equal(mockDB.devices.args[0].length, 1, 'db.devices was passed one argument')


### PR DESCRIPTION
Fixes #2199.

My error logging for #2188 was a smidgen over-zealous. Plenty of devices have no location set in redis and we shouldn't emit log noise for all of them. Really that error exists for the case where the translation lookup failed.

This PR fixes it by shortcutting the body of `marshallLocation` if `location` is not set. Opened against `train-99` for a prospective 99.1 patch.

@mozilla/fxa-devs r?