### PR TITLE
chore(logging): use a less confusing op on flow event errors

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -154,7 +154,7 @@ Lug.prototype.activityEvent = function (data) {
 
 Lug.prototype.flowEvent = function (data) {
   if (! data || ! data.event || ! data.flow_id || ! data.flow_time || ! data.time) {
-    this.error({ op: 'log.flowEvent', data: data })
+    this.error({ op: 'flow.missingData', data })
     return
   }
 

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -205,9 +205,9 @@ describe('log', () => {
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
       const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
-      assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
+      assert.equal(args[0], 'flow.missingData', 'first argument was op')
       assert.deepEqual(args[1], {
-        op: 'log.flowEvent',
+        op: 'flow.missingData',
         data: undefined
       }, 'argument was correct')
 
@@ -230,9 +230,9 @@ describe('log', () => {
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
       const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
-      assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
+      assert.equal(args[0], 'flow.missingData', 'first argument was op')
       assert.deepEqual(args[1], {
-        op: 'log.flowEvent',
+        op: 'flow.missingData',
         data: {
           flow_id: 'wibble',
           flow_time: 1000,
@@ -259,9 +259,9 @@ describe('log', () => {
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
       const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
-      assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
+      assert.equal(args[0], 'flow.missingData', 'first argument was op')
       assert.deepEqual(args[1], {
-        op: 'log.flowEvent',
+        op: 'flow.missingData',
         data: {
           event: 'wibble',
           flow_time: 1000,
@@ -288,9 +288,9 @@ describe('log', () => {
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
       const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
-      assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
+      assert.equal(args[0], 'flow.missingData', 'first argument was op')
       assert.deepEqual(args[1], {
-        op: 'log.flowEvent',
+        op: 'flow.missingData',
         data: {
           event: 'wibble',
           flow_id: 'blee',
@@ -317,9 +317,9 @@ describe('log', () => {
       assert.equal(logger.error.callCount, 1, 'logger.error was called once')
       const args = logger.error.args[0]
       assert.equal(args.length, 2, 'logger.error was passed two arguments')
-      assert.equal(args[0], 'log.flowEvent', 'first argument was function name')
+      assert.equal(args[0], 'flow.missingData', 'first argument was op')
       assert.deepEqual(args[1], {
-        op: 'log.flowEvent',
+        op: 'flow.missingData',
         data: {
           event: 'wibble',
           flow_id: 'blee',


### PR DESCRIPTION
While writing https://github.com/mozilla/fxa-auth-server/pull/2391#issuecomment-380728358, I noticed that the log line for an error in `log.flowEvent` is easy to confuse with an actual flow event.

Of course the error level is different, but the two bodies are kind of similar and the `op` property is very similar:

* ```
  log.flowEvent {"op":"log.flowEvent","data":{"event":"route.performance./account/reset","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:61.0) Gecko/20100101 Firefox/61.0","time":1523522808577,"device_id":"d90fff2f94684ee1b2733accc047b36e","flow_time":256,"flowCompleteSignal":"account.signed"}}
  ```

* ```
  flowEvent {"event":"route.performance./password/forgot/send_code","locale":"en","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","time":1523522757705,"device_id":"49d4379c942745dfb9b9469929b54378","flow_id":"e2f5005eb3035441b0a2391e8ffb7dd9a502121a846bb42fe4cef13819e283fb","flow_time":74,"flowBeginTime":1523522747580}
  ```

This PR follows the approach from the amplitude events, changing `op` to `flow.missingData`.

@mozilla/fxa-devs r?