### PR TITLE
feat(metrics): add user properties for active device counts

### DIFF
--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -8,6 +8,10 @@ const assert = require('insist')
 const amplitudeModule = require('../../../lib/metrics/amplitude')
 const mocks = require('../../mocks')
 
+const DAY = 1000 * 60 * 60 * 24
+const WEEK = DAY * 7
+const MONTH = DAY * 30
+
 describe('metrics/amplitude', () => {
   it('interface is correct', () => {
     assert.equal(typeof amplitudeModule, 'function')
@@ -86,6 +90,7 @@ describe('metrics/amplitude', () => {
 
     describe('account.confirmed', () => {
       beforeEach(() => {
+        const now = Date.now()
         return amplitude('account.confirmed', mocks.mockRequest({
           uaBrowser: 'foo',
           uaBrowserVersion: 'bar',
@@ -97,7 +102,12 @@ describe('metrics/amplitude', () => {
           credentials: {
             uid: 'blee'
           },
-          devices: [ {}, {}, {} ],
+          devices: [
+            { lastAccessTime: now - DAY + 10000 },
+            { lastAccessTime: now - WEEK + 10000 },
+            { lastAccessTime: now - MONTH + 10000 },
+            { lastAccessTime: now - MONTH - 1 }
+          ],
           geo: {
             location: {
               country: 'United Kingdom',
@@ -141,7 +151,10 @@ describe('metrics/amplitude', () => {
         })
         assert.deepEqual(args[0].user_properties, {
           flow_id: 'udge',
-          sync_device_count: 3,
+          sync_active_devices_day: 1,
+          sync_active_devices_week: 2,
+          sync_active_devices_month: 3,
+          sync_device_count: 4,
           ua_browser: 'foo',
           ua_version: 'bar',
           '$append': {
@@ -201,6 +214,9 @@ describe('metrics/amplitude', () => {
         })
         assert.deepEqual(args[0].user_properties, {
           flow_id: undefined,
+          sync_active_devices_day: 0,
+          sync_active_devices_week: 0,
+          sync_active_devices_month: 0,
           sync_device_count: 0,
           ua_browser: 'a',
           ua_version: 'b',
@@ -235,6 +251,9 @@ describe('metrics/amplitude', () => {
         assert.deepEqual(args[0].user_properties['$append'], {
           fxa_services_used: 'undefined_oauth'
         })
+        assert.equal(args[0].user_properties.sync_active_devices_day, undefined)
+        assert.equal(args[0].user_properties.sync_active_devices_week, undefined)
+        assert.equal(args[0].user_properties.sync_active_devices_month, undefined)
         assert.equal(args[0].user_properties.sync_device_count, undefined)
       })
     })

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -641,6 +641,9 @@ describe('metrics/events', () => {
         }, 'log.amplitudeEvent was passed correct event properties')
         assert.deepEqual(log.amplitudeEvent.args[0][0].user_properties, {
           flow_id: 'bar',
+          sync_active_devices_day: 0,
+          sync_active_devices_week: 0,
+          sync_active_devices_month: 0,
           sync_device_count: 0,
           ua_browser: request.app.ua.browser,
           ua_version: request.app.ua.browserVersion


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#60.

Amplitude's view of devices is skewed by the randomly-generated `device_id` that we're using until cross-project ids are implemented. And the `sync_device_count` property is skewed to a lesser degree by apparent session-related problems that seem to force some users to sign in repeatedly on a single device.

To mitigate those problems, this change adds three new properties that indicate the number of devices that were active in a given time period:

* `sync_active_devices_day`
* `sync_active_devices_week`
* `sync_active_devices_month`

In this case, a "month" is 30 days.

Example log line showing the new properties:

```
amplitudeEvent {"time":1522231500788,"user_id":"dbbf4e8198b34d60bf0bda7d1c7c7128","device_id":"9b56f22335484800871ba44ba6076c8a","event_type":"fxa_login - complete","session_id":1522231491568,"event_properties":{"service":"sync"},"user_properties":{"flow_id":"c2baca22bcd630c89590381b6849d236ebc3d363f2254e85bce4f6f3e7e6b6a3","ua_browser":"Firefox","ua_version":"58.0","sync_device_count":1,"sync_active_devices_day":1,"sync_active_devices_week":1,"sync_active_devices_month":1,"$append":{"fxa_services_used":"sync"}},"app_version":"108","language":"en","os_name":"Mac OS X","os_version":"10.11"}
```

@mozilla/fxa-devs r?