### PR TITLE
fix(scripts): Remove obsolete `bufferize` call from must-reset script.

### DIFF
--- a/scripts/must-reset.js
+++ b/scripts/must-reset.js
@@ -54,9 +54,9 @@ DB.connect(config[config.db.backend])
     function (db) {
       var json = require(path.resolve(commandLineOptions.input))
 
-      var uids = butil.bufferize(json.map(function (entry) {
+      var uids = json.map(function (entry) {
         return entry.uid
-      }), {inplace: true})
+      })
 
       return P.all(uids.map(
         function (uid) {


### PR DESCRIPTION
It looks like the `must-reset.js` script got left out of the epic "death to buffers" refactor of #1950 - it's still trying to call the long-since-removed `butil.bufferize` function, but in fact can safely leave the uid as a hex string.

This script does not have any tests, and I haven't added any here, but we should.  In the meantime this unbreaks it in service of https://bugzilla.mozilla.org/show_bug.cgi?id=1456771