### PR TITLE
chore(logging): downgrade redis.watch.conflict to warning level

### DIFF
--- a/lib/redis/connection.js
+++ b/lib/redis/connection.js
@@ -68,7 +68,9 @@ module.exports = (log, client) => {
         .then(result => {
           isUpdating = false
           if (! result) {
-            log.error({ op: 'redis.watch.conflict', key })
+            // Really this isn't an error as such, it just indicates that
+            // this function is operating sanely in concurrent conditions.
+            log.warn({ op: 'redis.watch.conflict', key })
             throw error.unexpectedError()
           }
         })

--- a/test/local/redis/connection.js
+++ b/test/local/redis/connection.js
@@ -490,10 +490,11 @@ describe('redis/connection:', () => {
         assert.equal(redisMulti.execAsync.callCount, 1)
       })
 
-      it('called log.error correctly', () => {
-        assert.equal(log.error.callCount, 1)
-        assert.equal(log.error.args[0].length, 1)
-        assert.deepEqual(log.error.args[0][0], {
+      it('called log.warn correctly', () => {
+        assert.equal(log.error.callCount, 0)
+        assert.equal(log.warn.callCount, 1)
+        assert.equal(log.warn.args[0].length, 1)
+        assert.deepEqual(log.warn.args[0][0], {
           op: 'redis.watch.conflict',
           key: 'wibble'
         })

--- a/test/remote/redis_tests.js
+++ b/test/remote/redis_tests.js
@@ -10,7 +10,7 @@ const assert = require('insist')
 const config = require(`${ROOT_DIR}/config`).getProperties()
 const P = require(`${ROOT_DIR}/lib/promise`)
 
-const log = { info () {}, error () {} }
+const log = { info () {}, warn () {}, error () {} }
 
 const redis = require(`${ROOT_DIR}/lib/redis`)(Object.assign({}, config.redis, { enabled: true }), log)
 


### PR DESCRIPTION
I can't remember where or who, but somebody mentioned this error in the last couple of days. It's really nothing we should worry about if it happens every now and then, it just means our guards against unsafe concurrent updates of data in Redis are kicking in successfully.

This change tries to make that a bit clearer, by logging the message at `warn` level and adding a friendly explanatory comment in the code. Don't panic! 😄

@mozilla/fxa-devs r?