### PR TITLE
Dockerpush fix moar enable newrelic

### DIFF
--- a/bin/email_notifications.js
+++ b/bin/email_notifications.js
@@ -4,6 +4,11 @@
 
 'use strict'
 
+// This MUST be the first require in the program.
+// Only `require()` the newrelic module if explicity enabled.
+// If required, modules will be instrumented.
+require('../lib/newrelic')()
+
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'fxa-email-bouncer')
 var error = require('../lib/error')

--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -4,6 +4,7 @@
 
 'use strict'
 
+// This MUST be the first require in the program.
 // Only `require()` the newrelic module if explicity enabled.
 // If required, modules will be instrumented.
 require('../lib/newrelic')()

--- a/bin/mailer_server.js
+++ b/bin/mailer_server.js
@@ -4,6 +4,11 @@
 
 'use strict'
 
+// This MUST be the first require in the program.
+// Only `require()` the newrelic module if explicity enabled.
+// If required, modules will be instrumented.
+require('../lib/newrelic')()
+
 var restify = require('restify')
 var safeJsonFormatter = require('restify-safe-json-formatter')
 var config = require('../config')

--- a/bin/profile_server_messaging.js
+++ b/bin/profile_server_messaging.js
@@ -4,6 +4,11 @@
 
 'use strict'
 
+// This MUST be the first require in the program.
+// Only `require()` the newrelic module if explicity enabled.
+// If required, modules will be instrumented.
+require('../lib/newrelic')()
+
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'profile-server-messaging')
 var error = require('../lib/error')

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -121,12 +121,12 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "typedarray@>=0.0.6 <0.0.7",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
@@ -334,13 +334,13 @@
     },
     "eslint-plugin-fxa": {
       "version": "1.0.0",
-      "from": "git+https://github.com/mozilla/eslint-plugin-fxa.git#master",
+      "from": "git+https://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95",
       "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95"
     },
     "fxa-auth-db-mysql": {
       "version": "1.98.0",
-      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0890bd9423bb298905675e78f99bb618fd2e3fb3",
+      "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#ca57f3e4da080f635b6953210e2338cab9801661",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#ca57f3e4da080f635b6953210e2338cab9801661",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -1140,9 +1140,9 @@
               "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.3.1.tgz",
               "dependencies": {
                 "moment": {
-                  "version": "2.19.1",
-                  "from": "moment@>=2.6.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz"
+                  "version": "2.19.2",
+                  "from": "moment@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
                 }
               }
             }
@@ -1359,9 +1359,9 @@
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "2.5.0",
+                  "version": "2.6.0",
                   "from": "async@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "4.17.4",
@@ -1620,7 +1620,7 @@
             },
             "node-uuid": {
               "version": "1.4.8",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
             "oauth-sign": {
@@ -2481,7 +2481,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2539,7 +2539,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2590,7 +2590,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.3 <3.0.0",
+              "from": "inherits@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "typedarray": {
@@ -3899,7 +3899,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4060,7 +4060,7 @@
                     },
                     "es6-iterator": {
                       "version": "2.0.3",
-                      "from": "es6-iterator@>=2.0.1 <2.1.0",
+                      "from": "es6-iterator@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
                     },
                     "es6-set": {
@@ -4102,7 +4102,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.1.1",
-                      "from": "es6-symbol@>=3.1.1 <4.0.0",
+                      "from": "es6-symbol@>=3.1.1 <3.2.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
                     }
                   }
@@ -4122,13 +4122,13 @@
               }
             },
             "espree": {
-              "version": "3.5.1",
+              "version": "3.5.2",
               "from": "espree@>=3.4.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "5.2.1",
-                  "from": "acorn@>=5.1.1 <6.0.0",
+                  "from": "acorn@>=5.2.1 <6.0.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz"
                 },
                 "acorn-jsx": {
@@ -5010,7 +5010,7 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "moment": {
@@ -5066,7 +5066,7 @@
     },
     "grunt-nunjucks-2-html": {
       "version": "0.3.4",
-      "from": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",
+      "from": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
       "resolved": "git://github.com/vitkarpov/grunt-nunjucks-2-html.git#1900f91a756b2eaf900b20ca7a28b10267ca55ba",
       "dependencies": {
         "async": {
@@ -5445,9 +5445,9 @@
                   }
                 },
                 "fsevents": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "fsevents@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "2.7.0",
@@ -5455,29 +5455,29 @@
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.36",
-                      "from": "node-pre-gyp@^0.6.36",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
-                    },
-                    "ajv": {
-                      "version": "4.11.8",
-                      "from": "ajv@4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+                      "version": "0.6.39",
+                      "from": "node-pre-gyp@^0.6.39",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz"
                     },
                     "abbrev": {
                       "version": "1.1.0",
                       "from": "abbrev@1.1.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
                     },
-                    "aproba": {
-                      "version": "1.1.1",
-                      "from": "aproba@1.1.1",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                    "ajv": {
+                      "version": "4.11.8",
+                      "from": "ajv@4.11.8",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
                     },
                     "ansi-regex": {
                       "version": "2.1.1",
                       "from": "ansi-regex@2.1.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    },
+                    "aproba": {
+                      "version": "1.1.1",
+                      "from": "aproba@1.1.1",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.1.4",
@@ -5599,6 +5599,11 @@
                       "from": "delegates@1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
+                    "detect-libc": {
+                      "version": "1.0.2",
+                      "from": "detect-libc@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
+                    },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "ecc-jsbn@0.1.1",
@@ -5614,15 +5619,20 @@
                       "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
                     "form-data": {
                       "version": "2.1.4",
                       "from": "form-data@2.1.4",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
                     },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@1.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "fstream": {
                       "version": "1.0.11",
@@ -5633,11 +5643,6 @@
                       "version": "1.0.5",
                       "from": "fstream-ignore@1.0.5",
                       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
-                    },
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "gauge": {
                       "version": "2.7.4",
@@ -5724,15 +5729,15 @@
                       "from": "jodid25519@1.0.2",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
                     "jsbn": {
                       "version": "0.1.1",
                       "from": "jsbn@0.1.1",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
@@ -5789,15 +5794,15 @@
                       "from": "npmlog@4.1.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@0.8.2",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
                     "number-is-nan": {
                       "version": "1.0.1",
                       "from": "number-is-nan@1.0.1",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@0.8.2",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                     },
                     "object-assign": {
                       "version": "4.1.1",
@@ -5834,15 +5839,15 @@
                       "from": "performance-now@0.2.0",
                       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
                     },
-                    "punycode": {
-                      "version": "1.4.1",
-                      "from": "punycode@1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                    },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "process-nextick-args@1.0.7",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                     },
                     "qs": {
                       "version": "6.4.0",
@@ -6040,7 +6045,7 @@
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "from": "camelcase@>=2.0.1 <3.0.0",
+                  "from": "camelcase@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                 },
                 "cliui": {
@@ -6050,7 +6055,7 @@
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
@@ -6184,7 +6189,7 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "from": "uglify-js@>=2.4.19 <3.0.0",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "dependencies": {
             "source-map": {
@@ -6359,7 +6364,7 @@
         },
         "hoek": {
           "version": "4.2.0",
-          "from": "hoek@>=4.2.0 <5.0.0",
+          "from": "hoek@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
         },
         "iron": {
@@ -6526,7 +6531,7 @@
     },
     "hapi-hpkp": {
       "version": "1.0.0",
-      "from": "git+https://github.com/vbudhram/hapi-hpkp.git#master",
+      "from": "git+https://github.com/vbudhram/hapi-hpkp.git#8e10f1b891486b8d6815218aea20d89acf2f67b9",
       "resolved": "git+https://github.com/vbudhram/hapi-hpkp.git#8e10f1b891486b8d6815218aea20d89acf2f67b9"
     },
     "hawk": {
@@ -7152,9 +7157,9 @@
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
         },
         "moment": {
-          "version": "2.19.1",
+          "version": "2.19.2",
           "from": "moment@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
         },
         "topo": {
           "version": "2.0.2",
@@ -7375,7 +7380,7 @@
                 },
                 "uglify-js": {
                   "version": "2.8.29",
-                  "from": "uglify-js@>=2.4.19 <3.0.0",
+                  "from": "uglify-js@>=2.6.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
                   "dependencies": {
                     "source-map": {
@@ -7952,9 +7957,9 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.11.tgz",
       "dependencies": {
         "moment": {
-          "version": "2.19.1",
-          "from": "moment@>=2.6.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz"
+          "version": "2.19.2",
+          "from": "moment@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
         }
       }
     },
@@ -8049,10 +8054,22 @@
       }
     },
     "newrelic": {
-      "version": "2.2.2",
-      "from": "newrelic@2.2.2",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-2.2.2.tgz",
+      "version": "2.3.2",
+      "from": "newrelic@2.3.2",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-2.3.2.tgz",
       "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "from": "async@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.4",
+              "from": "lodash@>=4.14.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            }
+          }
+        },
         "concat-stream": {
           "version": "1.6.0",
           "from": "concat-stream@>=1.5.0 <2.0.0",
@@ -8196,9 +8213,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                 },
                 "moment": {
-                  "version": "2.19.1",
+                  "version": "2.19.2",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
                 }
               }
             },
@@ -8330,7 +8347,7 @@
     },
     "node-uap": {
       "version": "0.0.3",
-      "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
+      "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
       "resolved": "git+https://github.com/vladikoff/node-uap.git#9cdd16247c8255d881820038d30db68b7926277d",
       "dependencies": {
         "array.prototype.find": {
@@ -8403,8 +8420,8 @@
         },
         "uap-core": {
           "version": "0.5.0",
-          "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#93f355552a236abd29a5685f96e85367ab7637e8"
+          "from": "git://github.com/ua-parser/uap-core.git#7e5b0c63f03657ebb3ee35672e78d44a15f9e9e5",
+          "resolved": "git://github.com/ua-parser/uap-core.git#7e5b0c63f03657ebb3ee35672e78d44a15f9e9e5"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -8856,15 +8873,15 @@
           "from": "babel-runtime@>=6.9.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
         },
-        "babel-traverse": {
-          "version": "6.18.0",
-          "from": "babel-traverse@>=6.18.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.18.0.tgz"
-        },
         "babel-template": {
           "version": "6.16.0",
           "from": "babel-template@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.18.0",
+          "from": "babel-traverse@>=6.18.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.18.0.tgz"
         },
         "babel-types": {
           "version": "6.18.0",
@@ -8876,11 +8893,6 @@
           "from": "babylon@>=6.13.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz"
         },
-        "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
         "brace-expansion": {
           "version": "1.1.6",
           "from": "brace-expansion@>=1.0.0 <2.0.0",
@@ -8890,6 +8902,11 @@
           "version": "1.8.5",
           "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -9011,15 +9028,15 @@
           "from": "get-caller-file@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
         },
-        "glob-parent": {
-          "version": "2.0.0",
-          "from": "glob-parent@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-        },
         "glob-base": {
           "version": "0.3.0",
           "from": "glob-base@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "from": "glob-parent@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
         },
         "globals": {
           "version": "9.12.0",
@@ -9161,15 +9178,15 @@
           "from": "js-tokens@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
         },
-        "jsesc": {
-          "version": "1.3.0",
-          "from": "jsesc@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-        },
         "kind-of": {
           "version": "3.0.4",
           "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "from": "jsesc@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -9271,15 +9288,15 @@
           "from": "os-locale@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "from": "parse-json@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-        },
         "parse-glob": {
           "version": "3.0.4",
           "from": "parse-glob@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "from": "parse-json@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
         },
         "path-exists": {
           "version": "2.1.0",
@@ -9411,15 +9428,15 @@
           "from": "spdx-correct@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
         },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-        },
         "spdx-license-ids": {
           "version": "1.2.2",
           "from": "spdx-license-ids@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
         },
         "string-width": {
           "version": "1.0.2",
@@ -9461,15 +9478,15 @@
           "from": "which@>=1.2.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
         },
-        "which-module": {
-          "version": "1.0.0",
-          "from": "which-module@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
-        },
         "window-size": {
           "version": "0.1.0",
           "from": "window-size@0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "from": "which-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -9486,15 +9503,15 @@
           "from": "wrappy@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
         },
-        "write-file-atomic": {
-          "version": "1.2.0",
-          "from": "write-file-atomic@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz"
-        },
         "y18n": {
           "version": "3.2.1",
           "from": "y18n@>=3.2.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+        },
+        "write-file-atomic": {
+          "version": "1.2.0",
+          "from": "write-file-atomic@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz"
         },
         "yallist": {
           "version": "2.0.0",
@@ -9662,7 +9679,7 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "lsmod": {
@@ -9780,7 +9797,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
@@ -10165,9 +10182,9 @@
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
             },
             "moment": {
-              "version": "2.19.1",
-              "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz"
+              "version": "2.19.2",
+              "from": "moment@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
             }
           }
         },
@@ -10360,7 +10377,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
+                      "from": "inherits@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
@@ -10427,7 +10444,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "from": "verror@1.10.0",
+          "from": "verror@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "dependencies": {
             "assert-plus": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "memcached": "2.2.2",
     "moment-timezone": "0.5.11",
     "mozlog": "2.0.6",
-    "newrelic": "2.2.2",
+    "newrelic": "2.3.2",
     "nexmo": "2.0.2",
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
     "nodemailer": "2.7.2",


### PR DESCRIPTION
This PR adds newrelic to some background daemons, noting that newrelic must be `require`d first, and updates to latest newrelic@2.3.2, with an `npm run shrink` using npm@2.15

r? - @vladikoff 