### PR TITLE
chore(db): prevent the possibility of future url-injection bugs

### DIFF
--- a/lib/customs.js
+++ b/lib/customs.js
@@ -13,6 +13,8 @@ var localizeTimestamp = require('fxa-shared').l10n.localizeTimestamp({
 })
 
 module.exports = function (log, error) {
+  const SafeUrl = require('./safe-url')(log)
+  const SAFE_URLS = {}
 
   // Perform a deep clone of payload and remove user password.
   function sanitizePayload(payload) {
@@ -44,10 +46,12 @@ module.exports = function (log, error) {
     }
   }
 
+  SAFE_URLS.check = new SafeUrl('/check')
   Customs.prototype.check = function (request, email, action) {
     log.trace({ op: 'customs.check', email: email, action: action })
     return this.pool.post(
-      '/check',
+      SAFE_URLS.check,
+      undefined,
       {
         ip: request.app.clientAddress,
         email: email,
@@ -97,11 +101,13 @@ module.exports = function (log, error) {
     }
   }
 
+  SAFE_URLS.checkAuthenticated = new SafeUrl('/checkAuthenticated')
   Customs.prototype.checkAuthenticated = function (action, ip, uid) {
     log.trace({ op: 'customs.checkAuthenticated', action: action,  uid: uid })
 
     return this.pool.post(
-      '/checkAuthenticated',
+      SAFE_URLS.checkAuthenticated,
+      undefined,
       {
         action: action,
         ip: ip,
@@ -127,9 +133,10 @@ module.exports = function (log, error) {
     )
   }
 
+  SAFE_URLS.checkIpOnly = new SafeUrl('/checkIpOnly')
   Customs.prototype.checkIpOnly = function (request, action) {
     log.trace({ op: 'customs.checkIpOnly', action: action })
-    return this.pool.post('/checkIpOnly', {
+    return this.pool.post(SAFE_URLS.checkIpOnly, undefined, {
       ip: request.app.clientAddress,
       action: action
     })
@@ -145,12 +152,14 @@ module.exports = function (log, error) {
     )
   }
 
+  SAFE_URLS.failedLoginAttempt = new SafeUrl('/failedLoginAttempt')
   Customs.prototype.flag = function (ip, info) {
     var email = info.email
     var errno = info.errno || error.ERRNO.UNEXPECTED_ERROR
     log.trace({ op: 'customs.flag', ip: ip, email: email, errno: errno })
     return this.pool.post(
-      '/failedLoginAttempt',
+      SAFE_URLS.failedLoginAttempt,
+      undefined,
       {
         ip: ip,
         email: email,
@@ -170,10 +179,12 @@ module.exports = function (log, error) {
     )
   }
 
+  SAFE_URLS.passwordReset = new SafeUrl('/passwordReset')
   Customs.prototype.reset = function (email) {
     log.trace({ op: 'customs.reset', email: email })
     return this.pool.post(
-      '/passwordReset',
+      SAFE_URLS.passwordReset,
+      undefined,
       {
         email: email
       }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -33,7 +33,13 @@ function Pool(url, options = {}) {
   )
 }
 
-Pool.prototype.request = function (method, path, data) {
+Pool.prototype.request = function (method, url, params, data) {
+  if (! url || typeof url.render !== 'function') {
+    return P.reject(new Error('Invalid url argument'))
+  }
+
+  const path = url.render(params)
+
   var d = P.defer()
   this.poolee.request(
     {
@@ -78,24 +84,24 @@ Pool.prototype.request = function (method, path, data) {
   }
 }
 
-Pool.prototype.post = function (path, data) {
-  return this.request('POST', path, data)
+Pool.prototype.post = function (path, params, data) {
+  return this.request('POST', path, params, data)
 }
 
-Pool.prototype.put = function (path, data) {
-  return this.request('PUT', path, data)
+Pool.prototype.put = function (path, params, data) {
+  return this.request('PUT', path, params, data)
 }
 
-Pool.prototype.get = function (path) {
-  return this.request('GET', path)
+Pool.prototype.get = function (path, params) {
+  return this.request('GET', path, params)
 }
 
-Pool.prototype.del = function (path, data) {
-  return this.request('DELETE', path, data)
+Pool.prototype.del = function (path, params, data) {
+  return this.request('DELETE', path, params, data)
 }
 
-Pool.prototype.head = function (path) {
-  return this.request('HEAD', path)
+Pool.prototype.head = function (path, params) {
+  return this.request('HEAD', path, params)
 }
 
 Pool.prototype.close = function () {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -34,11 +34,13 @@ function Pool(url, options = {}) {
 }
 
 Pool.prototype.request = function (method, url, params, data) {
-  if (! url || typeof url.render !== 'function') {
-    return P.reject(new Error('Invalid url argument'))
+  let path
+  try {
+    path = url.render(params)
   }
-
-  const path = url.render(params)
+  catch (err) {
+    return P.reject(err)
+  }
 
   var d = P.defer()
   this.poolee.request(

--- a/lib/safe-url.js
+++ b/lib/safe-url.js
@@ -60,6 +60,10 @@ module.exports = log => class SafeUrl {
 
       const value = params[key]
 
+      if (! value || typeof value !== 'string') {
+        this._fail('safeUrl.bad', { key, value })
+      }
+
       if (! SAFE_PATH_COMPONENT.test(value)) {
         this._fail('safeUrl.unsafe', { key, value })
       }

--- a/lib/safe-url.js
+++ b/lib/safe-url.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module exports a safe URL-builder interface, ensuring that no
+// unsafe input can leak into generated URLs.
+//
+// It takes the approach of throwing error.unexpectedError() when unsafe
+// input is encountered, for extra visibility. An alternative approach
+// would be to use encodeURIComponent instead to convert unsafe input on
+// the fly. However, we have no valid use case for encoding weird data
+// like that, since we explicitly hex-encode params that need it. So if
+// any weird input is encountered, we should fail the request as soon as
+// possible.
+//
+// Usage:
+//
+//   const SafeUrl = require('./safe-url')(log)
+//
+//   const url = new SafeUrl('/account/:uid/sessions', 'db.sessions')
+//   url.render({ uid: 'foo' })            // returns '/account/foo/sessions'
+//   url.render({ uid: 'bar' })            // returns '/account/bar/sessions'
+//   url.render({ uid: 'foo\n' })          // throws error.unexpectedError()
+//   url.render({})                        // throws error.unexpectedError()
+//   url.render({ uid: 'foo', id: 'bar' }) // throws error.unexpectedError()
+
+'use strict'
+
+const error = require('./error')
+const impl = require('safe-url-assembler')()
+
+const SAFE_PATH_COMPONENT = /^[\w.]+$/
+
+module.exports = log => class SafeUrl {
+  constructor (path, caller) {
+    const expectedKeys = path.split('/')
+      .filter(part => part.indexOf(':') === 0)
+      .map(part => part.substr(1))
+
+    this._expectedKeys = {
+      array: expectedKeys,
+      set: new Set(expectedKeys)
+    }
+    this._template = impl.template(path)
+    this._caller = caller
+  }
+
+  render (params = {}) {
+    const keys = Object.keys(params)
+    const { array: expected, set: expectedSet } = this._expectedKeys
+
+    if (keys.length !== expected.length) {
+      this._fail('safeUrl.mismatch', { keys, expected })
+    }
+
+    keys.forEach(key => {
+      if (! expectedSet.has(key)) {
+        this._fail('safeUrl.unexpected', { key, expected })
+      }
+
+      const value = params[key]
+
+      if (! SAFE_PATH_COMPONENT.test(value)) {
+        this._fail('safeUrl.unsafe', { key, value })
+      }
+    })
+
+    return this._template.param(params).toString()
+  }
+
+  _fail (op, data) {
+    log.error(Object.assign({ op, caller: this._caller }, data))
+    throw error.unexpectedError()
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -47,9 +47,9 @@
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz"
             },
             "ieee754": {
-              "version": "1.1.10",
+              "version": "1.1.11",
               "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz"
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz"
             }
           }
         },
@@ -121,12 +121,12 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.3 <3.0.0",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
@@ -1439,7 +1439,7 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
@@ -1544,7 +1544,7 @@
             },
             "node-uuid": {
               "version": "1.4.8",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
             "oauth-sign": {
@@ -1576,7 +1576,7 @@
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
@@ -2268,7 +2268,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.0 <4.0.0",
+          "from": "minimatch@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
@@ -2355,7 +2355,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
@@ -2434,7 +2434,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2492,7 +2492,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2596,9 +2596,9 @@
           }
         },
         "conventional-changelog": {
-          "version": "1.1.18",
+          "version": "1.1.19",
           "from": "conventional-changelog@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.18.tgz",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.19.tgz",
           "dependencies": {
             "conventional-changelog-angular": {
               "version": "1.6.6",
@@ -2632,24 +2632,24 @@
               }
             },
             "conventional-changelog-atom": {
-              "version": "0.2.4",
-              "from": "conventional-changelog-atom@>=0.2.4 <0.3.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz"
+              "version": "0.2.5",
+              "from": "conventional-changelog-atom@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.5.tgz"
             },
             "conventional-changelog-codemirror": {
-              "version": "0.3.4",
-              "from": "conventional-changelog-codemirror@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz"
+              "version": "0.3.5",
+              "from": "conventional-changelog-codemirror@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.5.tgz"
             },
             "conventional-changelog-core": {
-              "version": "2.0.5",
-              "from": "conventional-changelog-core@>=2.0.5 <3.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz",
+              "version": "2.0.6",
+              "from": "conventional-changelog-core@>=2.0.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.6.tgz",
               "dependencies": {
                 "conventional-changelog-writer": {
-                  "version": "3.0.4",
-                  "from": "conventional-changelog-writer@>=3.0.4 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz",
+                  "version": "3.0.5",
+                  "from": "conventional-changelog-writer@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.5.tgz",
                   "dependencies": {
                     "compare-func": {
                       "version": "1.3.2",
@@ -2676,9 +2676,9 @@
                       }
                     },
                     "conventional-commits-filter": {
-                      "version": "1.1.5",
-                      "from": "conventional-commits-filter@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz",
+                      "version": "1.1.6",
+                      "from": "conventional-commits-filter@>=1.1.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
                       "dependencies": {
                         "is-subset": {
                           "version": "0.1.1",
@@ -2686,9 +2686,9 @@
                           "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
                         },
                         "modify-values": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "modify-values@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz"
                         }
                       }
                     },
@@ -2934,9 +2934,9 @@
                   }
                 },
                 "conventional-commits-parser": {
-                  "version": "2.1.5",
-                  "from": "conventional-commits-parser@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz",
+                  "version": "2.1.6",
+                  "from": "conventional-commits-parser@>=2.1.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.6.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.3.2",
@@ -3334,9 +3334,9 @@
                   }
                 },
                 "git-raw-commits": {
-                  "version": "1.3.4",
-                  "from": "git-raw-commits@>=1.3.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz",
+                  "version": "1.3.5",
+                  "from": "git-raw-commits@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.5.tgz",
                   "dependencies": {
                     "dargs": {
                       "version": "4.1.0",
@@ -3623,9 +3623,9 @@
                   }
                 },
                 "git-semver-tags": {
-                  "version": "1.3.4",
-                  "from": "git-semver-tags@>=1.3.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.4.tgz",
+                  "version": "1.3.5",
+                  "from": "git-semver-tags@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.5.tgz",
                   "dependencies": {
                     "meow": {
                       "version": "4.0.0",
@@ -3887,7 +3887,7 @@
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=5.5.0 <6.0.0",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "validate-npm-package-license": {
@@ -4112,19 +4112,19 @@
               }
             },
             "conventional-changelog-ember": {
-              "version": "0.3.6",
-              "from": "conventional-changelog-ember@>=0.3.6 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz"
+              "version": "0.3.7",
+              "from": "conventional-changelog-ember@>=0.3.7 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.7.tgz"
             },
             "conventional-changelog-eslint": {
-              "version": "1.0.5",
-              "from": "conventional-changelog-eslint@>=1.0.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.5.tgz"
+              "version": "1.0.6",
+              "from": "conventional-changelog-eslint@>=1.0.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.6.tgz"
             },
             "conventional-changelog-express": {
-              "version": "0.3.4",
-              "from": "conventional-changelog-express@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz"
+              "version": "0.3.5",
+              "from": "conventional-changelog-express@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.5.tgz"
             },
             "conventional-changelog-jquery": {
               "version": "0.1.0",
@@ -4137,9 +4137,9 @@
               "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz"
             },
             "conventional-changelog-jshint": {
-              "version": "0.3.4",
-              "from": "conventional-changelog-jshint@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz",
+              "version": "0.3.5",
+              "from": "conventional-changelog-jshint@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.5.tgz",
               "dependencies": {
                 "compare-func": {
                   "version": "1.3.2",
@@ -4168,9 +4168,9 @@
               }
             },
             "conventional-changelog-preset-loader": {
-              "version": "1.1.6",
-              "from": "conventional-changelog-preset-loader@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz"
+              "version": "1.1.7",
+              "from": "conventional-changelog-preset-loader@>=1.1.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.7.tgz"
             }
           }
         },
@@ -4205,7 +4205,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4303,7 +4303,7 @@
                     },
                     "safe-buffer": {
                       "version": "5.1.1",
-                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
@@ -4521,9 +4521,9 @@
                           "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
                         },
                         "is-path-in-cwd": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
                           "dependencies": {
                             "is-path-inside": {
                               "version": "1.0.1",
@@ -5319,7 +5319,7 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "moment": {
@@ -5354,7 +5354,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.1 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "agent-base": {
@@ -5768,15 +5768,15 @@
                       "from": "node-pre-gyp@^0.6.39",
                       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz"
                     },
-                    "abbrev": {
-                      "version": "1.1.0",
-                      "from": "abbrev@1.1.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                    },
                     "ajv": {
                       "version": "4.11.8",
                       "from": "ajv@4.11.8",
                       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+                    },
+                    "abbrev": {
+                      "version": "1.1.0",
+                      "from": "abbrev@1.1.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
                     },
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -5838,15 +5838,15 @@
                       "from": "boom@2.10.1",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
-                    "brace-expansion": {
-                      "version": "1.1.7",
-                      "from": "brace-expansion@1.1.7",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-                    },
                     "buffer-shims": {
                       "version": "1.0.0",
                       "from": "buffer-shims@1.0.0",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.7",
+                      "from": "brace-expansion@1.1.7",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
                     },
                     "caseless": {
                       "version": "0.12.0",
@@ -5918,15 +5918,15 @@
                       "from": "ecc-jsbn@0.1.1",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
                     "extend": {
                       "version": "3.0.1",
                       "from": "extend@3.0.1",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
@@ -7556,7 +7556,7 @@
         },
         "topo": {
           "version": "2.0.2",
-          "from": "topo@>=2.0.0 <3.0.0",
+          "from": "topo@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
         }
       }
@@ -7567,9 +7567,9 @@
       "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-1.0.1.tgz",
       "dependencies": {
         "walk": {
-          "version": "2.3.9",
+          "version": "2.3.13",
           "from": "walk@>=2.3.9 <3.0.0",
-          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.13.tgz",
           "dependencies": {
             "foreachasync": {
               "version": "3.0.0",
@@ -8014,7 +8014,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.0 <4.0.0",
+              "from": "minimatch@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -8118,9 +8118,9 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
         },
         "uue": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "uue@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uue/-/uue-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/uue/-/uue-3.1.2.tgz",
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -9273,25 +9273,25 @@
           "from": "babel-code-frame@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
         },
-        "babel-generator": {
-          "version": "6.18.0",
-          "from": "babel-generator@>=6.18.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz"
-        },
         "babel-messages": {
           "version": "6.8.0",
           "from": "babel-messages@>=6.8.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
         },
-        "babel-runtime": {
+        "babel-generator": {
           "version": "6.18.0",
-          "from": "babel-runtime@>=6.9.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
+          "from": "babel-generator@>=6.18.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz"
         },
         "babel-template": {
           "version": "6.16.0",
           "from": "babel-template@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.18.0",
+          "from": "babel-runtime@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
         },
         "babel-traverse": {
           "version": "6.18.0",
@@ -9308,15 +9308,15 @@
           "from": "babylon@>=6.13.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz"
         },
-        "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
         "brace-expansion": {
           "version": "1.1.6",
           "from": "brace-expansion@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
         },
         "braces": {
           "version": "1.8.5",
@@ -9478,15 +9478,15 @@
           "from": "hosted-git-info@>=2.1.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
         },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-        },
         "inflight": {
           "version": "1.0.6",
           "from": "inflight@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         },
         "inherits": {
           "version": "2.0.3",
@@ -9518,15 +9518,15 @@
           "from": "is-builtin-module@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
         },
-        "is-dotfile": {
-          "version": "1.0.2",
-          "from": "is-dotfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
-        },
         "is-equal-shallow": {
           "version": "0.1.3",
           "from": "is-equal-shallow@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "from": "is-dotfile@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -9603,15 +9603,15 @@
           "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
         },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "from": "lazy-cache@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-        },
         "lcid": {
           "version": "1.0.0",
           "from": "lcid@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "from": "lazy-cache@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
         },
         "load-json-file": {
           "version": "1.1.0",
@@ -10987,7 +10987,7 @@
               "dependencies": {
                 "nan": {
                   "version": "2.10.0",
-                  "from": "nan@>=2.0.8 <3.0.0",
+                  "from": "nan@>=2.3.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
                 }
               }
@@ -11370,6 +11370,23 @@
       "version": "0.2.0",
       "from": "restify-safe-json-formatter@0.2.0",
       "resolved": "https://registry.npmjs.org/restify-safe-json-formatter/-/restify-safe-json-formatter-0.2.0.tgz"
+    },
+    "safe-url-assembler": {
+      "version": "1.3.5",
+      "from": "safe-url-assembler@1.3.5",
+      "resolved": "https://registry.npmjs.org/safe-url-assembler/-/safe-url-assembler-1.3.5.tgz",
+      "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+        },
+        "qs": {
+          "version": "6.3.2",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
+        }
+      }
     },
     "scrypt-hash": {
       "version": "1.1.14",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "request": "2.79.0",
     "restify": "4.3.0",
     "restify-safe-json-formatter": "0.2.0",
+    "safe-url-assembler": "1.3.5",
     "scrypt-hash": "1.1.14",
     "through": "2.3.8",
     "uuid": "1.4.1",

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -138,8 +138,11 @@ describe('db with redis disabled:', () => {
     return db.sessions('fakeUid')
       .then(result => {
         assert.equal(pool.get.callCount, 1)
-        assert.equal(pool.get.args[0].length, 1)
-        assert.equal(pool.get.args[0][0], '/account/fakeUid/sessions')
+        const args = pool.get.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { uid: 'fakeUid' })
         assert.deepEqual(result, [])
       })
   })
@@ -149,8 +152,11 @@ describe('db with redis disabled:', () => {
     return db.devices('fakeUid')
       .then(result => {
         assert.equal(pool.get.callCount, 1)
-        assert.equal(pool.get.args[0].length, 1)
-        assert.equal(pool.get.args[0][0], '/account/fakeUid/devices')
+        const args = pool.get.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { uid: 'fakeUid' })
         assert.deepEqual(result, [])
       })
   })
@@ -159,8 +165,11 @@ describe('db with redis disabled:', () => {
     return db.deleteAccount({ uid: 'fakeUid' })
       .then(() => {
         assert.equal(pool.del.callCount, 1)
-        assert.equal(pool.del.args[0].length, 1)
-        assert.equal(pool.del.args[0][0], '/account/fakeUid')
+        const args = pool.del.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { uid: 'fakeUid' })
       })
   })
 
@@ -168,8 +177,11 @@ describe('db with redis disabled:', () => {
     return db.deleteSessionToken({ id: 'foo', uid: 'bar'})
       .then(() => {
         assert.equal(pool.del.callCount, 1)
-        assert.equal(pool.del.args[0].length, 1)
-        assert.equal(pool.del.args[0][0], '/sessionToken/foo')
+        const args = pool.del.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { id: 'foo' })
       })
   })
 
@@ -178,8 +190,11 @@ describe('db with redis disabled:', () => {
     return db.deleteDevice('foo', 'bar')
       .then(() => {
         assert.equal(pool.del.callCount, 1)
-        assert.equal(pool.del.args[0].length, 1)
-        assert.equal(pool.del.args[0][0], '/account/foo/device/bar')
+        const args = pool.del.args[0]
+        assert.equal(args.length, 2)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { uid: 'foo', deviceId: 'bar' })
       })
   })
 
@@ -189,11 +204,14 @@ describe('db with redis disabled:', () => {
       .then(() => {
         const end = Date.now()
         assert.equal(pool.post.callCount, 1)
-        assert.equal(pool.post.args[0].length, 2)
-        assert.equal(pool.post.args[0][0], '/account/fakeUid/reset')
-        assert.equal(Object.keys(pool.post.args[0][1]).length, 1)
-        assert.ok(pool.post.args[0][1].verifierSetAt >= start)
-        assert.ok(pool.post.args[0][1].verifierSetAt <= end)
+        const args = pool.post.args[0]
+        assert.equal(args.length, 3)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.deepEqual(args[1], { uid: 'fakeUid' })
+        assert.equal(Object.keys(args[2]).length, 1)
+        assert.ok(args[2].verifierSetAt >= start)
+        assert.ok(args[2].verifierSetAt <= end)
       })
   })
 
@@ -218,11 +236,12 @@ describe('db with redis disabled:', () => {
       .then(() => {
         assert.equal(pool.put.callCount, 1)
         const args = pool.put.args[0]
-        assert.equal(args.length, 2)
-        const id = /^\/sessionToken\/([0-9a-f]{64})$/.exec(args[0])[1]
-        assert.ok(id)
-        assert.equal(args[1].tokenId, id)
-        assert.equal(args[1].uid, 'foo')
+        assert.equal(args.length, 3)
+        assert.equal(typeof args[0].render, 'function')
+        assert.equal(args[0].constructor.name, 'SafeUrl')
+        assert.ok(args[1].id)
+        assert.equal(args[2].tokenId, args[1].id)
+        assert.equal(args[2].uid, 'foo')
       })
   })
 })

--- a/test/local/pool.js
+++ b/test/local/pool.js
@@ -5,16 +5,21 @@
 'use strict'
 
 const assert = require('insist')
+const mocks = require('../mocks')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const ROOT_DIR = '../..'
+
 describe('Pool', () => {
 
-  let Pool, poolee
+  let log, SafeUrl, Pool, poolee
 
   beforeEach(() => {
+    log = mocks.mockLog()
+    SafeUrl = require(`${ROOT_DIR}/lib/safe-url`)(log)
     poolee = sinon.createStubInstance(require('poolee'))
-    Pool = proxyquire('../../lib/pool', {
+    Pool = proxyquire(`${ROOT_DIR}/lib/pool`, {
       poolee: function () {
         return poolee
       }
@@ -25,7 +30,7 @@ describe('Pool', () => {
     'pool.request with default options',
     () => {
       var pool = new Pool('http://example.com/ignore/me')
-      pool.request()
+      pool.request(null, new SafeUrl(''))
 
       assert.equal(poolee.request.callCount, 1, 'poolee.request was called once')
 
@@ -36,7 +41,7 @@ describe('Pool', () => {
       assert.equal(typeof options, 'object', 'options is object')
       assert.equal(Object.keys(options).length, 4, 'options has 4 properties')
       assert.equal(options.method, 'GET', 'options.method is GET')
-      assert.equal(options.path, undefined, 'options.path is undefined')
+      assert.equal(options.path, '', 'options.path is blank')
       assert.equal(typeof options.headers, 'object', 'options.headers is object')
       assert.equal(Object.keys(options.headers).length, 1, 'options.headers has 1 property')
       assert.equal(options.headers['Content-Type'], 'application/json', 'Content-Type header is application/json')
@@ -51,7 +56,7 @@ describe('Pool', () => {
     'pool.request with alternative options',
     () => {
       var pool = new Pool('http://example.com/')
-      pool.request('POST', '/foo', { bar: 'baz' })
+      pool.request('POST', new SafeUrl('/:foo'), { foo: 'bar' }, { baz: 'qux' })
 
       assert.equal(poolee.request.callCount, 1, 'poolee.request was called once')
 
@@ -62,22 +67,31 @@ describe('Pool', () => {
       assert.equal(typeof options, 'object', 'options is object')
       assert.equal(Object.keys(options).length, 4, 'options has 4 properties')
       assert.equal(options.method, 'POST', 'options.method is POST')
-      assert.equal(options.path, '/foo', 'options.path is /foo')
+      assert.equal(options.path, '/bar', 'options.path is /bar')
       assert.equal(typeof options.headers, 'object', 'options.headers is object')
       assert.equal(Object.keys(options.headers).length, 1, 'options.headers has 1 property')
       assert.equal(options.headers['Content-Type'], 'application/json', 'Content-Type header is application/json')
-      assert.equal(options.data, '{"bar":"baz"}', 'options.data is correct')
+      assert.equal(options.data, '{"baz":"qux"}', 'options.data is correct')
 
       var callback = args[1]
       assert.equal(typeof callback, 'function', 'callback is function')
     }
   )
 
+  it('pool.request with string path', () => {
+    const pool = new Pool('http://example.com/')
+    pool.request(null, '/foo')
+      .then(
+        () => assert(false, 'request should have failed'),
+        err => assert.equal(err.message, 'Invalid url argument')
+      )
+  })
+
   it(
     'pool.request callback with error',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -96,7 +110,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP error response',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -116,7 +130,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP error response and JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -137,7 +151,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and empty body',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function (result) {
           assert.equal(result, undefined, 'result is undefined')
         })
@@ -153,7 +167,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and valid JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function (result) {
           assert.equal(typeof result, 'object', 'result is object')
           assert.equal(Object.keys(result).length, 1, 'result has 1 property')
@@ -171,7 +185,7 @@ describe('Pool', () => {
     'pool.request callback with HTTP success response and invalid JSON body',
     () => {
       var pool = new Pool('http://example.com/')
-      const p = pool.request()
+      const p = pool.request(null, new SafeUrl(''))
         .then(function () {
           assert(false, 'request should have failed')
         }, function (error) {
@@ -192,14 +206,15 @@ describe('Pool', () => {
     () => {
       var pool = new Pool('http://example.com/')
       sinon.stub(pool, 'request', function () {})
-      pool.get('foo')
+      pool.get('foo', 'bar')
 
       assert.equal(pool.request.callCount, 1, 'pool.request was called once')
 
       var args = pool.request.getCall(0).args
-      assert.equal(args.length, 2, 'pool.request was passed three arguments')
-      assert.equal(args[0], 'GET', 'first argument to pool.request was POST')
+      assert.equal(args.length, 3, 'pool.request was passed three arguments')
+      assert.equal(args[0], 'GET', 'first argument to pool.request was GET')
       assert.equal(args[1], 'foo', 'second argument to pool.request was correct')
+      assert.equal(args[2], 'bar', 'third argument to pool.request was correct')
     }
   )
 
@@ -208,15 +223,16 @@ describe('Pool', () => {
     () => {
       var pool = new Pool('http://example.com/')
       sinon.stub(pool, 'request', function () {})
-      pool.put('baz', 'qux')
+      pool.put('baz', 'qux', 'wibble')
 
       assert.equal(pool.request.callCount, 1, 'pool.request was called once')
 
       var args = pool.request.getCall(0).args
-      assert.equal(args.length, 3, 'pool.request was passed three arguments')
-      assert.equal(args[0], 'PUT', 'first argument to pool.request was POST')
+      assert.equal(args.length, 4, 'pool.request was passed four arguments')
+      assert.equal(args[0], 'PUT', 'first argument to pool.request was PUT')
       assert.equal(args[1], 'baz', 'second argument to pool.request was correct')
       assert.equal(args[2], 'qux', 'third argument to pool.request was correct')
+      assert.equal(args[3], 'wibble', 'fourth argument to pool.request was correct')
     }
   )
 
@@ -225,15 +241,16 @@ describe('Pool', () => {
     () => {
       var pool = new Pool('http://example.com/')
       sinon.stub(pool, 'request', function () {})
-      pool.post('foo', 'bar')
+      pool.post('foo', 'bar', 'baz')
 
       assert.equal(pool.request.callCount, 1, 'pool.request was called once')
 
       var args = pool.request.getCall(0).args
-      assert.equal(args.length, 3, 'pool.request was passed three arguments')
+      assert.equal(args.length, 4, 'pool.request was passed four arguments')
       assert.equal(args[0], 'POST', 'first argument to pool.request was POST')
       assert.equal(args[1], 'foo', 'second argument to pool.request was correct')
       assert.equal(args[2], 'bar', 'third argument to pool.request was correct')
+      assert.equal(args[3], 'baz', 'fourth argument to pool.request was correct')
     }
   )
 
@@ -242,15 +259,16 @@ describe('Pool', () => {
     () => {
       var pool = new Pool('http://example.com/')
       sinon.stub(pool, 'request', function () {})
-      pool.del('foo', 'bar')
+      pool.del('foo', 'bar', 'baz')
 
       assert.equal(pool.request.callCount, 1, 'pool.request was called once')
 
       var args = pool.request.getCall(0).args
-      assert.equal(args.length, 3, 'pool.request was passed three arguments')
+      assert.equal(args.length, 4, 'pool.request was passed four arguments')
       assert.equal(args[0], 'DELETE', 'first argument to pool.request was POST')
       assert.equal(args[1], 'foo', 'second argument to pool.request was correct')
-      assert.equal(args[2], 'bar', 'second argument can be data')
+      assert.equal(args[2], 'bar', 'second argument was correct')
+      assert.equal(args[3], 'baz', 'third argument was correct')
     }
   )
 

--- a/test/local/pool.js
+++ b/test/local/pool.js
@@ -83,7 +83,16 @@ describe('Pool', () => {
     pool.request(null, '/foo')
       .then(
         () => assert(false, 'request should have failed'),
-        err => assert.equal(err.message, 'Invalid url argument')
+        err => assert(err instanceof Error)
+      )
+  })
+
+  it('pool.request with missing param', () => {
+    const pool = new Pool('http://example.com/')
+    pool.request(null, new SafeUrl('/:foo'), {})
+      .then(
+        () => assert(false, 'request should have failed'),
+        err => assert(err instanceof Error)
       )
   })
 

--- a/test/local/safe-url.js
+++ b/test/local/safe-url.js
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const assert = require('insist')
+const mocks = require('../mocks')
+
+describe('require:', () => {
+  let log, SafeUrl
+
+  beforeEach(() => {
+    log = mocks.mockLog()
+    SafeUrl = require('../../lib/safe-url')(log)
+  })
+
+  it('returned the expected interface', () => {
+    assert.equal(typeof SafeUrl, 'function')
+    assert.equal(SafeUrl.length, 2)
+  })
+
+  describe('instantiate:', () => {
+    let safeUrl
+
+    beforeEach(() => {
+      safeUrl = new SafeUrl('/foo/:bar', 'baz')
+    })
+
+    it('returned the expected interface', () => {
+      assert.equal(typeof safeUrl.render, 'function')
+      assert.equal(safeUrl.render.length, 0)
+    })
+
+    it('interpolates correctly', () => {
+      assert.equal(safeUrl.render({ bar: 'wibble' }), '/foo/wibble')
+    })
+
+    it('did not call log.error', () => {
+      assert.equal(log.error.callCount, 0)
+    })
+
+    it('logs an error and throws when param is missing', () => {
+      assert.throws(() => safeUrl.render({}))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.mismatch',
+        keys: [],
+        expected: [ 'bar' ],
+        caller: 'baz'
+      })
+    })
+
+    it('logs an error and throws when param has wrong key', () => {
+      assert.throws(() => safeUrl.render({ qux: 'wibble' }))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.unexpected',
+        key: 'qux',
+        expected: [ 'bar' ],
+        caller: 'baz'
+      })
+    })
+
+    it('logs an error and throws when param seems unsafe', () => {
+      assert.throws(() => safeUrl.render({ bar: 'wibble\n' }))
+      assert.equal(log.error.callCount, 1)
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'safeUrl.unsafe',
+        key: 'bar',
+        value: 'wibble\n',
+        caller: 'baz'
+      })
+    })
+  })
+
+  describe('instantiate with two params', () => {
+    let safeUrl
+
+    beforeEach(() => {
+      safeUrl = new SafeUrl('/foo/:bar/:baz')
+    })
+
+    it('interpolates correctly', () => {
+      assert.equal(safeUrl.render({ bar: 'wibble', baz: 'blee' }), '/foo/wibble/blee')
+    })
+  })
+})
+


### PR DESCRIPTION
Ref: [bug 1447452 (comment)](https://bugzilla.mozilla.org/show_bug.cgi?id=1447452#c19)

Even though we validate incoming data, we should belt-and-braces ensure that unsafe input can never make it into URLs that we request. This change seeks to do that by adding a new module to build parameterised path strings safely, failing any requests where bad input is encountered.

See also the discussion about bikeshed colours in #2361. The key difference from that PR here is that, if a raw path string is passed to `pool.request`, it now fails.

@mozilla/fxa-devs r?