### PR TITLE
feat(sms): Enable SMS in Belgium, France, Luxembourg

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -734,7 +734,7 @@ var conf = convict({
     },
     countryCodes: {
       doc: 'Allow sending SMS to these ISO 3166-1 alpha-2 country codes',
-      default: ['AT', 'CA', 'DE', 'GB', 'US'],
+      default: ['AT', 'BE', 'CA', 'DE', 'FR', 'GB', 'LU', 'US'],
       format: Array,
       env: 'SMS_COUNTRY_CODES'
     },


### PR DESCRIPTION
Monaco is not enabled as requested, I haven't found a phone
number that validates yet.

mozilla/fxa-content-server#5573