### PR TITLE
refactor(metrics): move amplitude email types back here from fxa-shared

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -15,6 +15,7 @@
 const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude')
 const P = require('../promise')
 
+// Maps template name to email type
 const EMAIL_TYPES = {
   lowRecoveryCodesEmail: '2fa',
   newDeviceLoginEmail: 'login',

--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -12,8 +12,30 @@
 
 'use strict'
 
-const { EMAIL_TYPES, GROUPS, initialize } = require('fxa-shared/metrics/amplitude')
+const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude')
 const P = require('../promise')
+
+const EMAIL_TYPES = {
+  lowRecoveryCodesEmail: '2fa',
+  newDeviceLoginEmail: 'login',
+  passwordChangedEmail: 'change_password',
+  passwordResetEmail: 'reset_password',
+  passwordResetRequiredEmail: 'reset_password',
+  postChangePrimaryEmail: 'change_email',
+  postRemoveSecondaryEmail: 'secondary_email',
+  postVerifyEmail: 'registration',
+  postVerifySecondaryEmail: 'secondary_email',
+  postConsumeRecoveryCodeEmail: '2fa',
+  postNewRecoveryCodesEmail: '2fa',
+  recoveryEmail: 'reset_password',
+  unblockCode: 'unblock',
+  verifyEmail: 'registration',
+  verifyLoginEmail: 'login',
+  verifyLoginCodeEmail: 'login',
+  verifyPrimaryEmail: 'verify',
+  verifySyncEmail: 'registration',
+  verifySecondaryEmail: 'secondary_email'
+}
 
 const EVENTS = {
   'account.confirmed': {
@@ -106,6 +128,7 @@ module.exports = (log, config) => {
           flowBeginTime: getFromMetricsContext(metricsContext, 'flowBeginTime', request, 'flowBeginTime'),
           lang: request.app.locale,
           emailDomain: data.email_domain,
+          emailTypes: EMAIL_TYPES,
           service: getService(request, data, metricsContext)
         }, getOs(request), getBrowser(request), getLocation(request)))
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8201,9 +8201,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.8.tgz",
-      "integrity": "sha512-s9sgVlk96VnTxtvzLJiG+dOi0ELysE/OLGlSU/Gcc7TeNd+/2sxsbyWYQ3cxbSVUWYqGAMpuFoODFhrbTSBa3A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.9.tgz",
+      "integrity": "sha512-H8ECHQG/V7yqU5vAJFBbcS7IcEona0qj8xE+K8LAtMvcEr4QR2jlr3Q/DE139r3/CzKc3ocQRRpJ/nFIv1Yo6g==",
       "requires": {
         "accept-language": "2.0.17",
         "moment": "2.20.1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "email-addresses": "2.0.2",
     "fxa-geodb": "1.0.1",
     "fxa-jwtool": "0.7.1",
-    "fxa-shared": "1.0.8",
+    "fxa-shared": "1.0.9",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "vitkarpov/grunt-nunjucks-2-html#1900f91a756b2eaf900b20",


### PR DESCRIPTION
Fixes mozilla/fxa-shared#23.

Moves `EMAIL_TYPES` back into this repo for easier maintenance when new email types get added.

@mozilla/fxa-devs r?