### PR TITLE
Add support for "device commands" feature.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -708,6 +708,32 @@ var conf = convict({
       default: /^https:\/\/[a-zA-Z0-9._-]+(\.services\.mozilla\.com|autopush\.dev\.mozaws\.net|autopush\.stage\.mozaws\.net)(\/.*)?$/
     }
   },
+  pushbox: {
+    enabled: {
+      doc: 'Indicates whether talking to the Pushbox server is enabled',
+      format: Boolean,
+      default: false,
+      env: 'PUSHBOX_ENABLED'
+    },
+    url: {
+      doc: 'Pushbox Server URL',
+      format: 'url',
+      default: 'https://pushbox.services.mozilla.com/',
+      env: 'PUSHBOX_URL'
+    },
+    key: {
+      doc: 'Authentication key to use when accessing pushbox server',
+      format: String,
+      default: 'Correct_Horse_Battery_Staple_1',
+      env: 'PUSHBOX_KEY'
+    },
+    maxTTL: {
+      doc: 'Maximum TTL to set on items written to pushbox',
+      format: 'duration',
+      default: '28 days',
+      env: 'PUSHBOX_MAX_TTL'
+    }
+  },
   sms: {
     enabled: {
       doc: 'Indicates whether POST /sms is enabled',

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,8 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [POST /account/destroy (:lock::unlock: sessionToken)](#post-accountdestroy)
   * [Devices and sessions](#devices-and-sessions)
     * [POST /account/device (:lock: sessionToken)](#post-accountdevice)
+    * [GET /account/device/commands (:lock: sessionToken)](#get-accountdevicecommands)
+    * [POST /account/devices/invoke_command (:lock: sessionToken)](#post-accountdevicesinvoke_command)
     * [POST /account/devices/notify (:lock: sessionToken)](#post-accountdevicesnotify)
     * [GET /account/devices (:lock: sessionToken)](#get-accountdevices)
     * [GET /account/sessions (:lock: sessionToken)](#get-accountsessions)
@@ -281,6 +283,8 @@ for `code` and `errno` are:
   A TOTP token not found.
 * `code: 400, errno: 156`:
   Recovery code not found.
+* `code: 400, errno: 157`:
+  Unavailable device command.
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -354,6 +358,7 @@ those common validations are defined here.
 * `recoveryData`: `string, regex(/[a-zA-Z0-9.]/), max(1024), required`
 * `E164_NUMBER`: `/^\+[1-9]\d{1,14}$/`
 * `DIGITS`: `/^[0-9]+$/`
+* `DEVICE_COMMAND_NAME`: `/^[a-zA-Z0-9._\/\-:]{1,100}$/`
 * `IP_ADDRESS`: `string, ip`
 
 #### lib/metrics/context
@@ -393,6 +398,8 @@ those common validations are defined here.
     * `pushPublicKey`: isA.string.max(88).regex(URL_SAFE_BASE_64).allow('')
     * `pushAuthKey`: isA.string.max(24).regex(URL_SAFE_BASE_64).allow('')
     * `pushEndpointExpired`: isA.boolean.strict
+    * `availableCommands`: isA.object.pattern(validators.DEVICE_COMMAND_NAME
+    * `isA.string.max(2048))
 
   }
 
@@ -1039,6 +1046,12 @@ can be made available to other connected devices.
   
   <!--end-request-body-post-accountdevice-pushAuthKey-->
 
+* `availableCommands`: *DEVICES_SCHEMA.availableCommands.optional*
+
+  <!--begin-request-body-post-accountdevice-availableCommands-->
+  
+  <!--end-request-body-post-accountdevice-availableCommands-->
+
 * `capabilities`: *array, length(0), optional*
 
   <!--begin-request-body-post-accountdevice-capabilities-->
@@ -1095,6 +1108,12 @@ can be made available to other connected devices.
   
   <!--end-response-body-post-accountdevice-pushEndpointExpired-->
 
+* `availableCommands`: *DEVICES_SCHEMA.availableCommands.optional*
+
+  <!--begin-response-body-post-accountdevice-availableCommands-->
+  
+  <!--end-response-body-post-accountdevice-availableCommands-->
+
 ##### Error responses
 
 Failing requests may be caused
@@ -1106,6 +1125,107 @@ by the following errors
 
 * `code: 503, errno: 202`:
   Feature not enabled
+
+
+#### GET /account/device/commands
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-get-accountdevicecommands-->
+Fetches commands enqueued for the current device
+by prior calls to `/account/devices/invoke_command`.
+The device can page through the enqueued commands
+by using the `index` and `limit` parameters.
+
+For more details,
+see the [device registration](device_registration.md) docs.
+<!--end-route-get-accountdevicecommands-->
+
+##### Query parameters
+
+* `index`: *number, optional*
+
+  <!--begin-query-param-get-accountdevicecommands-index-->
+  The index of the most recently seen command item.
+  Only commands enqueued after the given index will be returned.
+  <!--end-query-param-get-accountdevicecommands-index-->
+
+* `limit`: *number, optional, min(0), max(100), default(100)*
+
+  <!--begin-query-param-get-accountdevicecommands-limit-->
+  The maximum number of commands to return.
+  The default and maximum value for `limit` is 100.
+  <!--end-query-param-get-accountdevicecommands-limit-->
+
+##### Response body
+
+* `index`: *number, required*
+
+  <!--begin-response-body-get-accountdevicecommands-index-->
+  The largest index of the commands returned in this response.
+  This value can be passed as the `index` parameter
+  in subsequent calls in order to page through all the items.
+  <!--end-response-body-get-accountdevicecommands-index-->
+
+* `last`: *boolean, optional*
+
+  <!--begin-response-body-get-accountdevicecommands-last-->
+  Indicates whether more commands and enqueued than could
+  be returned within the specific limit.
+  <!--end-response-body-get-accountdevicecommands-last-->
+
+* `messages`: *array, items(object({ index: number, required, data: object({ command: string, max(255), required, payload: object, required, sender: DEVICES_SCHEMA.id, optional }), required })), optional*
+
+  <!--begin-response-body-get-accountdevicecommands-messages-->
+  An array of individual commands for the device to process.
+  <!--end-response-body-get-accountdevicecommands-messages-->
+
+
+#### POST /account/devices/invoke_command
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-post-accountdevicesinvoke_command-->
+Enqueues a command to be invoked on a target device.
+
+For more details,
+see the [device registration](device_registration.md) docs.
+<!--end-route-post-accountdevicesinvoke_command-->
+
+##### Request body
+
+* `target`: *DEVICES_SCHEMA.id.required*
+
+  <!--begin-request-body-post-accountdevicesinvoke_command-target-->
+  The id of the device on which to invoke the command.
+  <!--end-request-body-post-accountdevicesinvoke_command-target-->
+
+* `command`: *string, required*
+
+  <!--begin-request-body-post-accountdevicesinvoke_command-command-->
+  The id of the command to be invoked,
+  as found in the device's `availableCommands` set.
+  <!--end-request-body-post-accountdevicesinvoke_command-command-->
+
+* `payload`: *object, required*
+
+  <!--begin-request-body-post-accountdevicesinvoke_command-payload-->
+  Opaque payload to be forwarded to the device.
+  <!--end-request-body-post-accountdevicesinvoke_command-payload-->
+
+* `ttl`: *number, integer, min(0), max(10000000), optional*
+
+  <!--begin-request-body-post-accountdevicesinvoke_command-ttl-->
+  The time in milliseconds after which the command should expire,
+  if not processed by the device.
+  <!--end-request-body-post-accountdevicesinvoke_command-ttl-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+* `code: 400, errno: 157`:
+  Unavailable device command.
 
 
 #### POST /account/devices/notify
@@ -1262,6 +1382,12 @@ for the authenticated user.
   
   <!--end-response-body-get-accountdevices-pushEndpointExpired-->
 
+* `availableCommands`: *DEVICES_SCHEMA.availableCommands.optional*
+
+  <!--begin-response-body-get-accountdevices-availableCommands-->
+  
+  <!--end-response-body-get-accountdevices-availableCommands-->
+
 
 #### GET /account/sessions
 
@@ -1345,6 +1471,12 @@ for the authenticated user.
   <!--begin-response-body-get-accountsessions-deviceName-->
   
   <!--end-response-body-get-accountsessions-deviceName-->
+
+* `deviceAvailableCommands`: *DEVICES_SCHEMA.availableCommands.allow(null).required*
+
+  <!--begin-response-body-get-accountsessions-deviceAvailableCommands-->
+  
+  <!--end-response-body-get-accountsessions-deviceAvailableCommands-->
 
 * `deviceType`: *DEVICES_SCHEMA.type.allow(null).required*
 

--- a/docs/device_registration.md
+++ b/docs/device_registration.md
@@ -1,0 +1,350 @@
+# Firefox Accounts Device Registration
+
+When using Firefox Accounts
+to connect a device to Firefox Sync,
+it is possible to annotate
+the device's sessionToken
+with additional metadata
+to improve the user experience.
+Through the Device Registration API,
+a device can:
+
+* Customize the way it appears
+  in the list of connected devices,
+  by providing a display name
+  and device type.
+* Subscribe to push notification events
+  by providing a webpush subscription endpoint.
+* Provide functionality to its peers
+  in an extensible manner
+  by allowing other devices to send it commands,
+  and by sending commands to other devices in turn.
+
+## Basic Registration
+
+Devices can manage their details
+by POSTing a registration record
+to `/v1/account/device`, like so:
+
+```
+POST /v1/account/device HTTP/1.1
+Authorization: < sessionToken HAWK header >
+{
+  "name": "my custom name",
+  "type": "desktop"
+}
+------
+HTTP/1.1 200 OK
+{
+  "id": "d3fc82acca7fc8c50acc06d21babbc00",
+  "name": "my custom name",
+  "type": "desktop"
+}
+```
+
+The server allocates a unique ID for each device,
+which can be provided
+to update an existing device registration:
+
+```
+POST /v1/account/device HTTP/1.1
+Authorization: < sessionToken HAWK header >
+{
+  "id": "d3fc82acca7fc8c50acc06d21babbc00",
+  "name": "my new name"
+}
+------
+HTTP/1.1 200 OK
+{
+  "id": "d3fc82acca7fc8c50acc06d21babbc00",
+  "name": "my new name",
+  "type": "desktop"
+}
+```
+
+Supported device type values
+include "desktop", "mobile" and "tablet".
+
+## Push Notifications
+
+Devices can receive timely updates
+on account lifecycle events
+by providing a [push subscription](https://www.w3.org/TR/push-api/#push-subscription)
+to which to server can publish notifications.
+
+The push subscription consists of three fields:
+a public key and authentication secret
+that can be used to encrypt the notification,
+and a callback URL to which it should be sent.
+These can be provided in the device record
+either during initial registration,
+or as an update like so::
+
+```
+POST /v1/account/device HTTP/1.1
+Authorization: < sessionToken HAWK header >
+{
+  "id": "d3fc82acca7fc8c50acc06d21babbc00",
+  "pushCallback": "https://updates.push.services.mozilla.com/ggYxFjPEjSM/Cg9Et44JFpg",
+  "pushPublicKey": "jXPJHE7-n3cNZGyYBd0yz1BA0V1uLOn-QnOg4kOS1r-oHHep5lQc8KHySevTwVPmcS0oTs_MICMjoYCgA6979Hg",
+  "pushAuthKey": "Wj18qUd0YS2-9vob79WdWg"
+}
+------
+HTTP/1.1 200 OK
+{
+  "id": "d3fc82acca7fc8c50acc06d21babbc00",
+  "name": "my custom name",
+  "type": "desktop",
+  "pushCallback": "https://updates.push.services.mozilla.com/ggYxFjPEjSM/Cg9Et44JFpg",
+  "pushPublicKey": "jXPJHE7-n3cNZGyYBd0yz1BA0V1uLOn-QnOg4kOS1r-oHHep5lQc8KHySevTwVPmcS0oTs_MICMjoYCgA6979Hg",
+  "pushAuthKey": "Wj18qUd0YS2-9vob79WdWg"
+}
+```
+
+Once a webpush subscription is registered,
+the device will receive push notifications
+that match the JSON schema defined in [`pushpayloads.schema.json`](pushpayloads.schema.json).
+For legacy reasons,
+FxA may send an empty push notification
+to indicate that an account has become verified.
+All other notifications will have a "command" field
+indicating the type of event,
+and a "data" field containing an object
+with additional event-specific data.
+
+The currently supported notifications are:
+
+* An empty notification.
+  This indicates that the user's account
+  has become verified
+  and the device can start syncing data.
+* `fxaccounts:device_connected`:
+  A new device has been connected to the account.
+  The device may wish to update
+  any cached list of other connected devices.
+* `fxaccounts:device_disconnected`:
+  A device has been disconnected from the account.
+  The `data` field will have an `id` attribute
+  identifying the disconnected device.
+  If this matches the device's own id
+  then it should immediately discard
+  any cached authentication tokens.
+* `fxaccounts:profile_updated`:
+  The user's profile information has changed,
+  such as display name or email address.
+* `fxaccounts:password_changed`:
+  The user's password has changed.
+  The device should discard any cached authentication tokens
+  and prompt the user to re-enter their password.
+* `fxaccounts:password_reset`:
+  The user's password has changed.
+  The device should discard any cached authentication tokens
+  and prompt the user to re-enter their password.
+* `fxaccounts:account_destroyed`:
+  The user has deleted their account.
+  The device should discard any cached authentication tokens
+  and sign the user out.
+* `fxaccounts:command_received`:
+  Another device has invoked
+  one of this device's advertised commands.
+  See the next section for more details.
+
+
+## Device Commands
+
+Connected devices may be able to
+offer functionality to one another
+on a peer-to-peer basis,
+such as the ability to send a tab
+from one device to another.
+To support this in a flexible and extensible manner,
+FxA allows devices to advertize
+their support for arbitrary "commands"
+that can be invoked by other devices.
+The FxA server will forward command invocations
+from one device to another
+without attempting to define or enforce
+any particular semantics on them.
+
+By way of example,
+here is how two devices
+could use the commands functionality
+to implement the "send tab to device" feature
+of Firefox Sync.
+
+### Example: receiving a tab
+
+First, the devices must agree
+on a well-known name to identify the command.
+It's useful to use a URI for this purpose
+in order to avoid naming conflicts,
+such as "https://identity.mozilla.com/cmd/open-uri"
+
+A device wishing to receive tabs
+sent from other devices
+would first generate an ECDH keypair
+that can be used to encrypt the tab data
+while it's in transit.
+It would encrypt the public key component
+using a symmetric encryption key
+that is shared by all connected devices,
+such as the sync master key.
+It would then advertize its support for this command
+by including the "availableCommands" field
+in its device registration record, like this:
+
+```
+POST /v1/account/device HTTP/1.1
+Authorization: < sessionToken HAWK header >
+{
+  "name": My Firefox",
+  "type": "desktop",
+  "pushCallback": "https://updates.push.services.mozilla.com/ggYxFjPEjSM/Cg9Et44JFpg",
+  "pushPublicKey": "jXPJHE7-n3cNZGyYBd0yz1BA0V1uLOn-QnOg4kOS1r-oHHep5lQc8KHySevTwVPmcS0oTs_MICMjoYCgA6979Hg",
+  "pushAuthKey": "Wj18qUd0YS2-9vob79WdWg"
+  "availableCommands": {
+    "https://identity.mozilla.com/cmd/open-uri": "...encrypted public key..."
+  }
+}
+```
+
+When another device invokes this command,
+FxA will send a `command_received` push notification
+to the receiving device
+with a payload like:
+
+```
+{
+  version: 1,
+  command: "fxaccounts:command_received",
+  data: {
+    "command": "https://identity.mozilla.com/cmd/open-uri",
+    "sender": "0a4abb5e6f2e378f3aadda7f97482e99",
+    "url": "https://api.accounts.firefox.com/v1/device/commands?index=42&limit=1"
+  }
+}
+```
+
+Since push notifications can only contain
+a limited amount of data,
+the notification includes a URL
+at which to fetch the full command payload,
+which the device would load like so:
+
+```
+GET https://api.accounts.firefox.com/v1/device/commands?index=42&limit=1
+Authorization < sessionToken HAWK header >
+------
+HTTP/1.1 200 OK
+{
+  index: 42,
+  last: true,
+  messages: [
+    {
+      index: 42,
+      data: {
+        command: "https://identity.mozilla.com/cmd/open-uri",
+        sender: "0a4abb5e6f2e378f3aadda7f97482e99",
+        payload: "...encrypted tab data payload..."
+      }
+    }
+  ]
+}
+```
+
+Finally, the device would
+validate and decrypt the command payload
+using its private key
+and display the requested page.
+
+The `/v1/account/device/commands` endpoint
+allows fetching multiple messages,
+and paging through the available messages,
+using the [pushbox API](https://docs.google.com/document/d/1YT6gh125Tu03eM42Vb_LKjvgxc4qrGGZsty1_ajf2YM/edit?ts=5aefb8ad#heading=h.42fonoxbbyaz).
+The "index" field acts as a pointer
+into the message stream,
+while the "last" field
+indicates whether any more messages remain.
+A client wishing to fetch all available commands
+could page through the results like this:
+
+```
+let prev_index = <last seen index value>
+all_commands = []
+{ messages, index, last } = get(`/v1/account/device/commands?index=${prev_index}&limit=10`)
+all_commands.push(...messages)
+while not last:
+  prev_index = index
+  { messages, index, last } = get(`/v1/account/device/commands?index=${prev_index}&limit=10`)
+  all_commands.push(...messages)
+```
+
+However, clients are encouraged
+not to poll for commands in this manner
+unless they believe that
+they may have missed a push notification,
+such as if their push subscription was invalidated.
+
+
+### Example: sending a tab
+
+When a device wants to send a tab,
+it can use the device registration API
+to find other connected devices
+and their available commands:
+
+```
+GET /v1/account/devices HTTP/1.1
+Authorization < sessionToken HAWK header >
+------
+HTTP/1.1 200 OK
+[
+  {
+    "id": "d3fc82acca7fc8c50acc06d21babbc00",
+    "name": My Firefox",
+    "type": "desktop",
+    "pushCallback": "https://updates.push.services.mozilla.com/ggYxFjPEjSM/Cg9Et44JFpg",
+    "pushPublicKey": "jXPJHE7-n3cNZGyYBd0yz1BA0V1uLOn-QnOg4kOS1r-oHHep5lQc8KHySevTwVPmcS0oTs_MICMjoYCgA6979Hg",
+    "pushAuthKey": "Wj18qUd0YS2-9vob79WdWg"
+    "availableCommands": {
+      "https://identity.mozilla.com/cmd/open-uri": "...encrypted public key..."
+    }
+  },
+  {
+    "id": "0a4abb5e6f2e378f3aadda7f97482e99",
+    "name": My Fennec",
+    "type": "mobile",
+    "pushCallback": "https://updates.push.services.mozilla.com/ggYxFjPEjSM/Cg9Et44JFpg",
+    "pushPublicKey": "jXPJHE7-n3cNZGyYBd0yz1BA0V1uLOn-QnOg4kOS1r-oHHep5lQc8KHySevTwVPmcS0oTs_MICMjoYCgA6979Hg",
+    "pushAuthKey": "Wj18qUd0YS2-9vob79WdWg"
+    "availableCommands": {}
+  }
+]
+```
+
+It can identify possible target devices
+by looking in the "availableCommands" field.
+When a target is selected,
+it can decrypt the associated command metadata bundle
+to obtain the device's public key,
+and use that to construct
+an encrypted payload of tab data.
+
+It can then invoke the target device's "open-uri" command
+like so:
+
+```
+POST /v1/account/devices/invoke_command HTTP/1.1
+Authorization < sessionToken HAWK header >
+{
+  "target": "d3fc82acca7fc8c50acc06d21babbc00",
+  "command": "https://identity.mozilla.com/cmd/open-uri",
+  "payload": "...encrypted tab data payload..."
+}
+```
+
+The FxA server will store this command
+into the command queue for the target device,
+and send it a `fxaccounts:command_received` push notification,
+causing it to fetch the command
+via the procedure outlined above.

--- a/docs/pushpayloads.schema.json
+++ b/docs/pushpayloads.schema.json
@@ -10,7 +10,8 @@
     { "$ref":"#/definitions/collectionsChanged" },
     { "$ref":"#/definitions/passwordChanged" },
     { "$ref":"#/definitions/passwordReset" },
-    { "$ref":"#/definitions/accountDestroyed" }
+    { "$ref":"#/definitions/accountDestroyed" },
+    { "$ref":"#/definitions/commandReceived" }
   ],
   "definitions":{
     "deviceConnected":{
@@ -201,6 +202,52 @@
             "uid":{
               "type":"string",
               "description":"The UID of the account which was destroyed"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "commandReceived":{
+      "required":[
+        "version",
+        "command",
+        "data"
+      ],
+      "properties":{
+        "version":{
+          "type":"integer"
+        },
+        "command":{
+          "type":"string",
+          "enum":[
+            "fxaccounts:command_received"
+          ]
+        },
+        "data":{
+          "type":"object",
+          "required":[
+            "command",
+            "index",
+            "url"
+          ],
+          "properties":{
+            "command":{
+              "type":"string",
+              "description":"URI identifying the command that was invoked"
+            },
+            "index":{
+              "type":"integer",
+              "description":"index of this command in the device's command queue"
+            },
+            "sender":{
+              "type":"string",
+              "description":"The device ID from which the command was sent, if known"
+            },
+            "url":{
+              "type":"string",
+              "description":"URL at which to fetch the full command payload"
             }
           },
           "additionalProperties": false

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -29,7 +29,9 @@ const SCHEMA = {
   pushCallback: validators.url({ scheme: 'https' }).regex(PUSH_SERVER_REGEX).max(255).allow(''),
   pushPublicKey: isA.string().max(88).regex(URL_SAFE_BASE_64).allow(''),
   pushAuthKey: isA.string().max(24).regex(URL_SAFE_BASE_64).allow(''),
-  pushEndpointExpired: isA.boolean().strict()
+  pushEndpointExpired: isA.boolean().strict(),
+  // An object mapping command names to metadata bundles.
+  availableCommands: isA.object().pattern(validators.DEVICE_COMMAND_NAME, isA.string().max(2048))
 }
 
 module.exports = (log, db, push) => {

--- a/lib/error.js
+++ b/lib/error.js
@@ -68,6 +68,7 @@ var ERRNO = {
   TOTP_TOKEN_NOT_FOUND: 155,
 
   RECOVERY_CODE_NOT_FOUND: 156,
+  DEVICE_COMMAND_UNAVAILABLE: 157,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -780,6 +781,15 @@ AppError.recoveryCodeNotFound = () => {
     error: 'Bad Request',
     errno: ERRNO.RECOVERY_CODE_NOT_FOUND,
     message: 'Recovery code not found.'
+  })
+}
+
+AppError.unavailableDeviceCommand = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.DEVICE_COMMAND_UNAVAILABLE,
+    message: 'Unavailable device command.'
   })
 }
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -22,13 +22,15 @@ var PUSH_COMMANDS = {
   PROFILE_UPDATED: 'fxaccounts:profile_updated',
   PASSWORD_CHANGED: 'fxaccounts:password_changed',
   PASSWORD_RESET: 'fxaccounts:password_reset',
-  ACCOUNT_DESTROYED: 'fxaccounts:account_destroyed'
+  ACCOUNT_DESTROYED: 'fxaccounts:account_destroyed',
+  COMMAND_RECEIVED: 'fxaccounts:command_received'
 }
 
-var TTL_DEVICE_DISCONNECTED = 5 * 3600 // 5 hours
-var TTL_PASSWORD_CHANGED = 6 * 3600 // 6 hours
-var TTL_PASSWORD_RESET = TTL_PASSWORD_CHANGED
-var TTL_ACCOUNT_DESTROYED = TTL_DEVICE_DISCONNECTED
+const TTL_DEVICE_DISCONNECTED = 5 * 3600 // 5 hours
+const TTL_PASSWORD_CHANGED = 6 * 3600 // 6 hours
+const TTL_PASSWORD_RESET = TTL_PASSWORD_CHANGED
+const TTL_ACCOUNT_DESTROYED = TTL_DEVICE_DISCONNECTED
+const TTL_COMMAND_RECEIVED = TTL_PASSWORD_CHANGED
 
 // An arbitrary, but very generous, limit on the number of active devices.
 // Currently only for metrics purposes, not enforced.
@@ -37,7 +39,8 @@ var MAX_ACTIVE_DEVICES = 200
 const pushReasonsToEvents = (() => {
   const reasons = ['accountVerify', 'accountConfirm', 'passwordReset',
     'passwordChange', 'deviceConnected', 'deviceDisconnected',
-    'profileUpdated', 'devicesNotify', 'accountDestroyed']
+    'profileUpdated', 'devicesNotify', 'accountDestroyed',
+    'commandReceived']
   const events = {}
   for (const reason of reasons) {
     const id = reason.replace(/[A-Z]/, c => `_${c.toLowerCase()}`) // snake-cased.
@@ -191,6 +194,37 @@ module.exports = function (log, db, config) {
   return {
 
     isValidPublicKey,
+
+    /**
+     * Notify devices that a new command is ready to be retrieved.
+     *
+     * @param {String} uid
+     * @param {Device} device
+     * @param {Number} index - index of the newly-enqueued command
+     * @param {String} url - url to retrieve the command details.
+     * @param {String} topic
+     * @param {String} reason
+     * @promise
+     */
+    notifyCommandReceived(uid, device, command, sender, index, url, ttl) {
+      if (typeof ttl === 'undefined') {
+        ttl = TTL_COMMAND_RECEIVED
+      }
+      const options = {
+        data: {
+          version: PUSH_PAYLOAD_SCHEMA_VERSION,
+          command: PUSH_COMMANDS.COMMAND_RECEIVED,
+          data: {
+            command,
+            index,
+            sender,
+            url
+          }
+        },
+        TTL: ttl
+      }
+      return this.sendPush(uid, [device], 'commandReceived', options)
+    },
 
     /**
      * Notify devices that a new device was connected

--- a/lib/pushbox.js
+++ b/lib/pushbox.js
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * "Pushbox" is a durable queue service that allows customers to store and
+ * retrieve large payloads (~1 MB) that persist for generous lengths of time
+ * (~1 month).  We use it to provide a "command queue" for each connected device
+ * that is more reliable than its webpush subscription.
+ *
+ * This library implements a little proxy in front of the pushbox API,
+ * allowing it to be authenticated by the device's session token.
+ * It's likely that we'll eventually refacor this out into a standalone
+ * oauth-authenticated service, once we get more experience with using it.
+ */
+
+'use strict'
+
+const isA = require('joi')
+const error = require('./error')
+const Pool = require('./pool')
+const P = require('./promise')
+const validators = require('./routes/validators')
+
+const base64url = require('base64url')
+
+const LOG_OP_RETRIEVE = 'pushbox.retrieve'
+const LOG_OP_STORE = 'pushbox.store'
+
+const PUSHBOX_RETRIEVE_SCHEMA = isA.object({
+  last: isA.boolean().optional(),
+  index: isA.number().optional(),
+  messages: isA.array().items(isA.object({
+    index: isA.number().required(),
+    data: isA.string().regex(validators.URL_SAFE_BASE_64).required(),
+  })).optional(),
+  status: isA.number().required(),
+  error: isA.string().optional()
+}).and('last', 'messages').or('index', 'error')
+
+const PUSHBOX_STORE_SCHEMA = isA.object({
+  index: isA.number().optional(),
+  error: isA.string().optional(),
+  status: isA.number().required()
+}).or('index', 'error')
+
+const validateRetrieveResponse = P.promisify(PUSHBOX_RETRIEVE_SCHEMA.validate, {
+  context: PUSHBOX_RETRIEVE_SCHEMA
+})
+
+const validateStoreResponse = P.promisify(PUSHBOX_STORE_SCHEMA.validate, {
+  context: PUSHBOX_STORE_SCHEMA
+})
+
+
+// Pushbox stores strings, so these are a little pair
+// of helper functions to allow us to store arbitrary
+// JSON-serializable objects.
+
+function encodeForStorage(data) {
+  return base64url.encode(JSON.stringify(data))
+}
+
+function decodeFromStorage(data) {
+  return JSON.parse(base64url.decode(data))
+}
+
+
+module.exports = function (log, config) {
+  if (! config.pushbox.enabled) {
+    return {
+      retrieve() {
+        return Promise.reject(error.featureNotEnabled())
+      },
+      store() {
+        return Promise.reject(error.featureNotEnabled())
+      }
+    }
+  }
+
+  const pool = new Pool(config.pushbox.url, { timeout: 15000 })
+  // pushbox expects this in seconds, not millis.
+  const maxTTL = Math.round(config.pushbox.maxTTL / 1000)
+
+  const SafeUrl = require('./safe-url')(log)
+  const path = new SafeUrl('/v1/store/:uid/:deviceId')
+  const headers = {Authorization: `FxA-Server-Key ${config.pushbox.key}`}
+
+  return {
+    /**
+     * Retrieves enqueued items for a specific device.
+     * This simply relays the request to the pushbox service,
+     * decoding stored strings back into rich objects.
+     *
+     * @param {String} uid
+     * @param {String} deviceId
+     * @param {Object} options
+     * @param {Number} limit
+     * @param {String} [index]
+     * @returns {Promise}
+     */
+    retrieve (uid, deviceId, limit, index) {
+      log.trace({
+        op: LOG_OP_RETRIEVE,
+        uid,
+        deviceId,
+        index,
+        limit
+      })
+      const query = {
+        limit: limit.toString()
+      }
+      if (index) {
+        query.index = index.toString()
+      }
+      const params = {uid, deviceId}
+      return pool.get(path, params, {query, headers})
+      .then(body => {
+        log.info({ op: 'pushbox.retrieve.response', body: body })
+        return validateRetrieveResponse(body).catch(e => {
+          log.error({ op: 'pushbox.retrieve', error: 'response schema validation failed', body: body })
+          throw error.unexpectedError()
+        })
+      })
+      .then(body => {
+        if (body.error) {
+          log.error({ op: 'pushbox.retrieve', status: body.status, error: body.error })
+          throw error.unexpectedError()
+        }
+        return {
+          last: body.last,
+          index: body.index,
+          messages: (! body.messages) ? undefined : body.messages.map(msg => {
+            return {
+              index: msg.index,
+              data: decodeFromStorage(msg.data)
+            }
+          })
+        }
+      })
+    },
+
+    /**
+     * Enqueue an item for a specific device.
+     * This simply relays the request to the Pushbox service,
+     * encoding rich objects down into a string for storage.
+     *
+     * @param {String} uid - Firefox Account uid
+     * @param {String} deviceId
+     * @param {string} topic
+     * @param {Object} data - data object to serialize into storage
+     * @returns {Promise} direct url to the stored message
+     */
+    store (uid, deviceId, data, ttl) {
+      if (typeof ttl === 'undefined' || ttl > maxTTL) {
+        ttl = maxTTL
+      }
+      log.trace({
+        op: LOG_OP_STORE,
+        uid,
+        deviceId,
+      })
+      const body = {data: encodeForStorage(data), ttl}
+      const params = {uid, deviceId}
+      return pool.post(path, params, body, {headers})
+      .then(body => {
+        log.info({ op: 'pushbox.store.response', body: body })
+        return validateStoreResponse(body).catch(e => {
+          log.error({ op: 'pushbox.store', error: 'response schema validation failed', body: body })
+          throw error.unexpectedError()
+        })
+      })
+      .then(body => {
+        if (body.error) {
+          log.error({ op: 'pushbox.store', status: body.status, error: body.error })
+          throw error.unexpectedError()
+        }
+        return body
+      })
+    }
+  }
+}
+
+module.exports.RETRIEVE_SCHEMA = PUSHBOX_RETRIEVE_SCHEMA

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -31,8 +31,9 @@ module.exports = function (
     signinUtils,
     push
   )
+  const pushbox = require('../pushbox')(log, config)
   const devicesImpl = require('../devices')(log, db, push)
-  const devicesSessions = require('./devices-and-sessions')(log, db, config, customs, push, devicesImpl)
+  const devicesSessions = require('./devices-and-sessions')(log, db, config, customs, push, pushbox, devicesImpl)
   const emails = require('./emails')(log, db, mailer, config, customs, push)
   const password = require('./password')(
     log,

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -22,6 +22,8 @@ exports.E164_NUMBER = /^\+[1-9]\d{1,14}$/
 
 exports.DIGITS = /^[0-9]+$/
 
+exports.DEVICE_COMMAND_NAME = /^[a-zA-Z0-9._\/\-:]{1,100}$/
+
 exports.IP_ADDRESS = isA.string().ip()
 
 // Match display-safe unicode characters.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9029,8 +9029,9 @@
       }
     },
     "hapi-hpkp": {
-      "version": "git+https://github.com/vbudhram/hapi-hpkp.git#0db1dfe07c67bf1e05cdc9de715395e82aecd540",
-      "from": "git+https://github.com/vbudhram/hapi-hpkp.git#master",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-hpkp/-/hapi-hpkp-1.0.0.tgz",
+      "integrity": "sha1-txskDnOv/ZHFzT52cYr6DmlBwAM=",
       "requires": {
         "joi": "9.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "hapi": "16.6.3",
     "hapi-auth-hawk": "3.0.1",
     "hapi-fxa-oauth": "2.2.0",
-    "hapi-hpkp": "git+https://github.com/vbudhram/hapi-hpkp.git#master",
+    "hapi-hpkp": "1.0.0",
     "hkdf": "0.0.2",
     "i18n-abide": "0.0.25",
     "inert": "4.0.2",

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -6,9 +6,9 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const assert = Object.assign({}, sinon.assert, require('insist'))
 const ajv = require('ajv')()
 const fs = require('fs')
 const path = require('path')
@@ -36,6 +36,7 @@ describe('push', () => {
         'lastAccessTime': 1449235471335,
         'name': 'My Phone',
         'type': 'mobile',
+        'availableCommands': {},
         'pushCallback': 'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
         'pushPublicKey': mocks.MOCK_PUSH_KEY,
         'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong==',
@@ -47,6 +48,7 @@ describe('push', () => {
         'lastAccessTime': 1417699471335,
         'name': 'My Desktop',
         'type': null,
+        'availableCommands': {},
         'pushCallback': 'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
         'pushPublicKey': mocks.MOCK_PUSH_KEY,
         'pushAuthKey': 'w3b14Zjc-Afj2SDOLOyong==',
@@ -58,6 +60,7 @@ describe('push', () => {
         'lastAccessTime': 1402149471335,
         'name': 'My Ipad',
         'type': null,
+        'availableCommands': {},
         'uaOS': 'iOS',
         'pushCallback': 'https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a',
         'pushPublicKey': mocks.MOCK_PUSH_KEY,
@@ -537,6 +540,46 @@ describe('push', () => {
       return push.sendPush(mockUid, [mockDevices[0]], 'accountVerify')
         .then(() => {
           assert.equal(count, 1)
+        })
+    }
+  )
+
+  it(
+    'notifyCommandReceived calls sendPush',
+    () => {
+      const mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            return P.resolve()
+          }
+        }
+      }
+      const push = proxyquire(pushModulePath, mocks)(mockLog(), mockDb, mockConfig)
+      sinon.spy(push, 'sendPush')
+      return push.notifyCommandReceived(mockUid, mockDevices[0], 'commandName', 'sendingDevice', 12, 'http://fetch.url', 42)
+        .catch(err => {
+          assert.fail('must not throw')
+          throw err
+        })
+        .then(() => {
+          assert.ok(push.sendPush.calledOnce, 'sendPush was called')
+          assert.calledWithExactly(push.sendPush, mockUid, [mockDevices[0]], 'commandReceived', {
+            data: {
+              version: 1,
+              command: 'fxaccounts:command_received',
+              data: {
+                command: 'commandName',
+                index: 12,
+                sender: 'sendingDevice',
+                url: 'http://fetch.url'
+              }
+            },
+            TTL: 42
+          })
+          const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH)
+          const schema = JSON.parse(fs.readFileSync(schemaPath))
+          assert.ok(ajv.validate(schema, push.sendPush.getCall(0).args[3].data))
+          push.sendPush.restore()
         })
     }
   )

--- a/test/local/pushbox.js
+++ b/test/local/pushbox.js
@@ -1,0 +1,281 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const ROOT_DIR = '../..'
+
+const assert = require('insist')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const {mockLog} = require('../mocks')
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  pushbox: {
+    enabled: true,
+    url: 'https://foo.bar',
+    key: 'foo',
+    maxTTL: 123456000
+  }
+}
+const mockDeviceIds = ['bogusid1', 'bogusid2', 'bogusid3']
+const mockData = 'eyJmb28iOiAiYmFyIn0'
+const mockUid = 'myuid'
+const pushboxModulePath = `${ROOT_DIR}/lib/pushbox`
+
+describe('pushbox', () => {
+  it(
+    'retrieve',
+    () => {
+      const FakePool = function() {}
+      const getSpy = sinon.spy(() => Promise.resolve({
+        status: 200,
+        last: true,
+        index: '15',
+        messages: [{
+          index: '15',
+          // This is { foo: "bar", bar: "bar" }, encoded.
+          data: 'eyJmb28iOiJiYXIiLCAiYmFyIjogImJhciJ9'
+        }]
+      }))
+      FakePool.prototype.get = getSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const pushbox = proxyquire(pushboxModulePath, mocks)(mockLog(), mockConfig)
+
+      return pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10)
+        .then(resp => {
+          assert.equal(getSpy.callCount, 1, 'get request was made')
+          const args = getSpy.args[0]
+          assert.equal(args.length, 3)
+          assert.equal(args[0]._template.toString(), '/v1/store/:uid/:deviceId')
+          assert.deepEqual(args[1], {uid: mockUid, deviceId: mockDeviceIds[0]})
+          assert.deepEqual(args[2], {query: {limit:50, index:10}, headers: {Authorization: `FxA-Server-Key ${mockConfig.pushbox.key}`}})
+
+          assert.deepEqual(resp, {
+            last: true,
+            index: '15',
+            messages: [{
+              index: '15',
+              data: { foo: 'bar', bar: 'bar' }
+            }]
+          })
+        })
+    }
+  )
+
+  it(
+    'retrieve validates the pushbox server response',
+    () => {
+      const FakePool = function() {}
+      const getSpy = sinon.spy(() => Promise.resolve({
+        'bogus':'object'
+      }))
+      FakePool.prototype.get = getSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const log = mockLog()
+      const pushbox = proxyquire(pushboxModulePath, mocks)(log, mockConfig)
+
+      return pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10)
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.errno, 999)
+          assert.equal(log.error.callCount, 1, 'an error was logged')
+          assert.equal(log.error.getCall(0).args[0].op, 'pushbox.retrieve')
+          assert.equal(log.error.getCall(0).args[0].error, 'response schema validation failed')
+        })
+    }
+  )
+
+  it(
+    'retrieve throws on error response',
+    () => {
+      const FakePool = function() {}
+      const getSpy = sinon.spy(() => Promise.resolve({
+        'error': 'lamentably, an error hath occurred',
+        status: 1234
+      }))
+      FakePool.prototype.get = getSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const log = mockLog()
+      const pushbox = proxyquire(pushboxModulePath, mocks)(log, mockConfig)
+
+      return pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10)
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.errno, 999)
+          assert.equal(log.error.callCount, 1, 'an error was logged')
+          assert.equal(log.error.getCall(0).args[0].op, 'pushbox.retrieve')
+          assert.equal(log.error.getCall(0).args[0].error, 'lamentably, an error hath occurred')
+          assert.equal(log.error.getCall(0).args[0].status, 1234)
+        })
+    }
+  )
+
+  it(
+    'store',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy(() => Promise.resolve({
+        status: 200,
+        index: '12'
+      }))
+      FakePool.prototype.post = postSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const pushbox = proxyquire(pushboxModulePath, mocks)(mockLog(), mockConfig)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' })
+        .then(({index}) => {
+          assert.equal(postSpy.callCount, 1, 'post request was made')
+          const args = postSpy.args[0]
+          assert.equal(args.length, 4)
+          assert.equal(args[0]._template.toString(), '/v1/store/:uid/:deviceId')
+          assert.deepEqual(args[1], {uid: mockUid, deviceId: mockDeviceIds[0]})
+          assert.deepEqual(args[2], {data: 'eyJ0ZXN0IjoiZGF0YSJ9', ttl: 123456})
+          assert.deepEqual(args[3], {headers: {Authorization: `FxA-Server-Key ${mockConfig.pushbox.key}`}})
+
+          assert.equal(index, '12')
+        })
+    }
+  )
+
+  it(
+    'store with custom ttl',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy(() => Promise.resolve({
+        status: 200,
+        index: '12'
+      }))
+      FakePool.prototype.post = postSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const pushbox = proxyquire(pushboxModulePath, mocks)(mockLog(), mockConfig)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' }, 42)
+        .then(({index}) => {
+          assert.equal(postSpy.callCount, 1, 'post request was made')
+          const args = postSpy.args[0]
+          assert.deepEqual(args[2], {data: 'eyJ0ZXN0IjoiZGF0YSJ9', ttl: 42})
+
+          assert.equal(index, '12')
+        })
+    }
+  )
+
+  it(
+    'store caps ttl at configured maximum',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy(() => Promise.resolve({
+        status: 200,
+        index: '12'
+      }))
+      FakePool.prototype.post = postSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const pushbox = proxyquire(pushboxModulePath, mocks)(mockLog(), mockConfig)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' }, 999999999)
+        .then(({index}) => {
+          assert.equal(postSpy.callCount, 1, 'post request was made')
+          const args = postSpy.args[0]
+          assert.deepEqual(args[2], {data: 'eyJ0ZXN0IjoiZGF0YSJ9', ttl: 123456})
+
+          assert.equal(index, '12')
+        })
+    }
+  )
+
+  it(
+    'store validates the pushbox server response',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy(() => Promise.resolve({
+        'bogus':'object'
+      }))
+      FakePool.prototype.post = postSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const log = mockLog()
+      const pushbox = proxyquire(pushboxModulePath, mocks)(log, mockConfig)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' })
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.errno, 999)
+          assert.equal(log.error.callCount, 1, 'an error was logged')
+          assert.equal(log.error.getCall(0).args[0].op, 'pushbox.store')
+          assert.equal(log.error.getCall(0).args[0].error, 'response schema validation failed')
+        })
+    }
+  )
+
+  it(
+    'retrieve throws on error response',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy(() => Promise.resolve({
+        'error': 'Alas, an error! I knew it, Horatio.',
+        'status': 789
+      }))
+      FakePool.prototype.post = postSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const log = mockLog()
+      const pushbox = proxyquire(pushboxModulePath, mocks)(log, mockConfig)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' })
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.errno, 999)
+          assert.equal(log.error.callCount, 1, 'an error was logged')
+          assert.equal(log.error.getCall(0).args[0].op, 'pushbox.store')
+          assert.equal(log.error.getCall(0).args[0].error, 'Alas, an error! I knew it, Horatio.')
+          assert.equal(log.error.getCall(0).args[0].status, 789)
+        })
+    }
+  )
+
+  it(
+    'feature disabled',
+    () => {
+      const FakePool = function() {}
+      const postSpy = sinon.spy()
+      const getSpy = sinon.spy()
+      FakePool.prototype.post = postSpy
+      FakePool.prototype.get = getSpy
+      const mocks = {
+        './pool': FakePool
+      }
+      const config = Object.assign({}, mockConfig, {
+        pushbox: {enabled: false}
+      })
+      const pushbox = proxyquire(pushboxModulePath, mocks)(mockLog(), config)
+
+      return pushbox.store(mockUid, mockDeviceIds[0], 'sendtab', mockData)
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.message, 'Feature not enabled')
+        })
+        .then(() => pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10))
+        .then(() => assert.ok(false, 'should not happen'), (err) => {
+          assert.ok(err)
+          assert.equal(err.message, 'Feature not enabled')
+        })
+    }
+  )
+
+})

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -53,6 +53,7 @@ const DB_METHOD_NAMES = [
   'deleteRecoveryKey',
   'deleteTotpToken',
   'devices',
+  'device',
   'emailBounces',
   'emailRecord',
   'forgotPasswordVerified',
@@ -128,8 +129,14 @@ const PUSH_METHOD_NAMES = [
   'notifyPasswordReset',
   'notifyAccountUpdated',
   'notifyAccountDestroyed',
+  'notifyCommandReceived',
   'notifyProfileUpdated',
   'sendPush'
+]
+
+const PUSHBOX_METHOD_NAMES = [
+  'retrieve',
+  'store'
 ]
 
 module.exports = {
@@ -143,6 +150,7 @@ module.exports = {
   mockMailer: mockObject(MAILER_METHOD_NAMES),
   mockMetricsContext,
   mockPush,
+  mockPushbox,
   mockRequest
 }
 
@@ -299,6 +307,13 @@ function mockDB (data, errors) {
       assert.ok(typeof uid === 'string')
       return P.resolve(data.devices || [])
     }),
+    device: sinon.spy((uid, deviceId) => {
+      assert.ok(typeof uid === 'string')
+      assert.ok(typeof deviceId === 'string')
+      const device = data.devices.find(d => d.id === deviceId)
+      assert.ok(device)
+      return P.resolve(device)
+    }),
     deleteSessionToken: sinon.spy(() => {
       return P.resolve()
     }),
@@ -386,13 +401,22 @@ function mockObject (methodNames) {
 
 function mockPush (methods) {
   const push = Object.assign({}, methods)
-  // So far every push method has a uid for first argument, let's keep it simple.
   PUSH_METHOD_NAMES.forEach((name) => {
     if (! push[name]) {
       push[name] = sinon.spy(() => P.resolve())
     }
   })
   return push
+}
+
+function mockPushbox (methods) {
+  const pushbox = Object.assign({}, methods)
+  PUSHBOX_METHOD_NAMES.forEach((name) => {
+    if (! pushbox[name]) {
+      pushbox[name] = sinon.spy(() => P.resolve())
+    }
+  })
+  return pushbox
 }
 
 function mockDevices (data) {

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -178,6 +178,8 @@ describe('remote db', function() {
           assert.equal(sessions[0].lastAccessTime, sessions[0].createdAt, 'lastAccessTime property is correct')
           assert.equal(sessions[0].authAt, sessions[0].createdAt, 'authAt property is correct')
           assert.equal(sessions[0].location, undefined, 'location property is correct')
+          assert.deepEqual(sessions[0].deviceId, null, 'deviceId property is correct')
+          assert.deepEqual(sessions[0].deviceAvailableCommands, null, 'deviceAvailableCommands property is correct')
 
           // Fetch the session token
           return db.sessionToken(tokenId)
@@ -395,6 +397,7 @@ describe('remote db', function() {
         id: crypto.randomBytes(16).toString('hex'),
         name: '',
         type: 'mobile',
+        availableCommands:  { 'foo': 'bar', 'wibble': 'wobble' },
         pushCallback: 'https://foo/bar',
         pushPublicKey: base64url(Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])),
         pushAuthKey: base64url(crypto.randomBytes(16))
@@ -457,6 +460,7 @@ describe('remote db', function() {
           assert.ok(device.createdAt > 0, 'device.createdAt is set')
           assert.equal(device.name, deviceInfo.name, 'device.name is correct')
           assert.equal(device.type, deviceInfo.type, 'device.type is correct')
+          assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
           assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
           assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
           assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
@@ -488,6 +492,7 @@ describe('remote db', function() {
           assert.ok(device.lastAccessTime > 0, 'device.lastAccessTime is set')
           assert.equal(device.name, deviceInfo.name, 'device.name is correct')
           assert.equal(device.type, deviceInfo.type, 'device.type is correct')
+          assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
           assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
           assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
           assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
@@ -502,6 +507,7 @@ describe('remote db', function() {
           deviceInfo.id = device.id
           deviceInfo.name = 'wibble'
           deviceInfo.type = 'desktop'
+          deviceInfo.availableCommands = {}
           deviceInfo.pushCallback = ''
           deviceInfo.pushPublicKey = ''
           deviceInfo.pushAuthKey = ''
@@ -559,9 +565,17 @@ describe('remote db', function() {
           return devices[1]
         })
         .then((device) => {
+          // Fetch a single device
+          return db.device(account.uid, device.id).then(result => {
+            assert.deepEqual(device, result)
+            return device
+          })
+        })
+        .then((device) => {
           assert.equal(device.lastAccessTime, 42, 'device.lastAccessTime is correct')
           assert.equal(device.name, deviceInfo.name, 'device.name is correct')
           assert.equal(device.type, deviceInfo.type, 'device.type is correct')
+          assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
           assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
           assert.equal(device.pushPublicKey, '', 'device.pushPublicKey is correct')
           assert.equal(device.pushAuthKey, '', 'device.pushAuthKey is correct')

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -40,6 +40,7 @@ describe('remote device', function () {
             var deviceInfo = {
               name: 'test device 🍓🔥在𝌆',
               type: 'mobile',
+              availableCommands: { 'foo': 'bar' },
               pushCallback: '',
               pushPublicKey: '',
               pushAuthKey: ''
@@ -57,6 +58,7 @@ describe('remote device', function () {
                   assert.ok(device.createdAt > 0, 'device.createdAt was set')
                   assert.equal(device.name, deviceInfo.name, 'device.name is correct')
                   assert.equal(device.type, deviceInfo.type, 'device.type is correct')
+                  assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
                   assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
                   assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
                   assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')
@@ -73,6 +75,7 @@ describe('remote device', function () {
                   assert.equal(devices.length, 1, 'devices returned one item')
                   assert.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
                   assert.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
+                  assert.deepEqual(devices[0].availableCommands, deviceInfo.availableCommands, 'devices returned correct availableCommands')
                   assert.equal(devices[0].pushCallback, '', 'devices returned empty pushCallback')
                   assert.equal(devices[0].pushPublicKey, '', 'devices returned correct pushPublicKey')
                   assert.equal(devices[0].pushAuthKey, '', 'devices returned correct pushAuthKey')
@@ -235,6 +238,7 @@ describe('remote device', function () {
         id: crypto.randomBytes(16).toString('hex'),
         name: 'test device',
         type: 'desktop',
+        availableCommands: {},
         pushCallback: badPushCallback,
         pushPublicKey: mocks.MOCK_PUSH_KEY,
         pushAuthKey: base64url(crypto.randomBytes(16))
@@ -269,6 +273,7 @@ describe('remote device', function () {
         id: crypto.randomBytes(16).toString('hex'),
         name: 'test device',
         type: 'desktop',
+        availableCommands: {},
         pushCallback: badPushCallback,
         pushPublicKey: mocks.MOCK_PUSH_KEY,
         pushAuthKey: base64url(crypto.randomBytes(16))
@@ -305,6 +310,7 @@ describe('remote device', function () {
             var deviceInfo = {
               name: 'test device',
               type: 'mobile',
+              availableCommands: {},
               pushCallback: goodPushCallback,
               pushPublicKey: '',
               pushAuthKey: ''

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -71,6 +71,7 @@ describe('remote push db', function() {
         id: crypto.randomBytes(16).toString('hex'),
         name: 'my push device',
         type: 'mobile',
+        availableCommands: { 'foo': 'bar' },
         pushCallback: 'https://foo/bar',
         pushPublicKey: base64url(Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])),
         pushAuthKey: base64url(crypto.randomBytes(16)),

--- a/test/remote/session_tests.js
+++ b/test/remote/session_tests.js
@@ -101,8 +101,6 @@ describe('remote session', function() {
           })
           .then(() => {
             return client.api.sessionStatus(sessionTokenCreate)
-          }, () => {
-            assert(false, 'failed to destroy the session')
           })
           .then((status) => {
             assert(false, 'got status with destroyed session')


### PR DESCRIPTION
This is an extension of and alternative to the "device messages" feature from #2328, that's designed to support the latest requirements of new-send-tab while being a step along to road to a more general [peer discovery API](https://docs.google.com/document/d/1btFmS9jahtKllX3Xm-icPBxvnQKGUmT9-OZzq_M29Sw/).

As part of its device registration, a device can include a set of "supported commands".  This is a simple mapping where the keys are string URIs naming commands that the device can be asked to perform, and the values are additional metadata necessary in order to invoke the command.  Other devices can query the device list to discover their peers and the commands that they support, and can invoke a command on another device by issuing a `POST` request.

A good place to start is the new [device registration](https://github.com/mozilla/fxa-auth-server/blob/feature.pushbox-ng/docs/device_registration.md) documentation that's included as part of this PR.  This feature branch is also deployed to https://pushbox2.dev.lcip.org if you'd like to poke at the API live.

Connects to https://github.com/mozilla/fxa-auth-server/issues/2318