### PR TITLE
fix(metrics): emit route flow events from more endpoints

### DIFF
--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -49,16 +49,11 @@ const IGNORE_FLOW_EVENTS_FROM_SERVICES = {
   'account.signed': 'content-server'
 }
 
-const FLOW_EVENT_ROUTES = new Set([
-  '/account/create',
-  '/account/destroy',
-  '/account/keys',
-  '/account/login',
-  '/account/login/send_unblock_code',
-  '/account/reset',
-  '/recovery_email/resend_code',
-  '/recovery_email/verify_code',
-  '/sms'
+const IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS = new Set([
+  '/account/devices',
+  '/account/profile',
+  '/account/sessions',
+  '/certificate/sign'
 ])
 
 const PATH_PREFIX = /^\/v1/
@@ -134,7 +129,7 @@ module.exports = (log, config) => {
       const request = this
       const path = request.path.replace(PATH_PREFIX, '')
 
-      if (! FLOW_EVENT_ROUTES.has(path)) {
+      if (IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS.has(path)) {
         return P.resolve()
       }
 


### PR DESCRIPTION
Me and @vbudhram were trying to figure out just now why one of his endpoints wasn't emitting route summary flow events. I completely forgot that `FLOW_EVENT_ROUTES` existed.

Because forgetting is easier than remembering, this change flips opt-in to opt-out and replaces `FLOW_EVENT_ROUTES` with `IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS`. The routes in there are just some high-traffic ones that we know don't constitute part of a flow. It seems reasonable to try and emit route flow events for everything else.

@mozilla/fxa-devs r?
