### PR TITLE
fix(db): wait for redis to be ready in db.connect

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -78,7 +78,16 @@ module.exports = (
   }
 
   DB.connect = function (options) {
-    return P.resolve(new DB(options))
+    const db = new DB(options)
+    if (! db.redis) {
+      return P.resolve(db)
+    }
+
+    return new P(resolve => {
+      db.redis.on('ready', () => {
+        resolve(db)
+      })
+    })
   }
 
   DB.prototype.close = function () {

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -233,24 +233,35 @@ describe('redis enabled', () => {
         earliestSaneTimestamp: 1
       }
     }, log, tokens, {})
-    return DB.connect({})
-      .then(result => {
-        assert.equal(createClient.callCount, 1, 'redis.createClient was called once')
-        assert.equal(createClient.args[0].length, 1, 'redis.createClient was passed one argument')
-        assert.deepEqual(createClient.args[0][0], {
-          host: 'foo',
-          port: 'bar',
-          prefix: 'baz',
-          enable_offline_queue: false
-        }, 'redis.createClient was passed correct settings')
 
-        assert.equal(redis.on.callCount, 1, 'redis.on was called once')
-        assert.equal(redis.on.args[0].length, 2, 'redis.on was passed two arguments')
-        assert.equal(redis.on.args[0][0], 'error', 'redis.on was called for the `error` event')
-        assert.equal(typeof redis.on.args[0][1], 'function', 'redis.on was passed event handler')
+    const promise = DB.connect({})
+      .then(result => db = result)
 
-        db = result
-      })
+    assert.equal(createClient.callCount, 1, 'redis.createClient was called once')
+    assert.equal(createClient.args[0].length, 1, 'redis.createClient was passed one argument')
+    assert.deepEqual(createClient.args[0][0], {
+      host: 'foo',
+      port: 'bar',
+      prefix: 'baz',
+      enable_offline_queue: false
+    }, 'redis.createClient was passed correct settings')
+
+    assert.equal(redis.on.callCount, 2, 'redis.on was called twice')
+
+    let args = redis.on.args[0]
+    assert.equal(args.length, 2, 'redis.on was passed two arguments first time')
+    assert.equal(args[0], 'error', 'redis.on was called for the `error` event')
+    assert.equal(typeof args[1], 'function', 'redis.on was passed event handler')
+
+    args = redis.on.args[1]
+    assert.equal(args.length, 2, 'redis.on was passed two arguments second time')
+    assert.equal(args[0], 'ready', 'redis.on was called for the `ready` event')
+    assert.equal(typeof args[1], 'function', 'redis.on was passed event handler')
+    assert.notEqual(args[1], redis.on.args[0][1], 'event handlers are different')
+
+    args[1]()
+
+    return promise
   })
 
   it('should not call redis or the db in db.devices if uid is falsey', () => {


### PR DESCRIPTION
Fixes #2225. Supercedes #2226.

It's possible for requests to `db.sessions`, `db.devices` and `db.updateSessionToken` to fail if they arrive before the redis connection is ready. In practice I assume this shouldn't affect us because the servers aren't cut over to receive traffic until they've been up and running for a while. But for the sake of correctness I'm fixing it anyway.

@mozilla/fxa-devs r?