### PR TITLE
fix(totp): Restrict allowed chars in TOTP code input.

### DIFF
--- a/lib/routes/totp.js
+++ b/lib/routes/totp.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const errors = require('../error')
+const validators = require('./validators')
 const isA = require('joi')
 const P = require('../promise')
 const otplib = require('otplib')
@@ -180,7 +181,7 @@ module.exports = (log, db, customs, config) => {
         },
         validate: {
           payload: {
-            code: isA.string().max(32).required(),
+            code: isA.string().max(32).regex(validators.DIGITS).required(),
             metricsContext: METRICS_CONTEXT_SCHEMA
           }
         },

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -19,6 +19,8 @@ module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]+$/
 // Crude phone number validation. The handler code does it more thoroughly.
 exports.E164_NUMBER = /^\+[1-9]\d{1,14}$/
 
+exports.DIGITS = /^[0-9]+$/
+
 // Match display-safe unicode characters.
 // We're pretty liberal with what's allowed in a unicode string,
 // but we exclude the following classes of characters:

--- a/test/local/routes/totp.js
+++ b/test/local/routes/totp.js
@@ -94,7 +94,7 @@ describe('totp', () => {
   })
 
   describe('/session/verify/totp', () => {
-    it('should return false for valid TOTP code', () => {
+    it('should return true for valid TOTP code', () => {
       return setup({db: {}}, {}, '/session/verify/totp', requestOptions)
         .then((response) => {
           assert.equal(response.success, true, 'should be valid code')

--- a/test/remote/totp_tests.js
+++ b/test/remote/totp_tests.js
@@ -125,9 +125,19 @@ describe('remote totp', function () {
     })
 
     it('should fail to verify totp code', () => {
-      return client.verifyTotpCode('wrong', {metricsContext})
+      const code = otplib.authenticator.generate()
+      const incorrectCode = code === '123456' ? '123455' : '123456'
+      return client.verifyTotpCode(incorrectCode, {metricsContext})
         .then((result) => {
           assert.equal(result.success, false, 'failed')
+        })
+    })
+
+    it('should reject non-numeric codes', () => {
+      return client.verifyTotpCode('wrong', {metricsContext})
+        .then( assert.fail, (err) => {
+          assert.equal(err.code, 400, 'correct error code')
+          assert.equal(err.errno, 107, 'correct error errno')
         })
     })
 
@@ -137,7 +147,7 @@ describe('remote totp', function () {
         .then((x) => {
           client = x
           assert.ok(client.authAt, 'authAt was set')
-          return client.verifyTotpCode('wrong', {metricsContext})
+          return client.verifyTotpCode('123456', {metricsContext})
             .then(assert.fail, (err) => {
               assert.equal(err.code, 400, 'correct error code')
               assert.equal(err.errno, 155, 'correct error errno')


### PR DESCRIPTION
We expect TOTP codes to always be numeric, so let's validate that at the API boundary.

The only thing we do with these codes is pass them to `otplib.authenticator.check`, which runs them through `parseFloat`, so I don't think there's any badness that could ensue from passing in non-numeric values.  But we should reject them for completeness.

@vbudhram r?