### PR TITLE
fix(validation): Reject URLs with unexpected characters.

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -5,11 +5,12 @@
 'use strict'
 
 const isA = require('joi')
+const validators = require('./routes/validators')
 const {
   DISPLAY_SAFE_UNICODE_WITH_NON_BMP,
   HEX_STRING,
   URL_SAFE_BASE_64
-} = require('./routes/validators')
+} = validators
 const PUSH_SERVER_REGEX = require('../config').get('push.allowedServerRegex')
 
 const SCHEMA = {
@@ -26,7 +27,7 @@ const SCHEMA = {
   nameResponse: isA.string().max(255),
   type: isA.string().max(16),
   capabilities: isA.array().items(isA.string()),
-  pushCallback: isA.string().uri({ scheme: 'https' }).regex(PUSH_SERVER_REGEX).max(255).allow(''),
+  pushCallback: validators.url({ scheme: 'https' }).regex(PUSH_SERVER_REGEX).max(255).allow(''),
   pushPublicKey: isA.string().max(88).regex(URL_SAFE_BASE_64).allow(''),
   pushAuthKey: isA.string().max(24).regex(URL_SAFE_BASE_64).allow(''),
   pushEndpointExpired: isA.boolean().strict()

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -382,7 +382,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
             email: validators.email().required(),
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             service: validators.service,
-            redirectTo: isA.string().uri().optional(),
+            redirectTo: validators.redirectTo(config.smtp.redirectDomain).optional(),
             resume: isA.string().optional(),
             reason: isA.string().max(16).optional(),
             unblockCode: signinUtils.validators.UNBLOCK_CODE,

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -96,7 +96,7 @@ module.exports = function (log, db, Password, config, signinUtils) {
             email: validators.email().required(),
             authPW: isA.string().min(64).max(64).regex(HEX_STRING).required(),
             service: validators.service,
-            redirectTo: isA.string().uri().optional(),
+            redirectTo: validators.redirectTo(config.smtp.redirectDomain).optional(),
             resume: isA.string().optional(),
             reason: isA.string().max(16).optional(),
             unblockCode: signinUtils.validators.UNBLOCK_CODE,

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -4,9 +4,9 @@
 
 'use strict'
 
-var url = require('url')
-var punycode = require('punycode.js')
-var isA = require('joi')
+const { URL } = require('url')
+const punycode = require('punycode.js')
+const isA = require('joi')
 
 // Match any non-empty hex-encoded string.
 module.exports.HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/
@@ -134,40 +134,67 @@ module.exports.isValidEmailAddress = function(value) {
 }
 
 module.exports.redirectTo = function redirectTo(base) {
-  const redirectTo = isA.string().max(512)
+  const validator = isA.string().max(512)
   let hostnameRegex = null
   if (base) {
     hostnameRegex = new RegExp('(?:\\.|^)' + base.replace('.', '\\.') + '$')
   }
-  redirectTo._tests.push(
+  validator._tests.push(
     {
       func: (value, state, options) => {
         if (value !== undefined && value !== null) {
-          const normalizedValue = module.exports.isValidUrl(value, hostnameRegex)
-          if (normalizedValue) {
-            return normalizedValue
+          if (isValidUrl(value, hostnameRegex)) {
+            return value
           }
         }
 
-        return redirectTo.createError('string.base', { value }, state, options)
+        return validator.createError('string.base', { value }, state, options)
       }
     }
   )
-  return redirectTo
+  return validator
 }
 
-module.exports.isValidUrl = function (redirect, hostnameRegex) {
-  var parsed = url.parse(redirect)
+module.exports.url = function url(options) {
+  const validator = isA.string().uri(options)
+  validator._tests.push(
+    {
+      func: (value, state, options) => {
+        if (value !== undefined && value !== null) {
+          if (isValidUrl(value)) {
+            return value
+          }
+        }
+
+        return validator.createError('string.base', { value }, state, options)
+      }
+    }
+  )
+  return validator
+}
+
+function isValidUrl(url, hostnameRegex) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch (err) {
+    return false
+  }
   if (hostnameRegex && ! hostnameRegex.test(parsed.hostname)) {
     return false
   }
   if (! /^https?:$/.test(parsed.protocol)) {
     return false
   }
-  // Normalize to the full URL string as understood by node.
-  // This helps avoid edge-cases where the browser might parse the URL
-  // differently to the way that node parsed it.
-  // See e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1445927
+  // Reject anything that won't round-trip unambiguously
+  // through a parse.  This puts the onus on the requestor
+  // to e.g. escape special characters, normalize ports, etc.
+  // The only trick here is that `new URL()` will add a trailing
+  // slash if there's no path component, which is why we also
+  // compare to `origin` below.
+  if (parsed.href !== url && parsed.origin !== url) {
+    return false
+  }
   return parsed.href
 }
 

--- a/test/local/routes/session.js
+++ b/test/local/routes/session.js
@@ -14,6 +14,7 @@ const sinon = require('sinon')
 
 function makeRoutes (options = {}) {
   const config = options.config || {}
+  config.smtp = config.smtp ||  {}
   const db = options.db || mocks.mockDB()
   const log = options.log || mocks.mockLog()
   const mailer = options.mailer || {}

--- a/test/local/routes/validators.js
+++ b/test/local/routes/validators.js
@@ -36,10 +36,10 @@ describe('redirectTo() validator', () => {
       assert.equal(res.value, 'mailto:test@example.com')
     })
 
-    it('normalizes trisky quoted chars in the hostname', function () {
+    it('rejects tricksy quoted chars in the hostname', function () {
       const res = v.validate('https://example.com%2Eevil.com')
-      assert.ok(! res.error)
-      assert.equal(res.value, 'https://example.com/%2Eevil.com')
+      assert.ok(res.error)
+      assert.equal(res.value, 'https://example.com%2Eevil.com')
     })
   })
 
@@ -82,16 +82,14 @@ describe('redirectTo() validator', () => {
       assert.equal(res.value, 'http://test.example.com/path')
     })
 
-    it('normalizes trisky quoted chars after the base hostname', function () {
-      const res = v.validate('https://mozilla.com%2Eevil.com')
-      assert.ok(! res.error)
-      assert.equal(res.value, 'https://mozilla.com/%2Eevil.com')
-    })
-
-    it('rejects trisky quoted chars before the base hostname', function () {
-      const res = v.validate('https://evil.com%2Emozilla.com')
+    it('rejects tricksy quoted chars in the hostname', function () {
+      let res = v.validate('https://evil.com%2Emozilla.com')
       assert.ok(res.error)
       assert.equal(res.value, 'https://evil.com%2Emozilla.com')
+
+      res = v.validate('https://mozilla.com%2Eevil.com')
+      assert.ok(res.error)
+      assert.equal(res.value, 'https://mozilla.com%2Eevil.com')
     })
   })
 })

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -264,6 +264,41 @@ describe('remote device', function () {
   )
 
   it(
+    'update device fails with non-normalized callbackUrl',
+    () => {
+      var badPushCallback = 'https://updates.push.services.mozilla.com/invalid/\u010D/char'
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      var deviceInfo = {
+        id: crypto.randomBytes(16).toString('hex'),
+        name: 'test device',
+        type: 'desktop',
+        capabilities: ['pushbox'],
+        pushCallback: badPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16))
+      }
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            return client.updateDevice(deviceInfo)
+              .then(
+                function (r) {
+                  assert(false, 'request should have failed')
+                }
+              )
+              .catch(
+                function (err) {
+                  assert.equal(err.code, 400, 'err.code was 400')
+                  assert.equal(err.errno, 107, 'err.errno was 107, invalid parameter')
+                  assert.equal(err.validation.keys[0], 'pushCallback', 'bad pushCallback caught in validation')
+                }
+              )
+          })
+    }
+  )
+
+  it(
     'update device works with stage servers',
     () => {
       var goodPushCallback = 'https://updates-autopush.stage.mozaws.net'


### PR DESCRIPTION
Previously we could accept URLs with unescaped special characters such as newlines or unicode, which means we were depending on other layers of the code to handle them correctly.  This change makes the
requestor responsible for properly escaping any special characters in their URLs before passing them in to us.

@philbooth r?