### PR TITLE
fix(totp): throw unverified session in promise chain

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -347,6 +347,7 @@ those common validations are defined here.
 * `verificationMethod`: `string, valid()`
 * `E164_NUMBER`: `/^\+[1-9]\d{1,14}$/`
 * `DIGITS`: `/^[0-9]+$/`
+* `IP_ADDRESS`: `string, ip`
 
 #### lib/metrics/context
 
@@ -2173,7 +2174,7 @@ Verify a session using a recovery code.
 
 ##### Request body
 
-* `code`: *string, min(RECOVERY_CODE_LENGTH), max(RECOVERY_CODE_LENGTH), regex(HEX_STRING), required*
+* `code`: *string, length(RECOVERY_CODE_LENGTH), regex(HEX_STRING), required*
 
   <!--begin-request-body-post-sessionverifyrecoverycode-code-->
   

--- a/lib/routes/totp.js
+++ b/lib/routes/totp.js
@@ -169,13 +169,16 @@ module.exports = (log, db, mailer, customs, config) => {
           .then(() => reply({exists}), reply)
 
         function getTotpToken() {
-          if (sessionToken.tokenVerificationId) {
-            throw errors.unverifiedSession()
-          }
+          return P.resolve()
+            .then(() => {
+              if (sessionToken.tokenVerificationId) {
+                throw errors.unverifiedSession()
+              }
 
-          return db.totpToken(sessionToken.uid)
+              return db.totpToken(sessionToken.uid)
+            })
+
             .then((token) => {
-
               // If the token is not verified, lets delete it and report that
               // it doesn't exist. This will help prevent some edge
               // cases where the user started creating a token but never completed.


### PR DESCRIPTION
It turns out the `/totp/exists` endpoint was throwing unverified session error outside of a promise chain, which caused a 500.

Connect to https://github.com/mozilla/fxa-content-server/issues/5991. 