### PR TITLE
fix(devices): Do not echo 'capabilities' field in device registration response.

### DIFF
--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -160,6 +160,9 @@ module.exports = (log, db, config, customs, push, devices) => {
         const payload = request.payload
         const sessionToken = request.auth.credentials
 
+        // Remove obsolete field, so we don't try to echo it back to the client.
+        delete payload.capabilities
+
         // Some additional, slightly tricky validation to detect bad public keys.
         if (payload.pushPublicKey && ! push.isValidPublicKey(payload.pushPublicKey)) {
           return reply(error.invalidRequestParameter('invalid pushPublicKey'))

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -404,6 +404,33 @@ describe('remote device', function () {
   )
 
   it(
+    'device registration ignores deprecated "capabilities" field',
+    () => {
+      var email = server.uniqueEmail()
+      var password = 'test password'
+      return Client.create(config.publicUrl, email, password)
+        .then(
+          function (client) {
+            var deviceInfo = {
+              name: 'a very capable device',
+              type: 'desktop',
+              capabilities: [],
+            }
+            return client.updateDevice(deviceInfo)
+              .then(
+                function (device) {
+                  assert.ok(device.id, 'device.id was set')
+                  assert.ok(device.createdAt > 0, 'device.createdAt was set')
+                  assert.equal(device.name, deviceInfo.name, 'device.name is correct')
+                  assert.ok(! device.capabilities, 'device.capabilities was ignored')
+                }
+              )
+          }
+        )
+    }
+  )
+
+  it(
     'device registration from a different session',
     () => {
       var email = server.uniqueEmail()


### PR DESCRIPTION
The 'capabilities' field has been removed, but some clients still send it.
We need to explicitly avoid echoing it back to them in the registration
response, or the response will fail validation.

Fixes #2477; @jrgm r?