### PR TITLE
fix(password): require totp verified session to change password

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -372,7 +372,7 @@ those common validations are defined here.
 #### lib/devices
 
 * `schema`: {
-    * `id`: isA.string.length(32).regex(HEX_STRING)
+    * `id: isA.string.length(32).regex(HEX_STRING)
     * `location`: isA.object({ city: isA.string.optional.allow(null)
     * `country`: isA.string.optional.allow(null)
     * `state`: isA.string.optional.allow(null)
@@ -1860,6 +1860,15 @@ Optionally returns `sessionToken` and `keyFetchToken`.
   <!--begin-request-body-post-passwordchangefinish-sessionToken-->
   Indicates whether a new `sessionToken` is required, default to `false`.
   <!--end-request-body-post-passwordchangefinish-sessionToken-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+* `code: 400, errno: 138`:
+  Unverified session
 
 
 #### POST /password/forgot/send_code


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2313

This isn't the full refactor as described in the issue above, but it does add some checks around the `/password/change/finish` endpoint to ensure that the session has been TOTP verified.