### PR TITLE
chore(db): prevent the possibility of future url-injection bugs

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -37,6 +37,7 @@ module.exports = (
 
   const features = require('./features')(config)
   const redis = require('./redis')(config.redis, log)
+  const safeUrl = require('./safe-url')(log)
   const {
     SessionToken,
     KeyFetchToken,
@@ -46,6 +47,8 @@ module.exports = (
   } = Token
   const MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE = config.tokenLifetimes.sessionTokenWithoutDevice
   const { enabled: TOKEN_PRUNING_ENABLED, maxAge: TOKEN_PRUNING_MAX_AGE } = config.tokenPruning
+
+  const SAFE_URLS = {}
 
   function setAccountEmails(account) {
     return this.accountEmails(account.uid)
@@ -89,6 +92,7 @@ module.exports = (
 
   // CREATE
 
+  SAFE_URLS.createAccount = safeUrl('DB.createAccount', '/account/:uid')
   DB.prototype.createAccount = function (data) {
     log.trace(
       {
@@ -99,23 +103,20 @@ module.exports = (
     )
     data.createdAt = data.verifierSetAt = Date.now()
     data.normalizedEmail = data.email.toLowerCase()
-    return this.pool.put(
-      '/account/' + data.uid,
-      data
-    )
-    .then(
-      function () {
-        return data
-      },
-      function (err) {
-        if (isRecordAlreadyExistsError(err)) {
-          err = error.accountExists(data.email)
+    const { uid } = data
+    return this.pool.put(SAFE_URLS.createAccount({ uid }), data)
+      .then(
+        () => data,
+        err => {
+          if (isRecordAlreadyExistsError(err)) {
+            err = error.accountExists(data.email)
+          }
+          throw err
         }
-        throw err
-      }
-    )
+      )
   }
 
+  SAFE_URLS.createSessionToken = safeUrl('DB.createSessionToken', '/sessionToken/:id')
   DB.prototype.createSessionToken = function (authToken) {
     const { uid } = authToken
 
@@ -128,7 +129,7 @@ module.exports = (
         // Ensure there are no clashes with zombie tokens left behind in Redis
         return deleteSessionTokenFromRedis(uid, id)
           .catch(() => {})
-          .then(() => this.pool.put(`/sessionToken/${id}`,
+          .then(() => this.pool.put(SAFE_URLS.createSessionToken({ id }),
             Object.assign({
               // Marshall from this repo's id property to the db's tokenId
               tokenId: id
@@ -138,13 +139,15 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.createKeyFetchToken = safeUrl('DB.createKeyFetchToken', '/keyFetchToken/:id')
   DB.prototype.createKeyFetchToken = function (authToken) {
     log.trace({ op: 'DB.createKeyFetchToken', uid: authToken && authToken.uid })
     return KeyFetchToken.create(authToken)
       .then(
         function (keyFetchToken) {
+          const { id } = keyFetchToken
           return this.pool.put(
-            '/keyFetchToken/' + keyFetchToken.id,
+            SAFE_URLS.createKeyFetchToken({ id }),
             {
               tokenId: keyFetchToken.id,
               authKey: keyFetchToken.authKey,
@@ -163,13 +166,15 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.createPasswordForgotToken = safeUrl('DB.createPasswordForgotToken', '/passwordForgotToken/:id')
   DB.prototype.createPasswordForgotToken = function (emailRecord) {
     log.trace({ op: 'DB.createPasswordForgotToken', uid: emailRecord && emailRecord.uid })
     return PasswordForgotToken.create(emailRecord)
       .then(
         function (passwordForgotToken) {
+          const { id } = passwordForgotToken
           return this.pool.put(
-            '/passwordForgotToken/' + passwordForgotToken.id,
+            SAFE_URLS.createPasswordForgotToken({ id }),
             {
               tokenId: passwordForgotToken.id,
               data: passwordForgotToken.data,
@@ -188,13 +193,16 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.createPasswordChangeToken = safeUrl(
+    'DB.createPasswordChangeToken', '/passwordChangeToken/:id')
   DB.prototype.createPasswordChangeToken = function (data) {
     log.trace({ op: 'DB.createPasswordChangeToken', uid: data.uid })
     return PasswordChangeToken.create(data)
       .then(
         function (passwordChangeToken) {
+          const { id } = passwordChangeToken
           return this.pool.put(
-            '/passwordChangeToken/' + passwordChangeToken.id,
+            SAFE_URLS.createPasswordChangeToken({ id }),
             {
               tokenId: passwordChangeToken.id,
               data: passwordChangeToken.data,
@@ -213,9 +221,10 @@ module.exports = (
 
   // READ
 
+  SAFE_URLS.checkPassword = safeUrl('DB.checkPassword', '/account/:uid/checkPassword')
   DB.prototype.checkPassword = function (uid, verifyHash) {
-    log.trace({ op: 'DB.checkPassword', uid: uid, verifyHash: verifyHash })
-    return this.pool.post('/account/' + uid + '/checkPassword',
+    log.trace({ op: 'DB.checkPassword', uid, verifyHash })
+    return this.pool.post(SAFE_URLS.checkPassword({ uid }),
       {
         'verifyHash': verifyHash
       })
@@ -248,10 +257,11 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.sessions = safeUrl('DB.sessions', '/account/:uid/sessions')
   DB.prototype.sessions = function (uid) {
-    log.trace({ op: 'DB.sessions', uid: uid })
+    log.trace({ op: 'DB.sessions', uid })
     const promises = [
-      this.pool.get('/account/' + uid + '/sessions')
+      this.pool.get(SAFE_URLS.sessions({ uid }))
         .then(sessionTokens => {
           if (! MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
             return sessionTokens
@@ -325,9 +335,10 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.keyFetchToken = safeUrl('DB.keyFetchToken', '/keyFetchToken/:id')
   DB.prototype.keyFetchToken = function (id) {
-    log.trace({ op: 'DB.keyFetchToken', id: id })
-    return this.pool.get('/keyFetchToken/' + id)
+    log.trace({ op: 'DB.keyFetchToken', id })
+    return this.pool.get(SAFE_URLS.keyFetchToken({ id }))
       .then(
         function (data) {
           return KeyFetchToken.fromId(id, data)
@@ -339,9 +350,11 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.keyFetchTokenWithVerificationStatus = safeUrl(
+    'DB.keyFetchTokenWithVerificationStatus', '/keyFetchToken/:id/verified')
   DB.prototype.keyFetchTokenWithVerificationStatus = function (id) {
-    log.trace({ op: 'DB.keyFetchTokenWithVerificationStatus', id: id })
-    return this.pool.get('/keyFetchToken/' + id + '/verified')
+    log.trace({ op: 'DB.keyFetchTokenWithVerificationStatus', id })
+    return this.pool.get(SAFE_URLS.keyFetchTokenWithVerificationStatus({ id }))
       .then(
         function (data) {
           return KeyFetchToken.fromId(id, data)
@@ -353,9 +366,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.accountResetToken = safeUrl('DB.accountResetToken', '/accountResetToken/:id')
   DB.prototype.accountResetToken = function (id) {
-    log.trace({ op: 'DB.accountResetToken', id: id })
-    return this.pool.get('/accountResetToken/' + id)
+    log.trace({ op: 'DB.accountResetToken', id })
+    return this.pool.get(SAFE_URLS.accountResetToken({ id }))
       .then(
         function (data) {
           return AccountResetToken.fromHex(data.tokenData, data)
@@ -367,9 +381,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.passwordForgotToken = safeUrl('DB.passwordForgotToken', '/passwordForgotToken/:id')
   DB.prototype.passwordForgotToken = function (id) {
-    log.trace({ op: 'DB.passwordForgotToken', id: id })
-    return this.pool.get('/passwordForgotToken/' + id)
+    log.trace({ op: 'DB.passwordForgotToken', id })
+    return this.pool.get(SAFE_URLS.passwordForgotToken({ id }))
       .then(
         function (data) {
           return PasswordForgotToken.fromHex(data.tokenData, data)
@@ -381,9 +396,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.passwordChangeToken = safeUrl('DB.passwordChangeToken', '/passwordChangeToken/:id')
   DB.prototype.passwordChangeToken = function (id) {
-    log.trace({ op: 'DB.passwordChangeToken', id: id })
-    return this.pool.get('/passwordChangeToken/' + id)
+    log.trace({ op: 'DB.passwordChangeToken', id })
+    return this.pool.get(SAFE_URLS.passwordChangeToken({ id }))
       .then(
         function (data) {
           return PasswordChangeToken.fromHex(data.tokenData, data)
@@ -395,9 +411,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.emailRecord = safeUrl('DB.emailRecord', '/emailRecord/:email')
   DB.prototype.emailRecord = function (email) {
-    log.trace({ op: 'DB.emailRecord', email: email })
-    return this.pool.get('/emailRecord/' + hexEncode(email))
+    log.trace({ op: 'DB.emailRecord', email })
+    return this.pool.get(SAFE_URLS.emailRecord({ email: hexEncode(email) }))
       .then(
         (body) => {
           return setAccountEmails.call(this, body)
@@ -411,9 +428,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.accountRecord = safeUrl('DB.accountRecord', '/email/:email/account')
   DB.prototype.accountRecord = function (email) {
-    log.trace({op: 'DB.accountFromEmail', email: email})
-    return this.pool.get('/email/' + hexEncode(email) + '/account')
+    log.trace({ op: 'DB.accountRecord', email })
+    return this.pool.get(SAFE_URLS.accountRecord({ email: hexEncode(email) }))
       .then(
         (body) => {
           return setAccountEmails.call(this, body)
@@ -429,9 +447,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.setPrimaryEmail = safeUrl('DB.setPrimaryEmail', '/email/:email/account/:uid')
   DB.prototype.setPrimaryEmail = function (uid, email) {
-    log.trace({op: 'DB.accountFromEmail', email: email})
-    return this.pool.post('/email/' + hexEncode(email) + '/account/' + uid)
+    log.trace({ op: 'DB.setPrimaryEmail', email })
+    return this.pool.post(SAFE_URLS.setPrimaryEmail({ email: hexEncode(email), uid }))
       .then(
         function (body) {
           return body
@@ -445,9 +464,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.account = safeUrl('DB.account', '/account/:uid')
   DB.prototype.account = function (uid) {
-    log.trace({op: 'DB.account', uid: uid})
-    return this.pool.get('/account/' + uid)
+    log.trace({ op: 'DB.account', uid })
+    return this.pool.get(SAFE_URLS.account({ uid }))
       .then((body) => {
         body.emailVerified = !! body.emailVerified
 
@@ -460,15 +480,16 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.devices = safeUrl('DB.devices', '/account/:uid/devices')
   DB.prototype.devices = function (uid) {
-    log.trace({ op: 'DB.devices', uid: uid })
+    log.trace({ op: 'DB.devices', uid })
 
     if (! uid) {
       return P.reject(error.unknownAccount())
     }
 
     const promises = [
-      this.pool.get('/account/' + uid + '/devices')
+      this.pool.get(SAFE_URLS.devices({ uid }))
     ]
     let isRedisOk = true
 
@@ -521,9 +542,10 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.sessionToken = safeUrl('DB.sessionToken', '/sessionToken/:id/device')
   DB.prototype.sessionToken = function (id) {
-    log.trace({ op: 'DB.sessionToken', id: id })
-    return this.pool.get('/sessionToken/' + id + '/device')
+    log.trace({ op: 'DB.sessionToken', id })
+    return this.pool.get(SAFE_URLS.sessionToken({ id }))
     .then(
       function (data) {
         return SessionToken.fromHex(data.tokenData, data)
@@ -537,10 +559,13 @@ module.exports = (
 
   // UPDATE
 
+  SAFE_URLS.updatePasswordForgotToken = safeUrl(
+    'DB.udatePasswordForgotToken', '/passwordForgotToken/:id/update')
   DB.prototype.updatePasswordForgotToken = function (token) {
     log.trace({ op: 'DB.udatePasswordForgotToken', uid: token && token.uid })
+    const { id } = token
     return this.pool.post(
-      '/passwordForgotToken/' + token.id + '/update',
+      SAFE_URLS.updatePasswordForgotToken({ id }),
       {
         tries: token.tries
       }
@@ -603,6 +628,7 @@ module.exports = (
    * To do a cheaper write of transient metadata that only hits
    * redis, use touchSessionToken isntead.
    */
+  SAFE_URLS.updateSessionToken = safeUrl('DB.updateSessionToken', '/sessionToken/:id/update')
   DB.prototype.updateSessionToken = function (sessionToken, geo) {
     const { id, uid } = sessionToken
 
@@ -611,7 +637,7 @@ module.exports = (
     return this.touchSessionToken(sessionToken, geo)
       .then(() => {
         return this.pool.post(
-          `/sessionToken/${id}/update`,
+          SAFE_URLS.updateSessionToken({ id }),
           {
             authAt: sessionToken.authAt,
             uaBrowser: sessionToken.uaBrowser,
@@ -657,6 +683,7 @@ module.exports = (
     })
   }
 
+  SAFE_URLS.createDevice = safeUrl('DB.createDevice', '/account/:uid/device/:id')
   DB.prototype.createDevice = function (uid, sessionTokenId, deviceInfo) {
     log.trace({ op: 'DB.createDevice', uid: uid, id: deviceInfo.id })
 
@@ -665,8 +692,7 @@ module.exports = (
         deviceInfo.id = id
         deviceInfo.createdAt = Date.now()
         return this.pool.put(
-          '/account/' + uid +
-          '/device/' + deviceInfo.id,
+          SAFE_URLS.createDevice({ uid, id }),
           {
             sessionTokenId: sessionTokenId,
             createdAt: deviceInfo.createdAt,
@@ -719,11 +745,12 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.updateDevice = safeUrl('DB.updateDevice', '/account/:uid/device/:id/update')
   DB.prototype.updateDevice = function (uid, sessionTokenId, deviceInfo) {
-    log.trace({ op: 'DB.updateDevice', uid: uid, id: deviceInfo.id })
+    const { id } = deviceInfo
+    log.trace({ op: 'DB.updateDevice', uid, id })
     return this.pool.post(
-      '/account/' + uid +
-      '/device/' + deviceInfo.id + '/update',
+      SAFE_URLS.updateDevice({ uid, id }),
       {
         sessionTokenId: sessionTokenId,
         name: deviceInfo.name,
@@ -763,6 +790,7 @@ module.exports = (
 
   // DELETE
 
+  SAFE_URLS.deleteAccount = safeUrl('DB.deleteAccount', '/account/:uid')
   DB.prototype.deleteAccount = function (authToken) {
     const { uid } = authToken
 
@@ -774,66 +802,55 @@ module.exports = (
           return redis.del(uid)
         }
       })
-      .then(() => this.pool.del(`/account/${uid}`))
+      .then(() => this.pool.del(SAFE_URLS.deleteAccount({ uid })))
   }
 
+  SAFE_URLS.deleteSessionToken = safeUrl('DB.deleteSessionToken', '/sessionToken/:id')
   DB.prototype.deleteSessionToken = function (sessionToken) {
     const { id, uid } = sessionToken
 
     log.trace({ op: 'DB.deleteSessionToken', id, uid })
 
     return deleteSessionTokenFromRedis(uid, id)
-      .then(() => this.pool.del(`/sessionToken/${id}`))
+      .then(() => this.pool.del(SAFE_URLS.deleteSessionToken({ id })))
   }
 
+  SAFE_URLS.deleteKeyFetchToken = safeUrl('DB.deleteKeyFetchToken', '/keyFetchToken/:id')
   DB.prototype.deleteKeyFetchToken = function (keyFetchToken) {
-    log.trace(
-      {
-        op: 'DB.deleteKeyFetchToken',
-        id: keyFetchToken && keyFetchToken.id,
-        uid: keyFetchToken && keyFetchToken.uid
-      }
-    )
-    return this.pool.del('/keyFetchToken/' + keyFetchToken.id)
+    const { id, uid } = keyFetchToken
+    log.trace({ op: 'DB.deleteKeyFetchToken', id, uid })
+    return this.pool.del(SAFE_URLS.deleteKeyFetchToken({ id }))
   }
 
+  SAFE_URLS.deleteAccountResetToken = safeUrl(
+    'DB.deleteAccountResetToken', '/accountResetToken/:id')
   DB.prototype.deleteAccountResetToken = function (accountResetToken) {
-    log.trace(
-      {
-        op: 'DB.deleteAccountResetToken',
-        id: accountResetToken && accountResetToken.id,
-        uid: accountResetToken && accountResetToken.uid
-      }
-    )
-    return this.pool.del('/accountResetToken/' + accountResetToken.id)
+    const { id, uid } = accountResetToken
+    log.trace({ op: 'DB.deleteAccountResetToken', id, uid })
+    return this.pool.del(SAFE_URLS.deleteAccountResetToken({ id }))
   }
 
+  SAFE_URLS.deletePasswordForgotToken = safeUrl(
+    'DB.deletePasswordForgotToken', '/passwordForgotToken/:id')
   DB.prototype.deletePasswordForgotToken = function (passwordForgotToken) {
-    log.trace(
-      {
-        op: 'DB.deletePasswordForgotToken',
-        id: passwordForgotToken && passwordForgotToken.id,
-        uid: passwordForgotToken && passwordForgotToken.uid
-      }
-    )
-    return this.pool.del('/passwordForgotToken/' + passwordForgotToken.id)
+    const { id, uid } = passwordForgotToken
+    log.trace({ op: 'DB.deletePasswordForgotToken', id, uid })
+    return this.pool.del(SAFE_URLS.deletePasswordForgotToken({ id }))
   }
 
+  SAFE_URLS.deletePasswordChangeToken = safeUrl(
+    'DB.deletePasswordChangeToken', '/passwordChangeToken/:id')
   DB.prototype.deletePasswordChangeToken = function (passwordChangeToken) {
-    log.trace(
-      {
-        op: 'DB.deletePasswordChangeToken',
-        id: passwordChangeToken && passwordChangeToken.id,
-        uid: passwordChangeToken && passwordChangeToken.uid
-      }
-    )
-    return this.pool.del('/passwordChangeToken/' + passwordChangeToken.id)
+    const { id, uid } = passwordChangeToken
+    log.trace({ op: 'DB.deletePasswordChangeToken', id, uid })
+    return this.pool.del(SAFE_URLS.deletePasswordChangeToken({ id }))
   }
 
+  SAFE_URLS.deleteDevice = safeUrl('DB.deleteDevice', '/account/:uid/device/:deviceId')
   DB.prototype.deleteDevice = function (uid, deviceId) {
     log.trace({ op: 'DB.deleteDevice', uid, id: deviceId })
 
-    return this.pool.del(`/account/${uid}/device/${deviceId}`)
+    return this.pool.del(SAFE_URLS.deleteDevice({ uid, deviceId }))
       .then(result => deleteSessionTokenFromRedis(uid, result.sessionTokenId))
       .catch(err => {
         if (isNotFoundError(err)) {
@@ -843,29 +860,22 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.deviceFromTokenVerificationId = safeUrl(
+    'DB.deviceFromTokenVerificationId', '/account/:uid/tokens/:tokenVerificationId/device')
   DB.prototype.deviceFromTokenVerificationId = function (uid, tokenVerificationId) {
-    log.trace(
-      {
-        op: 'DB.deviceFromTokenVerificationId',
-        uid: uid,
-        tokenVerificationId: tokenVerificationId
-      }
-    )
-    return this.pool.get(
-      '/account/' + uid + '/tokens/' + tokenVerificationId + '/device'
-    )
-    .catch(
-      function (err) {
+    log.trace({ op: 'DB.deviceFromTokenVerificationId', uid, tokenVerificationId })
+    return this.pool.get(SAFE_URLS.deviceFromTokenVerificationId({ uid, tokenVerificationId }))
+      .catch(err => {
         if (isNotFoundError(err)) {
           throw error.unknownDevice()
         }
         throw err
-      }
-    )
+      })
   }
 
   // BATCH
 
+  SAFE_URLS.resetAccount = safeUrl('DB.resetAccount', '/account/:uid/reset')
   DB.prototype.resetAccount = function (accountResetToken, data) {
     const { uid } = accountResetToken
 
@@ -879,23 +889,22 @@ module.exports = (
       })
       .then(() => {
         data.verifierSetAt = Date.now()
-        return this.pool.post(`/account/${uid}/reset`, data)
+        return this.pool.post(SAFE_URLS.resetAccount({ uid }), data)
       })
   }
 
+  SAFE_URLS.verifyEmail = safeUrl('DB.verifyEmail', '/account/:uid/verifyEmail/:emailCode')
   DB.prototype.verifyEmail = function (account, emailCode) {
-    log.trace({
-      op: 'DB.verifyEmail',
-      uid: account && account.uid,
-      emailCode: emailCode
-    })
-    return this.pool.post('/account/' + account.uid + '/verifyEmail/' + emailCode)
+    const { uid } = account
+    log.trace({ op: 'DB.verifyEmail', uid, emailCode })
+    return this.pool.post(SAFE_URLS.verifyEmail({ uid, emailCode }))
   }
 
+  SAFE_URLS.verifyTokens = safeUrl('DB.verifyTokens', '/tokens/:tokenVerificationId/verify')
   DB.prototype.verifyTokens = function (tokenVerificationId, accountData) {
-    log.trace({ op: 'DB.verifyTokens', tokenVerificationId: tokenVerificationId })
+    log.trace({ op: 'DB.verifyTokens', tokenVerificationId })
     return this.pool.post(
-      '/tokens/' + tokenVerificationId + '/verify',
+      SAFE_URLS.verifyTokens({ tokenVerificationId }),
       { uid: accountData.uid }
     )
     .then(
@@ -911,18 +920,21 @@ module.exports = (
     )
   }
 
+  SAFE_URLS.verifyTokensWithMethod = safeUrl(
+    'DB.verifyTokensWithMethod', '/tokens/:tokenId/verifyWithMethod')
   DB.prototype.verifyTokensWithMethod = function (tokenId, verificationMethod) {
     log.trace({op: 'DB.verifyTokensWithMethod', tokenId, verificationMethod})
     return this.pool.post(
-      `/tokens/${tokenId}/verifyWithMethod`,
+      SAFE_URLS.verifyTokensWithMethod({ tokenId }),
       {verificationMethod}
     )
   }
 
+  SAFE_URLS.verifyTokenCode = safeUrl('DB.verifyTokenCode', '/tokens/:code/verifyCode')
   DB.prototype.verifyTokenCode = function (code, accountData) {
-    log.trace({ op: 'DB.verifyTokenCode', code: code })
+    log.trace({ op: 'DB.verifyTokenCode', code })
     return this.pool.post(
-      '/tokens/' + code + '/verifyCode',
+      SAFE_URLS.verifyTokenCode({ code }),
       { uid: accountData.uid }
     )
     .then(
@@ -940,13 +952,16 @@ module.exports = (
     )
   }
 
+  SAFE_URLS.forgotPasswordVerified = safeUrl(
+    'DB.forgotPasswordVerified', '/passwordForgotToken/:id/verified')
   DB.prototype.forgotPasswordVerified = function (passwordForgotToken) {
-    log.trace({ op: 'DB.forgotPasswordVerified', uid: passwordForgotToken && passwordForgotToken.uid })
-    return AccountResetToken.create({ uid: passwordForgotToken.uid })
+    const { id, uid } = passwordForgotToken
+    log.trace({ op: 'DB.forgotPasswordVerified', uid })
+    return AccountResetToken.create({ uid })
       .then(
         function (accountResetToken) {
           return this.pool.post(
-            '/passwordForgotToken/' + passwordForgotToken.id + '/verified',
+            SAFE_URLS.forgotPasswordVerified({ id }),
             {
               tokenId: accountResetToken.id,
               data: accountResetToken.data,
@@ -963,10 +978,11 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.updateLocale = safeUrl('DB.updateLocale', '/account/:uid/locale')
   DB.prototype.updateLocale = function (uid, locale) {
-    log.trace({ op: 'DB.updateLocale', uid: uid, locale: locale })
+    log.trace({ op: 'DB.updateLocale', uid, locale })
     return this.pool.post(
-      '/account/' + uid + '/locale',
+      SAFE_URLS.updateLocale({ uid }),
       { locale: locale }
     )
   }
@@ -980,24 +996,23 @@ module.exports = (
     return this.pool.post('/securityEvents', event)
   }
 
+  SAFE_URLS.securityEvents = safeUrl('DB.securityEvents', '/securityEvents/:uid/ip/:ipAddr')
   DB.prototype.securityEvents = function (params) {
     log.trace({
       op: 'DB.securityEvents',
       params: params
     })
-
-    return this.pool.get('/securityEvents/' + params.uid + '/ip/' + params.ipAddr)
+    const { ipAddr, uid } = params
+    return this.pool.get(SAFE_URLS.securityEvents({ ipAddr, uid }))
   }
 
+  SAFE_URLS.createUnblockCode = safeUrl('DB.createUnblockCode', '/account/:uid/unblock/:unblock')
   DB.prototype.createUnblockCode = function (uid) {
-    log.trace({
-      op: 'DB.createUnblockCode',
-      uid: uid
-    })
+    log.trace({ op: 'DB.createUnblockCode', uid })
     return UnblockCode()
       .then(
         (unblock) => {
-          return this.pool.put('/account/' + uid + '/unblock/' + unblock)
+          return this.pool.put(SAFE_URLS.createUnblockCode({ uid, unblock }))
             .then(
               () => {
                 return unblock
@@ -1020,12 +1035,10 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.consumeUnblockCode = safeUrl('DB.consumeUnblockCode', '/account/:uid/unblock/:code')
   DB.prototype.consumeUnblockCode = function (uid, code) {
-    log.trace({
-      op: 'DB.consumeUnblockCode',
-      uid: uid
-    })
-    return this.pool.del('/account/' + uid + '/unblock/' + code)
+    log.trace({ op: 'DB.consumeUnblockCode', uid })
+    return this.pool.del(SAFE_URLS.consumeUnblockCode({ uid, code }))
       .catch(
         function (err) {
           if (isNotFoundError(err)) {
@@ -1045,31 +1058,25 @@ module.exports = (
     return this.pool.post('/emailBounces', bounceData)
   }
 
+  SAFE_URLS.emailBounces = safeUrl('DB.emailBounces', '/emailBounces/:email')
   DB.prototype.emailBounces = function (email) {
-    log.trace({
-      op: 'DB.emailBounces',
-      email: email
-    })
+    log.trace({ op: 'DB.emailBounces', email })
 
-    return this.pool.get('/emailBounces/' + hexEncode(email))
+    return this.pool.get(SAFE_URLS.emailBounces({ email: hexEncode(email) }))
   }
 
+  SAFE_URLS.accountEmails = safeUrl('DB.accountEmails', '/account/:uid/emails')
   DB.prototype.accountEmails = function (uid) {
-    log.trace({
-      op: 'DB.accountEmails',
-      uid: uid
-    })
+    log.trace({ op: 'DB.accountEmails', uid })
 
-    return this.pool.get('/account/' + uid + '/emails')
+    return this.pool.get(SAFE_URLS.accountEmails({ uid }))
   }
 
+  SAFE_URLS.getSecondaryEmail = safeUrl('DB.getSecondaryEmail', '/email/:email')
   DB.prototype.getSecondaryEmail = function (email) {
-    log.trace({
-      op: 'DB.getSecondaryEmail',
-      email: email
-    })
+    log.trace({ op: 'DB.getSecondaryEmail', email })
 
-    return this.pool.get('/email/' + hexEncode(email))
+    return this.pool.get(SAFE_URLS.getSecondaryEmail({ email: hexEncode(email) }))
       .catch((err) => {
         if (isNotFoundError(err)) {
           throw error.unknownSecondaryEmail()
@@ -1078,14 +1085,15 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.createEmail = safeUrl('DB.createEmail', '/account/:uid/emails')
   DB.prototype.createEmail = function (uid, emailData) {
     log.trace({
       email: emailData.email,
       op: 'DB.createEmail',
-      uid: emailData.uid
+      uid
     })
 
-    return this.pool.post('/account/' + uid + '/emails', emailData)
+    return this.pool.post(SAFE_URLS.createEmail({ uid }), emailData)
       .catch(
         function (err) {
           if (isEmailAlreadyExistsError(err)) {
@@ -1096,13 +1104,11 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.deleteEmail = safeUrl('DB.deleteEmail', '/account/:uid/emails/:email')
   DB.prototype.deleteEmail = function (uid, email) {
-    log.trace({
-      op: 'DB.deleteEmail',
-      uid: uid
-    })
+    log.trace({ op: 'DB.deleteEmail', uid })
 
-    return this.pool.del('/account/' + uid + '/emails/' + hexEncode(email))
+    return this.pool.del(SAFE_URLS.deleteEmail({ uid, email: hexEncode(email) }))
       .catch(
         function (err) {
           if (isEmailDeletePrimaryError(err)) {
@@ -1113,13 +1119,14 @@ module.exports = (
       )
   }
 
+  SAFE_URLS.createSigninCode = safeUrl('DB.createSigninCode', '/signinCodes/:code')
   DB.prototype.createSigninCode = function (uid, flowId) {
     log.trace({ op: 'DB.createSigninCode' })
 
     return random.hex(config.signinCodeSize)
       .then(code => {
         const data = { uid, createdAt: Date.now(), flowId }
-        return this.pool.put(`/signinCodes/${code}`, data)
+        return this.pool.put(SAFE_URLS.createSigninCode({ code }), data)
           .then(() => code, err => {
             if (isRecordAlreadyExistsError(err)) {
               log.warn({ op: 'DB.createSigninCode.duplicate' })
@@ -1131,10 +1138,11 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.consumeSigninCode = safeUrl('DB.consumeSigninCode', '/signinCodes/:code/consume')
   DB.prototype.consumeSigninCode = function (code) {
     log.trace({ op: 'DB.consumeSigninCode', code })
 
-    return this.pool.post(`/signinCodes/${code}/consume`)
+    return this.pool.post(SAFE_URLS.consumeSigninCode({ code }))
       .catch(err => {
         if (isNotFoundError(err)) {
           throw error.invalidSigninCode()
@@ -1144,16 +1152,18 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.resetAccountTokens = safeUrl('DB.resetAccountTokens', '/account/:uid/resetTokens')
   DB.prototype.resetAccountTokens = function (uid) {
     log.trace({ op: 'DB.resetAccountTokens', uid })
 
-    return this.pool.post(`/account/${uid}/resetTokens`)
+    return this.pool.post(SAFE_URLS.resetAccountTokens({ uid }))
   }
 
+  SAFE_URLS.createTotpToken = safeUrl('DB.createTotpToken', '/totp/:uid')
   DB.prototype.createTotpToken = function (uid, sharedSecret, epoch) {
     log.trace({op: 'DB.createTotpToken', uid})
 
-    return this.pool.put(`/totp/${uid}`, {
+    return this.pool.put(SAFE_URLS.createTotpToken({ uid }), {
       sharedSecret: sharedSecret,
       epoch: epoch
     })
@@ -1165,10 +1175,11 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.totpToken = safeUrl('DB.totpToken', '/totp/:uid')
   DB.prototype.totpToken = function (uid) {
     log.trace({ op: 'DB.totpToken', uid})
 
-    return this.pool.get(`/totp/${uid}`)
+    return this.pool.get(SAFE_URLS.totpToken({ uid }))
       .catch(err => {
         if (isNotFoundError(err)) {
           throw error.totpTokenNotFound()
@@ -1177,10 +1188,11 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.deleteTotpToken = safeUrl('DB.deleteTotpToken', '/totp/:uid')
   DB.prototype.deleteTotpToken = function (uid) {
     log.trace({ op: 'DB.deleteTotpToken', uid})
 
-    return this.pool.del(`/totp/${uid}`)
+    return this.pool.del(SAFE_URLS.deleteTotpToken({ uid }))
       .catch(err => {
         if (isNotFoundError(err)) {
           throw error.totpTokenNotFound()
@@ -1189,10 +1201,11 @@ module.exports = (
       })
   }
 
+  SAFE_URLS.updateTotpToken = safeUrl('DB.updateTotpToken', '/totp/:uid/update')
   DB.prototype.updateTotpToken = function (uid, data) {
     log.trace({ op: 'DB.updateTotpToken', uid, data})
 
-    return this.pool.post(`/totp/${uid}/update`, {
+    return this.pool.post(SAFE_URLS.updateTotpToken({ uid }), {
       verified: data.verified,
       enabled: data.enabled
     })

--- a/lib/safe-url.js
+++ b/lib/safe-url.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module exports a safe URL-builder interface, ensuring that no
+// unsafe input can leak into generated URLs.
+//
+// It takes the approach of throwing error.unexpectedError() when unsafe
+// input is encountered, for extra visibility. An alternative approach
+// would be to use encodeURIComponent instead to convert unsafe input on
+// the fly. However, we have no valid use case for encoding weird data
+// like that, since we explicitly hex-encode params that need it. So if
+// any weird input is encountered, we should fail the request as soon as
+// possible.
+//
+// Usage:
+//
+//   const safeUrl = require('./safe-url')(log)
+//
+//   const endpoint1 = safeUrl('/foo/:bar')
+//   endpoint1({ bar: 'wibble' }) // returns "/foo/wibble"
+//   endpoint1({ bar: 'blee' })   // returns "/foo/blee"
+//   endpoint1({ bar: 'blee\n' }) // throws error.unexpectedError()
+//
+//   const endpoint2 = safeUrl('/foo/:bar/baz/:qux')
+//   endpoint2({ bar: 'wibble', qux: 'blee' }) // returns "/foo/wibble/baz/blee"
+//   endpoint2({ bar: 'wibble' })              // throws error.unexpectedError()
+
+'use strict'
+
+const error = require('./error')
+const impl = require('safe-url-assembler')()
+
+const SAFE_PATH_COMPONENT = /^[\w.]+$/
+
+module.exports = log => {
+  return (caller, path) => {
+    const expected = path.split('/')
+      .filter(part => part.indexOf(':') === 0)
+      .map(part => part.substr(1))
+    const expectedSet = new Set(expected)
+    const template = impl.template(path)
+
+    return params => {
+      const keys = Object.keys(params)
+      if (keys.length !== expected.length) {
+        log.error({ op: 'safeUrl.mismatch', keys, expected, caller })
+        throw error.unexpectedError()
+      }
+
+      keys.forEach(key => {
+        if (! expectedSet.has(key)) {
+          log.error({ op: 'safeUrl.unexpected', key, expected, caller })
+          throw error.unexpectedError()
+        }
+
+        const value = params[key]
+
+        if (! SAFE_PATH_COMPONENT.test(value)) {
+          log.error({ op: 'safeUrl.unsafe', key, value, caller })
+          throw error.unexpectedError()
+        }
+      })
+
+      return template.param(params).toString()
+    }
+  }
+}
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -121,12 +121,12 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.3 <3.0.0",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
@@ -1439,7 +1439,7 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
@@ -1544,7 +1544,7 @@
             },
             "node-uuid": {
               "version": "1.4.8",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
             "oauth-sign": {
@@ -1576,7 +1576,7 @@
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
@@ -2200,7 +2200,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.2 <1.6.0",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "getobject": {
@@ -2355,7 +2355,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
@@ -2434,7 +2434,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2492,7 +2492,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4205,7 +4205,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4303,7 +4303,7 @@
                     },
                     "safe-buffer": {
                       "version": "5.1.1",
-                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
@@ -5319,7 +5319,7 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "moment": {
@@ -5354,7 +5354,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.1 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "agent-base": {
@@ -5853,15 +5853,15 @@
                       "from": "caseless@0.12.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
                     },
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
                     "code-point-at": {
                       "version": "1.1.0",
                       "from": "code-point-at@1.1.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@4.6.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -5918,15 +5918,15 @@
                       "from": "ecc-jsbn@0.1.1",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
                     "extend": {
                       "version": "3.0.1",
                       "from": "extend@3.0.1",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
@@ -5958,15 +5958,15 @@
                       "from": "gauge@2.7.4",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
                     },
-                    "glob": {
-                      "version": "7.1.2",
-                      "from": "glob@7.1.2",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-                    },
                     "graceful-fs": {
                       "version": "4.1.11",
                       "from": "graceful-fs@4.1.11",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                    },
+                    "glob": {
+                      "version": "7.1.2",
+                      "from": "glob@7.1.2",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
                     },
                     "har-schema": {
                       "version": "1.0.5",
@@ -6528,7 +6528,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "align-text@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -6569,7 +6569,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "align-text@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -7556,7 +7556,7 @@
         },
         "topo": {
           "version": "2.0.2",
-          "from": "topo@>=2.0.0 <3.0.0",
+          "from": "topo@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
         }
       }
@@ -7595,7 +7595,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "gettext-parser": {
@@ -7803,7 +7803,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "from": "align-text@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -7844,7 +7844,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "from": "align-text@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -8213,7 +8213,7 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "glob": {
@@ -9548,15 +9548,15 @@
           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
         "is-number": {
           "version": "2.1.0",
           "from": "is-number@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "from": "is-glob@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -9773,15 +9773,15 @@
           "from": "read-pkg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
         },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "from": "read-pkg-up@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-        },
         "regenerator-runtime": {
           "version": "0.9.5",
           "from": "regenerator-runtime@>=0.9.5 <0.10.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
         },
         "regex-cache": {
           "version": "0.4.3",
@@ -10670,7 +10670,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <1.2.0",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -10987,7 +10987,7 @@
               "dependencies": {
                 "nan": {
                   "version": "2.10.0",
-                  "from": "nan@>=2.0.8 <3.0.0",
+                  "from": "nan@>=2.3.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
                 }
               }
@@ -11370,6 +11370,23 @@
       "version": "0.2.0",
       "from": "restify-safe-json-formatter@0.2.0",
       "resolved": "https://registry.npmjs.org/restify-safe-json-formatter/-/restify-safe-json-formatter-0.2.0.tgz"
+    },
+    "safe-url-assembler": {
+      "version": "1.3.5",
+      "from": "safe-url-assembler@1.3.5",
+      "resolved": "https://registry.npmjs.org/safe-url-assembler/-/safe-url-assembler-1.3.5.tgz",
+      "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+        },
+        "qs": {
+          "version": "6.3.2",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
+        }
+      }
     },
     "scrypt-hash": {
       "version": "1.1.14",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "request": "2.79.0",
     "restify": "4.3.0",
     "restify-safe-json-formatter": "0.2.0",
+    "safe-url-assembler": "1.3.5",
     "scrypt-hash": "1.1.14",
     "through": "2.3.8",
     "uuid": "1.4.1",

--- a/test/local/safe-url.js
+++ b/test/local/safe-url.js
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const mocks = require('../mocks')
+
+describe('instantiate:', () => {
+  let log, safeUrl
+
+  beforeEach(() => {
+    log = mocks.mockLog()
+    safeUrl = require('../../lib/safe-url')(log)
+  })
+
+  it('returned the expected interface', () => {
+    assert.equal(typeof safeUrl, 'function')
+    assert.equal(safeUrl.length, 2)
+  })
+
+  describe('endpoint with one param', () => {
+    let endpoint
+
+    beforeEach(() => {
+      endpoint = safeUrl('foo', '/bar/:baz')
+    })
+
+    it('returned the expected interface', () => {
+      assert.equal(typeof endpoint, 'function')
+      assert.equal(endpoint.length, 1)
+    })
+
+    it('interpolates correctly', () => {
+      assert.equal(endpoint({ baz: 'qux' }), '/bar/qux')
+    })
+
+    it('did not call log.error', () => {
+      assert.equal(log.error.callCount, 0)
+    })
+
+    it('logs an error and throws when param is missing', () => {
+      assert.throws(() => endpoint({}))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.mismatch',
+        keys: [],
+        expected: [ 'baz' ],
+        caller: 'foo'
+      })
+    })
+
+    it('logs an error and throws when param has wrong key', () => {
+      assert.throws(() => endpoint({ wibble: 'blee' }))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.unexpected',
+        key: 'wibble',
+        expected: [ 'baz' ],
+        caller: 'foo'
+      })
+    })
+
+    it('logs an error and throws when param seems unsafe', () => {
+      assert.throws(() => endpoint({ baz: 'qux\n' }))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.unsafe',
+        key: 'baz',
+        value: 'qux\n',
+        caller: 'foo'
+      })
+    })
+  })
+
+  describe('endpoint with two params', () => {
+    let endpoint
+
+    beforeEach(() => {
+      endpoint = safeUrl('foo', '/bar/:baz/:qux')
+    })
+
+    it('interpolates correctly', () => {
+      assert.equal(endpoint({ baz: 'wibble', qux: 'blee' }), '/bar/wibble/blee')
+    })
+  })
+})
+


### PR DESCRIPTION
Ref: [bug 1447452 (comment)](https://bugzilla.mozilla.org/show_bug.cgi?id=1447452#c19)

Even though we validate incoming data, we should belt-and-braces ensure that unsafe input can never make it into URLs that we request. This change seeks to do that by adding a new module to build parameterised path strings safely, failing any requests where bad input is encountered. It only applies that change to `lib/db.js` at the moment, but we could also expand it to `lib/customs.js` if people are happy with the approach.

@mozilla/fxa-devs r?