### PR TITLE
fix(db): ensure sane failure semantics for redis writes

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -540,52 +540,62 @@ module.exports = (
     )
   }
 
-  DB.prototype.updateSessionToken = function (token, ip, geo) {
-    log.trace({ op: 'DB.updateSessionToken', uid: token && token.uid })
+  DB.prototype.updateSessionToken = function (token, geo) {
+    const { id, uid } = token
 
-    const uid = token.uid
+    log.trace({ op: 'DB.updateSessionToken', id, uid })
+
     if (! this.redis || ! features.isLastAccessTimeEnabledForUser(uid)) {
       return P.resolve()
     }
 
-    const newToken = {
-      tokenId: token.id,
-      uid: uid,
-      uaBrowser: token.uaBrowser,
-      uaBrowserVersion: token.uaBrowserVersion,
-      uaOS: token.uaOS,
-      uaOSVersion: token.uaOSVersion,
-      uaDeviceType: token.uaDeviceType,
-      uaFormFactor: token.uaFormFactor,
-      lastAccessTime: token.lastAccessTime,
-      createdAt: token.createdAt
-    }
-    let sessionTokens
+    let location
     return geo
-    .then((res) => {
-      if (res.location) {
-        newToken.location = {
-          city: res.location.city,
-          country: res.location.country,
-          countryCode: res.location.countryCode,
-          state: res.location.state,
-          stateCode: res.location.stateCode
+      .then(result => location = {
+        city: result.location.city,
+        country: result.location.country,
+        countryCode: result.location.countryCode,
+        state: result.location.state,
+        stateCode: result.location.stateCode
+      })
+      .catch(() => {})
+      .then(() => this.redis.watchAsync(uid))
+      .then(() => this.redis.getAsync(uid))
+      .then(sessionTokens => {
+        if (sessionTokens) {
+          sessionTokens = JSON.parse(sessionTokens)
+        } else {
+          sessionTokens = {}
         }
-      }
-    })
-    .catch(err => {
-      newToken.location = null
-    })
-    // get the object of session tokens associated with the given uid
-    .then(() => this.redis.getAsync(uid))
-    .then(res => {
-      // update the hash with the new token
-      sessionTokens = res ? JSON.parse(res) : {}
-      sessionTokens[token.id] = newToken
 
-      return this.redis.setAsync(uid, JSON.stringify(sessionTokens))
-    })
-    .then(() => sessionTokens)
+        sessionTokens[id] = {
+          lastAccessTime: token.lastAccessTime,
+          location,
+          tokenId: id,
+          uaBrowser: token.uaBrowser,
+          uaBrowserVersion: token.uaBrowserVersion,
+          uaDeviceType: token.uaDeviceType,
+          uaFormFactor: token.uaFormFactor,
+          uaOS: token.uaOS,
+          uaOSVersion: token.uaOSVersion,
+          uid
+        }
+
+        const multi = this.redis.multi()
+        multi.set(uid, JSON.stringify(sessionTokens))
+        return multi.execAsync()
+      })
+      .catch(err => {
+        this.redis.unwatch()
+        log.error({ op: 'db.redis.multi.error', method: 'updateSessionToken', err: err.message })
+        throw err
+      })
+      .then(result => {
+        if (! result) {
+          log.error({ op: 'db.redis.watch.error', method: 'updateSessionToken' })
+          throw error.unexpectedError()
+        }
+      })
   }
 
   DB.prototype.createDevice = function (uid, sessionTokenId, deviceInfo) {
@@ -693,36 +703,59 @@ module.exports = (
   // DELETE
 
   DB.prototype.deleteAccount = function (authToken) {
-    log.trace({ op: 'DB.deleteAccount', uid: authToken && authToken.uid })
-    const promises = [this.pool.del('/account/' + authToken.uid)]
-    if (this.redis) {
-      promises.push(this.redis.del(authToken.uid))
-    }
-    return P.all(promises)
+    const { uid } = authToken
+
+    log.trace({ op: 'DB.deleteAccount', uid })
+
+    return P.resolve()
+      .then(() => {
+        if (this.redis) {
+          return this.redis.delAsync(uid)
+        }
+      })
+      .then(() => this.pool.del(`/account/${uid}`))
   }
 
   DB.prototype.deleteSessionToken = function (sessionToken) {
-    const uid = sessionToken && sessionToken.uid
-    log.trace(
-      {
-        op: 'DB.deleteSessionToken',
-        id: sessionToken && sessionToken.id,
-        uid: uid
-      }
-    )
-    const promises = [this.pool.del('/sessionToken/' + sessionToken.id)]
-    if (this.redis) {
-      promises.push(this.redis.getAsync(uid))
-    }
-    return P.all(promises)
-      .spread((deleteRes, redisTokens) => {
+    const { id, uid } = sessionToken
+
+    log.trace({ op: 'DB.deleteSessionToken', id, uid })
+
+    return P.resolve()
+      .then(() => {
         if (this.redis) {
-          const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : {}
-          delete redisSessionTokens[sessionToken.id]
-          return this.redis.setAsync(uid, JSON.stringify(redisSessionTokens))
+          return this.redis.watchAsync(uid)
+            .then(() => this.redis.getAsync(uid))
+            .then(sessionTokens => {
+              if (sessionTokens) {
+                sessionTokens = JSON.parse(sessionTokens)
+              }
+
+              if (! sessionTokens || ! sessionTokens[id]) {
+                this.redis.unwatch(uid)
+                return true
+              }
+
+              sessionTokens[id] = undefined
+
+              const multi = this.redis.multi()
+              multi.set(uid, JSON.stringify(sessionTokens))
+              return multi.execAsync()
+            })
+            .catch(err => {
+              this.redis.unwatch()
+              log.error({ op: 'db.redis.multi.error', method: 'deleteSessionToken', err: err.message })
+              throw err
+            })
+            .then(result => {
+              if (! result) {
+                log.error({ op: 'db.redis.watch.error', method: 'deleteSessionToken' })
+                throw error.unexpectedError()
+              }
+            })
         }
-        return deleteRes
       })
+      .then(() => this.pool.del(`/sessionToken/${id}`))
   }
 
   DB.prototype.deleteKeyFetchToken = function (keyFetchToken) {
@@ -814,16 +847,20 @@ module.exports = (
   // BATCH
 
   DB.prototype.resetAccount = function (accountResetToken, data) {
-    log.trace({ op: 'DB.resetAccount', uid: accountResetToken && accountResetToken.uid })
-    data.verifierSetAt = Date.now()
-    const promises = [this.pool.post(
-      '/account/' + accountResetToken.uid + '/reset',
-      data
-    )]
-    if (this.redis) {
-      promises.push(this.redis.del(accountResetToken.uid))
-    }
-    return P.all(promises)
+    const { uid } = accountResetToken
+
+    log.trace({ op: 'DB.resetAccount', uid })
+
+    return P.resolve()
+      .then(() => {
+        if (this.redis) {
+          return this.redis.delAsync(uid)
+        }
+      })
+      .then(() => {
+        data.verifierSetAt = Date.now()
+        return this.pool.post(`/account/${uid}/reset`, data)
+      })
   }
 
   DB.prototype.verifyEmail = function (account, emailCode) {

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -47,7 +47,6 @@ module.exports = (log, signer, db, domain, devices) => {
         var publicKey = request.payload.publicKey
         var duration = request.payload.duration
         var service = request.query.service
-        var clientIp = request.app.clientAddress
         var deviceId, uid, certResult
         if (request.headers['user-agent']) {
           const {
@@ -68,7 +67,7 @@ module.exports = (log, signer, db, domain, devices) => {
             lastAccessTime: Date.now()
           })
           // No need to wait for a response, update in the background.
-          db.updateSessionToken(sessionToken, clientIp, request.app.geo)
+          db.updateSessionToken(sessionToken, request.app.geo)
         } else {
           log.warn({
             op: 'signer.updateSessionToken', message: 'no user agent string, session token not updated'

--- a/test/local/routes/sign.js
+++ b/test/local/routes/sign.js
@@ -75,7 +75,7 @@ describe('/certificate/sign', () => {
     }, mockRequest, function () {
       assert.equal(db.updateSessionToken.callCount, 1, 'db.updateSessionToken was called once')
       let args = db.updateSessionToken.args[0]
-      assert.equal(args.length, 3, 'db.updateSessionToken was passed three arguments')
+      assert.equal(args.length, 2, 'db.updateSessionToken was passed two arguments')
       assert.equal(args[0].uid, sessionToken.uid, 'first argument uid property was correct')
       assert.equal(args[0].email, sessionToken.email, 'first argument email property was correct')
       assert.equal(args[0].uaBrowser, 'Firefox', 'first argument uaBrowser property was correct')
@@ -86,8 +86,7 @@ describe('/certificate/sign', () => {
       assert.equal(args[0].uaFormFactor, null, 'first argument uaFormFactor property was null')
       assert.ok(args[0].lastAccessTime, 'lastAccessTime is set')
       assert.ok(args[0].lastAccessTime > args[0].createdAt, 'lastAccessTime is updated')
-      assert.equal(args[1], mockRequest.app.clientAddress, 'second argument was client IP address')
-      assert.equal(args[2], mockRequest.app.geo, 'third argument was getGeoData result')
+      assert.equal(args[1], mockRequest.app.geo, 'second argument was getGeoData result')
 
       assert.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
       args = mockDevices.upsert.args[0]

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -194,7 +194,7 @@ describe('remote db', function() {
           lastAccessTimeUpdates.enabled = false
 
           // Attempt to update the session token
-          return db.updateSessionToken(sessionToken, '127.0.0.1', P.resolve({}))
+          return db.updateSessionToken(sessionToken, P.resolve({}))
         })
         .then(result => {
           assert.equal(result, undefined)
@@ -219,7 +219,7 @@ describe('remote db', function() {
           // Update the session token
           return db.updateSessionToken(Object.assign({}, sessionToken, {
             lastAccessTime: Date.now()
-          }), '127.0.0.1', P.resolve({
+          }), P.resolve({
             location: {
               city: 'Bournemouth',
               country: 'United Kingdom',
@@ -257,7 +257,7 @@ describe('remote db', function() {
             uaOSVersion: '4.4',
             uaDeviceType: 'mobile',
             uaFormFactor: null
-          }), '127.0.0.1', P.reject())
+          }), P.reject())
         })
         .then(tokens => {
           // Fetch all sessions for the account
@@ -463,7 +463,7 @@ describe('remote db', function() {
             // Update the device and the session token
             return P.all([
               db.updateDevice(account.uid, sessionToken.id, deviceInfo),
-              db.updateSessionToken(sessionToken, '127.0.0.1', P.resolve({
+              db.updateSessionToken(sessionToken, P.resolve({
                 location: {
                   city: 'Mountain View',
                   country: 'United States',


### PR DESCRIPTION
Fixes #2209.

Until now, it has been possible for deletes from redis and deletes from MySQL to fail independently, potentially leaving the other one in a conflicting state. This PR fixes that by making two changes:

1. Redis is deleted from first. Only when that operation succeeds do we then proceed with deleting from MySQL. This matches the way `db.sessions` and `db.devices` view the relationship between the two and ensures that token ids are not re-used in MySQL while stale data still exists in Redis.

2. Updates to redis are performed atomically, by leaning on Redis' `WATCH` command. You can [read more about it in the docs](https://redis.io/topics/transactions) but essentially it lets us abort a transaction if data for the key we're updating changes underneath us.

It's not possible to reliably trigger the various error paths that these changes introduce from our remote tests, so all of the new coverage is added in the local tests. Hopefully I've got everything covered.

@mozilla/fxa-devs r?