### PR TITLE
fix(metrics): stop sending raw client ids to amplitude

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -209,7 +209,7 @@ module.exports = (log, config) => {
   function mapEventProperties (group, request, data, metricsContext) {
     const service = data.service || request.payload.service || request.query.service
     return Object.assign({
-      service: SERVICES[service] || service
+      service: SERVICES[service] || (service === 'content-server' ? undefined : 'undefined_oauth')
     }, EVENT_PROPERTIES[group](request, data, metricsContext))
   }
 

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -228,6 +228,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_login - success')
+        assert.equal(args[0].event_properties.service, 'undefined_oauth')
         assert.equal(args[0].user_properties.sync_device_count, undefined)
         assert.equal(args[0].user_properties['$append'], undefined)
       })
@@ -291,7 +292,11 @@ describe('metrics/amplitude', () => {
 
     describe('account.signed', () => {
       beforeEach(() => {
-        return amplitude('account.signed', mocks.mockRequest({}))
+        return amplitude('account.signed', mocks.mockRequest({
+          payload: {
+            service: 'content-server'
+          }
+        }))
       })
 
       it('did not call log.error', () => {
@@ -302,6 +307,8 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_activity - cert_signed')
+        assert.equal(args[0].event_properties.service, undefined)
+        assert.equal(args[0].user_properties['$append'], undefined)
       })
     })
 
@@ -1109,7 +1116,7 @@ describe('metrics/amplitude', () => {
         assert.equal(log.amplitudeEvent.callCount, 1)
         const args = log.amplitudeEvent.args[0]
         assert.equal(args[0].user_id, 'frip')
-        assert.equal(args[0].event_properties.service, 'zang')
+        assert.equal(args[0].event_properties.service, 'undefined_oauth')
       })
     })
 

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -621,7 +621,7 @@ describe('metrics/events', () => {
         assert.equal(log.amplitudeEvent.args[0].length, 1, 'log.amplitudeEvent was passed one argument')
         assert.equal(log.amplitudeEvent.args[0][0].event_type, 'fxa_activity - cert_signed', 'log.amplitudeEvent was passed correct event_type')
         assert.deepEqual(log.amplitudeEvent.args[0][0].event_properties, {
-          service: 'content-server'
+          service: undefined
         }, 'log.amplitudeEvent was passed correct event properties')
         assert.deepEqual(log.amplitudeEvent.args[0][0].user_properties, {
           flow_id: 'bar',


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#28 (also see mozilla/fxa-content-server#5753).

Having raw client ids in Amplitude isn't helpful. This change replaces them with a fallback string, `undefined_oauth`.

@mozilla/fxa-devs r?