### PR TITLE
fix(db): wait for redis to be ready in db.connect

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -78,7 +78,16 @@ module.exports = (
   }
 
   DB.connect = function (options) {
-    return P.resolve(new DB(options))
+    const db = new DB(options)
+    if (! db.redis) {
+      return P.resolve(db)
+    }
+
+    return new P(resolve => {
+      db.redis.on('ready', () => {
+        resolve(db)
+      })
+    })
   }
 
   DB.prototype.close = function () {


### PR DESCRIPTION
Fixes #2225.

It's possible for requests to `db.sessions`, `db.devices` and `db.updateSessionToken` to fail if they arrive before the redis connection is ready. In practice I assume this shouldn't affect us because the servers aren't cut over to receive traffic until they've been up and running for a while. But for the sake of correctness I'm fixing it anyway.

Opened for a prospective 100.1 patch release, because the problem was introduced there.

@mozilla/fxa-devs r?