### PR TITLE
feat(amr): Report AMR and AAL in relier-facing APIs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -740,11 +740,38 @@ the scopes that the token is authorized for:
 
 * `email` requires `profile:email` scope.
 
-* `locale` require `profile:locale` scope.
+* `locale` requires `profile:locale` scope.
 
-The `profile` scope includes both
-of the `email` and `locale` sub-scopes.
+* `authenticationMethods` and `authenticatorAssuranceLevel` require `profile:amr` scope.
+
+The `profile` scope includes all the above sub-scopes.
 <!--end-route-get-accountprofile-->
+
+##### Response body
+
+* `email`: *string, optional*
+
+  <!--begin-response-body-get-accountprofile-email-->
+  
+  <!--end-response-body-get-accountprofile-email-->
+
+* `locale`: *string, optional*
+
+  <!--begin-response-body-get-accountprofile-locale-->
+  
+  <!--end-response-body-get-accountprofile-locale-->
+
+* `authenticationMethods`: *array, items(string, required), optional*
+
+  <!--begin-response-body-get-accountprofile-authenticationMethods-->
+  
+  <!--end-response-body-get-accountprofile-authenticationMethods-->
+
+* `authenticatorAssuranceLevel`: *number, min(0)*
+
+  <!--begin-response-body-get-accountprofile-authenticatorAssuranceLevel-->
+  
+  <!--end-response-body-get-accountprofile-authenticatorAssuranceLevel-->
 
 
 #### GET /account/keys

--- a/lib/authMethods.js
+++ b/lib/authMethods.js
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const error = require('./error')
+
+// Maps our variety of verification methods down to a few short standard
+// "authentication method reference" strings that we're happy to expose to
+// reliers. We try to use the values defined in RFC8176 where possible:
+//
+//   https://tools.ietf.org/html/rfc8176
+//
+// But invent our own where not (e.g. 'email').
+const METHOD_TO_AMR = {
+  'email': 'email',
+  'email-captcha': 'email',
+  'email-2fa': 'email',
+  'totp-2fa': 'otp'
+}
+
+// Maps AMR values to the type of authenticator they represent, e.g.
+// "something you know" vs "something you have".  This helps us determine
+// the level of assurance implied by a set of authentication methods.
+const AMR_TO_TYPE = {
+  'pwd': 'know',
+  'email': 'know',
+  'otp': 'have'
+}
+
+module.exports = {
+
+  /**
+   * Returns the set of authentication methods available
+   * for the given account, as amr value strings.
+   */
+  availableAuthenticationMethods(db, account) {
+    const amrValues = new Set()
+    // All accounts can authenticate with a password.
+    amrValues.add('pwd')
+    // All accounts can authenticate with an email confirmation loop.
+    amrValues.add('email')
+    // Some accounts have a TOTP token.
+    return db.totpToken(account.uid)
+      .then(
+        res => {
+          if (res && res.verified && res.enabled) {
+            amrValues.add('otp')
+          }
+        },
+        err => {
+          if (err.errno !== error.ERRNO.TOTP_TOKEN_NOT_FOUND) {
+            throw err
+          }
+        }
+      )
+      .then(() => {
+        return amrValues
+      })
+  },
+
+  /**
+   * Map a verificiationMethod name to one of the publicly-exposed
+   * amr value strings.  For example, "email-captcha" will map to
+   * "email" while "totp-2fa" will map to "otp".
+   */
+  verificationMethodToAMR(verificationMethod) {
+    const amr = METHOD_TO_AMR[verificationMethod]
+    if (! amr) {
+      throw new Error('unknown verificationMethod: ' + verificationMethod)
+    }
+    return amr
+  },
+
+  /**
+   * Given a set of AMR value strings, return the maximum authenticator assurance
+   * level that can be achieved using them.  We aim to follow the definition
+   * of levels 1, 2, and 3 from NIST SP 800-63B based on different categories
+   * of authenticator (e.g. "something you know" vs "something you have"),
+   * although we don't yet support any methods that would qualify the user
+   * for level 3.
+   */
+  maximumAssuranceLevel(amrValues) {
+    const types = new Set()
+    amrValues.forEach(amr => {
+      types.add(AMR_TO_TYPE[amr])
+    })
+    return types.size
+  }
+}

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -159,7 +159,9 @@ module.exports = (log, signer, db, domain, devices) => {
                   lastAuthAt: sessionToken.lastAuthAt(),
                   verifiedEmail: sessionToken.email,
                   deviceId: deviceId,
-                  tokenVerified: sessionToken.tokenVerified
+                  tokenVerified: sessionToken.tokenVerified,
+                  authenticationMethods: Array.from(sessionToken.authenticationMethods),
+                  authenticatorAssuranceLevel: sessionToken.authenticatorAssuranceLevel
                 }
               )
             }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -25,7 +25,9 @@ module.exports = function (secretKeyFile, domain) {
           'fxa-lastAuthAt': data.lastAuthAt,
           'fxa-verifiedEmail': data.verifiedEmail,
           'fxa-deviceId': data.deviceId,
-          'fxa-tokenVerified': data.tokenVerified
+          'fxa-tokenVerified': data.tokenVerified,
+          'fxa-amr': data.authenticationMethods,
+          'fxa-aal': data.authenticatorAssuranceLevel
         }
       )
       .then(

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -4,6 +4,8 @@
 
 'use strict'
 
+const authMethods = require('../authMethods')
+
 module.exports = (log, Token, config) => {
   const MAX_AGE_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
 
@@ -69,6 +71,23 @@ module.exports = (log, Token, config) => {
       } else {
         return 'unverified'
       }
+    }
+
+    get authenticationMethods() {
+      const amrValues = new Set()
+      // All sessionTokens require password authentication.
+      amrValues.add('pwd')
+      // Verified sessionTokens imply some additional authentication method(s).
+      if (this.verificationMethodValue) {
+        amrValues.add(authMethods.verificationMethodToAMR(this.verificationMethodValue))
+      } else if (this.tokenVerified) {
+        amrValues.add('email')
+      }
+      return amrValues
+    }
+
+    get authenticatorAssuranceLevel() {
+      return authMethods.maximumAssuranceLevel(this.authenticationMethods)
     }
 
     setUserAgentInfo(data) {

--- a/test/local/authMethods.js
+++ b/test/local/authMethods.js
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const sinon = require('sinon')
+const assert = Object.assign({}, sinon.assert, require('insist'))
+
+const mocks = require('../mocks')
+const P = require('../../lib/promise')
+const error = require('../../lib/error')
+
+const authMethods = require('../../lib/authMethods')
+
+const MOCK_ACCOUNT = {
+  uid: 'abcdef123456'
+}
+
+describe('availableAuthenticationMethods', () => {
+  let mockDb
+
+  beforeEach(() => {
+    mockDb = mocks.mockDB()
+  })
+
+  it('returns [`pwd`,`email`] for non-TOTP-enabled accounts', () => {
+    mockDb.totpToken = sinon.spy(() => { return P.reject(error.totpTokenNotFound()) })
+    return authMethods.availableAuthenticationMethods(mockDb, MOCK_ACCOUNT).then(amr => {
+      assert.calledWithExactly(mockDb.totpToken, MOCK_ACCOUNT.uid)
+      assert.deepEqual(Array.from(amr).sort(), ['email', 'pwd'])
+    })
+  })
+
+  it('returns [`pwd`,`email`,`otp`] for TOTP-enabled accounts', () => {
+    mockDb.totpToken = sinon.spy(() => {
+      return P.resolve({
+        verified: true,
+        enabled: true,
+        sharedSecret: 'secret!',
+      })
+    })
+    return authMethods.availableAuthenticationMethods(mockDb, MOCK_ACCOUNT).then(amr => {
+      assert.calledWithExactly(mockDb.totpToken, MOCK_ACCOUNT.uid)
+      assert.deepEqual(Array.from(amr).sort(), ['email', 'otp', 'pwd'])
+    })
+  })
+
+  it('returns [`pwd`,`email`] when TOTP token is not yet enabled', () => {
+    mockDb.totpToken = sinon.spy(() => {
+      return P.resolve({
+        verified: true,
+        enabled: false,
+        sharedSecret: 'secret!',
+      })
+    })
+    return authMethods.availableAuthenticationMethods(mockDb, MOCK_ACCOUNT).then(amr => {
+      assert.calledWithExactly(mockDb.totpToken, MOCK_ACCOUNT.uid)
+      assert.deepEqual(Array.from(amr).sort(), ['email', 'pwd'])
+    })
+  })
+
+  it('rethrows unexpected DB errors', () => {
+    mockDb.totpToken = sinon.spy(() => { return P.reject(error.serviceUnavailable()) })
+    return authMethods.availableAuthenticationMethods(mockDb, MOCK_ACCOUNT).then(
+      () => { assert.fail('error should have been re-thrown') },
+      (err) => {
+        assert.calledWithExactly(mockDb.totpToken, MOCK_ACCOUNT.uid)
+        assert.equal(err.errno, error.ERRNO.SERVER_BUSY)
+      }
+    )
+  })
+})
+
+describe('verificationMethodToAMR', () => {
+  it('maps `email` to `email`', () => {
+    assert.equal(authMethods.verificationMethodToAMR('email'), 'email')
+  })
+
+  it('maps `email-captcha` to `email`', () => {
+    assert.equal(authMethods.verificationMethodToAMR('email-captcha'), 'email')
+  })
+
+  it('maps `email-2fa` to `email`', () => {
+    assert.equal(authMethods.verificationMethodToAMR('email-2fa'), 'email')
+  })
+
+  it('maps `totp-2fa` to `otp`', () => {
+    assert.equal(authMethods.verificationMethodToAMR('totp-2fa'), 'otp')
+  })
+
+  it('throws when given an unknown verification method', () => {
+    assert.throws(() => { authMethods.verificationMethodToAMR('email-gotcha') }, /unknown verificationMethod/)
+  })
+})
+
+describe('maximumAssuranceLevel', () => {
+  it('returns 0 when no authentication methods are used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel([]), 0)
+    assert.equal(authMethods.maximumAssuranceLevel(new Set()), 0)
+  })
+
+  it('returns 1 when only `pwd` auth is used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel(['pwd']), 1)
+  })
+
+  it('returns 1 when only `email` auth is used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel(['email']), 1)
+  })
+
+  it('returns 1 when only `otp` auth is used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel(['otp']), 1)
+  })
+
+  it('returns 1 when only things-you-know auth mechanisms are used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel(['email', 'pwd']), 1)
+  })
+
+  it('returns 2 when both `pwd` and `otp` methods are used', () => {
+    assert.equal(authMethods.maximumAssuranceLevel(['pwd', 'otp']), 2)
+  })
+})

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -88,6 +88,8 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
             assert.equal(token.verificationMethod, token2.verificationMethod)
             assert.equal(token.verificationMethodValue, 'totp-2fa')
             assert.equal(token.verifiedAt, token2.verifiedAt)
+            assert.deepEqual(token.authenticationMethods, token2.authenticationMethods)
+            assert.deepEqual(token.authenticatorAssuranceLevel, token2.authenticatorAssuranceLevel)
           }
         )
     }
@@ -243,6 +245,49 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
       const token = new SessionToken({}, {})
       token.tokenVerified = true
       assert.equal(token.state, 'verified')
+    })
+  })
+
+  describe('authenticationMethods', () => {
+
+    it('should be [`pwd`] for unverified tokens', () => {
+      return SessionToken.create(Object.assign({}, TOKEN, {
+        verificationMethod: null,
+        verifiedAt: null
+      }))
+      .then(token => {
+        assert.deepEqual(Array.from(token.authenticationMethods).sort(), ['pwd'])
+      })
+    })
+
+    it('should be [`pwd`, `email`] for verified tokens', () => {
+      return SessionToken.create(Object.assign({}, TOKEN, {
+        tokenVerificationId: null,
+        verificationMethod: null,
+        verifiedAt: null
+      }))
+      .then(token => {
+        assert.deepEqual(Array.from(token.authenticationMethods).sort(), ['email', 'pwd'])
+      })
+    })
+
+    it('should be [`pwd`, `email`] for tokens verified via email-2fa', () => {
+      return SessionToken.create(Object.assign({}, TOKEN, {
+        tokenVerificationId: null,
+        verificationMethod: 1
+      }))
+      .then(token => {
+        assert.deepEqual(Array.from(token.authenticationMethods).sort(), ['email', 'pwd'])
+      })
+    })
+
+    it('should be [`pwd`, `otp`] for tokens verified via totp-2fa', () => {
+      return SessionToken.create(Object.assign({}, TOKEN, {
+        verificationMethod: 2
+      }))
+      .then(token => {
+        assert.deepEqual(Array.from(token.authenticationMethods).sort(), ['otp', 'pwd'])
+      })
     })
   })
 })

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -31,17 +31,15 @@ describe('remote account profile', function() {
     'account profile authenticated with session returns profile data',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            return c.api.accountProfile(c.sessionToken)
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(response.email, 'email address is returned')
-            assert.equal(response.locale, 'en-US', 'locale is returned')
-          }
-        )
+        .then(c => {
+          return c.api.accountProfile(c.sessionToken)
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.equal(response.locale, 'en-US', 'locale is returned')
+          assert.deepEqual(response.authenticationMethods, ['pwd', 'email'], 'authentication methods are returned')
+          assert.equal(response.authenticatorAssuranceLevel, 1, 'assurance level is returned')
+        })
     }
   )
 
@@ -49,22 +47,20 @@ describe('remote account profile', function() {
     'account profile authenticated with oauth returns profile data',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            return c.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: c.uid,
-                scope: ['profile']
-              })
+        .then(c => {
+          return c.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: c.uid,
+              scope: ['profile']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(response.email, 'email address is returned')
-            assert.equal(response.locale, 'en-US', 'locale is returned')
-          }
-        )
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.equal(response.locale, 'en-US', 'locale is returned')
+          assert.deepEqual(response.authenticationMethods, ['pwd', 'email'], 'authentication methods are returned')
+          assert.equal(response.authenticatorAssuranceLevel, 1, 'assurance level is returned')
+        })
     }
   )
 
@@ -88,21 +84,17 @@ describe('remote account profile', function() {
     'account profile authenticated with invalid oauth token returns an error',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            return c.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                code: 401,
-                errno: 108
-              })
+        .then(c => {
+          return c.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              code: 401,
+              errno: 108
             })
-          }
-        )
+          })
+        })
         .then(
-          function () {
-            assert(false, 'should get an error')
-          },
-          function (e) {
+          () => { assert(false, 'should get an error') },
+          (e) => {
             assert.equal(e.code, 401, 'correct error status code')
             assert.equal(e.errno, 110, 'correct errno')
           }
@@ -114,23 +106,21 @@ describe('remote account profile', function() {
     'account status authenticated with oauth for unknown uid returns an error',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            var UNKNOWN_UID = 'abcdef123456'
-            assert.notEqual(c.uid, UNKNOWN_UID)
-            return c.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: UNKNOWN_UID,
-                scope: ['profile']
-              })
+        .then(c => {
+          var UNKNOWN_UID = 'abcdef123456'
+          assert.notEqual(c.uid, UNKNOWN_UID)
+          return c.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: UNKNOWN_UID,
+              scope: ['profile']
             })
-          }
-        )
+          })
+        })
         .then(
-          function () {
+          () => {
             assert(false, 'should get an error')
           },
-          function (e) {
+          (e) => {
             assert.equal(e.code, 400, 'correct error status code')
             assert.equal(e.errno, 102, 'correct errno')
           }
@@ -142,21 +132,17 @@ describe('remote account profile', function() {
     'account status authenticated with oauth for wrong scope returns no info',
     () => {
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            return c.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: c.uid,
-                scope: ['readinglist', 'payments']
-              })
+        .then(c => {
+          return c.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: c.uid,
+              scope: ['readinglist', 'payments']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.deepEqual(response, {}, 'no info should be returned')
-          }
-        )
+          })
+        })
+        .then(response => {
+          assert.deepEqual(response, {}, 'no info should be returned')
+        })
     }
   )
 
@@ -165,39 +151,31 @@ describe('remote account profile', function() {
     () => {
       var client
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            client = c
-            return client.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: client.uid,
-                scope: ['profile:email']
-              })
+        .then(c => {
+          client = c
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['profile:email']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(response.email, 'email address is returned')
-            assert.ok(! response.locale, 'locale should not be returned')
-          }
-        )
-        .then(
-          function () {
-            return client.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: client.uid,
-                scope: ['profile:locale']
-              })
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.ok(! response.locale, 'locale should not be returned')
+        })
+        .then(() => {
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['profile:locale']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(! response.email, 'email address should not be returned')
-            assert.equal(response.locale, 'en-US', 'locale is returned')
-          }
-        )
+          })
+        })
+        .then(response => {
+          assert.ok(! response.email, 'email address should not be returned')
+          assert.equal(response.locale, 'en-US', 'locale is returned')
+        })
     }
   )
 
@@ -206,55 +184,63 @@ describe('remote account profile', function() {
     () => {
       var client
       return Client.create(config.publicUrl, server.uniqueEmail(), 'password', { lang: 'en-US' })
-        .then(
-          function (c) {
-            client = c
-            return client.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: client.uid,
-                scope: ['profile:write']
-              })
+        .then(c => {
+          client = c
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['profile:write']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(response.email, 'email address is returned')
-            assert.ok(response.locale, 'locale is returned')
-          }
-        )
-        .then(
-          function () {
-            return client.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: client.uid,
-                scope: ['profile:locale:write', 'readinglist']
-              })
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.ok(response.locale, 'locale is returned')
+          assert.ok(response.authenticationMethods, 'authenticationMethods is returned')
+          assert.ok(response.authenticatorAssuranceLevel, 'authenticatorAssuranceLevel is returned')
+        })
+        .then(() => {
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['profile:locale:write', 'readinglist']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(! response.email, 'email address should not be returned')
-            assert.ok(response.locale, 'locale is returned')
-          }
-        )
-        .then(
-          function () {
-            return client.api.accountProfile(null, {
-              Authorization: makeMockOAuthHeader({
-                user: client.uid,
-                scope: ['storage', 'profile:email:write']
-              })
+          })
+        })
+        .then(response => {
+          assert.ok(! response.email, 'email address should not be returned')
+          assert.ok(response.locale, 'locale is returned')
+          assert.ok(! response.authenticationMethods, 'authenticationMethods should not be returned')
+          assert.ok(! response.authenticatorAssuranceLevel, 'authenticatorAssuranceLevel should not be returned')
+        })
+        .then(() => {
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['storage', 'profile:email:write']
             })
-          }
-        )
-        .then(
-          function (response) {
-            assert.ok(response.email, 'email address is returned')
-            assert.ok(! response.locale, 'locale should not be returned')
-          }
-        )
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.ok(! response.locale, 'locale should not be returned')
+          assert.ok(! response.authenticationMethods, 'authenticationMethods should not be returned')
+          assert.ok(! response.authenticatorAssuranceLevel, 'authenticatorAssuranceLevel should not be returned')
+        })
+        .then(() => {
+          return client.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              scope: ['profile:amr', 'profile:email:write']
+            })
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.ok(! response.locale, 'locale should not be returned')
+          assert.ok(response.authenticationMethods, 'authenticationMethods is returned')
+          assert.ok(response.authenticatorAssuranceLevel, 'authenticatorAssuranceLevel is returned')
+        })
     }
   )
 
@@ -263,16 +249,33 @@ describe('remote account profile', function() {
     () => {
       var email = server.uniqueUnicodeEmail()
       return Client.create(config.publicUrl, email, 'password')
-        .then(
-          function (c) {
-            return c.api.accountProfile(c.sessionToken)
-          }
-        )
-        .then(
-          function (response) {
-            assert.equal(response.email, email, 'email address is returned')
-          }
-        )
+        .then(c => {
+          return c.api.accountProfile(c.sessionToken)
+        })
+        .then(response => {
+          assert.equal(response.email, email, 'email address is returned')
+        })
+    }
+  )
+
+  it(
+    'account profile reflects TOTP status',
+    () => {
+      return Client.createAndVerifyAndTOTP(config.publicUrl, server.uniqueEmail(), 'password', server.mailbox, { lang: 'en-US' })
+        .then(c => {
+          return c.api.accountProfile(null, {
+            Authorization: makeMockOAuthHeader({
+              user: c.uid,
+              scope: ['profile']
+            })
+          })
+        })
+        .then(response => {
+          assert.ok(response.email, 'email address is returned')
+          assert.equal(response.locale, 'en-US', 'locale is returned')
+          assert.deepEqual(response.authenticationMethods, ['pwd', 'email', 'otp'], 'correct authentication methods are returned')
+          assert.equal(response.authenticatorAssuranceLevel, 2, 'correct assurance level is returned')
+        })
     }
   )
 


### PR DESCRIPTION
This helps expose the user's MFA state to reliers, by reporting the "authentication methods" and "authenticator assurance level" used when creating a sessionToken, along with the available methods
and maximum level achieveable by the account.

Work in progress for now, but fixes #2314 and fixes #2315 once it's done.