### PR TITLE
fix(logs): fix broken log message

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -474,12 +474,9 @@ module.exports = (
     }
     return P.all(promises)
       .spread((devices, redisTokens) => {
+        log.info({ op: 'db.devices.redisSessionTokens', hasRedisTokens: !! redisTokens })
+
         const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : {}
-        log.info({
-          op: 'db.devices.redisSessionTokens',
-          hasRedisTokens: !! redisSessionTokens.length,
-          numRedisTokens: redisSessionTokens.length
-        })
         // for each device, if there is a redis token with a matching tokenId,
         // overwrite device's ua properties and lastAccessTime with redis token values
         const lastAccessTimeEnabled = isRedisOk && features.isLastAccessTimeEnabledForUser(uid)


### PR DESCRIPTION
Just noticed that `hasRedisTokens` is always `false` in this log message, it's left over from when we used to store the tokens in an array.

Working example:

```
~/c/fxa-local-dev (master) $ ./pm2 logs 2 | grep hasRedis
2|auth-ser | fxa-auth-server.INFO: db.devices.redisSessionTokens {"op":"db.devices.redisSessionTokens","hasRedisTokens":false}
2|auth-ser | fxa-auth-server.INFO: db.devices.redisSessionTokens {"op":"db.devices.redisSessionTokens","hasRedisTokens":true}
```

@mozilla/fxa-devs r?