### PR TITLE
fix(emails): update accountExists to check for secondary emails

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -236,13 +236,13 @@ module.exports = (
 
   DB.prototype.accountExists = function (email) {
     log.trace({ op: 'DB.accountExists', email: email })
-    return this.pool.head('/emailRecord/' + hexEncode(email))
+    return this.accountRecord(email)
       .then(
         function () {
           return true
         },
         function (err) {
-          if (err.statusCode === 404) {
+          if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
             return false
           }
           throw err


### PR DESCRIPTION
Updates `accountExists(email)` to check if email is a secondary email. Since secondary emails are owned by an account, the account is considered to exist.

This change fixes https://github.com/mozilla/fxa-content-server/issues/5394