### PR TITLE
fix(tests): Test that unauthenticated /account/profile rejects cleanly.

### DIFF
--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -69,6 +69,22 @@ describe('remote account profile', function() {
   )
 
   it(
+    'account profile with no authentication returns a 401',
+    () => {
+      return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
+        .then(c => {
+          return c.api.accountProfile(null, {})
+        })
+        .then(
+          (response) => { assert.fail('request should have failed') },
+          (err) => {
+            assert.equal(err.code, 401, 'request failed with a 401')
+          }
+        )
+    }
+  )
+
+  it(
     'account profile authenticated with invalid oauth token returns an error',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })


### PR DESCRIPTION
An extra test just to sanity-check #2290, based on some vague bad memories I have from writing the affected code.  It failed before #2290 and passes after, so 👍 AFAICT.  @philbooth r?