### PR TITLE
fix(sessions): only return major rev for browser version

### DIFF
--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -456,7 +456,8 @@ module.exports = (log, db, config, customs, push, devices) => {
               } else if (! session.uaBrowserVersion) {
                 userAgent = session.uaBrowser
               } else {
-                userAgent = `${session.uaBrowser} ${session.uaBrowserVersion}`
+                const { uaBrowser: browser, uaBrowserVersion: version } = session
+                userAgent = `${browser} ${version.split('.')[0]}`
               }
 
               return Object.assign({

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -756,7 +756,7 @@ describe('/account/sessions', () => {
   const sessions = [
     {
       id: tokenIds[0], uid: 'qux', createdAt: times[0], lastAccessTime: times[1],
-      uaBrowser: 'Firefox', uaBrowserVersion: '50', uaOS: 'Windows', uaOSVersion: '10',
+      uaBrowser: 'Firefox', uaBrowserVersion: '50.0', uaOS: 'Windows', uaOSVersion: '10',
       uaDeviceType: null, deviceId: null, deviceCreatedAt: times[2], deviceCapabilities: ['pushbox'],
       deviceCallbackURL: 'callback', deviceCallbackPublicKey: 'publicKey', deviceCallbackAuthKey: 'authKey',
       deviceCallbackIsExpired: false,


### PR DESCRIPTION
Fixes mozilla/fxa-content-server#6001.

When I changed the user-agent version info in #2356, I broke the sessions view in the content server. This change fixes that by only returning the major rev from `/account/sessions` and adds a test case that would have caught me breaking it originally.

Note that the related content server test will need to be changed again after this lands.

@vladikoff r?