### PR TITLE
feat(profile): Send "profileDataChanged" event when modifying 2FA status

### DIFF
--- a/lib/routes/totp.js
+++ b/lib/routes/totp.js
@@ -143,6 +143,11 @@ module.exports = (log, db, mailer, customs, config) => {
           }
 
           return db.deleteTotpToken(uid)
+            .then(() => {
+              return log.notifyAttachedServices('profileDataChanged', request, {
+                uid: sessionToken.uid
+              })
+            })
         }
 
         function sendEmailNotification() {
@@ -297,6 +302,10 @@ module.exports = (log, db, mailer, customs, config) => {
             return db.updateTotpToken(sessionToken.uid, {
               verified: true,
               enabled: true
+            }).then(() => {
+              return log.notifyAttachedServices('profileDataChanged', request, {
+                uid: sessionToken.uid
+              })
             })
           }
         }


### PR DESCRIPTION
When the user enables or disables TOTP on their account, publish a "profileDataChanged" event so that attached services will know to update their cached copy of the user's profile data.  Connects to https://github.com/mozilla/fxa-profile-server/issues/313; @vbudhram r?