### PR TITLE
feat(emails): add email to all manage account email links

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -810,7 +810,7 @@ module.exports = function (log, config) {
     log.trace({ op: 'mailer.postVerifySecondaryEmail', email: message.email, uid: message.uid })
 
     var templateName = 'postVerifySecondaryEmail'
-    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    var links = this._generateSettingLinks(message, templateName)
 
     var headers = {
       'X-Link': links.link
@@ -841,8 +841,8 @@ module.exports = function (log, config) {
   Mailer.prototype.postChangePrimaryEmail = function (message) {
     log.trace({ op: 'mailer.postChangePrimaryEmail', email: message.email, uid: message.uid })
 
-    var templateName = 'postChangePrimaryEmail'
-    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const templateName = 'postChangePrimaryEmail'
+    const links = this._generateSettingLinks(message, templateName)
 
     var headers = {
       'X-Link': links.link
@@ -873,8 +873,8 @@ module.exports = function (log, config) {
   Mailer.prototype.postRemoveSecondaryEmail = function (message) {
     log.trace({ op: 'mailer.postRemoveSecondaryEmail', email: message.email, uid: message.uid })
 
-    var templateName = 'postRemoveSecondaryEmail'
-    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const templateName = 'postRemoveSecondaryEmail'
+    const links = this._generateSettingLinks(message, templateName)
 
     var headers = {
       'X-Link': links.link
@@ -904,7 +904,7 @@ module.exports = function (log, config) {
     log.trace({ op: 'mailer.postAddTwoStepAuthenticationEmail', email: message.email, uid: message.uid })
 
     const templateName = 'postAddTwoStepAuthenticationEmail'
-    const links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const links = this._generateSettingLinks(message, templateName)
 
     const headers = {
       'X-Link': links.link
@@ -940,7 +940,7 @@ module.exports = function (log, config) {
     log.trace({op: 'mailer.postRemoveTwoStepAuthenticationEmail', email: message.email, uid: message.uid})
 
     const templateName = 'postRemoveTwoStepAuthenticationEmail'
-    const links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const links = this._generateSettingLinks(message, templateName)
 
     const headers = {
       'X-Link': links.link
@@ -976,7 +976,7 @@ module.exports = function (log, config) {
     log.trace({ op: 'mailer.postNewRecoveryCodesEmail', email: message.email, uid: message.uid })
 
     const templateName = 'postNewRecoveryCodesEmail'
-    const links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const links = this._generateSettingLinks(message, templateName)
 
     const headers = {
       'X-Link': links.link
@@ -1012,7 +1012,7 @@ module.exports = function (log, config) {
     log.trace({ op: 'mailer.postConsumeRecoveryCodeEmail', email: message.email, uid: message.uid })
 
     const templateName = 'postConsumeRecoveryCodeEmail'
-    const links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    const links = this._generateSettingLinks(message, templateName)
 
     const headers = {
       'X-Link': links.link
@@ -1103,6 +1103,15 @@ module.exports = function (log, config) {
     }
 
     return links
+  }
+
+  Mailer.prototype._generateSettingLinks = function (message, templateName) {
+    // Generate all possible links where the primary link is `accountSettingsUrl`.
+    const query = {}
+    if (message.email) {query.email = message.email}
+    if (message.uid) {query.uid = message.uid}
+
+    return this._generateLinks(this.accountSettingsUrl, message.email, query, templateName)
   }
 
   Mailer.prototype.createPasswordResetLink = function (email, templateName, emailToHashWith) {

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -118,6 +118,16 @@ const typesContainPasswordManagerInfoLinks = [
   'passwordResetRequiredEmail',
 ]
 
+const typesContainManageSettingsLinks = [
+  'postVerifySecondaryEmail',
+  'postChangePrimaryEmail',
+  'postRemoveSecondaryEmail',
+  'postAddTwoStepAuthenticationEmail',
+  'postRemoveTwoStepAuthenticationEmail',
+  'postNewRecoveryCodesEmail',
+  'postConsumeRecoveryCodeEmail',
+]
+
 function includes(haystack, needle) {
   return (haystack.indexOf(needle) > -1)
 }
@@ -395,6 +405,18 @@ describe(
               mailer[type](message)
             }
           )
+        }
+
+        if (includes(typesContainManageSettingsLinks, type)) {
+          it('account settings info link is in email template output for ' + type, () => {
+            const accountSettingsUrl = mailer._generateSettingLinks(message, type).link
+
+            mailer.mailer.sendMail = function (emailConfig) {
+              assert.ok(includes(emailConfig.html, accountSettingsUrl))
+              assert.ok(includes(emailConfig.text, accountSettingsUrl))
+            }
+            mailer[type](message)
+          })
         }
 
         if (includes(typesContainLocationData, type)) {


### PR DESCRIPTION
From IRC:
```
rfeeley> vbudhram: oooh also notice that the "Manage account" buttons in the email do not link to a specific email address. will help prevent accidents for some users if it does.
<vbudhram> Vijay Budhram rfeeley: ah didn't notice, there might be some more emails that need it too
```

This PR appends the email query param to `Manage Account` email link. When a user clicks the email link, it will try to open the settings page for that email or redirect to login if they are not currently logged in.

Fixes https://github.com/mozilla/fxa-auth-server/issues/2093