### PR TITLE
fix(redis): delete clashing tokens from redis in createSessionToken

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -366,7 +366,7 @@ var conf = convict({
       doc: 'Key prefix for session tokens in Redis'
     },
     maxConnections: {
-      default: 100,
+      default: 200,
       env: 'REDIS_POOL_MAX_CONNECTIONS',
       format: 'int',
       doc: 'Maximum connection count for Redis'


### PR DESCRIPTION
Fixes #2306.

Our pruning of session tokens from Redis is not perfect because we can only delete tokens that are expired-but-not-yet-pruned-from-MySQL. This leaves us with some number of zombie session tokens that are lying around in Redis, the effect of which could be to sometimes show incorrect session information in the device manager (albeit with very low probability).

To eliminate that possbility, this change speculatively deletes from Redis when creating the session token. In addition, the maximum number of Redis connections is bumped up from 100 to 200, because we can expect the number of concurrent Redis operations to increase significantly.

@mozilla/fxa-devs r?