### PR TITLE
fix(totp): Change 2FA removed email title to `Two-step authentication disabled`

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -952,7 +952,7 @@ module.exports = function (log, config) {
 
     return this.send(Object.assign({}, message, {
       headers,
-      subject: gettext('Two-step authentication removed'),
+      subject: gettext('Two-step authentication disabled'),
       template: templateName,
       templateValues: {
         androidLink: links.androidLink,


### PR DESCRIPTION
This change makes the email title consistent with the content.

fixes mozilla/fxa-content-server#6073

@mozilla/fxa-devs - r?