### PR TITLE
fix(params): remove query param for verificationMethod

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -411,7 +411,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
         const email = form.email
         const authPW = form.authPW
         const originalLoginEmail = request.payload.originalLoginEmail
-        let verificationMethod = request.payload.verificationMethod || request.query.verificationMethod
+        let verificationMethod = request.payload.verificationMethod
         const requestNow = Date.now()
 
         let accountRecord, password, sessionToken, keyFetchToken, didSigninUnblock

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -123,7 +123,7 @@ module.exports = function (log, db, Password, config, signinUtils) {
         const email = request.payload.email
         const authPW = request.payload.authPW
         const originalLoginEmail = request.payload.originalLoginEmail
-        const verificationMethod = request.payload.verificationMethod || request.query.verificationMethod
+        const verificationMethod = request.payload.verificationMethod
 
         let accountRecord, password, keyFetchToken
 

--- a/test/local/routes/session.js
+++ b/test/local/routes/session.js
@@ -249,19 +249,6 @@ describe('/session/reauth', () => {
     })
   })
 
-  it('correctly updates to mustVerify=true when explicit verificationMethod is requested in querystring', () => {
-    signinUtils.checkPassword = sinon.spy(() => { return P.resolve(true) })
-
-    assert.ok(! request.auth.credentials.mustVerify, 'sessionToken starts off with mustVerify=false')
-
-    request.query.verificationMethod = 'email-2fa'
-    return runTest(route, request).then((res) => {
-      assert.equal(db.updateSessionToken.callCount, 1, 'db.updateSessionToken was called')
-      const sessionToken = db.updateSessionToken.args[0][0]
-      assert.ok(sessionToken.mustVerify, 'sessionToken has updated to mustVerify=true')
-    })
-  })
-
   it('leaves mustVerify=false when not requesting keys', () => {
     signinUtils.checkPassword = sinon.spy(() => { return P.resolve(true) })
     request.query.keys = false


### PR DESCRIPTION
Per https://github.com/mozilla/fxa-auth-server/pull/2300#pullrequestreview-123105409, removes specifying `verificationMethod` via a query param.