### PR TITLE
fix(logging): log successful sms budget checks

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -751,6 +751,12 @@ var conf = convict({
       format: 'url',
       env: 'SMS_SIGNIN_CODES_BASE_URI'
     },
+    enableBudgetChecks: {
+      doc: 'enable checks of the monthly SMS spend against the available budget',
+      default: true,
+      format: Boolean,
+      env: 'SMS_ENABLE_BUDGET_CHECKS'
+    },
     minimumCreditThresholdUSD: {
       doc: 'The minimum amount of available credit that is necessary to enable SMS, in US dollars',
       default: 200,

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -111,6 +111,7 @@ module.exports = (log, translator, templates, config) => {
         }
 
         isBudgetOk = current <= limit - CREDIT_THRESHOLD
+        log.info({ op: 'sms.budget.ok', isBudgetOk, current, limit, threshold: CREDIT_THRESHOLD })
       })
       .catch(err => {
         log.error({ op: 'sms.budget.error', err: err.message })

--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -30,7 +30,9 @@ module.exports = (log, translator, templates, config) => {
 
   let isBudgetOk = true
 
-  setImmediate(pollCurrentSpend)
+  if (config.sms.enableBudgetChecks) {
+    setImmediate(pollCurrentSpend)
+  }
 
   return {
     isBudgetOk: () => isBudgetOk,

--- a/test/local/mailer_locales.js
+++ b/test/local/mailer_locales.js
@@ -8,13 +8,16 @@ const ROOT_DIR = '../..'
 
 const assert = require('insist')
 const config = require(`${ROOT_DIR}/config/index`).getProperties()
+const error = require(`${ROOT_DIR}/lib/error`)
+const mocks = require('../mocks')
+
 const bounces = {
   check() {
     return require(`${ROOT_DIR}/lib/promise`).resolve()
   }
 }
-const error = require(`${ROOT_DIR}/lib/error`)
-const log = {}
+
+const log = mocks.mockLog()
 
 describe('mailer locales', () => {
 

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -301,8 +301,8 @@ describe('lib/senders/index', () => {
             assert.equal(errorBounces.check.callCount, 2)
             assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT)
 
-            assert.equal(log.info.callCount, 2)
-            const msg = log.info.args[0][0]
+            assert.equal(log.info.callCount, 3)
+            const msg = log.info.args[1][0]
             assert.equal(msg.op, 'mailer.blocked')
             assert.equal(msg.errno, e.errno)
             assert.equal(msg.bouncedAt, DATE)
@@ -360,8 +360,8 @@ describe('lib/senders/index', () => {
             assert.equal(errorBounces.check.callCount, 1)
             assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT)
 
-            assert.equal(log.info.callCount, 1)
-            const msg = log.info.args[0][0]
+            assert.equal(log.info.callCount, 2)
+            const msg = log.info.args[1][0]
             assert.equal(msg.op, 'mailer.blocked')
             assert.equal(msg.errno, e.errno)
             assert.equal(msg.bouncedAt, DATE)

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -45,7 +45,11 @@ describe('lib/senders/index', () => {
     }
 
     function createSender(config, bounces, log) {
-      return senders(log || nullLog, config, error, bounces, {})
+      return senders(log || nullLog, Object.assign({}, config, {
+        sms: {
+          enableBudgetChecks: false
+        }
+      }), error, bounces, {})
         .then(sndrs => {
           const email = sndrs.email
           email._ungatedMailer.mailer.sendMail = sinon.spy((opts, cb) => {
@@ -301,8 +305,8 @@ describe('lib/senders/index', () => {
             assert.equal(errorBounces.check.callCount, 2)
             assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT)
 
-            assert.equal(log.info.callCount, 3)
-            const msg = log.info.args[1][0]
+            assert.equal(log.info.callCount, 2)
+            const msg = log.info.args[0][0]
             assert.equal(msg.op, 'mailer.blocked')
             assert.equal(msg.errno, e.errno)
             assert.equal(msg.bouncedAt, DATE)
@@ -360,8 +364,8 @@ describe('lib/senders/index', () => {
             assert.equal(errorBounces.check.callCount, 1)
             assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT)
 
-            assert.equal(log.info.callCount, 2)
-            const msg = log.info.args[1][0]
+            assert.equal(log.info.callCount, 1)
+            const msg = log.info.args[0][0]
             assert.equal(msg.op, 'mailer.blocked')
             assert.equal(msg.errno, e.errno)
             assert.equal(msg.bouncedAt, DATE)

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -21,6 +21,7 @@ describe('lib/senders/sms:', () => {
       smtp: {},
       sms: {
         apiRegion: 'us-east-1',
+        enableBudgetChecks: true,
         installFirefoxLink: 'https://baz/qux',
         installFirefoxWithSigninCodeBaseUri: 'https://wibble',
         minimumCreditThresholdUSD: 2,

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -117,6 +117,19 @@ describe('lib/senders/sms:', () => {
         assert.deepEqual(args[0].Statistics, [ 'Average' ])
       })
 
+      it('called log.info correctly', () => {
+        assert.equal(log.info.callCount, 1)
+        const args = log.info.args[0]
+        assert.equal(args.length, 1)
+        assert.deepEqual(args[0], {
+          op: 'sms.budget.ok',
+          isBudgetOk: true,
+          current: 0,
+          limit: config.sms.minimumCreditThresholdUSD,
+          threshold: config.sms.minimumCreditThresholdUSD
+        })
+      })
+
       it('isBudgetOk returns true', () => {
         assert.strictEqual(sms.isBudgetOk(), true)
       })
@@ -217,8 +230,8 @@ describe('lib/senders/sms:', () => {
       })
 
       it('called log.info correctly', () => {
-        assert.equal(log.info.callCount, 1)
-        const args = log.info.args[0]
+        assert.equal(log.info.callCount, 2)
+        const args = log.info.args[1]
         assert.equal(args.length, 1)
         assert.deepEqual(args[0], {
           op: 'sms.send.success',


### PR DESCRIPTION
Related to #2428.

Log a success message when a budget check succeeds, so we can easily compare the relative volumes of successful and failed checks in the logs.

I have a slight fear that the knock-on effect this message has in the tests may be non-deterministic, because the budget check happens in a subsequent tick and ends up inserting itself in the way of some unrelated test cases. But the test changes here seem to work both locally and in CI, so hopefully it's fine. It's worth keeping an eye out for future flakiness though, because this could easily be the cause of it.

@mozilla/fxa-devs r?