### PR TITLE
fix(db): prevent redis errors from being fatal

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -63,6 +63,12 @@ module.exports = (
       }
       log.info({op: 'db.redis.enabled', config: redisConfig})
       this.redis = redis.createClient(redisConfig)
+      // If the `error` event is not handled, redis errors become fatal
+      this.redis.on('error', err => log.error({
+        op: 'db.redis.error',
+        err: err.message,
+        stack: err.stack
+      }))
     } else {
       this.redis = false
       log.info({op: 'db.redis.disabled'})

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -17,7 +17,7 @@ describe('db, session tokens expire:', () => {
     sessionTokenWithoutDevice: 2419200000
   }
 
-  let results, pool, redis, log, tokens, db
+  let results, pool, log, tokens, db
 
   beforeEach(() => {
     results = {}
@@ -26,15 +26,10 @@ describe('db, session tokens expire:', () => {
       post: sinon.spy(() => P.resolve()),
       put: sinon.spy(() => P.resolve())
     }
-    redis = {
-      getAsync: sinon.spy(() => P.resolve(results.redis)),
-      setAsync: sinon.spy(() => P.resolve())
-    }
     log = mocks.mockLog()
     tokens = require(`${LIB_DIR}/tokens`)(log, { tokenLifetimes })
     const DB = proxyquire(`${LIB_DIR}/db`, {
-      './pool': function () { return pool },
-      redis: { createClient: () => redis }
+      './pool': function () { return pool }
     })({ tokenLifetimes, redis: {} }, log, tokens, {})
     return DB.connect({})
       .then(result => db = result)
@@ -51,7 +46,6 @@ describe('db, session tokens expire:', () => {
         { createdAt: now - tokenLifetimes.sessionTokenWithoutDevice + 1000, tokenId: 'baz' },
         { createdAt: now - tokenLifetimes.sessionTokenWithoutDevice - 1, tokenId: 'qux', deviceId: 'wibble' }
       ]
-      results.redis = []
       return db.sessions()
         .then(result => sessions = result)
     })
@@ -71,7 +65,7 @@ describe('db, session tokens do not expire:', () => {
     sessionTokenWithoutDevice: 0
   }
 
-  let results, pool, redis, log, tokens, db
+  let results, pool, log, tokens, db
 
   beforeEach(() => {
     results = {}
@@ -80,15 +74,10 @@ describe('db, session tokens do not expire:', () => {
       post: sinon.spy(() => P.resolve()),
       put: sinon.spy(() => P.resolve())
     }
-    redis = {
-      getAsync: sinon.spy(() => P.resolve(results.redis)),
-      setAsync: sinon.spy(() => P.resolve())
-    }
     log = mocks.mockLog()
     tokens = require(`${LIB_DIR}/tokens`)(log, { tokenLifetimes })
     const DB = proxyquire(`${LIB_DIR}/db`, {
-      './pool': function () { return pool },
-      redis: { createClient: () => redis }
+      './pool': function () { return pool }
     })({ tokenLifetimes, redis: {} }, log, tokens, {})
     return DB.connect({})
       .then(result => db = result)
@@ -105,7 +94,6 @@ describe('db, session tokens do not expire:', () => {
         { createdAt: now - tokenLifetimes.sessionTokenWithoutDevice + 1000, tokenId: 'baz' },
         { createdAt: now - tokenLifetimes.sessionTokenWithoutDevice - 1, tokenId: 'qux', deviceId: 'wibble' }
       ]
-      results.redis = []
       return db.sessions()
         .then(result => sessions = result)
     })
@@ -137,6 +125,7 @@ describe('db with redis disabled', () => {
     }
 
     redis = {
+      on: sinon.spy(),
       getAsync: sinon.spy(() => P.resolve(results.redis)),
       setAsync: sinon.spy(() => P.resolve()),
       del: sinon.spy(() => P.resolve())
@@ -149,17 +138,11 @@ describe('db with redis disabled', () => {
       redis: { createClient: () => redis }
     })({ tokenLifetimes, redis: {enabled: false} }, log, tokens, {})
     return DB.connect({})
-      .then(result => db = result)
-  })
+      .then(result => {
+        assert.equal(redis.on.callCount, 0, 'redis.on was not called')
 
-  afterEach(() => {
-    pool.get.reset()
-    pool.post.reset()
-    pool.del.reset()
-
-    redis.getAsync.reset()
-    redis.setAsync.reset()
-    redis.del.reset()
+        db = result
+      })
   })
 
   it('should not call redis when reading sessions', () => {
@@ -225,6 +208,7 @@ describe('redis enabled', () => {
       del: sinon.spy(() => P.resolve())
     }
     redis = {
+      on: sinon.spy(),
       getAsync: sinon.spy(() => P.resolve()),
       setAsync: sinon.spy(() => P.resolve()),
       del: sinon.spy(() => P.resolve())
@@ -234,9 +218,16 @@ describe('redis enabled', () => {
     const DB = proxyquire(`${LIB_DIR}/db`, {
       './pool': function () { return pool },
       redis: { createClient: () => redis }
-    })({ tokenLifetimes, redis: {enabled: false} }, log, tokens, {})
+    })({ tokenLifetimes, redis: {enabled: true} }, log, tokens, {})
     return DB.connect({})
-      .then(result => db = result)
+      .then(result => {
+        assert.equal(redis.on.callCount, 1, 'redis.on was called once')
+        assert.equal(redis.on.args[0].length, 2, 'redis.on was passed two arguments')
+        assert.equal(redis.on.args[0][0], 'error', 'redis.on was called for the `error` event')
+        assert.equal(typeof redis.on.args[0][1], 'function', 'redis.on was passed event handler')
+
+        db = result
+      })
   })
 
   it('should not call redis or the db in db.devices if uid is falsey', () => {
@@ -250,6 +241,31 @@ describe('redis enabled', () => {
           assert.equal(err.message, 'Unknown account')
         }
       )
+  })
+
+  it('should call redis and the db in db.devices if uid is not falsey', () => {
+    return db.devices('wibble')
+      .then(
+        result => assert.equal(result, 'db.devices should reject'),
+        () => {
+          assert.equal(pool.get.callCount, 1)
+          assert.equal(redis.getAsync.callCount, 1)
+        }
+      )
+  })
+
+  describe('redis error:', () => {
+    beforeEach(() => redis.on.args[0][1]({ message: 'foo', stack: 'bar' }))
+
+    it('should log the error', () => {
+      assert.equal(log.error.callCount, 1, 'log.error was called once')
+      assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'db.redis.error',
+        err: 'foo',
+        stack: 'bar'
+      }, 'log.error was passed the error details')
+    })
   })
 })
 

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -35,6 +35,7 @@ const redisDelSpy = sinon.stub()
 const DB = proxyquire('../../lib/db', {
   redis: {
     createClient: () => ({
+      on () {},
       getAsync: redisGetSpy,
       setAsync: redisSetSpy,
       del: redisDelSpy


### PR DESCRIPTION
Fixes #2207, addressing the immediate problem of redis connection errors crashing the auth server process.

However, it does not address a secondary issue of those errors causing visible delays in the front-end while redis is down. As it stands with these changes, the verification screen and the device manager both show a spinner until redis comes back. When it does return, they both carry on correctly and the UI is updated. In practice this may be good enough for a first step because we don't expect any redis outage to last very long, but I'm not sure.

I have a fix incoming for that secondary issue, but it's a bit more complex because it fundamentally changes the redis calling semantics. By default, the redis client keeps pending commands on an offline queue when it can't connect to redis. That queue causes a delay while the auth server waits for promises to resolve, hence the spinner is shown on the front-end. It's a straightforward enough change to disable the queue and make the calls to redis fail fast rather than wait, although for writes the queue would actually still be quite useful (see #2209).

But anyway, in case this patch is useful on its own, I've opened it here against the `train-99` branch. The other change won't be far behind though if this is not helpful.

If anyone wants to test it out locally, just start the auth server and then stop your redis service. On `master` that crashes, here it logs an error and continues:

```
fxa-auth-server.ERROR: db.redis.error {"op":"db.redis.error","err":"Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED 127.0.0.1:6379","stack":"Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED 127.0.0.1:6379\n    at Object.exports._errnoException (util.js:1020:11)\n    at exports._exceptionWithHostPort (util.js:1043:20)\n    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1090:14)"}
```

/cc @jrgm, @buck, @mozilla/fxa-devs