### PR TITLE
feat(amr): Report AMR and AAL in relier-facing APIs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -740,11 +740,38 @@ the scopes that the token is authorized for:
 
 * `email` requires `profile:email` scope.
 
-* `locale` require `profile:locale` scope.
+* `locale` requires `profile:locale` scope.
 
-The `profile` scope includes both
-of the `email` and `locale` sub-scopes.
+* `authenticationMethods` and `authenticatorAssuranceLevel` require `profile:amr` scope.
+
+The `profile` scope includes all the above sub-scopes.
 <!--end-route-get-accountprofile-->
+
+##### Response body
+
+* `email`: *string, optional*
+
+  <!--begin-response-body-get-accountprofile-email-->
+  
+  <!--end-response-body-get-accountprofile-email-->
+
+* `locale`: *string, optional*
+
+  <!--begin-response-body-get-accountprofile-locale-->
+  
+  <!--end-response-body-get-accountprofile-locale-->
+
+* `authenticationMethods`: *array, items(string, required), optional*
+
+  <!--begin-response-body-get-accountprofile-authenticationMethods-->
+  
+  <!--end-response-body-get-accountprofile-authenticationMethods-->
+
+* `authenticatorAssuranceLevel`: *number, min(0)*
+
+  <!--begin-response-body-get-accountprofile-authenticatorAssuranceLevel-->
+  
+  <!--end-response-body-get-accountprofile-authenticatorAssuranceLevel-->
 
 
 #### GET /account/keys

--- a/lib/authMethods.js
+++ b/lib/authMethods.js
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const error = require('./error')
+
+// Maps our variety of verification methods down to a few short standard
+// strings that can be part of our external API surface to reliers.
+// We try to use the values defined in RFC8176 where possible:
+//
+//  https://tools.ietf.org/html/rfc8176
+//
+// But invent our own where not (e.g. 'email').
+const METHOD_TO_AMR = {
+  'email': 'email',
+  'email-captcha': 'email',
+  'email-2fa': 'email',
+  'totp-2fa': 'otp'
+}
+
+// Maps AMR values to the type of authenticator they represent, e.g.
+// "something you know" vs "something you have".  This helps us determine
+// the level of assurance implied by a set of authentication methods.
+const AMR_TO_TYPE = {
+  'pwd': 'know',
+  'email': 'know',
+  'otp': 'have'
+}
+
+module.exports = (db) => {
+  return {
+
+    /**
+     * Returns the set of authentication methods available
+     * for the given account, as amr value strings.
+     */
+    availableAuthenticationMethods(account) {
+      const amrValues = new Set()
+      // All accounts can authenticate with a password.
+      amrValues.add('pwd')
+      // All accounts can authenticate with an email confirmation loop.
+      amrValues.add('email')
+      // Some accounts have a TOTP token.
+      return db.totpToken(account.uid)
+        .then(
+          res => {
+            if (res && res.verified && res.enabled) {
+              amrValues.add('otp')
+            }
+          },
+          err => {
+            if (err.errno !== error.ERRNO.TOTP_TOKEN_NOT_FOUND) {
+              throw err
+            }
+          }
+        )
+        .then(() => {
+          return amrValues
+        })
+    },
+
+    /**
+     * Map a verificiationMethod name to one of the publicly-exposed
+     * amr value strings.  For example, "email-captcha" will map to
+     * "email" while "totp-2fa" will map to "otp".
+     */
+    verificationMethodToAMR(verificationMethod) {
+      const amr = METHOD_TO_AMR[verificationMethod]
+      if (! amr) {
+        throw new Error('unknown verificationMethod: ' + verificationMethod)
+      }
+      return amr
+    },
+
+    /**
+     * Given a set of AMR value strings, return the maximum authenticator assurance
+     * level that can be achieved using them.  We aim to follow the definition
+     * of levels 1, 2, and 3 from NIST SP 800-63B based on different categories
+     * of authenticator (e.g. "something you know" vs "something you have"),
+     * although we don't yet support any methods that would qualify the user
+     * for level 3.
+     */
+    maximumAssuranceLevel(amrValues) {
+      const types = new Set()
+      for (const amr in amrValues) {
+        types.add(AMR_TO_TYPE[amr])
+      }
+      return types.length
+    }
+
+  }
+}
+

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -12,6 +12,7 @@ const random = require('../crypto/random')
 const requestHelper = require('../routes/utils/request_helper')
 const uuid = require('uuid')
 const validators = require('./validators')
+const authMethods = require('../authMethods')
 
 const HEX_STRING = validators.HEX_STRING
 
@@ -815,6 +816,14 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
             'sessionToken',
             'oauthToken'
           ]
+        },
+        response: {
+          schema: {
+            email: isA.string().optional(),
+            locale: isA.string().optional(),
+            authenticationMethods: isA.array().items(isA.string().required()).optional(),
+            authenticatorAssuranceLevel: isA.number().min(0)
+          }
         }
       },
       handler: function (request, reply) {
@@ -846,18 +855,24 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
           }
           return false
         }
+        const res = {}
         db.account(uid)
-          .then(
-            function (account) {
-              reply({
-                email: hasProfileItemScope('email') ? account.primaryEmail.email : undefined,
-                locale: hasProfileItemScope('locale') ? account.locale : undefined
-              })
-            },
-            function (err) {
-              reply(err)
+          .then(account => {
+            if (hasProfileItemScope('email')) {
+              res.email = account.primaryEmail.email
             }
-          )
+            if (hasProfileItemScope('locale')) {
+              res.locale = account.locale
+            }
+            if (hasProfileItemScope('amr')) {
+              return authMethods.availableAuthenticationMethods(account)
+                .then(amrValues => {
+                  res.authenticationMethods = Array.from(amrValues)
+                  res.authenticatorAssuranceLevel = authMethods.maximumAssuranceLevel(amrValues)
+                })
+            }
+          })
+          .then(() => reply(res), reply)
       }
     },
     {

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -159,7 +159,9 @@ module.exports = (log, signer, db, domain, devices) => {
                   lastAuthAt: sessionToken.lastAuthAt(),
                   verifiedEmail: sessionToken.email,
                   deviceId: deviceId,
-                  tokenVerified: sessionToken.tokenVerified
+                  tokenVerified: sessionToken.tokenVerified,
+                  authenticationMethods: sessionToken.authenticationMethods,
+                  authenticatorAssuranceLevel: sessionToken.authenticatorAssuranceLevel
                 }
               )
             }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -25,7 +25,9 @@ module.exports = function (secretKeyFile, domain) {
           'fxa-lastAuthAt': data.lastAuthAt,
           'fxa-verifiedEmail': data.verifiedEmail,
           'fxa-deviceId': data.deviceId,
-          'fxa-tokenVerified': data.tokenVerified
+          'fxa-tokenVerified': data.tokenVerified,
+          'fxa-amr': data.authenticationMethods,
+          'fxa-aal': data.authenticatorAssuranceLevel
         }
       )
       .then(

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -4,6 +4,8 @@
 
 'use strict'
 
+const authMethods = require('../authMethods')
+
 module.exports = (log, Token, config) => {
   const MAX_AGE_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
 
@@ -69,6 +71,21 @@ module.exports = (log, Token, config) => {
       } else {
         return 'unverified'
       }
+    }
+
+    get authenticationMethods() {
+      const amrValues = new Set()
+      // All sessionTokens require password authentication.
+      amrValues.add('pwd')
+      // Verified sessionTokens imply some additional authenticatin method.
+      if (this.verificationMethodValue) {
+        amrValues.add(authMethods.verificationMethodToAMR(this.verificationMethodValue))
+      }
+      return amrValues
+    }
+
+    get authenticatorAssuranceLevel() {
+      return authMethods.maximumAssuranceLevel(this.authenticationMethods)
     }
 
     setUserAgentInfo(data) {


### PR DESCRIPTION
This helps expose the user's MFA state to reliers, by reporting the "authentication methods" and "authenticator assurance level" used when creating a sessionToken, along with the available methods
and maximum level achieveable by the account.

Work in progress for now, but fixes #2314 and fixes #2315 once it's done.