### PR TITLE
fix(api): make authentication required on GET /account/profile

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1163,7 +1163,6 @@ module.exports = (log, db, mailer, Password, config, customs, checkPassword, pus
       path: '/account/profile',
       config: {
         auth: {
-          mode: 'optional',
           strategies: [
             'sessionToken',
             'oauthToken'


### PR DESCRIPTION
Saw this come past in a Sentry notification:

```
Error: An internal server error occurred
  File "/app/lib/routes/account.js", line 1188, in handler
    uid = auth.credentials.user
  File "/app/lib/server.js", line 318, in server.ext
    reply.continue()
```

Looking at that route, the entire thing assumes we have `request.auth.credentials` so I don't see why authentication is marked optional. Maybe it was an oversight, or maybe the route has changed from when that setting was made?

Anyway, this PR unoptionals the route, which I presume will prevent these errors showing up in the future. (and means we'll return a 401 instead of a 500)

@mozilla/fxa-devs r?