### PR TITLE
fix(codes): Take token-code uid from the token, not the request payload.

### DIFF
--- a/test/client/api.js
+++ b/test/client/api.js
@@ -730,7 +730,7 @@ module.exports = config => {
     )
   }
 
-  ClientApi.prototype.verifyTokenCode = function (sessionTokenHex, uid, code, options = {}) {
+  ClientApi.prototype.verifyTokenCode = function (sessionTokenHex, code, options = {}) {
     return tokens.SessionToken.fromHex(sessionTokenHex)
       .then((token) => {
         return this.doRequest(
@@ -738,8 +738,8 @@ module.exports = config => {
           this.baseURL + '/session/verify/token',
           token,
           {
-            uid: uid,
             code: code,
+            uid: options.uid || undefined,
             metricsContext: options.metricsContext
           }
         )

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -274,7 +274,7 @@ module.exports = config => {
   }
 
   Client.prototype.verifyTokenCode = function (code, options) {
-    return this.api.verifyTokenCode(this.sessionToken, this.uid, code, options)
+    return this.api.verifyTokenCode(this.sessionToken, code, options)
   }
 
   Client.prototype.emailStatus = function () {

--- a/test/local/routes/token-codes.js
+++ b/test/local/routes/token-codes.js
@@ -108,11 +108,11 @@ function setup(results, errors) {
   route = getRoute(routes, '/session/verify/token')
   request = mocks.mockRequest({
     credentials: {
+      uid: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
       email: TEST_EMAIL
     },
     log: log,
     payload: {
-      uid: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
       code: 'ASEFJK12'
     }
   })

--- a/test/remote/token_code_tests.js
+++ b/test/remote/token_code_tests.js
@@ -108,6 +108,65 @@ describe('remote tokenCodes', function () {
     })
   })
 
+  it('should accept optional uid parameter in request body', () => {
+    return Client.login(config.publicUrl, email, password, {
+      verificationMethod: 'email-2fa'
+    })
+    .then((res) => {
+      client = res
+      return server.mailbox.waitForEmail(email)
+    })
+    .then((emailData) => {
+      assert.equal(emailData.headers['x-template-name'], 'verifyLoginCodeEmail', 'sign-in code sent')
+      code = emailData.headers['x-signin-verify-code']
+      assert.ok(code, 'code is sent')
+      return client.verifyTokenCode(code, { uid: client.uid })
+    })
+    .then((res) => {
+      assert.ok(res, 'verified successful response')
+      return client.emailStatus()
+    })
+    .then((status) => {
+      assert.equal(status.verified, true, 'account is verified')
+      assert.equal(status.emailVerified, true, 'email is verified')
+      assert.equal(status.sessionVerified, true, 'session is verified')
+    })
+  })
+
+  it('should reject mismatched uid parameter in request body', () => {
+    const uid1 = client.uid
+    const email2 = server.uniqueEmail()
+    return Client.createAndVerify(config.publicUrl, email2, password, server.mailbox)
+    .then(() => {
+      return Client.login(config.publicUrl, email2, password, {
+        verificationMethod: 'email-2fa'
+      })
+    })
+    .then((res) => {
+      client = res
+      assert.notEqual(uid1, client.uid, 'new account has a different uid')
+      return server.mailbox.waitForEmail(email2)
+    })
+    .then((emailData) => {
+      assert.equal(emailData.headers['x-template-name'], 'verifyLoginCodeEmail', 'sign-in code sent')
+      code = emailData.headers['x-signin-verify-code']
+      assert.ok(code, 'code is sent')
+      return client.verifyTokenCode(code, { uid: uid1 })
+    })
+    .then(
+      () => { assert.fail('using a mismatched uid should have failed') },
+      err => {
+        assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER, 'uid parameter was rejected')
+        return client.emailStatus()
+      }
+    )
+    .then((status) => {
+      assert.equal(status.verified, false, 'account is verified')
+      assert.equal(status.emailVerified, true, 'email is verified')
+      assert.equal(status.sessionVerified, false, 'session is not verified')
+    })
+  })
+
   it('should retrieve account keys', () => {
     return Client.login(config.publicUrl, email, password, {
       verificationMethod: 'email-2fa',


### PR DESCRIPTION
This addresses an oddity that I noticed while digging in to https://bugzilla.mozilla.org/show_bug.cgi?id=1444204; I don't believe it has any security implications apart from possibly some weirdness around rate-limiting, but wanted to clean it up to avoid future confusion.

Since `/session/verify/token` is authenticated with a sessionToken, we know the uid that the session belongs to and do not need it to be passed in via the request body.  This change makes it so we continue to accept `uid` in the request body for b/w compat, but marks it optional and throws an error if it's different to the `uid` of the authenticated session.

@vbudhram r?