### PR TITLE
fix(logging): Make oauth_client_info use shared logging instance.

### DIFF
--- a/bin/mailer_server.js
+++ b/bin/mailer_server.js
@@ -24,7 +24,7 @@ var P = require('bluebird')
 // the legacy log module provides an interface to convert old logs to new mozlog logging.
 var mailerLog = require('../lib/senders/log')('mailer')
 var legacyMailerLog = require('../lib/senders/legacy_log')(mailerLog)
-var Mailer = require('../lib/senders/email')(legacyMailerLog)
+var Mailer = require('../lib/senders/email')(legacyMailerLog, config.getProperties())
 
 P.all(
   [

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -5,7 +5,6 @@
 'use strict'
 
 const emailUtils = require('../email/utils/helpers')
-const oauthClientInfo = require('./oauth_client_info')
 const moment = require('moment-timezone')
 const nodemailer = require('nodemailer')
 const P = require('bluebird')
@@ -21,10 +20,12 @@ const UTM_PREFIX = 'fx-'
 const X_SES_CONFIGURATION_SET = 'X-SES-CONFIGURATION-SET'
 const X_SES_MESSAGE_TAGS = 'X-SES-MESSAGE-TAGS'
 
-module.exports = function (log) {
+module.exports = function (log, config) {
+  const oauthClientInfo = require('./oauth_client_info')(log, config)
+
   // Email template to UTM campaign map, each of these should be unique and
   // map to exactly one email template.
-  var templateNameToCampaignMap = {
+  const templateNameToCampaignMap = {
     'newDeviceLoginEmail': 'new-device-signin',
     'passwordResetRequiredEmail': 'password-reset-required',
     'passwordChangedEmail': 'password-changed-success',
@@ -45,7 +46,7 @@ module.exports = function (log) {
 
   // Email template to UTM content, this is typically the main call out link/button
   // in template.
-  var templateNameToContentMap = {
+  const templateNameToContentMap = {
     'newDeviceLoginEmail': 'password-change',
     'passwordChangedEmail': 'password-change',
     'passwordResetEmail': 'password-reset',

--- a/lib/senders/index.js
+++ b/lib/senders/index.js
@@ -12,7 +12,7 @@ module.exports = (log, config, error, bounces, translator, sender) => {
   const defaultLanguage = config.i18n.defaultLanguage
 
   function createSenders() {
-    const Mailer = createMailer(log)
+    const Mailer = createMailer(log, config)
     return require('./templates').init()
       .then(function (templates) {
         return {

--- a/lib/senders/oauth_client_info.js
+++ b/lib/senders/oauth_client_info.js
@@ -9,84 +9,84 @@ const Keyv = require('keyv')
 const Joi = require('joi')
 
 const P = require('../promise')
-const config = require('../../config').getProperties()
-const log = require('./log')('oauth_client_info')
 const { DISPLAY_SAFE_UNICODE } = require('../routes/validators')
 
-const OAUTH_SERVER = config.oauth.url
-const OAUTH_CLIENT_INFO_CACHE_TTL = config.oauth.clientInfoCacheTTL
-const OAUTH_CLIENT_INFO_CACHE_NAMESPACE = 'oauthClientInfo'
-const FIREFOX_CLIENT = {
-  name: 'Firefox'
-}
+module.exports = (log, config) => {
 
-const clientCache = new Keyv({
-  ttl: OAUTH_CLIENT_INFO_CACHE_TTL,
-  namespace: OAUTH_CLIENT_INFO_CACHE_NAMESPACE
-})
-
-/**
- * Fetches OAuth client info from the OAuth server.
- * Stores the data into server memory.
- * @param clientId
- * @returns {Promise<any>}
- */
-function fetch(clientId) {
-  log.trace({ op: 'fetch.start' })
-
-  const options = {
-    url: `${OAUTH_SERVER}/v1/client/${clientId}`,
-    method: 'GET',
-    json: true
+  const OAUTH_SERVER = config.oauth.url
+  const OAUTH_CLIENT_INFO_CACHE_TTL = config.oauth.clientInfoCacheTTL
+  const OAUTH_CLIENT_INFO_CACHE_NAMESPACE = 'oauthClientInfo'
+  const FIREFOX_CLIENT = {
+    name: 'Firefox'
   }
 
-  return new P((resolve) => {
-    if (! clientId || clientId === 'sync') {
-      log.trace({ op: 'fetch.sync' })
-      return resolve(FIREFOX_CLIENT)
-    }
-
-    clientCache.get(clientId)
-      .then((cachedRecord) => {
-        if (cachedRecord) {
-          // used the cachedRecord
-          log.trace({ op: 'fetch.usedCache' })
-          return resolve(cachedRecord)
-        }
-
-        // request info from the OAuth server
-        request(options, function (err, res, body) {
-          if (err || res.statusCode !== 200 || ! body.name) {
-            if (err) {
-              log.critical({ op: 'fetch.failed', err: err })
-            } else {
-              log.warn({ op: 'fetch.failedForClient', clientId: clientId, name: !! body.name })
-            }
-            // fallback to the Firefox client if request fails
-            return resolve(FIREFOX_CLIENT)
-          }
-
-          const validation = Joi.validate(body.name, Joi.string().max(256).regex(DISPLAY_SAFE_UNICODE).required())
-          if (validation.error) {
-            // fallback to the Firefox client if invalid name
-            return resolve(FIREFOX_CLIENT)
-          }
-
-          log.trace({ op: 'fetch.usedServer', body: body })
-          const clientInfo = {
-            // only providing `name` for now
-            name: body.name
-          }
-          resolve(clientInfo)
-          clientCache.set(clientId, clientInfo)
-        })
-
-      })
+  const clientCache = new Keyv({
+    ttl: OAUTH_CLIENT_INFO_CACHE_TTL,
+    namespace: OAUTH_CLIENT_INFO_CACHE_NAMESPACE
   })
 
+  /**
+   * Fetches OAuth client info from the OAuth server.
+   * Stores the data into server memory.
+   * @param clientId
+   * @returns {Promise<any>}
+   */
+  function fetch(clientId) {
+    log.trace({ op: 'fetch.start' })
 
-}
-module.exports = {
-  fetch: fetch,
-  __clientCache: clientCache
+    const options = {
+      url: `${OAUTH_SERVER}/v1/client/${clientId}`,
+      method: 'GET',
+      json: true
+    }
+
+    return new P((resolve) => {
+      if (! clientId || clientId === 'sync') {
+        log.trace({ op: 'fetch.sync' })
+        return resolve(FIREFOX_CLIENT)
+      }
+
+      clientCache.get(clientId)
+        .then((cachedRecord) => {
+          if (cachedRecord) {
+            // used the cachedRecord
+            log.trace({ op: 'fetch.usedCache' })
+            return resolve(cachedRecord)
+          }
+
+          // request info from the OAuth server
+          request(options, function (err, res, body) {
+            if (err || res.statusCode !== 200 || ! body.name) {
+              if (err) {
+                log.critical({ op: 'fetch.failed', err: err })
+              } else {
+                log.warn({ op: 'fetch.failedForClient', clientId: clientId, name: !! body.name })
+              }
+              // fallback to the Firefox client if request fails
+              return resolve(FIREFOX_CLIENT)
+            }
+
+            const validation = Joi.validate(body.name, Joi.string().max(256).regex(DISPLAY_SAFE_UNICODE).required())
+            if (validation.error) {
+              // fallback to the Firefox client if invalid name
+              return resolve(FIREFOX_CLIENT)
+            }
+
+            log.trace({ op: 'fetch.usedServer', body: body })
+            const clientInfo = {
+              // only providing `name` for now
+              name: body.name
+            }
+            resolve(clientInfo)
+            clientCache.set(clientId, clientInfo)
+          })
+
+        })
+    })
+  }
+
+  return {
+    fetch: fetch,
+    __clientCache: clientCache
+  }
 }

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -19,7 +19,7 @@ const mockLog = {
 }
 
 const config = require(`${ROOT_DIR}/config`)
-const Mailer = require(`${ROOT_DIR}/lib/senders/email`)(mockLog)
+const Mailer = require(`${ROOT_DIR}/lib/senders/email`)(mockLog, config.getProperties())
 
 const TEMPLATE_VERSIONS = require(`${ROOT_DIR}/lib/senders/templates/_versions.json`)
 

--- a/test/local/senders/oauth_client_info.js
+++ b/test/local/senders/oauth_client_info.js
@@ -24,28 +24,21 @@ describe('lib/senders/oauth_client_info:', () => {
     let fetch
     let mockLog
     const mockConfig = {
-      getProperties() {
-        return {
-          oauth: {
-            url: 'http://localhost:9010',
-            clientInfoCacheTTL: 5
-          }
-        }
+      oauth: {
+        url: 'http://localhost:9010',
+        clientInfoCacheTTL: 5
       }
-    }
-    let mocks = {
-      '../../config': mockConfig
     }
 
     beforeEach(() => {
-      clientInfo = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)
-      fetch = clientInfo.fetch
       mockLog = {
         fatal: sinon.spy(),
         trace: sinon.spy(),
         critical: sinon.spy(),
         warn: sinon.spy()
       }
+      clientInfo = require(`${ROOT_DIR}/lib/senders/oauth_client_info`)(mockLog, mockConfig)
+      fetch = clientInfo.fetch
     })
 
     afterEach(() => {
@@ -65,16 +58,13 @@ describe('lib/senders/oauth_client_info:', () => {
     })
 
     it('falls back to Firefox if error', () => {
-      mocks = {
+      const mocks = {
         'request': function (options, cb) {
           cb(new Error('Request failed'))
-        },
-        './log': function() {
-          return mockLog
         }
       }
 
-      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks).fetch
+      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)(mockLog, mockConfig).fetch
 
       return fetch('24bdbfa45cd300c5').then((res) => {
         assert.deepEqual(res, FIREFOX_CLIENT)
@@ -83,7 +73,7 @@ describe('lib/senders/oauth_client_info:', () => {
     })
 
     it('falls back to Firefox if non-200 response', () => {
-      mocks = {
+      const mocks = {
         'request': function (options, cb) {
           cb(null, {
             statusCode: 400
@@ -91,13 +81,10 @@ describe('lib/senders/oauth_client_info:', () => {
             code: 400,
             errno: 109
           })
-        },
-        './log': function() {
-          return mockLog
         }
       }
 
-      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks).fetch
+      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)(mockLog, mockConfig).fetch
 
       return fetch('f00bdbfa45cd300c5').then((res) => {
         assert.deepEqual(res, FIREFOX_CLIENT)
@@ -114,14 +101,11 @@ describe('lib/senders/oauth_client_info:', () => {
           statusCode: 200
         }, OAUTH_CLIENT)
       })
-      mocks = {
-        'request': requestMock,
-        './log': function() {
-          return mockLog
-        }
+      const mocks = {
+        'request': requestMock
       }
 
-      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks).fetch
+      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)(mockLog, mockConfig).fetch
 
       return fetch('24bdbfa45cd300c5').then((res) => {
         assert.deepEqual(res, OAUTH_CLIENT)
@@ -148,15 +132,11 @@ describe('lib/senders/oauth_client_info:', () => {
           statusCode: 200
         }, OAUTH_CLIENT)
       })
-      mocks = {
-        'request': requestMock,
-        './log': function() {
-          return mockLog
-        },
-        '../../config': mockConfig
+      const mocks = {
+        'request': requestMock
       }
 
-      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks).fetch
+      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)(mockLog, mockConfig).fetch
 
       return fetch('24bdbfa45cd300c5').delay(15).then((res) => {
         assert.deepEqual(res, OAUTH_CLIENT)
@@ -180,14 +160,11 @@ describe('lib/senders/oauth_client_info:', () => {
           name: Array(512).fill('a').join('')
         })
       })
-      mocks = {
-        'request': requestMock,
-        './log': function() {
-          return mockLog
-        }
+      const mocks = {
+        'request': requestMock
       }
 
-      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks).fetch
+      fetch = proxyquire(`${ROOT_DIR}/lib/senders/oauth_client_info`, mocks)(mockLog, mockConfig).fetch
 
       return fetch('24bdbfa45cd300c5').then((res) => {
         assert.deepEqual(res, FIREFOX_CLIENT)


### PR DESCRIPTION
Previously it would require() its own version of the logging module, and hence would not correctly use various test stubs and mocks, and hence caused `npm test` to dump a bunch of logging output to the screen when executing the remote tests.  This changes it to accept the `log` object as an argument in a similar style to other modules in this repo.

@vladikoff r?