### PR TITLE
fix(bounce): Update bounces lib to use `accountRecord`

### DIFF
--- a/lib/email/bounces.js
+++ b/lib/email/bounces.js
@@ -22,7 +22,7 @@ module.exports = function (log, error) {
     }
 
     function findEmailRecord(email) {
-      return db.emailRecord(email)
+      return db.accountRecord(email)
     }
 
     function recordBounce(bounce) {

--- a/test/local/email/bounce.js
+++ b/test/local/email/bounce.js
@@ -70,9 +70,11 @@ describe('bounce messages', () => {
     'should handle multiple recipients in turn',
     () => {
       const log = mockLog()
+
+
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -95,10 +97,10 @@ describe('bounce messages', () => {
       })
       return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
         assert.equal(mockDB.createEmailBounce.callCount, 2)
-        assert.equal(mockDB.emailRecord.callCount, 2)
+        assert.equal(mockDB.accountRecord.callCount, 2)
         assert.equal(mockDB.deleteAccount.callCount, 2)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
         assert.equal(log.info.callCount, 6)
         assert.equal(log.info.args[5][0].op, 'accountDeleted')
         assert.equal(log.info.args[5][0].email, 'foobar@example.com')
@@ -113,7 +115,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -139,10 +141,10 @@ describe('bounce messages', () => {
         assert.equal(mockDB.createEmailBounce.callCount, 2)
         assert.equal(mockDB.createEmailBounce.args[0][0].bounceType, 'Complaint')
         assert.equal(mockDB.createEmailBounce.args[0][0].bounceSubType, complaintType)
-        assert.equal(mockDB.emailRecord.callCount, 2)
+        assert.equal(mockDB.accountRecord.callCount, 2)
         assert.equal(mockDB.deleteAccount.callCount, 2)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.emailRecord.args[1][0], 'foobar@example.com')
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
         assert.equal(log.info.callCount, 6)
         assert.equal(log.info.args[0][0].op, 'emailEvent')
         assert.equal(log.info.args[0][0].domain, 'other')
@@ -160,7 +162,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -181,9 +183,9 @@ describe('bounce messages', () => {
           ]
         }
       })).then(function () {
-        assert.equal(mockDB.emailRecord.callCount, 2)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.emailRecord.args[1][0], 'verified@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 2)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.args[1][0], 'verified@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
         assert.equal(log.info.callCount, 5)
@@ -208,7 +210,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.reject(new error({}))
         })
       }
@@ -221,8 +223,8 @@ describe('bounce messages', () => {
         }
       })
       return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
         assert.equal(log.info.callCount, 2)
         assert.equal(log.info.args[1][0].op, 'handleBounce')
         assert.equal(log.info.args[1][0].email, 'test@example.com')
@@ -240,7 +242,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -260,8 +262,8 @@ describe('bounce messages', () => {
         }
       })
       return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
         assert.equal(log.info.callCount, 2)
@@ -282,7 +284,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           // Lookup only succeeds when using original, unquoted email addr.
           if (email !== 'test.@example.com') {
             return P.reject(new error.unknownAccount(email))
@@ -309,8 +311,8 @@ describe('bounce messages', () => {
       })).then(function () {
         assert.equal(mockDB.createEmailBounce.callCount, 1)
         assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test.@example.com')
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test.@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test.@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test.@example.com')
       })
@@ -323,7 +325,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           // Lookup only succeeds when using original, unquoted email addr.
           if (email !== 'test..me@example.com') {
             return P.reject(new error.unknownAccount(email))
@@ -350,8 +352,8 @@ describe('bounce messages', () => {
       })).then(function () {
         assert.equal(mockDB.createEmailBounce.callCount, 1)
         assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test..me@example.com')
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test..me@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test..me@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test..me@example.com')
       })
@@ -364,7 +366,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function () {
+        accountRecord: sinon.spy(function () {
           return P.reject(new error.unknownAccount())
         }),
         deleteAccount: sinon.spy(function (record) {
@@ -380,7 +382,7 @@ describe('bounce messages', () => {
         }
       })).then(function () {
         assert.equal(mockDB.createEmailBounce.callCount, 0)
-        assert.equal(mockDB.emailRecord.callCount, 0)
+        assert.equal(mockDB.accountRecord.callCount, 0)
         assert.equal(mockDB.deleteAccount.callCount, 0)
         assert.equal(log.warn.callCount, 2)
         assert.equal(log.warn.args[1][0].op, 'handleBounce.addressParseFailure')
@@ -394,7 +396,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -428,8 +430,8 @@ describe('bounce messages', () => {
       })
 
       return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
         assert.equal(log.info.callCount, 3)
@@ -449,7 +451,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,
@@ -491,8 +493,8 @@ describe('bounce messages', () => {
       })
 
       return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.emailRecord.callCount, 1)
-        assert.equal(mockDB.emailRecord.args[0][0], 'test@example.com')
+        assert.equal(mockDB.accountRecord.callCount, 1)
+        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
         assert.equal(mockDB.deleteAccount.callCount, 1)
         assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
         assert.equal(log.flowEvent.callCount, 1)
@@ -515,7 +517,7 @@ describe('bounce messages', () => {
       const log = mockLog()
       var mockDB = {
         createEmailBounce: sinon.spy(() => P.resolve({})),
-        emailRecord: sinon.spy(function (email) {
+        accountRecord: sinon.spy(function (email) {
           return P.resolve({
             uid: '123456',
             email: email,

--- a/test/local/email/bounce.js
+++ b/test/local/email/bounce.js
@@ -14,7 +14,7 @@ const { mockLog } = require('../../mocks')
 const P = require(`${ROOT_DIR}/lib/promise`)
 const sinon = require('sinon')
 
-var mockBounceQueue = new EventEmitter()
+const mockBounceQueue = new EventEmitter()
 mockBounceQueue.start = function start() {}
 
 function mockMessage(msg) {
@@ -28,19 +28,33 @@ function mockedBounces(log, db) {
 }
 
 describe('bounce messages', () => {
+  let log, mockDB
+  beforeEach(() => {
+    log = mockLog()
+    mockDB = {
+      createEmailBounce: sinon.spy(() =>P.resolve({})),
+      accountRecord: sinon.spy((email) => {
+        return P.resolve({
+          uid: '123456',
+          email: email,
+          emailVerified: false
+        })
+      }),
+      deleteAccount: sinon.spy(() => P.resolve({}))
+    }
+  })
+
   afterEach(() => {
     mockBounceQueue.removeAllListeners()
   })
 
   it('should not log an error for headers', () => {
-    const log = mockLog()
     return mockedBounces(log, {})
       .handleBounce(mockMessage({ junk: 'message' }))
       .then(() => assert.equal(log.error.callCount, 0))
   })
 
   it('should log an error for missing headers', () => {
-    const log = mockLog()
     const message = mockMessage({
       junk: 'message'
     })
@@ -50,530 +64,372 @@ describe('bounce messages', () => {
       .then(() => assert.equal(log.error.callCount, 1))
   })
 
-  it(
-    'should ignore unknown message types',
-    () => {
-      const log = mockLog()
-      var mockDB = {}
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        junk: 'message'
-      })).then(function () {
-        assert.equal(log.info.callCount, 0)
-        assert.equal(log.error.callCount, 0)
-        assert.equal(log.warn.callCount, 1)
-        assert.equal(log.warn.args[0][0].op, 'emailHeaders.keys')
-      })
-    }
-  )
+  it('should ignore unknown message types', () => {
+    return mockedBounces(log, {}).handleBounce(mockMessage({
+      junk: 'message'
+    })).then(() =>  {
+      assert.equal(log.info.callCount, 0)
+      assert.equal(log.error.callCount, 0)
+      assert.equal(log.warn.callCount, 1)
+      assert.equal(log.warn.args[0][0].op, 'emailHeaders.keys')
+    })
+  })
 
-  it(
-    'should handle multiple recipients in turn',
-    () => {
-      const log = mockLog()
-
-
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+  it('should handle multiple recipients in turn', () => {
+    const bounceType = 'Permanent'
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: bounceType,
+        bouncedRecipients: [
+          {emailAddress: 'test@example.com'},
+          {emailAddress: 'foobar@example.com'}
+        ]
       }
-      const bounceType = 'Permanent'
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: bounceType,
-          bouncedRecipients: [
-            { emailAddress: 'test@example.com' },
-            { emailAddress: 'foobar@example.com'}
-          ]
-        }
-      })
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.createEmailBounce.callCount, 2)
-        assert.equal(mockDB.accountRecord.callCount, 2)
-        assert.equal(mockDB.deleteAccount.callCount, 2)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
-        assert.equal(log.info.callCount, 6)
-        assert.equal(log.info.args[5][0].op, 'accountDeleted')
-        assert.equal(log.info.args[5][0].email, 'foobar@example.com')
-        assert.equal(mockMsg.del.callCount, 1)
-      })
-    }
-  )
+    })
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(() =>  {
+      assert.equal(mockDB.createEmailBounce.callCount, 2)
+      assert.equal(mockDB.accountRecord.callCount, 2)
+      assert.equal(mockDB.deleteAccount.callCount, 2)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
+      assert.equal(log.info.callCount, 6)
+      assert.equal(log.info.args[5][0].op, 'accountDeleted')
+      assert.equal(log.info.args[5][0].email, 'foobar@example.com')
+      assert.equal(mockMsg.del.callCount, 1)
+    })
+  })
 
-  it(
-    'should treat complaints like bounces',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+  it('should treat complaints like bounces', () => {
+    const complaintType = 'abuse'
+    return mockedBounces(log, mockDB).handleBounce(mockMessage({
+      complaint: {
+        userAgent: 'AnyCompany Feedback Loop (V0.01)',
+        complaintFeedbackType: complaintType,
+        complainedRecipients: [
+          {emailAddress: 'test@example.com'},
+          {emailAddress: 'foobar@example.com'}
+        ]
       }
-      const complaintType = 'abuse'
+    })).then(() =>  {
+      assert.equal(mockDB.createEmailBounce.callCount, 2)
+      assert.equal(mockDB.createEmailBounce.args[0][0].bounceType, 'Complaint')
+      assert.equal(mockDB.createEmailBounce.args[0][0].bounceSubType, complaintType)
+      assert.equal(mockDB.accountRecord.callCount, 2)
+      assert.equal(mockDB.deleteAccount.callCount, 2)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
+      assert.equal(log.info.callCount, 6)
+      assert.equal(log.info.args[0][0].op, 'emailEvent')
+      assert.equal(log.info.args[0][0].domain, 'other')
+      assert.equal(log.info.args[0][0].type, 'bounced')
+      assert.equal(log.info.args[4][0].complaint, true)
+      assert.equal(log.info.args[4][0].complaintFeedbackType, complaintType)
+      assert.equal(log.info.args[4][0].complaintUserAgent, 'AnyCompany Feedback Loop (V0.01)')
+    })
+  })
 
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        complaint: {
-          userAgent: 'AnyCompany Feedback Loop (V0.01)',
-          complaintFeedbackType: complaintType,
-          complainedRecipients: [
-            { emailAddress: 'test@example.com' },
-            { emailAddress: 'foobar@example.com'}
-          ]
-        }
-      })).then(function () {
-        assert.equal(mockDB.createEmailBounce.callCount, 2)
-        assert.equal(mockDB.createEmailBounce.args[0][0].bounceType, 'Complaint')
-        assert.equal(mockDB.createEmailBounce.args[0][0].bounceSubType, complaintType)
-        assert.equal(mockDB.accountRecord.callCount, 2)
-        assert.equal(mockDB.deleteAccount.callCount, 2)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.accountRecord.args[1][0], 'foobar@example.com')
-        assert.equal(log.info.callCount, 6)
-        assert.equal(log.info.args[0][0].op, 'emailEvent')
-        assert.equal(log.info.args[0][0].domain, 'other')
-        assert.equal(log.info.args[0][0].type, 'bounced')
-        assert.equal(log.info.args[4][0].complaint, true)
-        assert.equal(log.info.args[4][0].complaintFeedbackType, complaintType)
-        assert.equal(log.info.args[4][0].complaintUserAgent, 'AnyCompany Feedback Loop (V0.01)')
+  it('should not delete verified accounts on bounce', () => {
+    mockDB.accountRecord = sinon.spy((email) => {
+      return P.resolve({
+        uid: '123456',
+        email: email,
+        emailVerified: (email === 'verified@example.com')
       })
-    }
-  )
+    })
 
-  it(
-    'should not delete verified accounts on bounce',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: (email === 'verified@example.com')
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+    return mockedBounces(log, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        // docs: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#bounced-recipients
+        bouncedRecipients: [
+          { emailAddress: 'test@example.com', action: 'failed', status: '5.0.0', diagnosticCode: 'smtp; 550 user unknown' },
+          { emailAddress: 'verified@example.com', status: '4.0.0' }
+        ]
       }
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          // docs: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#bounced-recipients
-          bouncedRecipients: [
-            { emailAddress: 'test@example.com', action: 'failed', status: '5.0.0', diagnosticCode: 'smtp; 550 user unknown' },
-            { emailAddress: 'verified@example.com', status: '4.0.0' }
-          ]
-        }
-      })).then(function () {
-        assert.equal(mockDB.accountRecord.callCount, 2)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.accountRecord.args[1][0], 'verified@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(log.info.callCount, 5)
-        assert.equal(log.info.args[1][0].op, 'handleBounce')
-        assert.equal(log.info.args[1][0].email, 'test@example.com')
-        assert.equal(log.info.args[1][0].domain, 'other')
-        assert.equal(log.info.args[1][0].status, '5.0.0')
-        assert.equal(log.info.args[1][0].action, 'failed')
-        assert.equal(log.info.args[1][0].diagnosticCode, 'smtp; 550 user unknown')
-        assert.equal(log.info.args[2][0].op, 'accountDeleted')
-        assert.equal(log.info.args[2][0].email, 'test@example.com')
-        assert.equal(log.info.args[4][0].op, 'handleBounce')
-        assert.equal(log.info.args[4][0].email, 'verified@example.com')
-        assert.equal(log.info.args[4][0].status, '4.0.0')
-      })
-    }
-  )
+    })).then(() =>  {
+      assert.equal(mockDB.accountRecord.callCount, 2)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.accountRecord.args[1][0], 'verified@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      assert.equal(log.info.callCount, 5)
+      assert.equal(log.info.args[1][0].op, 'handleBounce')
+      assert.equal(log.info.args[1][0].email, 'test@example.com')
+      assert.equal(log.info.args[1][0].domain, 'other')
+      assert.equal(log.info.args[1][0].status, '5.0.0')
+      assert.equal(log.info.args[1][0].action, 'failed')
+      assert.equal(log.info.args[1][0].diagnosticCode, 'smtp; 550 user unknown')
+      assert.equal(log.info.args[2][0].op, 'accountDeleted')
+      assert.equal(log.info.args[2][0].email, 'test@example.com')
+      assert.equal(log.info.args[4][0].op, 'handleBounce')
+      assert.equal(log.info.args[4][0].email, 'verified@example.com')
+      assert.equal(log.info.args[4][0].status, '4.0.0')
+    })
+  })
 
-  it(
-    'should log errors when looking up the email record',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.reject(new error({}))
-        })
+  it('should log errors when looking up the email record', () => {
+    mockDB.accountRecord = sinon.spy(() => P.reject(new error({})))
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          {emailAddress: 'test@example.com'},
+        ]
       }
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bouncedRecipients: [
-            { emailAddress: 'test@example.com' },
-          ]
-        }
-      })
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(log.info.callCount, 2)
-        assert.equal(log.info.args[1][0].op, 'handleBounce')
-        assert.equal(log.info.args[1][0].email, 'test@example.com')
-        assert.equal(log.error.callCount, 2)
-        assert.equal(log.error.args[1][0].op, 'databaseError')
-        assert.equal(log.error.args[1][0].email, 'test@example.com')
-        assert.equal(mockMsg.del.callCount, 1)
-      })
-    }
-  )
+    })
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(() =>  {
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(log.info.callCount, 2)
+      assert.equal(log.info.args[1][0].op, 'handleBounce')
+      assert.equal(log.info.args[1][0].email, 'test@example.com')
+      assert.equal(log.error.callCount, 2)
+      assert.equal(log.error.args[1][0].op, 'databaseError')
+      assert.equal(log.error.args[1][0].email, 'test@example.com')
+      assert.equal(mockMsg.del.callCount, 1)
+    })
+  })
 
-  it(
-    'should log errors when deleting the email record',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.reject(new error.unknownAccount('test@example.com'))
-        })
+  it('should log errors when deleting the email record', () => {
+    mockDB.deleteAccount = sinon.spy(() => P.reject(new error.unknownAccount('test@example.com')))
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          {emailAddress: 'test@example.com'},
+        ]
       }
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bouncedRecipients: [
-            { emailAddress: 'test@example.com' },
-          ]
-        }
-      })
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(log.info.callCount, 2)
-        assert.equal(log.info.args[1][0].op, 'handleBounce')
-        assert.equal(log.info.args[1][0].email, 'test@example.com')
-        assert.equal(log.error.callCount, 2)
-        assert.equal(log.error.args[1][0].op, 'databaseError')
-        assert.equal(log.error.args[1][0].email, 'test@example.com')
-        assert.equal(log.error.args[1][0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
-        assert.equal(mockMsg.del.callCount, 1)
-      })
-    }
-  )
+    })
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(() =>  {
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      assert.equal(log.info.callCount, 2)
+      assert.equal(log.info.args[1][0].op, 'handleBounce')
+      assert.equal(log.info.args[1][0].email, 'test@example.com')
+      assert.equal(log.error.callCount, 2)
+      assert.equal(log.error.args[1][0].op, 'databaseError')
+      assert.equal(log.error.args[1][0].email, 'test@example.com')
+      assert.equal(log.error.args[1][0].err.errno, error.ERRNO.ACCOUNT_UNKNOWN)
+      assert.equal(mockMsg.del.callCount, 1)
+    })
+  })
 
-  it(
-    'should normalize quoted email addresses for lookup',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          // Lookup only succeeds when using original, unquoted email addr.
-          if (email !== 'test.@example.com') {
-            return P.reject(new error.unknownAccount(email))
+  it('should normalize quoted email addresses for lookup', () => {
+    mockDB.accountRecord = sinon.spy((email) => {
+      // Lookup only succeeds when using original, unquoted email addr.
+      if (email !== 'test.@example.com') {
+        return P.reject(new error.unknownAccount(email))
+      }
+      return P.resolve({
+        uid: '123456',
+        email: email,
+        emailVerified: false
+      })
+    })
+    return mockedBounces(log, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          // Bounce message has email addr in quoted form, since some
+          // mail agents normalize it in this way.
+          {emailAddress: '"test."@example.com'},
+        ]
+      }
+    })).then(() =>  {
+      assert.equal(mockDB.createEmailBounce.callCount, 1)
+      assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test.@example.com')
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test.@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test.@example.com')
+    })
+  })
+
+  it('should handle multiple consecutive dots even if not quoted', () => {
+    mockDB.accountRecord = sinon.spy((email) => {
+      // Lookup only succeeds when using original, unquoted email addr.
+      if (email !== 'test..me@example.com') {
+        return P.reject(new error.unknownAccount(email))
+      }
+      return P.resolve({
+        uid: '123456',
+        email: email,
+        emailVerified: false
+      })
+    })
+
+    return mockedBounces(log, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          // Some mail agents incorrectly fail to quote addresses that
+          // contain multiple consecutive dots.  Ensure we work around it.
+          {emailAddress: 'test..me@example.com'},
+        ]
+      }
+    })).then(() =>  {
+      assert.equal(mockDB.createEmailBounce.callCount, 1)
+      assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test..me@example.com')
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test..me@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test..me@example.com')
+    })
+  })
+
+  it('should log a warning if it receives an unparseable email address', () => {
+    mockDB.accountRecord = sinon.spy(() => P.reject(new error.unknownAccount()))
+    return mockedBounces(log, mockDB).handleBounce(mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bouncedRecipients: [
+          {emailAddress: 'how did this even happen?'},
+        ]
+      }
+    })).then(() =>  {
+      assert.equal(mockDB.createEmailBounce.callCount, 0)
+      assert.equal(mockDB.accountRecord.callCount, 0)
+      assert.equal(mockDB.deleteAccount.callCount, 0)
+      assert.equal(log.warn.callCount, 2)
+      assert.equal(log.warn.args[1][0].op, 'handleBounce.addressParseFailure')
+    })
+  })
+
+  it('should log email template name, language, and bounceType', () => {
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bounceSubType: 'General',
+        bouncedRecipients: [
+          {emailAddress: 'test@example.com'}
+        ]
+      },
+      mail: {
+        headers: [
+          {
+            name: 'Content-Language',
+            value: 'db-LB'
+          },
+          {
+            name: 'X-Template-Name',
+            value: 'verifyLoginEmail'
           }
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+        ]
       }
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bouncedRecipients: [
-            // Bounce message has email addr in quoted form, since some
-            // mail agents normalize it in this way.
-            { emailAddress: '"test."@example.com' },
-          ]
-        }
-      })).then(function () {
-        assert.equal(mockDB.createEmailBounce.callCount, 1)
-        assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test.@example.com')
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test.@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test.@example.com')
-      })
-    }
-  )
+    })
 
-  it(
-    'should handle multiple consecutive dots even if not quoted',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          // Lookup only succeeds when using original, unquoted email addr.
-          if (email !== 'test..me@example.com') {
-            return P.reject(new error.unknownAccount(email))
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(() =>  {
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      assert.equal(log.info.callCount, 3)
+      assert.equal(log.info.args[1][0].op, 'handleBounce')
+      assert.equal(log.info.args[1][0].email, 'test@example.com')
+      assert.equal(log.info.args[1][0].template, 'verifyLoginEmail')
+      assert.equal(log.info.args[1][0].bounceType, 'Permanent')
+      assert.equal(log.info.args[1][0].bounceSubType, 'General')
+      assert.equal(log.info.args[1][0].lang, 'db-LB')
+    })
+  })
+
+  it('should emit flow metrics', () => {
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bounceSubType: 'General',
+        bouncedRecipients: [
+          {emailAddress: 'test@example.com'}
+        ]
+      },
+      mail: {
+        headers: [
+          {
+            name: 'X-Template-Name',
+            value: 'verifyLoginEmail'
+          },
+          {
+            name: 'X-Flow-Id',
+            value: 'someFlowId'
+          },
+          {
+            name: 'X-Flow-Begin-Time',
+            value: '1234'
+          },
+          {
+            name: 'Content-Language',
+            value: 'en'
           }
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+        ]
       }
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bouncedRecipients: [
-            // Some mail agents incorrectly fail to quote addresses that
-            // contain multiple consecutive dots.  Ensure we work around it.
-            { emailAddress: 'test..me@example.com' },
-          ]
-        }
-      })).then(function () {
-        assert.equal(mockDB.createEmailBounce.callCount, 1)
-        assert.equal(mockDB.createEmailBounce.args[0][0].email, 'test..me@example.com')
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test..me@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test..me@example.com')
-      })
-    }
-  )
+    })
 
-  it(
-    'should log a warning if it receives an unparseable email address',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function () {
-          return P.reject(new error.unknownAccount())
-        }),
-        deleteAccount: sinon.spy(function (record) {
-          return P.resolve({ })
-        })
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
+      assert.equal(mockDB.accountRecord.callCount, 1)
+      assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
+      assert.equal(mockDB.deleteAccount.callCount, 1)
+      assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
+      assert.equal(log.flowEvent.callCount, 1)
+      assert.equal(log.flowEvent.args[0][0].event, 'email.verifyLoginEmail.bounced')
+      assert.equal(log.flowEvent.args[0][0].flow_id, 'someFlowId')
+      assert.equal(log.flowEvent.args[0][0].flow_time > 0, true)
+      assert.equal(log.flowEvent.args[0][0].time > 0, true)
+      assert.equal(log.info.callCount, 3)
+      assert.equal(log.info.args[0][0].op, 'emailEvent')
+      assert.equal(log.info.args[0][0].type, 'bounced')
+      assert.equal(log.info.args[0][0].template, 'verifyLoginEmail')
+      assert.equal(log.info.args[0][0].flow_id, 'someFlowId')
+    })
+  })
+
+  it('should log email domain if popular one', () => {
+    const mockMsg = mockMessage({
+      bounce: {
+        bounceType: 'Permanent',
+        bounceSubType: 'General',
+        bouncedRecipients: [
+          {emailAddress: 'test@aol.com'}
+        ]
+      },
+      mail: {
+        headers: [
+          {
+            name: 'X-Template-Name',
+            value: 'verifyLoginEmail'
+          },
+          {
+            name: 'X-Flow-Id',
+            value: 'someFlowId'
+          },
+          {
+            name: 'X-Flow-Begin-Time',
+            value: '1234'
+          },
+          {
+            name: 'Content-Language',
+            value: 'en'
+          }
+        ]
       }
-      return mockedBounces(log, mockDB).handleBounce(mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bouncedRecipients: [
-            { emailAddress: 'how did this even happen?' },
-          ]
-        }
-      })).then(function () {
-        assert.equal(mockDB.createEmailBounce.callCount, 0)
-        assert.equal(mockDB.accountRecord.callCount, 0)
-        assert.equal(mockDB.deleteAccount.callCount, 0)
-        assert.equal(log.warn.callCount, 2)
-        assert.equal(log.warn.args[1][0].op, 'handleBounce.addressParseFailure')
-      })
-    }
-  )
+    })
 
-  it(
-    'should log email template name, language, and bounceType',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function () {
-          return P.resolve({ })
-        })
-      }
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bounceSubType: 'General',
-          bouncedRecipients: [
-            {emailAddress: 'test@example.com'}
-          ]
-        },
-        mail: {
-          headers: [
-            {
-              name: 'Content-Language',
-              value: 'db-LB'
-            },
-            {
-              name: 'X-Template-Name',
-              value: 'verifyLoginEmail'
-            }
-          ]
-        }
-      })
-
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(log.info.callCount, 3)
-        assert.equal(log.info.args[1][0].op, 'handleBounce')
-        assert.equal(log.info.args[1][0].email, 'test@example.com')
-        assert.equal(log.info.args[1][0].template, 'verifyLoginEmail')
-        assert.equal(log.info.args[1][0].bounceType, 'Permanent')
-        assert.equal(log.info.args[1][0].bounceSubType, 'General')
-        assert.equal(log.info.args[1][0].lang, 'db-LB')
-      })
-    }
-  )
-
-  it(
-    'should emit flow metrics',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function () {
-          return P.resolve({ })
-        })
-      }
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bounceSubType: 'General',
-          bouncedRecipients: [
-            {emailAddress: 'test@example.com'}
-          ]
-        },
-        mail: {
-          headers: [
-            {
-              name: 'X-Template-Name',
-              value: 'verifyLoginEmail'
-            },
-            {
-              name: 'X-Flow-Id',
-              value: 'someFlowId'
-            },
-            {
-              name: 'X-Flow-Begin-Time',
-              value: '1234'
-            },
-            {
-              name: 'Content-Language',
-              value: 'en'
-            }
-          ]
-        }
-      })
-
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(mockDB.accountRecord.callCount, 1)
-        assert.equal(mockDB.accountRecord.args[0][0], 'test@example.com')
-        assert.equal(mockDB.deleteAccount.callCount, 1)
-        assert.equal(mockDB.deleteAccount.args[0][0].email, 'test@example.com')
-        assert.equal(log.flowEvent.callCount, 1)
-        assert.equal(log.flowEvent.args[0][0].event, 'email.verifyLoginEmail.bounced')
-        assert.equal(log.flowEvent.args[0][0].flow_id, 'someFlowId')
-        assert.equal(log.flowEvent.args[0][0].flow_time > 0, true)
-        assert.equal(log.flowEvent.args[0][0].time > 0, true)
-        assert.equal(log.info.callCount, 3)
-        assert.equal(log.info.args[0][0].op, 'emailEvent')
-        assert.equal(log.info.args[0][0].type, 'bounced')
-        assert.equal(log.info.args[0][0].template, 'verifyLoginEmail')
-        assert.equal(log.info.args[0][0].flow_id, 'someFlowId')
-      })
-    }
-  )
-
-  it(
-    'should log email domain if popular one',
-    () => {
-      const log = mockLog()
-      var mockDB = {
-        createEmailBounce: sinon.spy(() => P.resolve({})),
-        accountRecord: sinon.spy(function (email) {
-          return P.resolve({
-            uid: '123456',
-            email: email,
-            emailVerified: false
-          })
-        }),
-        deleteAccount: sinon.spy(function () {
-          return P.resolve({ })
-        })
-      }
-      var mockMsg = mockMessage({
-        bounce: {
-          bounceType: 'Permanent',
-          bounceSubType: 'General',
-          bouncedRecipients: [
-            {emailAddress: 'test@aol.com'}
-          ]
-        },
-        mail: {
-          headers: [
-            {
-              name: 'X-Template-Name',
-              value: 'verifyLoginEmail'
-            },
-            {
-              name: 'X-Flow-Id',
-              value: 'someFlowId'
-            },
-            {
-              name: 'X-Flow-Begin-Time',
-              value: '1234'
-            },
-            {
-              name: 'Content-Language',
-              value: 'en'
-            }
-          ]
-        }
-      })
-
-      return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
-        assert.equal(log.flowEvent.callCount, 1)
-        assert.equal(log.flowEvent.args[0][0].event, 'email.verifyLoginEmail.bounced')
-        assert.equal(log.flowEvent.args[0][0].flow_id, 'someFlowId')
-        assert.equal(log.flowEvent.args[0][0].flow_time > 0, true)
-        assert.equal(log.flowEvent.args[0][0].time > 0, true)
-        assert.equal(log.info.callCount, 3)
-        assert.equal(log.info.args[0][0].op, 'emailEvent')
-        assert.equal(log.info.args[0][0].domain, 'aol.com')
-        assert.equal(log.info.args[0][0].type, 'bounced')
-        assert.equal(log.info.args[0][0].template, 'verifyLoginEmail')
-        assert.equal(log.info.args[0][0].locale, 'en')
-        assert.equal(log.info.args[0][0].flow_id, 'someFlowId')
-        assert.equal(log.info.args[1][0].email, 'test@aol.com')
-        assert.equal(log.info.args[1][0].domain, 'aol.com')
-      })
-    }
-  )
+    return mockedBounces(log, mockDB).handleBounce(mockMsg).then(function () {
+      assert.equal(log.flowEvent.callCount, 1)
+      assert.equal(log.flowEvent.args[0][0].event, 'email.verifyLoginEmail.bounced')
+      assert.equal(log.flowEvent.args[0][0].flow_id, 'someFlowId')
+      assert.equal(log.flowEvent.args[0][0].flow_time > 0, true)
+      assert.equal(log.flowEvent.args[0][0].time > 0, true)
+      assert.equal(log.info.callCount, 3)
+      assert.equal(log.info.args[0][0].op, 'emailEvent')
+      assert.equal(log.info.args[0][0].domain, 'aol.com')
+      assert.equal(log.info.args[0][0].type, 'bounced')
+      assert.equal(log.info.args[0][0].template, 'verifyLoginEmail')
+      assert.equal(log.info.args[0][0].locale, 'en')
+      assert.equal(log.info.args[0][0].flow_id, 'someFlowId')
+      assert.equal(log.info.args[1][0].email, 'test@aol.com')
+      assert.equal(log.info.args[1][0].domain, 'aol.com')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #2272 

This PR also contains some slight test/ES6 updates in https://github.com/mozilla/fxa-auth-server/pull/2273/commits/2aad78270d414f766c00511c9bacfda0451e84c7, which is probably best to review with `?w=1` flag.