### PR TITLE
feat(redis): eliminate property names from redis-stored tokens

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,14 @@ const P = require('./promise')
 const Pool = require('./pool')
 const random = require('./crypto/random')
 
+// To save space in Redis, we serialise session token updates as arrays using
+// fixed property indices, thereby not any encoding property names. The order
+// of those properties is defined here in REDIS_SESSION_TOKEN_PROPERTIES and
+// REDIS_SESSION_TOKEN_LOCATION_PROPERTIES. Note that, to maintain backwards
+// compatibility, any future changes to these constansts may only append items
+// to the end of each array. There's no safe way to change the array index for
+// any property, without introducing an explicit migration process for our Redis
+// instance.
 const REDIS_SESSION_TOKEN_PROPERTIES = [
   'lastAccessTime', 'uaBrowser', 'uaBrowserVersion',
   'uaOS', 'uaOSVersion', 'uaDeviceType', 'uaFormFactor'

--- a/lib/db.js
+++ b/lib/db.js
@@ -1129,20 +1129,39 @@ module.exports = (
     return Object.keys(tokens).reduce((result, tokenId) => {
       const unpackedToken = tokens[tokenId]
 
-      result[tokenId] = REDIS_SESSION_TOKEN_PROPERTIES.map((property, index) => {
-        const value = unpackedToken[property]
+      result[tokenId] = truncatePackedArray(REDIS_SESSION_TOKEN_PROPERTIES.map(
+        (property, index) => {
+          const value = unpackedToken[property]
 
-        if (index === REDIS_SESSION_TOKEN_LOCATION_INDEX && value) {
-          return REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.map(
-            locationProperty => value[locationProperty]
-          )
+          if (index === REDIS_SESSION_TOKEN_LOCATION_INDEX && value) {
+            return truncatePackedArray(REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.map(
+              locationProperty => value[locationProperty]
+            ))
+          }
+
+          return unpackedToken[property]
         }
-
-        return unpackedToken[property]
-      })
+      ))
 
       return result
     }, {})
+  }
+
+  // Trailing null and undefined don't need to be stored.
+  function truncatePackedArray (array) {
+    const length = array.length
+    if (length === 0) {
+      return array
+    }
+
+    const item = array[length - 1]
+    if (item !== null && item !== undefined) {
+      return array
+    }
+
+    array.pop()
+
+    return truncatePackedArray(array)
   }
 
   // Sanely unpack both the packed and raw formats from redis. Takes a redis

--- a/lib/db.js
+++ b/lib/db.js
@@ -18,9 +18,11 @@ const random = require('./crypto/random')
 // any property, without introducing an explicit migration process for our Redis
 // instance.
 const REDIS_SESSION_TOKEN_PROPERTIES = [
-  'lastAccessTime', 'uaBrowser', 'uaBrowserVersion',
+  'lastAccessTime', 'location', 'uaBrowser', 'uaBrowserVersion',
   'uaOS', 'uaOSVersion', 'uaDeviceType', 'uaFormFactor'
 ]
+
+const REDIS_SESSION_TOKEN_LOCATION_INDEX = REDIS_SESSION_TOKEN_PROPERTIES.indexOf('location')
 
 const REDIS_SESSION_TOKEN_LOCATION_PROPERTIES = [
   'city', 'state', 'stateCode', 'country', 'countryCode'
@@ -1121,22 +1123,24 @@ module.exports = (
   }
 
   // Reduce redis memory usage by not encoding the keys. Store properties
-  // as fixed indices into arrays instead. Takes a session token object as
-  // its argument, returns an array.
+  // as fixed indices into arrays instead. Takes an unpacked session tokens
+  // structure as its argument, returns an array.
   function packTokensForRedis (tokens) {
     return Object.keys(tokens).reduce((result, tokenId) => {
       const unpackedToken = tokens[tokenId]
 
-      const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(property => unpackedToken[property])
+      result[tokenId] = REDIS_SESSION_TOKEN_PROPERTIES.map((property, index) => {
+        const value = unpackedToken[property]
 
-      const location = unpackedToken.location
-      if (location) {
-        REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach(
-          property => packedToken.push(location[property])
-        )
-      }
+        if (index === REDIS_SESSION_TOKEN_LOCATION_INDEX && value) {
+          return REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.map(
+            locationProperty => value[locationProperty]
+          )
+        }
 
-      result[tokenId] = packedToken
+        return unpackedToken[property]
+      })
+
       return result
     }, {})
   }
@@ -1156,17 +1160,11 @@ module.exports = (
       const packedToken = tokens[tokenId]
 
       if (Array.isArray(packedToken)) {
-        const unpackedToken = REDIS_SESSION_TOKEN_PROPERTIES.reduce((data, property, index) => {
-          data[property] = packedToken[index]
-          return data
-        }, {})
+        const unpackedToken = unpackToken(packedToken, REDIS_SESSION_TOKEN_PROPERTIES)
 
-        const locationPropertyOffset = REDIS_SESSION_TOKEN_PROPERTIES.length
-        if (packedToken.length > locationPropertyOffset) {
-          unpackedToken.location = {}
-          REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach((property, index) => {
-            unpackedToken.location[property] = packedToken[locationPropertyOffset + index]
-          })
+        const location = unpackedToken.location
+        if (Array.isArray(location)) {
+          unpackedToken.location = unpackToken(location, REDIS_SESSION_TOKEN_LOCATION_PROPERTIES)
         }
 
         result[tokenId] = unpackedToken
@@ -1174,6 +1172,13 @@ module.exports = (
         result[tokenId] = packedToken
       }
 
+      return result
+    }, {})
+  }
+
+  function unpackToken (packedToken, properties) {
+    return properties.reduce((result, property, index) => {
+      result[property] = packedToken[index]
       return result
     }, {})
   }

--- a/lib/db.js
+++ b/lib/db.js
@@ -1124,7 +1124,7 @@ module.exports = (
 
   // Reduce redis memory usage by not encoding the keys. Store properties
   // as fixed indices into arrays instead. Takes an unpacked session tokens
-  // structure as its argument, returns an array.
+  // structure as its argument, returns the packed structure.
   function packTokensForRedis (tokens) {
     return Object.keys(tokens).reduce((result, tokenId) => {
       const unpackedToken = tokens[tokenId]

--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,15 @@ const P = require('./promise')
 const Pool = require('./pool')
 const random = require('./crypto/random')
 
+const REDIS_SESSION_TOKEN_PROPERTIES = [
+  'lastAccessTime', 'uaBrowser', 'uaBrowserVersion',
+  'uaOS', 'uaOSVersion', 'uaDeviceType', 'uaFormFactor'
+]
+
+const REDIS_SESSION_TOKEN_LOCATION_PROPERTIES = [
+  'city', 'state', 'stateCode', 'country', 'countryCode'
+]
+
 module.exports = (
   config,
   log,
@@ -253,13 +262,13 @@ module.exports = (
               // Ensure that we don't return lastAccessTime if redis is down
               isRedisOk = false
             }
-            return result
+            return unpackTokensFromRedis(result)
           })
       )
     }
 
     return P.all(promises)
-      .spread((mysqlSessionTokens, redisTokens) => {
+      .spread((mysqlSessionTokens, redisSessionTokens = {}) => {
         if (MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
           // Filter out any expired sessions
           mysqlSessionTokens = mysqlSessionTokens.filter(sessionToken => {
@@ -273,7 +282,6 @@ module.exports = (
         // for each db session token, if there is a matching redis token
         // overwrite the properties of the db token with the redis token values
         const lastAccessTimeEnabled = isRedisOk && features.isLastAccessTimeEnabledForUser(uid)
-        const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : {}
         const sessions = mysqlSessionTokens.map((sessionToken) => {
           const id = sessionToken.tokenId
           const redisToken = redisSessionTokens[id]
@@ -452,18 +460,12 @@ module.exports = (
               // Ensure that we don't return lastAccessTime if redis is down
               isRedisOk = false
             }
-            return result
+            return unpackTokensFromRedis(result)
           })
       )
     }
     return P.all(promises)
-      .spread((devices, redisTokens) => {
-        const redisSessionTokens = redisTokens ? JSON.parse(redisTokens) : {}
-        log.info({
-          op: 'db.devices.redisSessionTokens',
-          hasRedisTokens: !! redisSessionTokens.length,
-          numRedisTokens: redisSessionTokens.length
-        })
+      .spread((devices, redisSessionTokens = {}) => {
         // for each device, if there is a redis token with a matching tokenId,
         // overwrite device's ua properties and lastAccessTime with redis token values
         const lastAccessTimeEnabled = isRedisOk && features.isLastAccessTimeEnabledForUser(uid)
@@ -544,13 +546,9 @@ module.exports = (
       })
       .catch(() => {})
       .then(() => redis.update(uid, sessionTokens => {
-        if (sessionTokens) {
-          sessionTokens = JSON.parse(sessionTokens)
-        } else {
-          sessionTokens = {}
-        }
+        sessionTokens = unpackTokensFromRedis(sessionTokens)
 
-        sessionTokens[id] = {
+        sessionTokens[id] = packTokenForRedis({
           lastAccessTime: token.lastAccessTime,
           location,
           uaBrowser: token.uaBrowser,
@@ -559,7 +557,7 @@ module.exports = (
           uaFormFactor: token.uaFormFactor,
           uaOS: token.uaOS,
           uaOSVersion: token.uaOSVersion,
-        }
+        })
 
         return JSON.stringify(sessionTokens)
       }))
@@ -1112,6 +1110,60 @@ module.exports = (
         // Allow callers to distinguish between the null result and connection errors
         return false
       })
+  }
+
+  // Reduce redis memory usage by not encoding the keys. Store properties
+  // as fixed indices into arrays instead. Takes a session token object as
+  // its argument, returns an array.
+  function packTokenForRedis (token) {
+    // Use `|| 0` to save space, because it's the shortest falsey value we can stringify
+    const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(property => token[property] || 0)
+
+    const location = token.location
+    if (location) {
+      REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach(
+        property => packedToken.push(location[property] || 0)
+      )
+    }
+
+    return packedToken
+  }
+
+  // Sanely unpack both the packed and raw formats from redis. Takes a redis
+  // result as it's argument (may be null or a stringified mish mash of packed
+  // and/or unpacked stored tokens), returns the unpacked session tokens
+  // structure.
+  function unpackTokensFromRedis (tokens) {
+    if (! tokens) {
+      return {}
+    }
+
+    tokens = JSON.parse(tokens)
+
+    return Object.keys(tokens).reduce((result, tokenId) => {
+      const packedToken = tokens[tokenId]
+
+      if (Array.isArray(packedToken)) {
+        const unpackedToken = REDIS_SESSION_TOKEN_PROPERTIES.reduce((data, property, index) => {
+          data[property] = packedToken[index] || null
+          return data
+        }, {})
+
+        const locationPropertyOffset = REDIS_SESSION_TOKEN_PROPERTIES.length
+        if (packedToken.length > locationPropertyOffset) {
+          unpackedToken.location = {}
+          REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach((property, index) => {
+            unpackedToken.location[property] = packedToken[locationPropertyOffset + index] || null
+          })
+        }
+
+        result[tokenId] = unpackedToken
+      } else {
+        result[tokenId] = packedToken
+      }
+
+      return result
+    }, {})
   }
 
   return DB

--- a/lib/db.js
+++ b/lib/db.js
@@ -13,7 +13,7 @@ const random = require('./crypto/random')
 // fixed property indices, thereby not any encoding property names. The order
 // of those properties is defined here in REDIS_SESSION_TOKEN_PROPERTIES and
 // REDIS_SESSION_TOKEN_LOCATION_PROPERTIES. Note that, to maintain backwards
-// compatibility, any future changes to these constansts may only append items
+// compatibility, any future changes to these constants may only append items
 // to the end of each array. There's no safe way to change the array index for
 // any property, without introducing an explicit migration process for our Redis
 // instance.

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,7 +10,7 @@ const Pool = require('./pool')
 const random = require('./crypto/random')
 
 // To save space in Redis, we serialise session token updates as arrays using
-// fixed property indices, thereby not any encoding property names. The order
+// fixed property indices, thereby not encoding any property names. The order
 // of those properties is defined here in REDIS_SESSION_TOKEN_PROPERTIES and
 // REDIS_SESSION_TOKEN_LOCATION_PROPERTIES. Note that, to maintain backwards
 // compatibility, any future changes to these constants may only append items

--- a/lib/db.js
+++ b/lib/db.js
@@ -548,7 +548,7 @@ module.exports = (
       .then(() => redis.update(uid, sessionTokens => {
         sessionTokens = unpackTokensFromRedis(sessionTokens)
 
-        sessionTokens[id] = packTokenForRedis({
+        sessionTokens[id] = {
           lastAccessTime: token.lastAccessTime,
           location,
           uaBrowser: token.uaBrowser,
@@ -557,9 +557,9 @@ module.exports = (
           uaFormFactor: token.uaFormFactor,
           uaOS: token.uaOS,
           uaOSVersion: token.uaOSVersion,
-        })
+        }
 
-        return JSON.stringify(sessionTokens)
+        return JSON.stringify(packTokensForRedis(sessionTokens))
       }))
   }
 
@@ -1115,18 +1115,25 @@ module.exports = (
   // Reduce redis memory usage by not encoding the keys. Store properties
   // as fixed indices into arrays instead. Takes a session token object as
   // its argument, returns an array.
-  function packTokenForRedis (token) {
-    // Use `|| 0` to save space, because it's the shortest falsey value we can stringify
-    const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(property => token[property] || 0)
+  function packTokensForRedis (tokens) {
+    return Object.keys(tokens).reduce((result, tokenId) => {
+      const unpackedToken = tokens[tokenId]
 
-    const location = token.location
-    if (location) {
-      REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach(
-        property => packedToken.push(location[property] || 0)
+      // Use `|| 0` to save space, because it's the shortest falsey value we can stringify
+      const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(
+        property => unpackedToken[property] || 0
       )
-    }
 
-    return packedToken
+      const location = unpackedToken.location
+      if (location) {
+        REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach(
+          property => packedToken.push(location[property] || 0)
+        )
+      }
+
+      result[tokenId] = packedToken
+      return result
+    }, {})
   }
 
   // Sanely unpack both the packed and raw formats from redis. Takes a redis

--- a/lib/db.js
+++ b/lib/db.js
@@ -1127,15 +1127,12 @@ module.exports = (
     return Object.keys(tokens).reduce((result, tokenId) => {
       const unpackedToken = tokens[tokenId]
 
-      // Use `|| 0` to save space, because it's the shortest falsey value we can stringify
-      const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(
-        property => unpackedToken[property] || 0
-      )
+      const packedToken = REDIS_SESSION_TOKEN_PROPERTIES.map(property => unpackedToken[property])
 
       const location = unpackedToken.location
       if (location) {
         REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach(
-          property => packedToken.push(location[property] || 0)
+          property => packedToken.push(location[property])
         )
       }
 
@@ -1160,7 +1157,7 @@ module.exports = (
 
       if (Array.isArray(packedToken)) {
         const unpackedToken = REDIS_SESSION_TOKEN_PROPERTIES.reduce((data, property, index) => {
-          data[property] = packedToken[index] || null
+          data[property] = packedToken[index]
           return data
         }, {})
 
@@ -1168,7 +1165,7 @@ module.exports = (
         if (packedToken.length > locationPropertyOffset) {
           unpackedToken.location = {}
           REDIS_SESSION_TOKEN_LOCATION_PROPERTIES.forEach((property, index) => {
-            unpackedToken.location[property] = packedToken[locationPropertyOffset + index] || null
+            unpackedToken.location[property] = packedToken[locationPropertyOffset + index]
           })
         }
 

--- a/lib/redis/index.js
+++ b/lib/redis/index.js
@@ -37,7 +37,7 @@
 //     })
 //
 //   redis.update(key, value => updatedValue)
-//     .then(value => {
+//     .then(() => {
 //       // :)
 //     })
 //     .catch(error => {

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -328,7 +328,7 @@ describe('redis enabled', () => {
     }
     const newFormat = [
       1, [ 'Mountain View', 'California', 'CA', 'United States', 'US' ],
-      'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
+      'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile'
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
     pool.get = sinon.spy(() => P.resolve([
@@ -407,7 +407,7 @@ describe('redis enabled', () => {
     }
     const newFormat = [
       42, [ 'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB' ],
-      'Firefox', '59', 'Mac OS X', '10.11', null, null
+      'Firefox', '59', 'Mac OS X', '10.11'
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
     pool.get = sinon.spy(() => P.resolve([
@@ -497,20 +497,20 @@ describe('redis enabled', () => {
               countryCode: 'US'
             }
           },
-          newFormat: [ 2, [], 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
+          newFormat: [ 2, [], 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile' ]
         }))
         assert.deepEqual(JSON.parse(result), {
           wibble: [
             42, [ 'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'],
-            'Firefox', '59', 'Mac OS X', '10.11', null, null
+            'Firefox', '59', 'Mac OS X', '10.11'
           ],
           oldFormat: [
             1, [ 'Mountain View', 'California', 'CA', 'United States', 'US' ],
-            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
+            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile'
           ],
           newFormat: [
-            2, [ null, null, null, null, null],
-            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
+            2, [],
+            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile'
           ]
         })
       })

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -327,7 +327,7 @@ describe('redis enabled', () => {
       }
     }
     const newFormat = [
-      1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0,
+      1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null,
       'Mountain View', 'California', 'CA', 'United States', 'US'
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
@@ -406,7 +406,7 @@ describe('redis enabled', () => {
       }
     }
     const newFormat = [
-      42, 'Firefox', '59', 'Mac OS X', '10.11', 0, 0,
+      42, 'Firefox', '59', 'Mac OS X', '10.11', null, null,
       'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
@@ -497,18 +497,18 @@ describe('redis enabled', () => {
               countryCode: 'US'
             }
           },
-          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
+          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
         }))
         assert.deepEqual(JSON.parse(result), {
           wibble: [
-            42, 'Firefox', '59', 'Mac OS X', '10.11', 0, 0,
+            42, 'Firefox', '59', 'Mac OS X', '10.11', null, null,
             'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
           ],
           oldFormat: [
-            1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0,
+            1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null,
             'Mountain View', 'California', 'CA', 'United States', 'US'
           ],
-          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
+          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
         })
       })
   })

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -327,8 +327,8 @@ describe('redis enabled', () => {
       }
     }
     const newFormat = [
-      1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null,
-      'Mountain View', 'California', 'CA', 'United States', 'US'
+      1, [ 'Mountain View', 'California', 'CA', 'United States', 'US' ],
+      'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
     pool.get = sinon.spy(() => P.resolve([
@@ -406,8 +406,8 @@ describe('redis enabled', () => {
       }
     }
     const newFormat = [
-      42, 'Firefox', '59', 'Mac OS X', '10.11', null, null,
-      'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
+      42, [ 'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB' ],
+      'Firefox', '59', 'Mac OS X', '10.11', null, null
     ]
     redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
     pool.get = sinon.spy(() => P.resolve([
@@ -497,18 +497,21 @@ describe('redis enabled', () => {
               countryCode: 'US'
             }
           },
-          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
+          newFormat: [ 2, [], 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
         }))
         assert.deepEqual(JSON.parse(result), {
           wibble: [
-            42, 'Firefox', '59', 'Mac OS X', '10.11', null, null,
-            'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
+            42, [ 'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'],
+            'Firefox', '59', 'Mac OS X', '10.11', null, null
           ],
           oldFormat: [
-            1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null,
-            'Mountain View', 'California', 'CA', 'United States', 'US'
+            1, [ 'Mountain View', 'California', 'CA', 'United States', 'US' ],
+            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
           ],
-          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null ]
+          newFormat: [
+            2, [ null, null, null, null, null],
+            'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', null
+          ]
         })
       })
   })

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -309,32 +309,37 @@ describe('redis enabled', () => {
       })
   })
 
-  it('db.devices handles old-format token objects from redis', () => {
-    const oldResult = {
-      blee: {
-        lastAccessTime: 42,
-        uaBrowser: 'Firefox',
-        uaBrowserVersion: '59',
-        uaOS: 'Mac OS X',
-        uaOSVersion: '10.11',
-        uaDeviceType: null,
-        uaFormFactor: null,
-        location: {
-          city: 'Bournemouth',
-          state: 'England',
-          stateCode: 'EN',
-          country: 'United Kingdom',
-          countryCode: 'GB'
-        }
+  it('db.devices handles old-format and new-format token objects from redis', () => {
+    const oldFormat = {
+      lastAccessTime: 42,
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '59',
+      uaOS: 'Mac OS X',
+      uaOSVersion: '10.11',
+      uaDeviceType: null,
+      uaFormFactor: null,
+      location: {
+        city: 'Bournemouth',
+        state: 'England',
+        stateCode: 'EN',
+        country: 'United Kingdom',
+        countryCode: 'GB'
       }
     }
-    redis.get = sinon.spy(() => P.resolve(JSON.stringify(oldResult)))
-    pool.get = sinon.spy(() => P.resolve([ { id: 'device-id', sessionTokenId: 'blee' } ]))
+    const newFormat = [
+      1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0,
+      'Mountain View', 'California', 'CA', 'United States', 'US'
+    ]
+    redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
+    pool.get = sinon.spy(() => P.resolve([
+      { id: 'device-id', sessionTokenId: 'oldFormat' },
+      { id: 'device-id', sessionTokenId: 'newFormat' }
+    ]))
     return db.devices('wibble')
       .then(result => assert.deepEqual(result, [
         {
           id: 'device-id',
-          sessionToken: 'blee',
+          sessionToken: 'oldFormat',
           name: undefined,
           type: undefined,
           pushCallback: undefined,
@@ -355,24 +360,10 @@ describe('redis enabled', () => {
             country: 'United Kingdom',
             countryCode: 'GB'
           }
-        }
-      ]))
-  })
-
-  it('db.devices handles new-format token objects from redis', () => {
-    const newResult = {
-      blee: [
-        1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0,
-        'Mountain View', 'California', 'CA', 'United States', 'US'
-      ]
-    }
-    redis.get = sinon.spy(() => P.resolve(JSON.stringify(newResult)))
-    pool.get = sinon.spy(() => P.resolve([ { id: 'device-id', sessionTokenId: 'blee' } ]))
-    return db.devices('wibble')
-      .then(result => assert.deepEqual(result, [
+        },
         {
           id: 'device-id',
-          sessionToken: 'blee',
+          sessionToken: 'newFormat',
           name: undefined,
           type: undefined,
           pushCallback: undefined,
@@ -397,31 +388,36 @@ describe('redis enabled', () => {
       ]))
   })
 
-  it('db.sessions handles old-format token objects from redis', () => {
-    const oldResult = {
-      blee: {
-        lastAccessTime: 1,
-        uaBrowser: 'Firefox Focus',
-        uaBrowserVersion: '4.0.1',
-        uaOS: 'Android',
-        uaOSVersion: '8.1',
-        uaDeviceType: 'mobile',
-        uaFormFactor: null,
-        location: {
-          city: 'Mountain View',
-          state: 'California',
-          stateCode: 'CA',
-          country: 'United States',
-          countryCode: 'US'
-        }
+  it('db.sessions handles old-format and new-format token objects from redis', () => {
+    const oldFormat = {
+      lastAccessTime: 1,
+      uaBrowser: 'Firefox Focus',
+      uaBrowserVersion: '4.0.1',
+      uaOS: 'Android',
+      uaOSVersion: '8.1',
+      uaDeviceType: 'mobile',
+      uaFormFactor: null,
+      location: {
+        city: 'Mountain View',
+        state: 'California',
+        stateCode: 'CA',
+        country: 'United States',
+        countryCode: 'US'
       }
     }
-    redis.get = sinon.spy(() => P.resolve(JSON.stringify(oldResult)))
-    pool.get = sinon.spy(() => P.resolve([ { tokenId: 'blee', deviceId: 'device-id' } ]))
+    const newFormat = [
+      42, 'Firefox', '59', 'Mac OS X', '10.11', 0, 0,
+      'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
+    ]
+    redis.get = sinon.spy(() => P.resolve(JSON.stringify({ oldFormat, newFormat })))
+    pool.get = sinon.spy(() => P.resolve([
+      { tokenId: 'oldFormat', deviceId: 'device-id' },
+      { tokenId: 'newFormat', deviceId: 'device-id' }
+    ]))
     return db.sessions('wibble')
       .then(result => assert.deepEqual(result, [
         {
-          id: 'blee',
+          id: 'oldFormat',
           deviceId: 'device-id',
           lastAccessTime: 1,
           uaBrowser: 'Firefox Focus',
@@ -437,23 +433,9 @@ describe('redis enabled', () => {
             country: 'United States',
             countryCode: 'US'
           }
-        }
-      ]))
-  })
-
-  it('db.sessions handles new-format token objects from redis', () => {
-    const newResult = {
-      blee: [
-        42, 'Firefox', '59', 'Mac OS X', '10.11', 0, 0,
-        'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
-      ]
-    }
-    redis.get = sinon.spy(() => P.resolve(JSON.stringify(newResult)))
-    pool.get = sinon.spy(() => P.resolve([ { tokenId: 'blee', deviceId: 'device-id' } ]))
-    return db.sessions('wibble')
-      .then(result => assert.deepEqual(result, [
+        },
         {
-          id: 'blee',
+          id: 'newFormat',
           deviceId: 'device-id',
           lastAccessTime: 42,
           uaBrowser: 'Firefox',
@@ -499,7 +481,7 @@ describe('redis enabled', () => {
         assert.equal(typeof getUpdatedValue, 'function')
 
         const result = getUpdatedValue(JSON.stringify({
-          old: {
+          oldFormat: {
             lastAccessTime: 1,
             uaBrowser: 'Firefox Focus',
             uaBrowserVersion: '4.0.1',
@@ -515,18 +497,18 @@ describe('redis enabled', () => {
               countryCode: 'US'
             }
           },
-          new: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
+          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
         }))
         assert.deepEqual(JSON.parse(result), {
           wibble: [
             42, 'Firefox', '59', 'Mac OS X', '10.11', 0, 0,
             'Bournemouth', 'England', 'EN', 'United Kingdom', 'GB'
           ],
-          old: [
+          oldFormat: [
             1, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0,
             'Mountain View', 'California', 'CA', 'United States', 'US'
           ],
-          new: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
+          newFormat: [ 2, 'Firefox Focus', '4.0.1', 'Android', '8.1', 'mobile', 0 ]
         })
       })
   })

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -457,6 +457,7 @@ describe('remote db', function() {
           deviceInfo.pushCallback = ''
           deviceInfo.pushPublicKey = ''
           deviceInfo.pushAuthKey = ''
+          sessionToken.lastAccessTime = 42
           sessionToken.uaBrowser = 'Firefox'
           sessionToken.uaBrowserVersion = '44'
           sessionToken.uaOS = 'Mac OS X'
@@ -510,7 +511,7 @@ describe('remote db', function() {
           return devices[1]
         })
         .then((device) => {
-          assert.ok(device.lastAccessTime > 0, 'device.lastAccessTime is set')
+          assert.equal(device.lastAccessTime, 42, 'device.lastAccessTime is correct')
           assert.equal(device.name, deviceInfo.name, 'device.name is correct')
           assert.equal(device.type, deviceInfo.type, 'device.type is correct')
           assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')


### PR DESCRIPTION
Fixes #2222, although I'm also open to the possibility that maybe it's not worth the effort making this last step and just leaving things as they currently are. It's up to you guys.

But anyway, this change stops us paying to store property keys in Redis, by re-packaging them as arrays before writing and unpacking them to the proper object format after reading. In practice, based on my back-of-a-fag-packet calculation made using [this script](https://github.com/mozilla/fxa-auth-server/blob/893dea954f79a009c48e62c26f3a60d3e4b789aa/scripts/redis-benchmark.js), I think it will reduce our stored token size by about 16% or so, depending on the data in the token.

No tests added because the whole point is that this should be invisible to the rest of the code, so the existing test coverage is sufficient (I think).

@mozilla/fxa-devs r?