### PR TITLE
fix(tests): Make email-polling-expiry tests pass in March.

### DIFF
--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -20,7 +20,9 @@ var TEST_EMAIL = 'foo@gmail.com'
 var TEST_EMAIL_ADDITIONAL = 'foo2@gmail.com'
 var TEST_EMAIL_INVALID = 'example@dotless-domain'
 const MS_IN_DAY = 1000 * 60 * 60 * 24
-const MS_IN_TWO_MONTHS = MS_IN_DAY * 60
+// This is slightly less than 2 months ago, regardless of which
+// months are in question (I'm looking at you, February...)
+const MS_IN_ALMOST_TWO_MONTHS = MS_IN_DAY * 58
 
 var makeRoutes = function (options, requireMocks) {
   options = options || {}
@@ -130,7 +132,7 @@ describe('/recovery_email/status', function () {
         begin: sinon.spy()
       }
       const db = mocks.mockDB()
-      config.emailStatusPollingTimeout = MS_IN_TWO_MONTHS
+      config.emailStatusPollingTimeout = MS_IN_ALMOST_TWO_MONTHS
       const routes = makeRoutes({
         config,
         db,


### PR DESCRIPTION
The tests assume that doing `date.setMonth(date.getMonth() - 2)` here:

  https://github.com/mozilla/fxa-auth-server/blob/fcf4052d9ff3e2a0dd4e3bb6df83c1089ee5dda3/test/local/routes/emails.js#L148

Will move the timestamp at least 60 days into the past.  That's not true in March, where it will only move it 31+28=59 days.  Thanks so much for an afternoon of complete bafflement at spontaneous test failures, February!

@mozilla/fxa-devs r?