### PR TITLE
feat(redis): prune expired session tokens from redis

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -432,6 +432,20 @@ var conf = convict({
       default: '4 weeks'
     }
   },
+  tokenPruning: {
+    enabled: {
+      doc: 'Turn on Redis token pruning',
+      format: Boolean,
+      default: true,
+      env: 'TOKEN_PRUNING_ENABLED'
+    },
+    maxAge: {
+      doc: 'Age at which to prune tokens from Redis, should be equal to config.pruneTokensMaxAge in fxa-auth-db-mysql',
+      format: 'duration',
+      default: '3 months',
+      env: 'TOKEN_PRUNING_MAX_AGE'
+    }
+  },
   verifierVersion: {
     doc: 'verifer version for new and changed passwords',
     format: 'int',

--- a/config/index.js
+++ b/config/index.js
@@ -379,7 +379,7 @@ var conf = convict({
       doc: 'Key prefix for session tokens in Redis'
     },
     maxConnections: {
-      default: 10,
+      default: 100,
       env: 'REDIS_POOL_MAX_CONNECTIONS',
       format: 'int',
       doc: 'Maximum connection count for Redis'

--- a/config/index.js
+++ b/config/index.js
@@ -440,9 +440,9 @@ var conf = convict({
       env: 'TOKEN_PRUNING_ENABLED'
     },
     maxAge: {
-      doc: 'Age at which to prune tokens from Redis, should be equal to config.pruneTokensMaxAge in fxa-auth-db-mysql',
+      doc: 'Age at which to prune expired tokens from Redis',
       format: 'duration',
-      default: '3 months',
+      default: '1 month',
       env: 'TOKEN_PRUNING_MAX_AGE'
     }
   },

--- a/lib/db.js
+++ b/lib/db.js
@@ -288,6 +288,7 @@ module.exports = (
           }
 
           return this.pruneSessionTokens(uid, expiredSessionTokens)
+            .catch(() => {})
             .then(() => sessionTokens)
         })
     ]

--- a/lib/db.js
+++ b/lib/db.js
@@ -574,16 +574,22 @@ module.exports = (
       }))
   }
 
-  DB.prototype.pruneSessionToken = function (sessionToken) {
-    const { createdAt, id, uid } = sessionToken
+  DB.prototype.pruneSessionTokens = function (uid, sessionTokens) {
+    log.trace({ op: 'DB.pruneSessionTokens', uid, tokenCount: sessionTokens.length })
 
-    log.trace({ op: 'DB.pruneSessionToken', createdAt, id, uid })
-
-    if (! redis || ! features.isLastAccessTimeEnabledForUser(uid)) {
+    if (! redis || ! TOKEN_PRUNING_ENABLED || ! features.isLastAccessTimeEnabledForUser(uid)) {
       return P.resolve()
     }
 
-    if (! TOKEN_PRUNING_ENABLED || createdAt > Date.now() - TOKEN_PRUNING_MAX_AGE) {
+    const tokenIds = sessionTokens.reduce((set, token) => {
+      if (token.createdAt <= Date.now() - TOKEN_PRUNING_MAX_AGE) {
+        set.add(token.id)
+      }
+      return set
+    }, new Set())
+
+    const pruneCount = tokenIds.size
+    if (pruneCount === 0) {
       return P.resolve()
     }
 
@@ -591,17 +597,20 @@ module.exports = (
       sessionTokens = unpackTokensFromRedis(sessionTokens)
 
       const keys = Object.keys(sessionTokens)
-      let count = keys.length
+      let keyCount = keys.length
+      let doneCount = 0
 
       keys.some(key => {
-        if (key === id) {
+        if (tokenIds.has(key)) {
           delete sessionTokens[key]
-          count -= 1
-          return true
+          keyCount -= 1
+          if (++doneCount === pruneCount) {
+            return true
+          }
         }
       })
 
-      if (count > 0) {
+      if (keyCount > 0) {
         return JSON.stringify(packTokensForRedis(sessionTokens))
       }
     })

--- a/lib/db.js
+++ b/lib/db.js
@@ -262,6 +262,34 @@ module.exports = (
     log.trace({ op: 'DB.sessions', uid: uid })
     const promises = [
       this.pool.get('/account/' + uid + '/sessions')
+        .then(sessionTokens => {
+          if (! MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
+            return sessionTokens
+          }
+
+          const expiredSessionTokens = []
+
+          // Filter out any expired sessions
+          sessionTokens = sessionTokens.filter(sessionToken => {
+            if (sessionToken.deviceId) {
+              return true
+            }
+
+            if (sessionToken.createdAt > Date.now() - MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
+              return true
+            }
+
+            expiredSessionTokens.push(Object.assign({}, sessionToken, { id: sessionToken.tokenId }))
+            return false
+          })
+
+          if (expiredSessionTokens.length === 0) {
+            return sessionTokens
+          }
+
+          return this.pruneSessionTokens(uid, expiredSessionTokens)
+            .then(() => sessionTokens)
+        })
     ]
     let isRedisOk = true
 
@@ -280,16 +308,6 @@ module.exports = (
 
     return P.all(promises)
       .spread((mysqlSessionTokens, redisSessionTokens = {}) => {
-        if (MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
-          // Filter out any expired sessions
-          mysqlSessionTokens = mysqlSessionTokens.filter(sessionToken => {
-            if (sessionToken.deviceId) {
-              return true
-            }
-
-            return sessionToken.createdAt > Date.now() - MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE
-          })
-        }
         // for each db session token, if there is a matching redis token
         // overwrite the properties of the db token with the redis token values
         const lastAccessTimeEnabled = isRedisOk && features.isLastAccessTimeEnabledForUser(uid)

--- a/lib/db.js
+++ b/lib/db.js
@@ -45,6 +45,7 @@ module.exports = (
     PasswordChangeToken
   } = Token
   const MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
+  const { enabled: TOKEN_PRUNING_ENABLED, maxAge: TOKEN_PRUNING_MAX_AGE } = config.tokenPruning
 
   function setAccountEmails(account) {
     return this.accountEmails(account.uid)
@@ -571,6 +572,39 @@ module.exports = (
 
         return JSON.stringify(packTokensForRedis(sessionTokens))
       }))
+  }
+
+  DB.prototype.pruneSessionToken = function (sessionToken) {
+    const { createdAt, id, uid } = sessionToken
+
+    log.trace({ op: 'DB.pruneSessionToken', createdAt, id, uid })
+
+    if (! redis || ! features.isLastAccessTimeEnabledForUser(uid)) {
+      return P.resolve()
+    }
+
+    if (! TOKEN_PRUNING_ENABLED || createdAt > Date.now() - TOKEN_PRUNING_MAX_AGE) {
+      return P.resolve()
+    }
+
+    return redis.update(uid, sessionTokens => {
+      sessionTokens = unpackTokensFromRedis(sessionTokens)
+
+      const keys = Object.keys(sessionTokens)
+      let count = keys.length
+
+      keys.some(key => {
+        if (key === id) {
+          delete sessionTokens[key]
+          count -= 1
+          return true
+        }
+      })
+
+      if (count > 0) {
+        return JSON.stringify(packTokensForRedis(sessionTokens))
+      }
+    })
   }
 
   DB.prototype.createDevice = function (uid, sessionTokenId, deviceInfo) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -83,15 +83,20 @@ function create(log, error, config, routes, db, translator) {
         return process.nextTick(cb.bind(null, null, null)) // not found
       }
       dbGetFn(id)
-        .then(
-          function (token) {
-            if (token.expired(Date.now())) {
-              return cb(error.invalidToken('The authentication token has expired'))
+        .then(token => {
+          if (token.expired(Date.now())) {
+            const err = error.invalidToken('The authentication token has expired')
+
+            if (token.tokenTypeID === 'sessionToken') {
+              return db.pruneSessionToken(token)
+               .then(() => cb(err))
             }
-            return cb(null, token)
-          },
-          cb
-        )
+
+            return cb(err)
+          }
+
+          return cb(null, token)
+        }, cb)
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -89,7 +89,8 @@ function create(log, error, config, routes, db, translator) {
 
             if (token.tokenTypeID === 'sessionToken') {
               return db.pruneSessionTokens(token.uid, [ token ])
-               .then(() => cb(err))
+                .catch(() => {})
+                .then(() => cb(err))
             }
 
             return cb(err)

--- a/lib/server.js
+++ b/lib/server.js
@@ -88,7 +88,7 @@ function create(log, error, config, routes, db, translator) {
             const err = error.invalidToken('The authentication token has expired')
 
             if (token.tokenTypeID === 'sessionToken') {
-              return db.pruneSessionToken(token)
+              return db.pruneSessionTokens(token.uid, [ token ])
                .then(() => cb(err))
             }
 

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -10,6 +10,7 @@ const assert = require('insist')
 const EndpointError = require('poolee/lib/error')(require('util').inherits)
 const error = require(`${ROOT_DIR}/lib/error`)
 const hapi = require('hapi')
+const hawk = require('hawk')
 const mocks = require('../mocks')
 const server = require(`${ROOT_DIR}/lib/server`)
 const sinon = require('sinon')
@@ -62,209 +63,138 @@ describe('lib/server', () => {
     })
   })
 
-  describe('create:', () => {
-    let log, config, routes, db, instance, response, locale, translator
+  describe('set up mocks:', () => {
+    let config, log, locale, routes, Token, translator, response
 
     beforeEach(() => {
-      log = mocks.mockLog()
       config = getConfig()
-      routes = getRoutes()
-      db = mocks.mockDB({
-        devices: [ { id: 'fake device id' } ]
-      })
       locale = 'en'
+      log = mocks.mockLog()
+      routes = getRoutes()
+      Token = require(`${ROOT_DIR}/lib/tokens`)(log, config)
       translator = {
         getTranslator: sinon.spy(() => ({ en: { format: () => {}, language: 'en' } })),
         getLocale: sinon.spy(() => locale)
       }
-      instance = server.create(log, error, config, routes, db, translator)
     })
 
-    it('returned a hapi Server instance', () => {
-      assert.ok(instance instanceof hapi.Server)
-    })
+    describe('create:', () => {
+      let db, instance
 
-    describe('server.start:', () => {
-      beforeEach(() => instance.start())
-      afterEach(() => instance.stop())
-
-      it('did not call log.begin', () => {
-        assert.equal(log.begin.callCount, 0)
+      beforeEach(() => {
+        db = mocks.mockDB({
+          devices: [ { id: 'fake device id' } ]
+        })
+        instance = server.create(log, error, config, routes, db, translator, Token)
       })
 
-      it('did not call log.summary', () => {
-        assert.equal(log.summary.callCount, 0)
+      it('returned a hapi Server instance', () => {
+        assert.ok(instance instanceof hapi.Server)
       })
 
-      describe('successful request, authenticated, acceptable locale, signinCodes feature enabled:', () => {
-        let request
+      describe('server.start:', () => {
+        beforeEach(() => instance.start())
+        afterEach(() => instance.stop())
 
-        beforeEach(() => {
-          response = 'ok'
-          return instance.inject({
-            credentials: {
-              uid: 'fake uid'
-            },
-            headers: {
-              'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
-              'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:57.0) Gecko/20100101 Firefox/57.0',
-              'x-forwarded-for': '63.245.221.32'
-            },
-            method: 'POST',
-            url: '/account/create',
-            payload: {
-              features: [ 'signinCodes' ]
-            },
-            remoteAddress: '63.245.221.32'
-          }).then(response => request = response.request)
+        it('did not call log.begin', () => {
+          assert.equal(log.begin.callCount, 0)
         })
 
-        it('called log.begin correctly', () => {
-          assert.equal(log.begin.callCount, 1)
-          const args = log.begin.args[0]
-          assert.equal(args.length, 2)
-          assert.equal(args[0], 'server.onRequest')
-          assert.ok(args[1])
-          assert.equal(args[1].path, '/account/create')
-          assert.equal(args[1].app.locale, 'en')
+        it('did not call log.summary', () => {
+          assert.equal(log.summary.callCount, 0)
         })
 
-        it('called log.summary correctly', () => {
-          assert.equal(log.summary.callCount, 1)
-          const args = log.summary.args[0]
-          assert.equal(args.length, 2)
-          assert.equal(args[0], log.begin.args[0][1])
-          assert.ok(args[1])
-          assert.equal(args[1].isBoom, undefined)
-          assert.equal(args[1].errno, undefined)
-          assert.equal(args[1].statusCode, 200)
-          assert.equal(args[1].source, 'ok')
-        })
-
-        it('did not call log.error', () => {
-          assert.equal(log.error.callCount, 0)
-        })
-
-        it('parsed features correctly', () => {
-          assert.ok(request.app.features)
-          assert.equal(typeof request.app.features.has, 'function')
-          assert.equal(request.app.features.has('signinCodes'), true)
-        })
-
-        it('parsed remote address chain correctly', () => {
-          assert.ok(Array.isArray(request.app.remoteAddressChain))
-          assert.equal(request.app.remoteAddressChain.length, 2)
-          assert.equal(request.app.remoteAddressChain[0], '63.245.221.32')
-          assert.equal(request.app.remoteAddressChain[1], request.app.remoteAddressChain[0])
-        })
-
-        it('parsed client address correctly', () => {
-          assert.equal(request.app.clientAddress, '63.245.221.32')
-        })
-
-        it('parsed accept-language correctly', () => {
-          assert.equal(request.app.acceptLanguage, 'fr-CH, fr;q=0.9, en-GB, en;q=0.5')
-        })
-
-        it('parsed locale correctly', () => {
-          assert.equal(translator.getLocale.callCount, 0)
-          assert.equal(request.app.locale, 'en')
-          assert.equal(translator.getLocale.callCount, 1)
-        })
-
-        it('parsed user agent correctly', () => {
-          assert.ok(request.app.ua)
-          assert.equal(request.app.ua.browser, 'Firefox')
-          assert.equal(request.app.ua.browserVersion, '57')
-          assert.equal(request.app.ua.os, 'Mac OS X')
-          assert.equal(request.app.ua.osVersion, '10.11')
-          assert.equal(request.app.ua.deviceType, null)
-          assert.equal(request.app.ua.formFactor, null)
-        })
-
-        it('parsed location correctly', () => {
-          assert.ok(request.app.geo)
-          assert.equal(typeof request.app.geo.then, 'function')
-          return request.app.geo.then(geo => {
-            assert.ok(geo)
-            assert.equal(geo.location.city, 'Mountain View')
-            assert.equal(geo.location.country, 'United States')
-            assert.equal(geo.location.countryCode, 'US')
-            assert.equal(geo.location.state, 'California')
-            assert.equal(geo.location.stateCode, 'CA')
-            assert.equal(geo.timeZone, 'America/Los_Angeles')
-          })
-        })
-
-        it('fetched devices correctly', () => {
-          assert.ok(request.app.devices)
-          assert.equal(typeof request.app.devices.then, 'function')
-          assert.equal(db.devices.callCount, 1)
-          assert.equal(db.devices.args[0].length, 1)
-          assert.equal(db.devices.args[0][0], 'fake uid')
-          return request.app.devices.then(devices => {
-            assert.deepEqual(devices, [ { id: 'fake device id' } ])
-          })
-        })
-
-        describe('successful request, unauthenticated, uid in payload:', () => {
-          let secondRequest
+        describe('successful request, authenticated, acceptable locale, signinCodes feature enabled:', () => {
+          let request
 
           beforeEach(() => {
             response = 'ok'
-            locale = 'fr'
             return instance.inject({
+              credentials: {
+                uid: 'fake uid'
+              },
               headers: {
                 'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
-                'user-agent': 'Firefox-Android-FxAccounts/34.0a1 (Nightly)',
-                'x-forwarded-for': ' 194.12.187.0 , 194.12.187.1 '
+                'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:57.0) Gecko/20100101 Firefox/57.0',
+                'x-forwarded-for': '63.245.221.32'
               },
               method: 'POST',
               url: '/account/create',
               payload: {
-                features: [ 'signinCodes' ],
-                uid: 'another fake uid'
+                features: [ 'signinCodes' ]
               },
               remoteAddress: '63.245.221.32'
-            }).then(response => secondRequest = response.request)
+            }).then(response => request = response.request)
           })
 
-          it('second request has its own remote address chain', () => {
-            assert.notEqual(request, secondRequest)
-            assert.notEqual(request.app.remoteAddressChain, secondRequest.app.remoteAddressChain)
-            assert.equal(secondRequest.app.remoteAddressChain.length, 3)
-            assert.equal(secondRequest.app.remoteAddressChain[0], '194.12.187.0')
-            assert.equal(secondRequest.app.remoteAddressChain[1], '194.12.187.1')
-            assert.equal(secondRequest.app.remoteAddressChain[2], '63.245.221.32')
+          it('called log.begin correctly', () => {
+            assert.equal(log.begin.callCount, 1)
+            const args = log.begin.args[0]
+            assert.equal(args.length, 2)
+            assert.equal(args[0], 'server.onRequest')
+            assert.ok(args[1])
+            assert.equal(args[1].path, '/account/create')
+            assert.equal(args[1].app.locale, 'en')
           })
 
-          it('second request has its own client address', () => {
-            assert.equal(secondRequest.app.clientAddress, '63.245.221.32')
+          it('called log.summary correctly', () => {
+            assert.equal(log.summary.callCount, 1)
+            const args = log.summary.args[0]
+            assert.equal(args.length, 2)
+            assert.equal(args[0], log.begin.args[0][1])
+            assert.ok(args[1])
+            assert.equal(args[1].isBoom, undefined)
+            assert.equal(args[1].errno, undefined)
+            assert.equal(args[1].statusCode, 200)
+            assert.equal(args[1].source, 'ok')
           })
 
-          it('second request has its own accept-language', () => {
-            assert.equal(secondRequest.app.acceptLanguage, 'fr-CH, fr;q=0.9, en-GB, en;q=0.5')
+          it('did not call log.error', () => {
+            assert.equal(log.error.callCount, 0)
           })
 
-          it('second request has its own locale', () => {
+          it('parsed features correctly', () => {
+            assert.ok(request.app.features)
+            assert.equal(typeof request.app.features.has, 'function')
+            assert.equal(request.app.features.has('signinCodes'), true)
+          })
+
+          it('parsed remote address chain correctly', () => {
+            assert.ok(Array.isArray(request.app.remoteAddressChain))
+            assert.equal(request.app.remoteAddressChain.length, 2)
+            assert.equal(request.app.remoteAddressChain[0], '63.245.221.32')
+            assert.equal(request.app.remoteAddressChain[1], request.app.remoteAddressChain[0])
+          })
+
+          it('parsed client address correctly', () => {
+            assert.equal(request.app.clientAddress, '63.245.221.32')
+          })
+
+          it('parsed accept-language correctly', () => {
+            assert.equal(request.app.acceptLanguage, 'fr-CH, fr;q=0.9, en-GB, en;q=0.5')
+          })
+
+          it('parsed locale correctly', () => {
             assert.equal(translator.getLocale.callCount, 0)
-            assert.equal(secondRequest.app.locale, 'fr')
+            assert.equal(request.app.locale, 'en')
             assert.equal(translator.getLocale.callCount, 1)
           })
 
-          it('second request has its own user agent info', () => {
-            assert.notEqual(request.app.ua, secondRequest.app.ua)
-            assert.equal(secondRequest.app.ua.browser, 'Nightly')
-            assert.equal(secondRequest.app.ua.browserVersion, '34.0a1')
-            assert.equal(secondRequest.app.ua.os, 'Android')
-            assert.equal(secondRequest.app.ua.osVersion, null)
-            assert.equal(secondRequest.app.ua.deviceType, 'mobile')
-            assert.equal(secondRequest.app.ua.formFactor, null)
+          it('parsed user agent correctly', () => {
+            assert.ok(request.app.ua)
+            assert.equal(request.app.ua.browser, 'Firefox')
+            assert.equal(request.app.ua.browserVersion, '57')
+            assert.equal(request.app.ua.os, 'Mac OS X')
+            assert.equal(request.app.ua.osVersion, '10.11')
+            assert.equal(request.app.ua.deviceType, null)
+            assert.equal(request.app.ua.formFactor, null)
           })
 
-          it('second request has its own location info', () => {
-            assert.notEqual(request.app.geo, secondRequest.app.geo)
-            return secondRequest.app.geo.then(geo => {
+          it('parsed location correctly', () => {
+            assert.ok(request.app.geo)
+            assert.equal(typeof request.app.geo.then, 'function')
+            return request.app.geo.then(geo => {
+              assert.ok(geo)
               assert.equal(geo.location.city, 'Mountain View')
               assert.equal(geo.location.country, 'United States')
               assert.equal(geo.location.countryCode, 'US')
@@ -274,120 +204,275 @@ describe('lib/server', () => {
             })
           })
 
-          it('second request fetched devices correctly', () => {
-            assert.notEqual(request.app.devices, secondRequest.app.devices)
-            assert.equal(db.devices.callCount, 2)
-            assert.equal(db.devices.args[1].length, 1)
-            assert.equal(db.devices.args[1][0], 'another fake uid')
+          it('fetched devices correctly', () => {
+            assert.ok(request.app.devices)
+            assert.equal(typeof request.app.devices.then, 'function')
+            assert.equal(db.devices.callCount, 1)
+            assert.equal(db.devices.args[0].length, 1)
+            assert.equal(db.devices.args[0][0], 'fake uid')
             return request.app.devices.then(devices => {
               assert.deepEqual(devices, [ { id: 'fake device id' } ])
             })
           })
-        })
-      })
 
-      describe('successful request, unacceptable locale, no features enabled:', () => {
-        let request
+          describe('successful request, unauthenticated, uid in payload:', () => {
+            let secondRequest
 
-        beforeEach(() => {
-          response = 'ok'
-          return instance.inject({
-            headers: {
-              'accept-language': 'fr-CH, fr;q=0.9',
-              'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1'
-            },
-            method: 'POST',
-            url: '/account/create',
-            payload: {}
-          }).then(response => request = response.request)
-        })
+            beforeEach(() => {
+              response = 'ok'
+              locale = 'fr'
+              return instance.inject({
+                headers: {
+                  'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
+                  'user-agent': 'Firefox-Android-FxAccounts/34.0a1 (Nightly)',
+                  'x-forwarded-for': ' 194.12.187.0 , 194.12.187.1 '
+                },
+                method: 'POST',
+                url: '/account/create',
+                payload: {
+                  features: [ 'signinCodes' ],
+                  uid: 'another fake uid'
+                },
+                remoteAddress: '63.245.221.32'
+              }).then(response => secondRequest = response.request)
+            })
 
-        it('called log.begin correctly', () => {
-          assert.equal(log.begin.callCount, 1)
-          const args = log.begin.args[0]
-          assert.equal(args[1].app.locale, 'en')
-          assert.equal(args[1].app.ua.browser, 'Chrome Mobile iOS')
-          assert.equal(args[1].app.ua.browserVersion, '56')
-          assert.equal(args[1].app.ua.os, 'iOS')
-          assert.equal(args[1].app.ua.osVersion, '10.3')
-          assert.equal(args[1].app.ua.deviceType, 'mobile')
-          assert.equal(args[1].app.ua.formFactor, 'iPhone')
-        })
+            it('second request has its own remote address chain', () => {
+              assert.notEqual(request, secondRequest)
+              assert.notEqual(request.app.remoteAddressChain, secondRequest.app.remoteAddressChain)
+              assert.equal(secondRequest.app.remoteAddressChain.length, 3)
+              assert.equal(secondRequest.app.remoteAddressChain[0], '194.12.187.0')
+              assert.equal(secondRequest.app.remoteAddressChain[1], '194.12.187.1')
+              assert.equal(secondRequest.app.remoteAddressChain[2], '63.245.221.32')
+            })
 
-        it('called log.summary once', () => {
-          assert.equal(log.summary.callCount, 1)
-        })
+            it('second request has its own client address', () => {
+              assert.equal(secondRequest.app.clientAddress, '63.245.221.32')
+            })
 
-        it('did not call log.error', () => {
-          assert.equal(log.error.callCount, 0)
-        })
+            it('second request has its own accept-language', () => {
+              assert.equal(secondRequest.app.acceptLanguage, 'fr-CH, fr;q=0.9, en-GB, en;q=0.5')
+            })
 
-        it('parsed features correctly', () => {
-          assert.ok(request.app.features)
-          assert.equal(request.app.features.has('signinCodes'), false)
-        })
-      })
+            it('second request has its own locale', () => {
+              assert.equal(translator.getLocale.callCount, 0)
+              assert.equal(secondRequest.app.locale, 'fr')
+              assert.equal(translator.getLocale.callCount, 1)
+            })
 
-      describe('unsuccessful request:', () => {
-        beforeEach(() => {
-          response = error.requestBlocked()
-          return instance.inject({
-            method: 'POST',
-            url: '/account/create',
-            payload: {}
-          }).catch(() => {})
-        })
+            it('second request has its own user agent info', () => {
+              assert.notEqual(request.app.ua, secondRequest.app.ua)
+              assert.equal(secondRequest.app.ua.browser, 'Nightly')
+              assert.equal(secondRequest.app.ua.browserVersion, '34.0a1')
+              assert.equal(secondRequest.app.ua.os, 'Android')
+              assert.equal(secondRequest.app.ua.osVersion, null)
+              assert.equal(secondRequest.app.ua.deviceType, 'mobile')
+              assert.equal(secondRequest.app.ua.formFactor, null)
+            })
 
-        it('called log.begin', () => {
-          assert.equal(log.begin.callCount, 1)
-        })
+            it('second request has its own location info', () => {
+              assert.notEqual(request.app.geo, secondRequest.app.geo)
+              return secondRequest.app.geo.then(geo => {
+                assert.equal(geo.location.city, 'Mountain View')
+                assert.equal(geo.location.country, 'United States')
+                assert.equal(geo.location.countryCode, 'US')
+                assert.equal(geo.location.state, 'California')
+                assert.equal(geo.location.stateCode, 'CA')
+                assert.equal(geo.timeZone, 'America/Los_Angeles')
+              })
+            })
 
-        it('called log.summary correctly', () => {
-          assert.equal(log.summary.callCount, 1)
-          const args = log.summary.args[0]
-          assert.equal(args.length, 2)
-          assert.equal(args[0], log.begin.args[0][1])
-          assert.ok(args[1])
-          assert.equal(args[1].statusCode, undefined)
-          assert.equal(args[1].source, undefined)
-          assert.equal(args[1].isBoom, true)
-          assert.equal(args[1].message, 'The request was blocked for security reasons')
-          assert.equal(args[1].errno, 125)
-        })
-
-        it('did not call log.error', () => {
-          assert.equal(log.error.callCount, 0)
-        })
-      })
-
-      describe('unsuccessful request, db error:', () => {
-        beforeEach(() => {
-          response = new EndpointError('request failed', { reason: 'because i said so' })
-          return instance.inject({
-            method: 'POST',
-            url: '/account/create',
-            payload: {}
-          }).catch(() => {})
-        })
-
-        it('called log.begin', () => {
-          assert.equal(log.begin.callCount, 1)
-        })
-
-        it('called log.summary', () => {
-          assert.equal(log.summary.callCount, 1)
-        })
-
-        it('called log.error correctly', () => {
-          assert.equal(log.error.callCount, 1)
-          const args = log.error.args[0]
-          assert.equal(args.length, 1)
-          assert.deepEqual(args[0], {
-            op: 'server.EndpointError',
-            message: 'request failed',
-            reason: 'because i said so'
+            it('second request fetched devices correctly', () => {
+              assert.notEqual(request.app.devices, secondRequest.app.devices)
+              assert.equal(db.devices.callCount, 2)
+              assert.equal(db.devices.args[1].length, 1)
+              assert.equal(db.devices.args[1][0], 'another fake uid')
+              return request.app.devices.then(devices => {
+                assert.deepEqual(devices, [ { id: 'fake device id' } ])
+              })
+            })
           })
         })
+
+        describe('successful request, unacceptable locale, no features enabled:', () => {
+          let request
+
+          beforeEach(() => {
+            response = 'ok'
+            return instance.inject({
+              headers: {
+                'accept-language': 'fr-CH, fr;q=0.9',
+                'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1'
+              },
+              method: 'POST',
+              url: '/account/create',
+              payload: {}
+            }).then(response => request = response.request)
+          })
+
+          it('called log.begin correctly', () => {
+            assert.equal(log.begin.callCount, 1)
+            const args = log.begin.args[0]
+            assert.equal(args[1].app.locale, 'en')
+            assert.equal(args[1].app.ua.browser, 'Chrome Mobile iOS')
+            assert.equal(args[1].app.ua.browserVersion, '56')
+            assert.equal(args[1].app.ua.os, 'iOS')
+            assert.equal(args[1].app.ua.osVersion, '10.3')
+            assert.equal(args[1].app.ua.deviceType, 'mobile')
+            assert.equal(args[1].app.ua.formFactor, 'iPhone')
+          })
+
+          it('called log.summary once', () => {
+            assert.equal(log.summary.callCount, 1)
+          })
+
+          it('did not call log.error', () => {
+            assert.equal(log.error.callCount, 0)
+          })
+
+          it('parsed features correctly', () => {
+            assert.ok(request.app.features)
+            assert.equal(request.app.features.has('signinCodes'), false)
+          })
+        })
+
+        describe('unsuccessful request:', () => {
+          beforeEach(() => {
+            response = error.requestBlocked()
+            return instance.inject({
+              method: 'POST',
+              url: '/account/create',
+              payload: {}
+            }).catch(() => {})
+          })
+
+          it('called log.begin', () => {
+            assert.equal(log.begin.callCount, 1)
+          })
+
+          it('called log.summary correctly', () => {
+            assert.equal(log.summary.callCount, 1)
+            const args = log.summary.args[0]
+            assert.equal(args.length, 2)
+            assert.equal(args[0], log.begin.args[0][1])
+            assert.ok(args[1])
+            assert.equal(args[1].statusCode, undefined)
+            assert.equal(args[1].source, undefined)
+            assert.equal(args[1].isBoom, true)
+            assert.equal(args[1].message, 'The request was blocked for security reasons')
+            assert.equal(args[1].errno, 125)
+          })
+
+          it('did not call log.error', () => {
+            assert.equal(log.error.callCount, 0)
+          })
+        })
+
+        describe('unsuccessful request, db error:', () => {
+          beforeEach(() => {
+            response = new EndpointError('request failed', { reason: 'because i said so' })
+            return instance.inject({
+              method: 'POST',
+              url: '/account/create',
+              payload: {}
+            }).catch(() => {})
+          })
+
+          it('called log.begin', () => {
+            assert.equal(log.begin.callCount, 1)
+          })
+
+          it('called log.summary', () => {
+            assert.equal(log.summary.callCount, 1)
+          })
+
+          it('called log.error correctly', () => {
+            assert.equal(log.error.callCount, 1)
+            const args = log.error.args[0]
+            assert.equal(args.length, 1)
+            assert.deepEqual(args[0], {
+              op: 'server.EndpointError',
+              message: 'request failed',
+              reason: 'because i said so'
+            })
+          })
+        })
+
+        describe('authenticated request, session token not expired:', () => {
+          beforeEach(() => {
+            response = 'ok'
+            const auth = hawk.client.header(`${config.publicUrl}account/status`, 'GET', {
+              credentials: {
+                id: 'deadbeef',
+                key: 'baadf00d',
+                algorithm: 'sha256'
+              }
+            })
+            return instance.inject({
+              headers: {
+                authorization: auth.field
+              },
+              method: 'GET',
+              url: '/account/status'
+            })
+          })
+
+          it('called db.sessionToken correctly', () => {
+            assert.equal(db.sessionToken.callCount, 1)
+            const args = db.sessionToken.args[0]
+            assert.equal(args.length, 1)
+            assert.equal(args[0], 'deadbeef')
+          })
+
+          it('did not call db.pruneSessionToken', () => {
+            assert.equal(db.pruneSessionToken.callCount, 0)
+          })
+        })
+      })
+    })
+
+    describe('authenticated request, session token expired:', () => {
+      let db, instance
+
+      beforeEach(() => {
+        response = 'ok'
+        db = mocks.mockDB({
+          sessionTokenId: 'wibble',
+          uid: 'blee',
+          expired: true
+        })
+        instance = server.create(log, error, config, routes, db, translator, Token)
+        return instance.start()
+          .then(() => {
+            const auth = hawk.client.header(`${config.publicUrl}account/status`, 'GET', {
+              credentials: {
+                id: 'deadbeef',
+                key: 'baadf00d',
+                algorithm: 'sha256'
+              }
+            })
+            return instance.inject({
+              headers: {
+                authorization: auth.field
+              },
+              method: 'GET',
+              url: '/account/status'
+            })
+          })
+      })
+
+      afterEach(() => instance.stop())
+
+      it('called db.sessionToken', () => {
+        assert.equal(db.sessionToken.callCount, 1)
+      })
+
+      it('called db.pruneSessionToken correctly', () => {
+        assert.equal(db.pruneSessionToken.callCount, 1)
+        const args = db.pruneSessionToken.args[0]
+        assert.equal(args.length, 1)
+        assert.equal(args[0].id, 'wibble')
+        assert.equal(args[0].uid, 'blee')
       })
     })
 
@@ -396,6 +481,19 @@ describe('lib/server', () => {
         {
           path: '/account/create',
           method: 'POST',
+          handler (request, reply) {
+            return reply(response)
+          }
+        },
+        {
+          path: '/account/status',
+          method: 'GET',
+          config: {
+            auth: {
+              mode: 'required',
+              strategy: 'sessionToken'
+            }
+          },
           handler (request, reply) {
             return reply(response)
           }

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -424,8 +424,8 @@ describe('lib/server', () => {
             assert.equal(args[0], 'deadbeef')
           })
 
-          it('did not call db.pruneSessionToken', () => {
-            assert.equal(db.pruneSessionToken.callCount, 0)
+          it('did not call db.pruneSessionTokens', () => {
+            assert.equal(db.pruneSessionTokens.callCount, 0)
           })
         })
       })
@@ -467,12 +467,14 @@ describe('lib/server', () => {
         assert.equal(db.sessionToken.callCount, 1)
       })
 
-      it('called db.pruneSessionToken correctly', () => {
-        assert.equal(db.pruneSessionToken.callCount, 1)
-        const args = db.pruneSessionToken.args[0]
-        assert.equal(args.length, 1)
-        assert.equal(args[0].id, 'wibble')
-        assert.equal(args[0].uid, 'blee')
+      it('called db.pruneSessionTokens correctly', () => {
+        assert.equal(db.pruneSessionTokens.callCount, 1)
+        const args = db.pruneSessionTokens.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(args[0], 'blee')
+        assert.ok(Array.isArray(args[1]))
+        assert.equal(args[1].length, 1)
+        assert.equal(args[1][0].id, 'wibble')
       })
     })
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -58,7 +58,7 @@ const DB_METHOD_NAMES = [
   'keyFetchTokenWithVerificationStatus',
   'passwordChangeToken',
   'passwordForgotToken',
-  'pruneSessionToken',
+  'pruneSessionTokens',
   'resetAccount',
   'resetAccountTokens',
   'securityEvent',

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -58,6 +58,7 @@ const DB_METHOD_NAMES = [
   'keyFetchTokenWithVerificationStatus',
   'passwordChangeToken',
   'passwordForgotToken',
+  'pruneSessionToken',
   'resetAccount',
   'resetAccountTokens',
   'securityEvent',
@@ -324,13 +325,17 @@ function mockDB (data, errors) {
       return P.resolve(device)
     }),
     sessionToken: sinon.spy(() => {
-      var res = {
+      const res = {
+        id: data.sessionTokenId || 'fake session token id',
+        uid: data.uid || 'fake uid',
         tokenVerified: true,
         uaBrowser: data.uaBrowser,
         uaBrowserVersion: data.uaBrowserVersion,
         uaOS: data.uaOS,
         uaOSVersion: data.uaOSVersion,
-        uaDeviceType: data.uaDeviceType
+        uaDeviceType: data.uaDeviceType,
+        tokenTypeID: 'sessionToken',
+        expired: () => data.expired || false
       }
       if (data.devices && data.devices.length > 0) {
         Object.keys(data.devices[0]).forEach(key => {

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -292,7 +292,7 @@ describe('remote db', function() {
 
           // Attempt to prune a session token that is younger than maxAge
           sessionToken.createdAt = Date.now() - tokenPruning.maxAge + 10000
-          return db.pruneSessionToken(sessionToken)
+          return db.pruneSessionTokens(account.uid, [ sessionToken ])
         })
         .then(() => {
           // Fetch all sessions for the account
@@ -313,7 +313,7 @@ describe('remote db', function() {
         .then(sessionToken => {
           // Prune a session token that is older than maxAge
           sessionToken.createdAt = Date.now() - tokenPruning.maxAge - 1
-          return db.pruneSessionToken(sessionToken)
+          return db.pruneSessionTokens(account.uid, [ sessionToken ])
         })
         .then(() => {
           // Fetch all sessions for the account

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -27,11 +27,16 @@ const Token = require('../../lib/tokens')(log, {
   }
 })
 
+const tokenPruning = {
+  enabled: true,
+  maxAge: 1000 * 60 * 60
+}
 const DB = require('../../lib/db')({
   lastAccessTimeUpdates,
   signinCodeSize: config.signinCodeSize,
   redis: Object.assign({}, config.redis, { enabled: true }),
-  tokenLifetimes: {}
+  tokenLifetimes: {},
+  tokenPruning
 }, log, Token, UnblockCode)
 
 const redis = require('redis').createClient({
@@ -259,7 +264,7 @@ describe('remote db', function() {
             uaFormFactor: null
           }), P.reject())
         })
-        .then(tokens => {
+        .then(() => {
           // Fetch all sessions for the account
           return db.sessions(account.uid)
         })
@@ -285,6 +290,48 @@ describe('remote db', function() {
           assert.equal(sessionToken.uaOSVersion, '10.10')
           assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt)
 
+          // Attempt to prune a session token that is younger than maxAge
+          sessionToken.createdAt = Date.now() - tokenPruning.maxAge + 10000
+          return db.pruneSessionToken(sessionToken)
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid)
+        })
+        .then(sessions => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item')
+          assert.equal(sessions[0].uaBrowser, 'Firefox Mobile', 'uaBrowser property is correct')
+          assert.equal(sessions[0].uaBrowserVersion, '42', 'uaBrowserVersion property is correct')
+          assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct')
+          assert.equal(sessions[0].uaOSVersion, '4.4', 'uaOSVersion property is correct')
+          assert.equal(sessions[0].uaDeviceType, 'mobile', 'uaDeviceType property is correct')
+          assert.equal(sessions[0].uaFormFactor, null, 'uaFormFactor property is correct')
+
+          // Fetch the session token
+          return db.sessionToken(tokenId)
+        })
+        .then(sessionToken => {
+          // Prune a session token that is older than maxAge
+          sessionToken.createdAt = Date.now() - tokenPruning.maxAge - 1
+          return db.pruneSessionToken(sessionToken)
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid)
+        })
+        .then(sessions => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item')
+          assert.equal(sessions[0].uaBrowser, 'Firefox', 'uaBrowser property is the original value')
+          assert.equal(sessions[0].uaBrowserVersion, '41', 'uaBrowserVersion property is the original value')
+          assert.equal(sessions[0].uaOS, 'Mac OS X', 'uaOS property is the original value')
+          assert.equal(sessions[0].uaOSVersion, '10.10', 'uaOSVersion property is the original value')
+          assert.equal(sessions[0].uaDeviceType, null, 'uaDeviceType property is the original value')
+          assert.equal(sessions[0].uaFormFactor, null, 'uaFormFactor property is the original value')
+
+          // Fetch the session token
+          return db.sessionToken(tokenId)
+        })
+        .then(sessionToken => {
           // Delete the session token
           return db.deleteSessionToken(sessionToken)
         })


### PR DESCRIPTION
Optimistically fixes #2223.

I say "optimistically" because we're limited by my decision to remove `createdAt` from Redis-stored tokens back in #2235. Because of that change, we need the proper session token object from MySQL in order to make a decision about pruning. But of course, many session tokens were already pruned from MySQL so we don't know what their `createdAt` was and can't prune them. Fixing that properly would require us to speculatively read from MySQL for every token in Redis, which is obviously not practical given the size of our database.

Instead, the approach I've taken here is to conditionally prune tokens from Redis whenever we encounter an expired session token object from MySQL. There are two places where that can happen: the authentication hook in `lib/server.js` and when returning the session token array from `db.sessions`. (remember that `db.devices` is no use because we never expire session tokens that have a device record)

This seems like the best option to me. Even if we were to reintroduce `createdAt` to Redis now, we'd still never be able to prune all of the older tokens. Here we get the same result but we don't pay to store the extra field in Redis.

The last commit in this changeset may be contentious, so I've left it out on it's own: d8ec9f5. It reduces the default maximum age a token must be to qualify for pruning, from 3 months to a month. 3 months would have matched the setting we use for MySQL, but I think that's worse because there's a finite window in which we can prune tokens from Redis, which is only until they've been pruned from MySQL. Reducing `maxAge` increases the length of that window. And the reasons for the increased `maxAge` in the MySQL pruning don't apply here, I think.

If you want to test this out locally, you need to run against the MySQL back-end and use workbench to manually edit the value of `createdAt` for the token(s) you want to prune. Then you can use [`redis-commander`](https://github.com/joeferner/redis-commander) (or whatever) to verify that the token was actually pruned.

@mozilla/fxa-devs r?