### PR TITLE
chore(tests): Set defaults for env vars in test-local.sh script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ addons:
     - mysql-client-5.6
 
 env:
-  global:
-    - NODE_ENV=test
   matrix:
     - DB=memory
     - DB=mysql

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "shrink": "npmshrink && npm run postinstall",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
-    "test": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar VERIFIER_VERSION=0 MEMCACHE_METRICS_CONTEXT_ADDRESS=none NO_COVERAGE=1 USE_REDIS=false scripts/test-local.sh",
-    "test-ci": "NODE_ENV=dev CORS_ORIGIN=http://foo,http://bar USE_REDIS=false scripts/test-local.sh",
+    "test": "VERIFIER_VERSION=0 MEMCACHE_METRICS_CONTEXT_ADDRESS=none NO_COVERAGE=1 USE_REDIS=false scripts/test-local.sh",
+    "test-ci": "USE_REDIS=false scripts/test-local.sh",
     "test-e2e": "NODE_ENV=dev mocha test/e2e",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha --timeout=300000 test/remote"
   },

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 
-set -eu
+set -e
+
+if [ -z "$NODE_ENV" ]; then export NODE_ENV=dev; fi;
+if [ -z "$CORS_ORIGIN" ]; then export CORS_ORIGIN="http://foo,http://bar"; fi;
+
+set -u
 
 glob=$*
 if [ -z "$glob" ]; then
-  glob="--recursive test/local test/remote"
+  glob="test/local test/remote"
 fi
 
 ./scripts/gen_keys.js
 ./scripts/gen_vapid_keys.js
-./scripts/mocha-coverage.js -R dot $glob
+./scripts/mocha-coverage.js -R dot --recursive $glob
 grunt eslint copyright


### PR DESCRIPTION
This adjusts the test-local.sh script to set default values for important env vars like NODE_ENV.  Previously these were only set by `npm test`, and their absense would cause test failures when invoking ./scripts/test-local.sh directly.

I also made a slight change to always pass --recursive flag to mocha, since I can't imagine us ever not wanting this in practice.

~@mozilla/fxa-devs r?~