### PR TITLE
refactor(metrics): use boiler-plate amplitude code from fxa-shared

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -3,14 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This module contains mappings from activity/flow event names to
-// amplitude event definitions. The intention is for the returned
-// `receiveEvent` function to be invoked for every event and the
-// mappings determine which of those will be transformed into an
-// amplitude event.
-//
-// You can read more about the amplitude event structure here:
-//
-// https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API
+// amplitude event definitions. A module in fxa-shared is responsible
+// for performing the actual transformations.
 //
 // You can see the event taxonomy here:
 //
@@ -18,21 +12,8 @@
 
 'use strict'
 
+const { EMAIL_TYPES, GROUPS, initialize } = require('fxa-shared/metrics/amplitude')
 const P = require('../promise')
-
-const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1]
-
-const DAY = 1000 * 60 * 60 * 24
-const WEEK = DAY * 7
-const MONTH_ISH = DAY * 28
-
-const GROUPS = {
-  activity: 'fxa_activity',
-  email: 'fxa_email',
-  login: 'fxa_login',
-  registration: 'fxa_reg',
-  sms: 'fxa_sms'
-}
 
 const EVENTS = {
   'account.confirmed': {
@@ -67,56 +48,33 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'email_confirmed'
   },
-  'flow.complete': {
-    isDynamicGroup: true,
-    group: (request, data, metricsContext) => GROUPS[metricsContext.flowType],
-    event: 'complete'
-  },
   'sms.installFirefox.sent': {
     group: GROUPS.sms,
     event: 'sent'
   }
 }
 
-const EMAIL_EVENTS = /^email\.(\w+)\.(bounced|sent)$/
-
-const EMAIL_TYPES = {
-  newDeviceLoginEmail: 'login',
-  passwordChangedEmail: 'change_password',
-  passwordResetEmail: 'reset_password',
-  passwordResetRequiredEmail: 'reset_password',
-  postChangePrimaryEmail: 'change_email',
-  postRemoveSecondaryEmail: 'secondary_email',
-  postVerifyEmail: 'registration',
-  postVerifySecondaryEmail: 'secondary_email',
-  postConsumeRecoveryCodeEmail: '2fa',
-  postNewRecoveryCodesEmail: '2fa',
-  recoveryEmail: 'reset_password',
-  unblockCode: 'unblock',
-  verifyEmail: 'registration',
-  verifyLoginEmail: 'login',
-  verifyLoginCodeEmail: 'login',
-  verifyPrimaryEmail: 'verify',
-  verifySyncEmail: 'registration',
-  verifySecondaryEmail: 'secondary_email'
-}
-
-const NOP = () => {}
-
-const EVENT_PROPERTIES = {
-  [GROUPS.activity]: NOP,
-  [GROUPS.email]: mapEmailEventProperties,
-  [GROUPS.login]: NOP,
-  [GROUPS.registration]: NOP,
-  [GROUPS.sms]: NOP
-}
+const FUZZY_EVENTS = new Map([
+  [ /^email\.(\w+)\.bounced$/, {
+    group: eventCategory => EMAIL_TYPES[eventCategory] ? GROUPS.email : null,
+    event: 'bounced'
+  } ],
+  [ /^email\.(\w+)\.sent$/, {
+    group: eventCategory => EMAIL_TYPES[eventCategory] ? GROUPS.email : null,
+    event: 'sent'
+  } ],
+  [ /^flow\.complete\.(\w+)$/, {
+    group: eventCategory => GROUPS[eventCategory],
+    event: 'complete'
+  } ]
+])
 
 module.exports = (log, config) => {
   if (! log || ! config.oauth.clientIds) {
     throw new TypeError('Missing argument')
   }
 
-  const SERVICES = config.oauth.clientIds
+  const transformEvent = initialize(config.oauth.clientIds, EVENTS, FUZZY_EVENTS)
 
   return receiveEvent
 
@@ -126,181 +84,89 @@ module.exports = (log, config) => {
       return P.resolve()
     }
 
-    let mapping = EVENTS[event]
+    return request.app.devices
+      .catch(() => {})
+      .then(devices => {
+        const { formFactor } = request.app.ua
 
-    if (! mapping) {
-      const matches = EMAIL_EVENTS.exec(event)
-      if (matches) {
-        const eventCategory = matches[1]
-        if (EMAIL_TYPES[eventCategory]) {
-          mapping = {
-            group: GROUPS.email,
-            event: matches[2],
-            eventCategory: matches[1]
-          }
+        if (event === 'flow.complete') {
+          // HACK: Push flowType into the event so it can be parsed as eventCategory
+          event += `.${metricsContext.flowType}`
         }
-      }
-    }
 
-    if (mapping) {
-      let group = mapping.group
-      if (mapping.isDynamicGroup) {
-        group = group(request, data, metricsContext)
-        if (! group) {
-          return P.resolve()
+        const amplitudeEvent = transformEvent({
+          type: event,
+          time: metricsContext.time || Date.now()
+        }, Object.assign({}, data, {
+          devices,
+          formFactor,
+          uid: data.uid || getFromToken(request, 'uid'),
+          deviceId: getFromMetricsContext(metricsContext, 'device_id', request, 'deviceId'),
+          flowId: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
+          flowBeginTime: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
+          lang: request.app.locale,
+          emailDomain: data.email_domain,
+          service: getService(request, data, metricsContext)
+        }, getOs(request), getBrowser(request), getLocation(request)))
+
+        if (amplitudeEvent) {
+          log.amplitudeEvent(amplitudeEvent)
         }
-      }
-
-      if (mapping.eventCategory) {
-        data.eventCategory = mapping.eventCategory
-      }
-
-      return request.app.devices
-        .catch(() => {})
-        .then(devices => {
-          const { formFactor } = request.app.ua
-
-          data.location = request.app.geo.location
-          data.devices = devices
-
-          log.amplitudeEvent(Object.assign({
-            time: metricsContext.time || Date.now(),
-            user_id: data.uid || getFromToken(request, 'uid'),
-            device_id: getFromMetricsContext(metricsContext, 'device_id', request, 'deviceId'),
-            event_type: `${group} - ${mapping.event}`,
-            session_id: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
-            event_properties: mapEventProperties(group, request, data, metricsContext),
-            user_properties: mapUserProperties(group, request, data, metricsContext),
-            app_version: APP_VERSION,
-            language: getLocale(request),
-            country: getLocationProperty(data, 'country'),
-            region: getLocationProperty(data, 'state'),
-            device_model: safeGet(formFactor)
-          }, mapOs(request)))
-        })
-    }
-
-    return P.resolve()
+      })
   }
+}
 
-  function mapOs (request) {
-    const { os, osVersion } = request.app.ua
-
-    if (os) {
-      return {
-        os_name: safeGet(os),
-        os_version: safeGet(osVersion)
-      }
-    }
+function getFromToken (request, key) {
+  if (request.auth && request.auth.credentials) {
+    return request.auth.credentials[key]
   }
+}
 
-  function getFromToken (request, key) {
-    if (request.auth.credentials) {
-      return request.auth.credentials[key]
-    }
+function getFromMetricsContext (metricsContext, key, request, payloadKey) {
+  return metricsContext[key] ||
+    (request.payload && request.payload.metricsContext && request.payload.metricsContext[payloadKey])
+}
+
+function getOs (request) {
+  const { os, osVersion } = request.app.ua
+
+  if (os) {
+    return { os, osVersion }
   }
+}
 
-  function getFromMetricsContext (metricsContext, key, request, payloadKey) {
-    return metricsContext[key] ||
-      (request.payload.metricsContext && request.payload.metricsContext[payloadKey])
+function getBrowser (request) {
+  const { browser, browserVersion } = request.app.ua
+
+  if (browser) {
+    return { browser, browserVersion }
   }
+}
 
-  function mapEventProperties (group, request, data, metricsContext) {
-    const { serviceName, clientId } = getServiceNameAndClientId(request, data, metricsContext)
+function getLocation (request) {
+  const { location } = request.app.geo
 
-    return Object.assign({
-      service: serviceName,
-      oauth_client_id: clientId
-    }, EVENT_PROPERTIES[group](request, data, metricsContext))
-  }
-
-  function getServiceNameAndClientId (request, data, metricsContext) {
-    let serviceName, clientId
-    const service = data.service ||
-      request.payload.service ||
-      request.query.service ||
-      metricsContext.service
-
-    if (service && service !== 'content-server') {
-      if (service === 'sync') {
-        serviceName = service
-      } else {
-        serviceName = SERVICES[service] || 'undefined_oauth'
-        clientId = service
-      }
-    }
-
-    return { serviceName, clientId }
-  }
-
-  function mapUserProperties (group, request, data, metricsContext) {
-    const { browser, browserVersion } = request.app.ua
-    return Object.assign({
-      flow_id: getFromMetricsContext(metricsContext, 'flow_id', request, 'flowId'),
-      ua_browser: safeGet(browser),
-      ua_version: safeGet(browserVersion)
-    },
-      getDeviceProperties(data.devices),
-      getServicesUsed(request, metricsContext),
-      getNewsletterState(data))
-  }
-
-  function safeGet (value) {
-    // Prevent null or the empty string from accidentally nuking
-    // properties in Amplitude (undefined is not serialised).
-    return value || undefined
-  }
-
-  function getLocale (request) {
-    return safeGet(request.app.locale)
-  }
-
-  function getLocationProperty (data, key) {
-    return safeGet(data.location && data.location[key])
-  }
-
-  function getDeviceProperties (devices) {
-    if (Array.isArray(devices)) {
-      return {
-        sync_device_count: devices.length,
-        sync_active_devices_day: countDevices(devices, DAY),
-        sync_active_devices_week: countDevices(devices, WEEK),
-        sync_active_devices_month: countDevices(devices, MONTH_ISH)
-      }
-    }
-  }
-
-  function countDevices (devices, period) {
-    return devices.filter(device => device.lastAccessTime >= Date.now() - period).length
-  }
-
-  function getServicesUsed (request, metricsContext) {
-    const { serviceName } = getServiceNameAndClientId(request, {}, metricsContext)
-    if (serviceName) {
-      return {
-        '$append': {
-          fxa_services_used: serviceName
-        }
-      }
-    }
-  }
-
-  function getNewsletterState (data) {
-    if (data.marketingOptIn === true || data.marketingOptIn === false) {
-      return { newsletter_state: data.marketingOptIn ? 'subscribed' : 'unsubscribed' }
+  if (location && (location.country || location.state)) {
+    return {
+      country: location.country,
+      region: location.state
     }
   }
 }
 
-function mapEmailEventProperties (request, data) {
-  const emailType = EMAIL_TYPES[data.eventCategory]
-  if (emailType) {
-    return {
-      email_provider: data.email_domain,
-      email_template: data.eventCategory,
-      email_type: emailType,
-      email_version: data.templateVersion
-    }
+function getService (request, data, metricsContext) {
+  if (data.service) {
+    return data.service
   }
+
+  if (request.payload && request.payload.service) {
+    return request.payload.service
+  }
+
+  if (request.query && request.query.service) {
+    return request.query.service
+  }
+
+  return metricsContext.service
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1439,7 +1439,7 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "assert-plus@1.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
@@ -1651,9 +1651,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.6",
-      "from": "git://github.com/mozilla/fxa-shared.git#pb/11",
-      "resolved": "git://github.com/mozilla/fxa-shared.git#b26d552ec7874dbdd901d2b6f1038cdd16487cdc",
+      "version": "1.0.7",
+      "from": "fxa-shared@1.0.7",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.7.tgz",
       "dependencies": {
         "accept-language": {
           "version": "2.0.17",
@@ -2207,7 +2207,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.2 <1.6.0",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "getobject": {
@@ -2282,7 +2282,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.0 <3.1.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
@@ -2781,7 +2781,7 @@
                         },
                         "minimist": {
                           "version": "1.2.0",
-                          "from": "minimist@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "minimist-options": {
@@ -2937,7 +2937,7 @@
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "semver@>=5.5.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "split": {
@@ -5333,7 +5333,7 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "moment": {
@@ -5867,15 +5867,15 @@
                       "from": "caseless@0.12.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
                     },
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
                     "code-point-at": {
                       "version": "1.1.0",
                       "from": "code-point-at@1.1.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@4.6.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -5892,15 +5892,15 @@
                       "from": "console-control-strings@1.1.0",
                       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                     },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@2.0.5",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
@@ -5922,15 +5922,15 @@
                       "from": "delegates@1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
                     "detect-libc": {
                       "version": "1.0.2",
                       "from": "detect-libc@^1.0.2",
                       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "extend": {
                       "version": "3.0.1",
@@ -5947,15 +5947,15 @@
                       "from": "forever-agent@0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "form-data": {
-                      "version": "2.1.4",
-                      "from": "form-data@2.1.4",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-                    },
                     "fs.realpath": {
                       "version": "1.0.0",
                       "from": "fs.realpath@1.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "from": "form-data@2.1.4",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
                     },
                     "fstream": {
                       "version": "1.0.11",
@@ -6122,15 +6122,15 @@
                       "from": "number-is-nan@1.0.1",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     },
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    },
                     "oauth-sign": {
                       "version": "0.8.2",
                       "from": "oauth-sign@0.8.2",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                    },
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "from": "object-assign@4.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                     },
                     "once": {
                       "version": "1.4.0",
@@ -6297,10 +6297,10 @@
                       "from": "wrappy@1.0.2",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "getpass": {
+                      "version": "0.1.7",
+                      "from": "getpass@0.1.7",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
@@ -6309,10 +6309,10 @@
                         }
                       }
                     },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "from": "getpass@0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@1.14.1",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
@@ -7801,7 +7801,7 @@
                 },
                 "uglify-js": {
                   "version": "2.8.29",
-                  "from": "uglify-js@>=2.4.19 <3.0.0",
+                  "from": "uglify-js@>=2.6.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
                   "dependencies": {
                     "source-map": {
@@ -8042,7 +8042,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.0 <3.1.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -8248,7 +8248,7 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "from": "escape-string-regexp@1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "glob": {
@@ -9283,15 +9283,15 @@
           "from": "append-transform@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
         },
-        "arr-diff": {
-          "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-        },
         "arr-flatten": {
           "version": "1.0.1",
           "from": "arr-flatten@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "from": "arr-diff@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
         },
         "array-unique": {
           "version": "0.2.1",
@@ -9503,25 +9503,25 @@
           "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
-        "hosted-git-info": {
-          "version": "2.1.5",
-          "from": "hosted-git-info@>=2.1.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-        },
         "has-flag": {
           "version": "1.0.0",
           "from": "has-flag@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
         },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+        "hosted-git-info": {
+          "version": "2.1.5",
+          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
         },
         "inflight": {
           "version": "1.0.6",
           "from": "inflight@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         },
         "inherits": {
           "version": "2.0.3",
@@ -9728,15 +9728,15 @@
           "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
         },
-        "os-homedir": {
-          "version": "1.0.2",
-          "from": "os-homedir@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-        },
         "os-locale": {
           "version": "1.4.0",
           "from": "os-locale@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "from": "os-homedir@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
         },
         "parse-glob": {
           "version": "3.0.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -338,9 +338,9 @@
       "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#e082927b4c6dc17d21414e35f4c94312adbaba92"
     },
     "fxa-auth-db-mysql": {
-      "version": "1.108.0",
+      "version": "1.109.0",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
-      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#1400a264838a8d91647bd703a2c79e1b335a8b05",
+      "resolved": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#2129ede955f3173bf8635978ba9198e8eeb489c3",
       "dependencies": {
         "base64url": {
           "version": "2.0.0",
@@ -1197,9 +1197,9 @@
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.6.0",
+              "version": "1.7.0",
               "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
             },
             "bl": {
               "version": "1.1.2",
@@ -1604,9 +1604,16 @@
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.19",
+                  "version": "0.4.21",
                   "from": "iconv-lite@>=0.4.13 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+                  "dependencies": {
+                    "safer-buffer": {
+                      "version": "2.1.2",
+                      "from": "safer-buffer@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -1645,8 +1652,8 @@
     },
     "fxa-shared": {
       "version": "1.0.6",
-      "from": "fxa-shared@1.0.6",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.6.tgz",
+      "from": "git://github.com/mozilla/fxa-shared.git#pb/11",
+      "resolved": "git://github.com/mozilla/fxa-shared.git#b26d552ec7874dbdd901d2b6f1038cdd16487cdc",
       "dependencies": {
         "accept-language": {
           "version": "2.0.17",
@@ -2238,9 +2245,16 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.19",
+          "version": "0.4.21",
           "from": "iconv-lite@>=0.4.13 <0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "dependencies": {
+            "safer-buffer": {
+              "version": "2.1.2",
+              "from": "safer-buffer@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+            }
+          }
         },
         "js-yaml": {
           "version": "3.5.5",
@@ -2434,7 +2448,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2492,7 +2506,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2552,9 +2566,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "readable-stream": {
-              "version": "2.3.5",
+              "version": "2.3.6",
               "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -2577,9 +2591,9 @@
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                 },
                 "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                  "version": "1.1.1",
+                  "from": "string_decoder@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
@@ -2923,7 +2937,7 @@
                     },
                     "semver": {
                       "version": "5.5.0",
-                      "from": "semver@>=5.5.0 <6.0.0",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "split": {
@@ -4061,9 +4075,9 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "2.3.5",
+                      "version": "2.3.6",
                       "from": "readable-stream@>=2.1.5 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -4091,9 +4105,9 @@
                           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                         },
                         "string_decoder": {
-                          "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.3 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                          "version": "1.1.1",
+                          "from": "string_decoder@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -4205,7 +4219,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4282,9 +4296,9 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.3.5",
+                  "version": "2.3.6",
                   "from": "readable-stream@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -4307,9 +4321,9 @@
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                      "version": "1.1.1",
+                      "from": "string_decoder@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -4999,9 +5013,9 @@
                   "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
                   "dependencies": {
                     "resolve": {
-                      "version": "1.6.0",
+                      "version": "1.7.0",
                       "from": "resolve@>=1.1.6 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
                       "dependencies": {
                         "path-parse": {
                           "version": "1.0.5",
@@ -5277,15 +5291,15 @@
               "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
-            "deep-extend": {
-              "version": "0.4.2",
-              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-            },
             "debug": {
               "version": "2.6.9",
               "from": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -5710,9 +5724,9 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.3.5",
+                      "version": "2.3.6",
                       "from": "readable-stream@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -5735,9 +5749,9 @@
                           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                         },
                         "string_decoder": {
-                          "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.3 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                          "version": "1.1.1",
+                          "from": "string_decoder@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -5908,15 +5922,15 @@
                       "from": "delegates@1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
-                    "detect-libc": {
-                      "version": "1.0.2",
-                      "from": "detect-libc@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
-                    },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "ecc-jsbn@0.1.1",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "detect-libc": {
+                      "version": "1.0.2",
+                      "from": "detect-libc@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
                     },
                     "extend": {
                       "version": "3.0.1",
@@ -6058,15 +6072,15 @@
                       "from": "json-stringify-safe@5.0.1",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "from": "mime-db@1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-                    },
                     "jsonify": {
                       "version": "0.0.0",
                       "from": "jsonify@0.0.0",
                       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "mime-db@1.27.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.15",
@@ -6108,15 +6122,15 @@
                       "from": "number-is-nan@1.0.1",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@0.8.2",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
                     "object-assign": {
                       "version": "4.1.1",
                       "from": "object-assign@4.1.1",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@0.8.2",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                     },
                     "once": {
                       "version": "1.4.0",
@@ -6178,15 +6192,15 @@
                       "from": "rimraf@2.6.1",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
                     },
-                    "semver": {
-                      "version": "5.3.0",
-                      "from": "semver@5.3.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                    },
                     "safe-buffer": {
                       "version": "5.0.1",
                       "from": "safe-buffer@5.0.1",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "from": "semver@5.3.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     },
                     "set-blocking": {
                       "version": "2.0.0",
@@ -6720,9 +6734,9 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
           "dependencies": {
             "isemail": {
-              "version": "3.1.1",
+              "version": "3.1.2",
               "from": "isemail@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "2.1.0",
@@ -7051,9 +7065,16 @@
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.19",
+                      "version": "0.4.21",
                       "from": "iconv-lite@>=0.4.13 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+                      "dependencies": {
+                        "safer-buffer": {
+                          "version": "2.1.2",
+                          "from": "safer-buffer@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                        }
+                      }
                     }
                   }
                 },
@@ -7543,9 +7564,9 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
         },
         "isemail": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "isemail@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "2.1.0",
@@ -7595,7 +7616,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "gettext-parser": {
@@ -7609,9 +7630,16 @@
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.19",
+                      "version": "0.4.21",
                       "from": "iconv-lite@>=0.4.13 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+                      "dependencies": {
+                        "safer-buffer": {
+                          "version": "2.1.2",
+                          "from": "safer-buffer@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                        }
+                      }
                     }
                   }
                 },
@@ -8106,9 +8134,16 @@
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
           "dependencies": {
             "iconv-lite": {
-              "version": "0.4.19",
+              "version": "0.4.21",
               "from": "iconv-lite@>=0.4.13 <0.5.0",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+              "dependencies": {
+                "safer-buffer": {
+                  "version": "2.1.2",
+                  "from": "safer-buffer@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                }
+              }
             }
           }
         },
@@ -8213,7 +8248,7 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "glob": {
@@ -8537,9 +8572,9 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "readable-stream": {
-          "version": "2.3.5",
+          "version": "2.3.6",
           "from": "readable-stream@>=2.1.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -8567,9 +8602,9 @@
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
             },
             "string_decoder": {
-              "version": "1.0.3",
-              "from": "string_decoder@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+              "version": "1.1.1",
+              "from": "string_decoder@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -8836,7 +8871,7 @@
         "uap-core": {
           "version": "0.5.0",
           "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#0436c22ec8600d4cb1a9004301728ab999cb7478"
+          "resolved": "git://github.com/ua-parser/uap-core.git#184fe9f913dd7f46a4fc62d94497b87ad04c80d3"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -9468,15 +9503,15 @@
           "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "from": "has-flag@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-        },
         "hosted-git-info": {
           "version": "2.1.5",
           "from": "hosted-git-info@>=2.1.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
         },
         "imurmurhash": {
           "version": "0.1.4",
@@ -9498,15 +9533,15 @@
           "from": "invariant@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
         },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "from": "is-arrayish@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-        },
         "invert-kv": {
           "version": "1.0.0",
           "from": "invert-kv@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "from": "is-arrayish@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
         },
         "is-buffer": {
           "version": "1.1.4",
@@ -9618,15 +9653,15 @@
           "from": "load-json-file@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
         },
-        "longest": {
-          "version": "1.0.1",
-          "from": "longest@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-        },
         "lodash": {
           "version": "4.16.6",
           "from": "lodash@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
+        },
+        "longest": {
+          "version": "1.0.1",
+          "from": "longest@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
         },
         "loose-envify": {
           "version": "1.3.0",
@@ -10038,9 +10073,16 @@
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.19",
+                  "version": "0.4.21",
                   "from": "iconv-lite@>=0.4.13 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+                  "dependencies": {
+                    "safer-buffer": {
+                      "version": "2.1.2",
+                      "from": "safer-buffer@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -10620,9 +10662,9 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
         },
         "caseless": {
           "version": "0.11.0",
@@ -11254,9 +11296,9 @@
                   "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.3.5",
+                  "version": "2.3.6",
                   "from": "readable-stream@>=2.2.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -11279,9 +11321,9 @@
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
                     },
                     "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                      "version": "1.1.1",
+                      "from": "string_decoder@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "email-addresses": "2.0.2",
     "fxa-geodb": "1.0.0",
     "fxa-jwtool": "0.7.1",
-    "fxa-shared": "1.0.6",
+    "fxa-shared": "git://github.com/mozilla/fxa-shared.git#pb/11",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "email-addresses": "2.0.2",
     "fxa-geodb": "1.0.0",
     "fxa-jwtool": "0.7.1",
-    "fxa-shared": "git://github.com/mozilla/fxa-shared.git#pb/11",
+    "fxa-shared": "1.0.7",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -213,7 +213,6 @@ describe('metrics/amplitude', () => {
           oauth_client_id: '1'
         })
         assert.deepEqual(args[0].user_properties, {
-          flow_id: undefined,
           sync_active_devices_day: 0,
           sync_active_devices_week: 0,
           sync_active_devices_month: 0,

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -18,6 +18,7 @@ const events = require('../../../lib/metrics/events')(log, {
   }
 })
 const mocks = require('../../mocks')
+const P = require('../../../lib/promise')
 
 describe('metrics/events', () => {
   afterEach(() => {
@@ -220,7 +221,10 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = {
       app: {
-        locale: 'en'
+        devices: P.resolve(),
+        geo: {},
+        locale: 'en',
+        ua: {}
       },
       auth: null,
       clearMetricsContext: metricsContext.clear,
@@ -472,6 +476,11 @@ describe('metrics/events', () => {
   it('.emit with flow event and missing headers', () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = {
+      app: {
+        devices: P.resolve(),
+        geo: {},
+        ua: {}
+      },
       clearMetricsContext: metricsContext.clear,
       gatherMetricsContext: metricsContext.gather,
       payload: {
@@ -635,10 +644,7 @@ describe('metrics/events', () => {
         assert.equal(log.amplitudeEvent.args[0][0].event_type, 'fxa_activity - cert_signed', 'log.amplitudeEvent was passed correct event_type')
         assert.equal(log.amplitudeEvent.args[0][0].device_id, 'foo', 'log.amplitudeEvent was passed correct device_id')
         assert.equal(log.amplitudeEvent.args[0][0].session_id, flowBeginTime, 'log.amplitudeEvent was passed correct session_id')
-        assert.deepEqual(log.amplitudeEvent.args[0][0].event_properties, {
-          service: undefined,
-          oauth_client_id: undefined
-        }, 'log.amplitudeEvent was passed correct event properties')
+        assert.deepEqual(log.amplitudeEvent.args[0][0].event_properties, {}, 'log.amplitudeEvent was passed correct event properties')
         assert.deepEqual(log.amplitudeEvent.args[0][0].user_properties, {
           flow_id: 'bar',
           sync_active_devices_day: 0,


### PR DESCRIPTION
Fixes mozilla/fxa-shared#11.

WIP until I fix the tests and the `fxa-shared` changes land.