### PR TITLE
fix(scripts): use latest Husky module for git hooks

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -338,9 +338,9 @@
       "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95"
     },
     "fxa-auth-db-mysql": {
-      "version": "1.100.0",
+      "version": "1.101.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#b06a8ed112d5cbcd07b6b2b6a3d138dffa8a529a",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#35d596342d3880e64b2127d57af40d8a665266d5",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -1020,9 +1020,9 @@
               "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.3.1.tgz",
               "dependencies": {
                 "moment": {
-                  "version": "2.19.2",
+                  "version": "2.20.0",
                   "from": "moment@>=2.6.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz"
                 }
               }
             }
@@ -1304,9 +1304,9 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.16.1",
+                  "version": "2.17.1",
                   "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
@@ -2132,7 +2132,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.2 <1.6.0",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "getobject": {
@@ -2424,7 +2424,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2528,9 +2528,9 @@
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
           "dependencies": {
             "conventional-changelog-angular": {
-              "version": "1.5.2",
+              "version": "1.6.0",
               "from": "conventional-changelog-angular@>=1.5.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz",
               "dependencies": {
                 "compare-func": {
                   "version": "1.3.2",
@@ -2569,14 +2569,14 @@
               "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz"
             },
             "conventional-changelog-core": {
-              "version": "1.9.3",
+              "version": "1.9.5",
               "from": "conventional-changelog-core@>=1.9.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.3.tgz",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz",
               "dependencies": {
                 "conventional-changelog-writer": {
-                  "version": "2.0.2",
-                  "from": "conventional-changelog-writer@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.2.tgz",
+                  "version": "2.0.3",
+                  "from": "conventional-changelog-writer@>=2.0.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
                   "dependencies": {
                     "compare-func": {
                       "version": "1.3.2",
@@ -2603,9 +2603,9 @@
                       }
                     },
                     "conventional-commits-filter": {
-                      "version": "1.1.0",
-                      "from": "conventional-commits-filter@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.0.tgz",
+                      "version": "1.1.1",
+                      "from": "conventional-commits-filter@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
                       "dependencies": {
                         "is-subset": {
                           "version": "0.1.1",
@@ -2739,7 +2739,7 @@
                     },
                     "semver": {
                       "version": "5.4.1",
-                      "from": "semver@>=5.0.1 <6.0.0",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
                     },
                     "split": {
@@ -2750,14 +2750,14 @@
                   }
                 },
                 "conventional-commits-parser": {
-                  "version": "2.0.1",
-                  "from": "conventional-commits-parser@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.1.tgz",
+                  "version": "2.1.0",
+                  "from": "conventional-commits-parser@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.3.1",
+                      "version": "1.3.2",
                       "from": "JSONStream@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.3.1",
@@ -3316,9 +3316,9 @@
                       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
                       "dependencies": {
                         "ini": {
-                          "version": "1.3.4",
+                          "version": "1.3.5",
                           "from": "ini@>=1.3.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
                         }
                       }
                     },
@@ -3449,7 +3449,7 @@
                     },
                     "semver": {
                       "version": "5.4.1",
-                      "from": "semver@>=5.0.1 <6.0.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
                     }
                   }
@@ -3483,7 +3483,7 @@
                     },
                     "semver": {
                       "version": "5.4.1",
-                      "from": "semver@>=5.0.1 <6.0.0",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
                     },
                     "validate-npm-package-license": {
@@ -3696,9 +3696,9 @@
               }
             },
             "conventional-changelog-ember": {
-              "version": "0.2.9",
+              "version": "0.2.10",
               "from": "conventional-changelog-ember@>=0.2.9 <0.3.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.9.tgz"
+              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz"
             },
             "conventional-changelog-eslint": {
               "version": "0.2.1",
@@ -3912,16 +3912,9 @@
               }
             },
             "doctrine": {
-              "version": "2.0.0",
+              "version": "2.0.2",
               "from": "doctrine@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-              "dependencies": {
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz"
             },
             "escope": {
               "version": "3.6.0",
@@ -3939,9 +3932,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.35",
+                      "version": "0.10.37",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.3",
@@ -3976,9 +3969,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.35",
+                      "version": "0.10.37",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.3",
@@ -4100,9 +4093,9 @@
                           "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                           "dependencies": {
                             "is-path-inside": {
-                              "version": "1.0.0",
+                              "version": "1.0.1",
                               "from": "is-path-inside@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz"
                             }
                           }
                         },
@@ -4380,9 +4373,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.16.1",
+              "version": "2.17.1",
               "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -4414,16 +4407,9 @@
               }
             },
             "is-resolvable": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "is-resolvable@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.3",
-                  "from": "tryit@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz"
             },
             "js-yaml": {
               "version": "3.10.0",
@@ -4565,9 +4551,9 @@
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
               "dependencies": {
                 "interpret": {
-                  "version": "1.0.4",
+                  "version": "1.1.0",
                   "from": "interpret@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz"
                 },
                 "rechoir": {
                   "version": "0.6.2",
@@ -4713,7 +4699,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
@@ -4893,15 +4879,15 @@
               "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
             },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
             "moment": {
               "version": "2.18.1",
               "from": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "ms": {
               "version": "2.0.0",
@@ -4930,7 +4916,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "from": "xtend@>=4.0.1 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "agent-base": {
@@ -5228,9 +5214,9 @@
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
-                      "version": "1.10.0",
+                      "version": "1.11.0",
                       "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz"
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz"
                     }
                   }
                 },
@@ -5494,15 +5480,15 @@
                       "from": "ecc-jsbn@0.1.1",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
                     "extend": {
                       "version": "3.0.1",
                       "from": "extend@3.0.1",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
@@ -5609,35 +5595,40 @@
                       "from": "isstream@0.1.2",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
                     "jodid25519": {
                       "version": "1.0.2",
                       "from": "jodid25519@1.0.2",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "jsbn@0.1.1",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.3",
                       "from": "json-schema@0.2.3",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "from": "json-stable-stringify@1.0.1",
                       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
                     },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
                     "jsonify": {
                       "version": "0.0.0",
                       "from": "jsonify@0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "from": "minimatch@3.0.4",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
                     },
                     "mime-db": {
                       "version": "1.27.0",
@@ -5649,25 +5640,20 @@
                       "from": "mime-types@2.1.15",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
                     },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-                    },
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     },
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    },
                     "mkdirp": {
                       "version": "0.5.1",
                       "from": "mkdirp@0.5.1",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                     },
                     "nopt": {
                       "version": "4.0.1",
@@ -5684,15 +5670,15 @@
                       "from": "number-is-nan@1.0.1",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@0.8.2",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
                     "object-assign": {
                       "version": "4.1.1",
                       "from": "object-assign@4.1.1",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@0.8.2",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                     },
                     "once": {
                       "version": "1.4.0",
@@ -5883,18 +5869,6 @@
                         }
                       }
                     },
-                    "rc": {
-                      "version": "1.2.1",
-                      "from": "rc@1.2.1",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
                     "jsprim": {
                       "version": "1.4.0",
                       "from": "jsprim@1.4.0",
@@ -5904,6 +5878,18 @@
                           "version": "1.0.0",
                           "from": "assert-plus@1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.2.1",
+                      "from": "rc@1.2.1",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         }
                       }
                     },
@@ -6074,7 +6060,7 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "from": "uglify-js@>=2.4.19 <3.0.0",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "dependencies": {
             "source-map": {
@@ -6280,9 +6266,9 @@
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.31.0",
+              "version": "1.32.0",
               "from": "mime-db@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.31.0.tgz"
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz"
             }
           }
         },
@@ -6452,70 +6438,19 @@
       "resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz"
     },
     "husky": {
-      "version": "0.13.1",
-      "from": "husky@0.13.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.1.tgz",
+      "version": "0.14.3",
+      "from": "husky@0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "find-parent-dir": {
-          "version": "0.3.0",
-          "from": "find-parent-dir@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
-        },
         "is-ci": {
           "version": "1.0.10",
-          "from": "is-ci@>=1.0.9 <2.0.0",
+          "from": "is-ci@>=1.0.10 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
           "dependencies": {
             "ci-info": {
-              "version": "1.1.1",
+              "version": "1.1.2",
               "from": "ci-info@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz"
             }
           }
         },
@@ -6523,6 +6458,11 @@
           "version": "1.0.0",
           "from": "normalize-path@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz"
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "from": "strip-indent@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
         }
       }
     },
@@ -7042,9 +6982,9 @@
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
         },
         "moment": {
-          "version": "2.19.2",
+          "version": "2.20.0",
           "from": "moment@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz"
         },
         "topo": {
           "version": "2.0.2",
@@ -7087,7 +7027,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "gettext-parser": {
@@ -7265,7 +7205,7 @@
                 },
                 "uglify-js": {
                   "version": "2.8.29",
-                  "from": "uglify-js@>=2.4.19 <3.0.0",
+                  "from": "uglify-js@>=2.6.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
                   "dependencies": {
                     "source-map": {
@@ -7593,9 +7533,9 @@
           }
         },
         "mime": {
-          "version": "1.4.1",
+          "version": "1.6.0",
           "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
         },
         "uue": {
           "version": "3.1.0",
@@ -7842,9 +7782,9 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.11.tgz",
       "dependencies": {
         "moment": {
-          "version": "2.19.2",
+          "version": "2.20.0",
           "from": "moment@>=2.6.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz"
         }
       }
     },
@@ -8098,9 +8038,9 @@
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                 },
                 "moment": {
-                  "version": "2.19.2",
+                  "version": "2.20.0",
                   "from": "moment@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz"
                 }
               }
             },
@@ -8139,9 +8079,9 @@
               "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
             },
             "ms": {
-              "version": "2.0.0",
+              "version": "2.1.1",
               "from": "ms@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
             },
             "xtend": {
               "version": "4.0.1",
@@ -8258,9 +8198,9 @@
               }
             },
             "es-abstract": {
-              "version": "1.9.0",
+              "version": "1.10.0",
               "from": "es-abstract@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
               "dependencies": {
                 "es-to-primitive": {
                   "version": "1.1.1",
@@ -8306,7 +8246,7 @@
         "uap-core": {
           "version": "0.5.0",
           "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#7e5b0c63f03657ebb3ee35672e78d44a15f9e9e5"
+          "resolved": "git://github.com/ua-parser/uap-core.git#aad0412268f877ff9d5e806d2ac0a7256210a72b"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -8743,11 +8683,6 @@
           "from": "babel-code-frame@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
         },
-        "babel-messages": {
-          "version": "6.8.0",
-          "from": "babel-messages@>=6.8.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-        },
         "babel-generator": {
           "version": "6.18.0",
           "from": "babel-generator@>=6.18.0 <7.0.0",
@@ -8757,6 +8692,11 @@
           "version": "6.18.0",
           "from": "babel-runtime@>=6.9.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
+        },
+        "babel-messages": {
+          "version": "6.8.0",
+          "from": "babel-messages@>=6.8.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
         },
         "babel-template": {
           "version": "6.16.0",
@@ -8873,15 +8813,15 @@
           "from": "expand-brackets@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
         },
-        "expand-range": {
-          "version": "1.8.2",
-          "from": "expand-range@>=1.8.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-        },
         "extglob": {
           "version": "0.3.2",
           "from": "extglob@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "from": "expand-range@>=1.8.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
         },
         "filename-regex": {
           "version": "2.0.0",
@@ -8903,15 +8843,15 @@
           "from": "for-own@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
         },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "from": "fs.realpath@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-        },
         "get-caller-file": {
           "version": "1.0.2",
           "from": "get-caller-file@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
         },
         "glob-base": {
           "version": "0.3.0",
@@ -9003,40 +8943,40 @@
           "from": "is-extendable@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
         },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
         "is-finite": {
           "version": "1.0.2",
           "from": "is-finite@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "from": "is-extglob@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
-        "is-number": {
-          "version": "2.1.0",
-          "from": "is-number@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-        },
         "is-glob": {
           "version": "2.0.1",
           "from": "is-glob@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
         },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+        "is-number": {
+          "version": "2.1.0",
+          "from": "is-number@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
         },
         "is-primitive": {
           "version": "2.0.0",
           "from": "is-primitive@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
         },
         "is-utf8": {
           "version": "0.2.1",
@@ -9113,15 +9053,15 @@
           "from": "md5-o-matic@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
         },
-        "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-        },
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         },
         "ms": {
           "version": "0.7.1",
@@ -9213,30 +9153,30 @@
           "from": "pinkie@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
         },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "from": "pkg-dir@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-        },
         "pinkie-promise": {
           "version": "2.0.1",
           "from": "pinkie-promise@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "from": "pkg-dir@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
         },
         "preserve": {
           "version": "0.2.0",
           "from": "preserve@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
         },
-        "randomatic": {
-          "version": "1.1.5",
-          "from": "randomatic@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
-        },
         "pseudomap": {
           "version": "1.0.2",
           "from": "pseudomap@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "from": "randomatic@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -9308,15 +9248,15 @@
           "from": "source-map@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "from": "spdx-correct@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-        },
         "spdx-expression-parse": {
           "version": "1.0.4",
           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "from": "spdx-correct@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
         },
         "spdx-license-ids": {
           "version": "1.2.2",
@@ -9403,18 +9343,6 @@
           "from": "yallist@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
         },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            }
-          }
-        },
         "handlebars": {
           "version": "4.0.5",
           "from": "handlebars@>=4.0.3 <5.0.0",
@@ -9424,6 +9352,18 @@
               "version": "0.4.4",
               "from": "source-map@>=0.4.4 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+            }
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
@@ -9682,7 +9622,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
@@ -9717,9 +9657,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.16.1",
+              "version": "2.17.1",
               "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -10067,9 +10007,9 @@
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
             },
             "moment": {
-              "version": "2.19.2",
-              "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+              "version": "2.20.0",
+              "from": "moment@>=2.6.0",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.0.tgz"
             }
           }
         },
@@ -10150,9 +10090,9 @@
           }
         },
         "mime": {
-          "version": "1.4.1",
+          "version": "1.6.0",
           "from": "mime@>=1.2.11 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
         },
         "negotiator": {
           "version": "0.6.1",
@@ -10329,7 +10269,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "from": "verror@1.10.0",
+          "from": "verror@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "dependencies": {
             "assert-plus": {
@@ -10343,9 +10283,9 @@
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "extsprintf": {
-              "version": "1.3.0",
+              "version": "1.4.0",
               "from": "extsprintf@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "grunt-newer": "1.2.0",
     "grunt-nsp": "2.3.1",
     "hawk": "2.3.1",
-    "husky": "0.13.1",
+    "husky": "0.14.3",
     "insist": "1.0.0",
     "jsxgettext-recursive": "1.0.1",
     "jws": "3.1.3",


### PR DESCRIPTION
Fixes #2128

Fixes nvm usage via https://github.com/typicode/husky/blob/master/CHANGELOG.md#0143

@mozilla/fxa-devs @vbudhram r?