### PR TITLE
fix(metrics): stop using user-agent string in flow id check

### DIFF
--- a/test/mocks.js
+++ b/test/mocks.js
@@ -446,8 +446,7 @@ function generateMetricsContext(){
   const flowSignature = crypto.createHmac('sha256', config.metrics.flow_id_key)
     .update([
       randomBytes,
-      flowBeginTime.toString(16),
-      undefined
+      flowBeginTime.toString(16)
     ].join('\n'))
     .digest('hex')
     .substr(0, 32)


### PR DESCRIPTION
We're tweaking the flow id validation a little bit, so this PR introduces a dual check. First it tries to check the new way then, if that fails, we try again the old way. In the next train, we can remove the old way entirely and update the tests to match.

Only way to test this really is to make sure flow events are emitted when it is run against the content server in `master` and the content server in `pb/flow-sig-ua`, which I'll be opening a PR for presently.

@mozilla/fxa-devs r?