### PR TITLE
chore(config): update redirect domain for dev.json

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -15,7 +15,8 @@
   "smtp": {
     "host": "127.0.0.1",
     "port": 9999,
-    "secure": false
+    "secure": false,
+    "redirectDomain": "127.0.0.1"
   },
   "snsTopicArn": "arn:aws:sns:local-01:000000000000:local-topic1",
   "snsTopicEndpoint": "http://localhost:4100/",


### PR DESCRIPTION
To help test https://github.com/mozilla/fxa-content-server/pull/5922, the redirect domain env needs to be set to `127.0.0.1`.

@mozilla/fxa-devs r?