### PR TITLE
feat(totp): Add verification methods

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -908,6 +908,14 @@ module.exports = (
     )
   }
 
+  DB.prototype.verifyTokensWithMethod = function (tokenId, verificationMethod) {
+    log.trace({op: 'DB.verifyTokensWithMethod', tokenId, verificationMethod})
+    return this.pool.post(
+      `/tokens/${tokenId}/verifyWithMethod`,
+      {verificationMethod}
+    )
+  }
+
   DB.prototype.verifyTokenCode = function (code, accountData) {
     log.trace({ op: 'DB.verifyTokenCode', code: code })
     return this.pool.post(
@@ -1170,6 +1178,21 @@ module.exports = (
     log.trace({ op: 'DB.deleteTotpToken', uid})
 
     return this.pool.del(`/totp/${uid}`)
+      .catch(err => {
+        if (isNotFoundError(err)) {
+          throw error.totpTokenNotFound()
+        }
+        throw err
+      })
+  }
+
+  DB.prototype.updateTotpToken = function (uid, data) {
+    log.trace({ op: 'DB.updateTotpToken', uid, data})
+
+    return this.pool.post(`/totp/${uid}/update`, {
+      verified: data.verified,
+      enabled: data.enabled
+    })
       .catch(err => {
         if (isNotFoundError(err)) {
           throw error.totpTokenNotFound()

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -512,12 +512,12 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
         }
 
         function checkTotpToken () {
-          // Check to see if the user has a TOTP token, if so then
-          // the verification method is automatically forced so that
+          // Check to see if the user has a TOTP token and it is verified and
+          // enabled, if so then the verification method is automatically forced so that
           // they have to verify the token.
           return db.totpToken(accountRecord.uid)
             .then((result) => {
-              if (result) {
+              if (result && result.verified && result.enabled) {
                 verificationMethod = 'totp-2fa'
               }
             }, (err) => {

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -7,6 +7,16 @@
 module.exports = (log, Token, config) => {
   const MAX_AGE_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
 
+  // Convert verificationMethod to a more readable format. Maps to
+  // https://github.com/mozilla/fxa-auth-db-mysql/blob/master/lib/db/util.js#L34
+  const VERIFICATION_METHODS = new Map(
+    [
+      [0, 'email'],
+      [1, 'email-2fa'],
+      [2, 'totp-2fa']
+    ]
+  )
+
   class SessionToken extends Token {
 
     constructor(keys, details) {
@@ -32,6 +42,10 @@ module.exports = (log, Token, config) => {
 
       this.tokenVerificationCode = details.tokenVerificationCode || null
       this.tokenVerificationCodeExpiresAt = details.tokenVerificationCodeExpiresAt || null
+
+      this.verificationMethod = details.verificationMethod || null
+      this.verificationMethodValue = VERIFICATION_METHODS.get(this.verificationMethod)
+      this.verifiedAt = details.verifiedAt || null
     }
 
     static create(details) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -293,7 +293,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "moment": {
@@ -338,9 +338,9 @@
       "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95"
     },
     "fxa-auth-db-mysql": {
-      "version": "1.105.0",
+      "version": "1.106.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0d874f9ae8b8415f838673e927d0be325022e596",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#f6d603c706477c9c372fb76691b285a5119fd0d0",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -1563,9 +1563,9 @@
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
-              "version": "2.3.3",
+              "version": "2.3.4",
               "from": "tough-cookie@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -1781,26 +1781,38 @@
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -2176,7 +2188,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.2 <2.0.0",
+              "from": "async@>=1.5.2 <1.6.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "getobject": {
@@ -2524,7 +2536,7 @@
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
@@ -2567,14 +2579,14 @@
           }
         },
         "conventional-changelog": {
-          "version": "1.1.16",
+          "version": "1.1.17",
           "from": "conventional-changelog@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.16.tgz",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.17.tgz",
           "dependencies": {
             "conventional-changelog-angular": {
-              "version": "1.6.5",
-              "from": "conventional-changelog-angular@>=1.6.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.5.tgz",
+              "version": "1.6.6",
+              "from": "conventional-changelog-angular@>=1.6.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
               "dependencies": {
                 "compare-func": {
                   "version": "1.3.2",
@@ -2603,24 +2615,24 @@
               }
             },
             "conventional-changelog-atom": {
-              "version": "0.2.3",
-              "from": "conventional-changelog-atom@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.3.tgz"
+              "version": "0.2.4",
+              "from": "conventional-changelog-atom@>=0.2.4 <0.3.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz"
             },
             "conventional-changelog-codemirror": {
-              "version": "0.3.3",
-              "from": "conventional-changelog-codemirror@>=0.3.3 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.3.tgz"
+              "version": "0.3.4",
+              "from": "conventional-changelog-codemirror@>=0.3.4 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz"
             },
             "conventional-changelog-core": {
-              "version": "2.0.4",
-              "from": "conventional-changelog-core@>=2.0.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.4.tgz",
+              "version": "2.0.5",
+              "from": "conventional-changelog-core@>=2.0.5 <3.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz",
               "dependencies": {
                 "conventional-changelog-writer": {
-                  "version": "3.0.3",
-                  "from": "conventional-changelog-writer@>=3.0.3 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.3.tgz",
+                  "version": "3.0.4",
+                  "from": "conventional-changelog-writer@>=3.0.4 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz",
                   "dependencies": {
                     "compare-func": {
                       "version": "1.3.2",
@@ -2647,9 +2659,9 @@
                       }
                     },
                     "conventional-commits-filter": {
-                      "version": "1.1.4",
-                      "from": "conventional-commits-filter@>=1.1.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.4.tgz",
+                      "version": "1.1.5",
+                      "from": "conventional-commits-filter@>=1.1.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz",
                       "dependencies": {
                         "is-subset": {
                           "version": "0.1.1",
@@ -2669,26 +2681,48 @@
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                      "version": "4.0.0",
+                      "from": "meow@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.1.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                          "version": "4.2.0",
+                          "from": "camelcase-keys@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.1",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                              "version": "4.1.0",
+                              "from": "camelcase@>=4.1.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "2.0.0",
+                              "from": "map-obj@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+                            },
+                            "quick-lru": {
+                              "version": "1.1.0",
+                              "from": "quick-lru@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
                             }
                           }
                         },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                        "decamelize-keys": {
+                          "version": "1.1.0",
+                          "from": "decamelize-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                          "dependencies": {
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
                         },
                         "loud-rejection": {
                           "version": "1.6.0",
@@ -2714,76 +2748,165 @@
                             }
                           }
                         },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
                         "minimist": {
                           "version": "1.2.0",
                           "from": "minimist@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                        "minimist-options": {
+                          "version": "3.0.2",
+                          "from": "minimist-options@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
                           "dependencies": {
-                            "indent-string": {
+                            "arrify": {
+                              "version": "1.0.1",
+                              "from": "arrify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                            },
+                            "is-plain-obj": {
+                              "version": "1.1.0",
+                              "from": "is-plain-obj@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "3.0.0",
+                          "from": "read-pkg-up@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                          "dependencies": {
+                            "find-up": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "from": "find-up@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                               "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.1",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                                "locate-path": {
+                                  "version": "2.0.0",
+                                  "from": "locate-path@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                                   "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.2",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                    "p-locate": {
+                                      "version": "2.0.0",
+                                      "from": "p-locate@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                                       "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.1",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        "p-limit": {
+                                          "version": "1.2.0",
+                                          "from": "p-limit@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                                          "dependencies": {
+                                            "p-try": {
+                                              "version": "1.0.0",
+                                              "from": "p-try@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                                            }
+                                          }
                                         }
                                       }
+                                    },
+                                    "path-exists": {
+                                      "version": "3.0.0",
+                                      "from": "path-exists@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
                                     }
                                   }
                                 }
                               }
                             },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                            "read-pkg": {
+                              "version": "3.0.0",
+                              "from": "read-pkg@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                               "dependencies": {
-                                "get-stdin": {
-                                  "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                "load-json-file": {
+                                  "version": "4.0.0",
+                                  "from": "load-json-file@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.11",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "4.0.0",
+                                      "from": "parse-json@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.1",
+                                          "from": "error-ex@>=1.3.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "json-parse-better-errors": {
+                                          "version": "1.0.1",
+                                          "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    },
+                                    "strip-bom": {
+                                      "version": "3.0.0",
+                                      "from": "strip-bom@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "3.0.0",
+                                  "from": "path-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                                  "dependencies": {
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             }
                           }
                         },
+                        "redent": {
+                          "version": "2.0.0",
+                          "from": "redent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "3.2.0",
+                              "from": "indent-string@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+                            },
+                            "strip-indent": {
+                              "version": "2.0.0",
+                              "from": "strip-indent@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+                            }
+                          }
+                        },
                         "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                          "version": "2.0.0",
+                          "from": "trim-newlines@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "semver@>=5.5.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "split": {
@@ -2794,9 +2917,9 @@
                   }
                 },
                 "conventional-commits-parser": {
-                  "version": "2.1.4",
-                  "from": "conventional-commits-parser@>=2.1.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.4.tgz",
+                  "version": "2.1.5",
+                  "from": "conventional-commits-parser@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.3.2",
@@ -2823,26 +2946,48 @@
                       }
                     },
                     "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                      "version": "4.0.0",
+                      "from": "meow@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.1.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                          "version": "4.2.0",
+                          "from": "camelcase-keys@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.1",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                              "version": "4.1.0",
+                              "from": "camelcase@>=4.1.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "2.0.0",
+                              "from": "map-obj@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+                            },
+                            "quick-lru": {
+                              "version": "1.1.0",
+                              "from": "quick-lru@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
                             }
                           }
                         },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                        "decamelize-keys": {
+                          "version": "1.1.0",
+                          "from": "decamelize-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                          "dependencies": {
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
                         },
                         "loud-rejection": {
                           "version": "1.6.0",
@@ -2868,70 +3013,159 @@
                             }
                           }
                         },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
                         "minimist": {
                           "version": "1.2.0",
                           "from": "minimist@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                        "minimist-options": {
+                          "version": "3.0.2",
+                          "from": "minimist-options@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
                           "dependencies": {
-                            "indent-string": {
+                            "arrify": {
+                              "version": "1.0.1",
+                              "from": "arrify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                            },
+                            "is-plain-obj": {
+                              "version": "1.1.0",
+                              "from": "is-plain-obj@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "3.0.0",
+                          "from": "read-pkg-up@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                          "dependencies": {
+                            "find-up": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "from": "find-up@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                               "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.1",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                                "locate-path": {
+                                  "version": "2.0.0",
+                                  "from": "locate-path@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                                   "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.2",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                    "p-locate": {
+                                      "version": "2.0.0",
+                                      "from": "p-locate@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                                       "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.1",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        "p-limit": {
+                                          "version": "1.2.0",
+                                          "from": "p-limit@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                                          "dependencies": {
+                                            "p-try": {
+                                              "version": "1.0.0",
+                                              "from": "p-try@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                                            }
+                                          }
                                         }
                                       }
+                                    },
+                                    "path-exists": {
+                                      "version": "3.0.0",
+                                      "from": "path-exists@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
                                     }
                                   }
                                 }
                               }
                             },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                            "read-pkg": {
+                              "version": "3.0.0",
+                              "from": "read-pkg@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                               "dependencies": {
-                                "get-stdin": {
-                                  "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                "load-json-file": {
+                                  "version": "4.0.0",
+                                  "from": "load-json-file@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.11",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "4.0.0",
+                                      "from": "parse-json@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.1",
+                                          "from": "error-ex@>=1.3.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "json-parse-better-errors": {
+                                          "version": "1.0.1",
+                                          "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    },
+                                    "strip-bom": {
+                                      "version": "3.0.0",
+                                      "from": "strip-bom@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "3.0.0",
+                                  "from": "path-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                                  "dependencies": {
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             }
                           }
                         },
+                        "redent": {
+                          "version": "2.0.0",
+                          "from": "redent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "3.2.0",
+                              "from": "indent-string@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+                            },
+                            "strip-indent": {
+                              "version": "2.0.0",
+                              "from": "strip-indent@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+                            }
+                          }
+                        },
                         "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                          "version": "2.0.0",
+                          "from": "trim-newlines@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
                         }
                       }
                     },
@@ -2948,122 +3182,9 @@
                   }
                 },
                 "dateformat": {
-                  "version": "1.0.12",
-                  "from": "dateformat@>=1.0.12 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    },
-                    "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                      "dependencies": {
-                        "camelcase-keys": {
-                          "version": "2.1.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "2.1.1",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                        },
-                        "loud-rejection": {
-                          "version": "1.6.0",
-                          "from": "loud-rejection@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-                          "dependencies": {
-                            "currently-unhandled": {
-                              "version": "0.4.1",
-                              "from": "currently-unhandled@>=0.4.1 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                              "dependencies": {
-                                "array-find-index": {
-                                  "version": "1.0.2",
-                                  "from": "array-find-index@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "signal-exit": {
-                              "version": "3.0.2",
-                              "from": "signal-exit@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                            }
-                          }
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                          "dependencies": {
-                            "indent-string": {
-                              "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                              "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.1",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.2",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.1",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "version": "3.0.3",
+                  "from": "dateformat@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
                 },
                 "get-pkg-repo": {
                   "version": "1.4.0",
@@ -3196,9 +3317,9 @@
                   }
                 },
                 "git-raw-commits": {
-                  "version": "1.3.3",
-                  "from": "git-raw-commits@>=1.3.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.3.tgz",
+                  "version": "1.3.4",
+                  "from": "git-raw-commits@>=1.3.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz",
                   "dependencies": {
                     "dargs": {
                       "version": "4.1.0",
@@ -3230,26 +3351,48 @@
                       }
                     },
                     "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                      "version": "4.0.0",
+                      "from": "meow@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.1.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                          "version": "4.2.0",
+                          "from": "camelcase-keys@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.1",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                              "version": "4.1.0",
+                              "from": "camelcase@>=4.1.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "2.0.0",
+                              "from": "map-obj@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+                            },
+                            "quick-lru": {
+                              "version": "1.1.0",
+                              "from": "quick-lru@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
                             }
                           }
                         },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                        "decamelize-keys": {
+                          "version": "1.1.0",
+                          "from": "decamelize-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                          "dependencies": {
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
                         },
                         "loud-rejection": {
                           "version": "1.6.0",
@@ -3275,70 +3418,159 @@
                             }
                           }
                         },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
                         "minimist": {
                           "version": "1.2.0",
                           "from": "minimist@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                        "minimist-options": {
+                          "version": "3.0.2",
+                          "from": "minimist-options@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
                           "dependencies": {
-                            "indent-string": {
+                            "arrify": {
+                              "version": "1.0.1",
+                              "from": "arrify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                            },
+                            "is-plain-obj": {
+                              "version": "1.1.0",
+                              "from": "is-plain-obj@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "3.0.0",
+                          "from": "read-pkg-up@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                          "dependencies": {
+                            "find-up": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "from": "find-up@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                               "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.1",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                                "locate-path": {
+                                  "version": "2.0.0",
+                                  "from": "locate-path@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                                   "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.2",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                    "p-locate": {
+                                      "version": "2.0.0",
+                                      "from": "p-locate@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                                       "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.1",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        "p-limit": {
+                                          "version": "1.2.0",
+                                          "from": "p-limit@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                                          "dependencies": {
+                                            "p-try": {
+                                              "version": "1.0.0",
+                                              "from": "p-try@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                                            }
+                                          }
                                         }
                                       }
+                                    },
+                                    "path-exists": {
+                                      "version": "3.0.0",
+                                      "from": "path-exists@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
                                     }
                                   }
                                 }
                               }
                             },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                            "read-pkg": {
+                              "version": "3.0.0",
+                              "from": "read-pkg@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                               "dependencies": {
-                                "get-stdin": {
-                                  "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                "load-json-file": {
+                                  "version": "4.0.0",
+                                  "from": "load-json-file@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.11",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "4.0.0",
+                                      "from": "parse-json@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.1",
+                                          "from": "error-ex@>=1.3.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "json-parse-better-errors": {
+                                          "version": "1.0.1",
+                                          "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    },
+                                    "strip-bom": {
+                                      "version": "3.0.0",
+                                      "from": "strip-bom@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "3.0.0",
+                                  "from": "path-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                                  "dependencies": {
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             }
                           }
                         },
+                        "redent": {
+                          "version": "2.0.0",
+                          "from": "redent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "3.2.0",
+                              "from": "indent-string@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+                            },
+                            "strip-indent": {
+                              "version": "2.0.0",
+                              "from": "strip-indent@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+                            }
+                          }
+                        },
                         "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                          "version": "2.0.0",
+                          "from": "trim-newlines@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
                         }
                       }
                     },
@@ -3374,31 +3606,53 @@
                   }
                 },
                 "git-semver-tags": {
-                  "version": "1.3.3",
-                  "from": "git-semver-tags@>=1.3.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.3.tgz",
+                  "version": "1.3.4",
+                  "from": "git-semver-tags@>=1.3.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.4.tgz",
                   "dependencies": {
                     "meow": {
-                      "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                      "version": "4.0.0",
+                      "from": "meow@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.1.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                          "version": "4.2.0",
+                          "from": "camelcase-keys@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.1",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                              "version": "4.1.0",
+                              "from": "camelcase@>=4.1.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "2.0.0",
+                              "from": "map-obj@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+                            },
+                            "quick-lru": {
+                              "version": "1.1.0",
+                              "from": "quick-lru@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
                             }
                           }
                         },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                        "decamelize-keys": {
+                          "version": "1.1.0",
+                          "from": "decamelize-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                          "dependencies": {
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "decamelize@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
                         },
                         "loud-rejection": {
                           "version": "1.6.0",
@@ -3424,83 +3678,172 @@
                             }
                           }
                         },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        },
                         "minimist": {
                           "version": "1.2.0",
                           "from": "minimist@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                        "minimist-options": {
+                          "version": "3.0.2",
+                          "from": "minimist-options@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
                           "dependencies": {
-                            "indent-string": {
+                            "arrify": {
+                              "version": "1.0.1",
+                              "from": "arrify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                            },
+                            "is-plain-obj": {
+                              "version": "1.1.0",
+                              "from": "is-plain-obj@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "3.0.0",
+                          "from": "read-pkg-up@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                          "dependencies": {
+                            "find-up": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "from": "find-up@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                               "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.1",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                                "locate-path": {
+                                  "version": "2.0.0",
+                                  "from": "locate-path@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                                   "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.2",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                    "p-locate": {
+                                      "version": "2.0.0",
+                                      "from": "p-locate@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                                       "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.1",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        "p-limit": {
+                                          "version": "1.2.0",
+                                          "from": "p-limit@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                                          "dependencies": {
+                                            "p-try": {
+                                              "version": "1.0.0",
+                                              "from": "p-try@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                                            }
+                                          }
                                         }
                                       }
+                                    },
+                                    "path-exists": {
+                                      "version": "3.0.0",
+                                      "from": "path-exists@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
                                     }
                                   }
                                 }
                               }
                             },
-                            "strip-indent": {
-                              "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                            "read-pkg": {
+                              "version": "3.0.0",
+                              "from": "read-pkg@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
                               "dependencies": {
-                                "get-stdin": {
-                                  "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                "load-json-file": {
+                                  "version": "4.0.0",
+                                  "from": "load-json-file@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.11",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "4.0.0",
+                                      "from": "parse-json@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.1",
+                                          "from": "error-ex@>=1.3.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "json-parse-better-errors": {
+                                          "version": "1.0.1",
+                                          "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    },
+                                    "strip-bom": {
+                                      "version": "3.0.0",
+                                      "from": "strip-bom@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "3.0.0",
+                                  "from": "path-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                                  "dependencies": {
+                                    "pify": {
+                                      "version": "3.0.0",
+                                      "from": "pify@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             }
                           }
                         },
+                        "redent": {
+                          "version": "2.0.0",
+                          "from": "redent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "3.2.0",
+                              "from": "indent-string@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+                            },
+                            "strip-indent": {
+                              "version": "2.0.0",
+                              "from": "strip-indent@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+                            }
+                          }
+                        },
                         "trim-newlines": {
-                          "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                          "version": "2.0.0",
+                          "from": "trim-newlines@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=5.0.1 <6.0.0",
+                      "from": "semver@>=5.5.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     }
                   }
                 },
                 "lodash": {
                   "version": "4.17.5",
-                  "from": "lodash@>=4.0.0 <5.0.0",
+                  "from": "lodash@>=4.2.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
                 },
                 "normalize-package-data": {
@@ -3527,30 +3870,42 @@
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "semver@>=5.5.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -3740,19 +4095,19 @@
               }
             },
             "conventional-changelog-ember": {
-              "version": "0.3.5",
-              "from": "conventional-changelog-ember@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.5.tgz"
+              "version": "0.3.6",
+              "from": "conventional-changelog-ember@>=0.3.6 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz"
             },
             "conventional-changelog-eslint": {
-              "version": "1.0.3",
-              "from": "conventional-changelog-eslint@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "conventional-changelog-eslint@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.4.tgz"
             },
             "conventional-changelog-express": {
-              "version": "0.3.3",
-              "from": "conventional-changelog-express@>=0.3.3 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.3.tgz"
+              "version": "0.3.4",
+              "from": "conventional-changelog-express@>=0.3.4 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz"
             },
             "conventional-changelog-jquery": {
               "version": "0.1.0",
@@ -3765,9 +4120,9 @@
               "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz"
             },
             "conventional-changelog-jshint": {
-              "version": "0.3.3",
-              "from": "conventional-changelog-jshint@>=0.3.3 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.3.tgz",
+              "version": "0.3.4",
+              "from": "conventional-changelog-jshint@>=0.3.4 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz",
               "dependencies": {
                 "compare-func": {
                   "version": "1.3.2",
@@ -3796,9 +4151,9 @@
               }
             },
             "conventional-changelog-preset-loader": {
-              "version": "1.1.5",
-              "from": "conventional-changelog-preset-loader@>=1.1.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.5.tgz"
+              "version": "1.1.6",
+              "from": "conventional-changelog-preset-loader@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz"
             }
           }
         },
@@ -4035,16 +4390,9 @@
                   }
                 },
                 "esrecurse": {
-                  "version": "4.2.0",
+                  "version": "4.2.1",
                   "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz"
                 }
               }
             },
@@ -4054,9 +4402,9 @@
               "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "5.4.1",
+                  "version": "5.5.0",
                   "from": "acorn@>=5.4.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz"
                 },
                 "acorn-jsx": {
                   "version": "3.0.1",
@@ -5375,9 +5723,9 @@
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "2.8.0",
+                      "version": "2.9.2",
                       "from": "nan@>=2.3.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
                     },
                     "node-pre-gyp": {
                       "version": "0.6.39",
@@ -5469,15 +5817,15 @@
                       "from": "caseless@0.12.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
                     },
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
                     "code-point-at": {
                       "version": "1.1.0",
                       "from": "code-point-at@1.1.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@4.6.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -5559,15 +5907,15 @@
                       "from": "fs.realpath@1.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
-                    "fstream-ignore": {
-                      "version": "1.0.5",
-                      "from": "fstream-ignore@1.0.5",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
-                    },
                     "fstream": {
                       "version": "1.0.11",
                       "from": "fstream@1.0.11",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "from": "fstream-ignore@1.0.5",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
                     },
                     "gauge": {
                       "version": "2.7.4",
@@ -5589,15 +5937,15 @@
                       "from": "har-schema@1.0.5",
                       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
                     },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "from": "har-validator@4.2.1",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-                    },
                     "has-unicode": {
                       "version": "2.0.1",
                       "from": "has-unicode@2.0.1",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "from": "har-validator@4.2.1",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
                     },
                     "hawk": {
                       "version": "3.1.3",
@@ -5634,6 +5982,11 @@
                       "from": "is-fullwidth-code-point@1.0.0",
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
                     },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
                     "is-typedarray": {
                       "version": "1.0.0",
                       "from": "is-typedarray@1.0.0",
@@ -5643,11 +5996,6 @@
                       "version": "0.1.2",
                       "from": "isstream@0.1.2",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
@@ -5764,15 +6112,15 @@
                       "from": "performance-now@0.2.0",
                       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
                     },
-                    "punycode": {
-                      "version": "1.4.1",
-                      "from": "punycode@1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                    },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "process-nextick-args@1.0.7",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                     },
                     "qs": {
                       "version": "6.4.0",
@@ -5869,15 +6217,15 @@
                       "from": "tweetnacl@0.14.5",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                     },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@0.0.6",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@1.0.2",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@0.0.6",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                     },
                     "uuid": {
                       "version": "3.0.1",
@@ -5923,18 +6271,6 @@
                         }
                       }
                     },
-                    "rc": {
-                      "version": "1.2.1",
-                      "from": "rc@1.2.1",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
                     "jsprim": {
                       "version": "1.4.0",
                       "from": "jsprim@1.4.0",
@@ -5944,6 +6280,18 @@
                           "version": "1.0.0",
                           "from": "assert-plus@1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.2.1",
+                      "from": "rc@1.2.1",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         }
                       }
                     },
@@ -6045,7 +6393,7 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
@@ -6114,7 +6462,7 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "from": "uglify-js@>=2.6.0 <3.0.0",
+          "from": "uglify-js@>=2.4.19 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "dependencies": {
             "source-map": {
@@ -6259,7 +6607,7 @@
         },
         "boom": {
           "version": "5.2.0",
-          "from": "boom@>=5.2.0 <6.0.0",
+          "from": "boom@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
         },
         "call": {
@@ -6755,7 +7103,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.3 <0.2.0",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -7042,7 +7390,7 @@
         },
         "topo": {
           "version": "2.0.2",
-          "from": "topo@>=2.0.0 <3.0.0",
+          "from": "topo@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
         }
       }
@@ -7259,7 +7607,7 @@
                 },
                 "uglify-js": {
                   "version": "2.8.29",
-                  "from": "uglify-js@>=2.6.0 <3.0.0",
+                  "from": "uglify-js@>=2.4.19 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
                   "dependencies": {
                     "source-map": {
@@ -8070,9 +8418,9 @@
           "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-2.2.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.8.0",
+              "version": "2.9.2",
               "from": "nan@>=2.8.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
             }
           }
         }
@@ -8704,15 +9052,15 @@
             }
           }
         },
-        "align-text": {
-          "version": "0.1.4",
-          "from": "align-text@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-        },
         "amdefine": {
           "version": "1.0.1",
           "from": "amdefine@>=0.0.4",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "from": "align-text@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
         },
         "ansi-regex": {
           "version": "2.0.0",
@@ -9079,15 +9427,15 @@
           "from": "jsesc@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
         },
-        "kind-of": {
-          "version": "3.0.4",
-          "from": "kind-of@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
-        },
         "lazy-cache": {
           "version": "1.0.4",
           "from": "lazy-cache@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+        },
+        "kind-of": {
+          "version": "3.0.4",
+          "from": "kind-of@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
         },
         "lcid": {
           "version": "1.0.0",
@@ -9164,15 +9512,15 @@
           "from": "object.omit@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
         },
-        "once": {
-          "version": "1.4.0",
-          "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-        },
         "optimist": {
           "version": "0.6.1",
           "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+        },
+        "once": {
+          "version": "1.4.0",
+          "from": "once@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -9299,15 +9647,15 @@
           "from": "right-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
         },
-        "semver": {
-          "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-        },
         "set-blocking": {
           "version": "2.0.0",
           "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.3.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
         },
         "slide": {
           "version": "1.1.6",
@@ -9915,26 +10263,38 @@
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                         },
                         "validate-npm-package-license": {
-                          "version": "3.0.1",
+                          "version": "3.0.3",
                           "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                           "dependencies": {
                             "spdx-correct": {
-                              "version": "1.0.2",
-                              "from": "spdx-correct@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "version": "3.0.0",
+                              "from": "spdx-correct@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
-                                  "version": "1.2.2",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                                  "version": "3.0.0",
+                                  "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
-                              "version": "1.0.4",
-                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "2.1.0",
+                                  "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "3.0.0",
+                                  "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                                }
+                              }
                             }
                           }
                         }
@@ -10062,9 +10422,9 @@
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
-          "version": "1.3.1",
+          "version": "1.3.5",
           "from": "redis-commands@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz"
         },
         "redis-parser": {
           "version": "2.6.0",
@@ -10134,7 +10494,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <1.2.0",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -10394,9 +10754,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.3.3",
+          "version": "2.3.4",
           "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
@@ -10450,9 +10810,9 @@
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.8.0",
-                  "from": "nan@>=2.0.8 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+                  "version": "2.9.2",
+                  "from": "nan@>=2.3.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
                 }
               }
             },
@@ -10628,7 +10988,7 @@
         },
         "node-uuid": {
           "version": "1.4.8",
-          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
         },
         "once": {
@@ -10729,7 +11089,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "from": "inherits@>=2.0.3 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
@@ -10822,9 +11182,9 @@
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.8.0",
-              "from": "nan@>=2.0.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+              "version": "2.9.2",
+              "from": "nan@>=2.3.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
             }
           }
         }
@@ -10952,7 +11312,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
+          "from": "minimist@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "urlsafe-base64": {

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -19,7 +19,9 @@ const TOKEN = {
   email: Buffer('test@example.com').toString('hex'),
   emailCode: '123456',
   emailVerified: true,
-  tokenVerificationId: crypto.randomBytes(16)
+  tokenVerificationId: crypto.randomBytes(16),
+  verificationMethod: 2, // Totp verification method
+  verifiedAt: Date.now()
 }
 
 describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
@@ -83,6 +85,9 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
             assert.equal(token.tokenVerified, token2.tokenVerified)
             assert.equal(token.tokenVerificationId, token2.tokenVerificationId)
             assert.equal(token.state, token2.state)
+            assert.equal(token.verificationMethod, token2.verificationMethod)
+            assert.equal(token.verificationMethodValue, 'totp-2fa')
+            assert.equal(token.verifiedAt, token2.verifiedAt)
           }
         )
     }

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -72,6 +72,7 @@ const DB_METHOD_NAMES = [
   'updateDevice',
   'updateLocale',
   'updateSessionToken',
+  'updateTotpToken',
   'verifyEmail',
   'verifyTokens',
   'verifyTokenCode',


### PR DESCRIPTION
This PR updates the auth-server to use the new verification methods in https://github.com/mozilla/fxa-auth-db-mysql/pull/309. When a TOTP code has been confirmed, the TOTP will become verified and enabled and the `verificationMethod` on the session will be set.

- [x] Update shrinkwrap use new auth db once https://github.com/mozilla/fxa-auth-db-mysql/pull/309 lands.

Fixes https://github.com/mozilla/fxa-auth-server/issues/2295