### PR TITLE
fix(customs): Fail closed if customs-server gives an error.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -155,7 +155,7 @@ var conf = convict({
     }
   },
   customsUrl: {
-    doc: 'fraud / abuse server url',
+    doc: 'fraud / abuse server url; set to the string \'none\' to disable',
     default: 'http://127.0.0.1:7000',
     env: 'CUSTOMS_SERVER_URL'
   },

--- a/lib/customs.js
+++ b/lib/customs.js
@@ -65,10 +65,7 @@ module.exports = function (log, error) {
       handleCustomsResult.bind(request),
       err => {
         log.error({ op: 'customs.check.1', email: email, action: action, err: err })
-        // If this happens, either:
-        // - (1) the url in config doesn't point to a real customs server
-        // - (2) the customs server returned an internal server error
-        // Either way, allow the request through so we fail open.
+        throw error.backendServiceFailure('customs', 'check')
       }
     )
   }
@@ -125,10 +122,7 @@ module.exports = function (log, error) {
       },
       function (err) {
         log.error({ op: 'customs.checkAuthenticated', uid: uid, action: action, err: err })
-        // If this happens, either:
-        // - (1) the url in config doesn't point to a real customs server
-        // - (2) the customs server returned an internal server error
-        // Either way, allow the request through so we fail open.
+        throw error.backendServiceFailure('customs', 'checkAuthenticated')
       }
     )
   }
@@ -144,10 +138,7 @@ module.exports = function (log, error) {
       handleCustomsResult.bind(request),
       err => {
         log.error({ op: 'customs.checkIpOnly.1', action: action, err: err })
-        // If this happens, either:
-        // - (1) the url in config doesn't point to a real customs server
-        // - (2) the customs server returned an internal server error
-        // Either way, allow the request through so we fail open.
+        throw error.backendServiceFailure('customs', 'checkIpOnly')
       }
     )
   }
@@ -171,10 +162,7 @@ module.exports = function (log, error) {
       function () {},
       function (err) {
         log.error({ op: 'customs.flag.1', email: email, err: err })
-        // If this happens, either:
-        // - (1) the url in config doesn't point to a real customs server
-        // - (2) the customs server returned an internal server error
-        // Either way, allow the request through so we fail open.
+        throw error.backendServiceFailure('customs', 'flag')
       }
     )
   }
@@ -194,10 +182,7 @@ module.exports = function (log, error) {
       function () {},
       function (err) {
         log.error({ op: 'customs.reset.1', email: email, err: err })
-        // If this happens, either:
-        // - (1) the url in config doesn't point to a real customs server
-        // - (2) the customs server returned an internal server error
-        // Either way, allow the request through so we fail open.
+        throw error.backendServiceFailure('customs', 'reset')
       }
     )
   }

--- a/lib/error.js
+++ b/lib/error.js
@@ -72,6 +72,7 @@ var ERRNO = {
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
+  BACKEND_SERVICE_FAILURE: 203,
   UNEXPECTED_ERROR: 999
 }
 
@@ -544,7 +545,7 @@ AppError.invalidMessageId = () => {
 AppError.messageRejected = (reason, reasonCode) => {
   return new AppError({
     code: 500,
-    error: 'Bad Request',
+    error: 'Internal Server Error',
     errno: ERRNO.MESSAGE_REJECTED,
     message: 'Message rejected'
   }, {
@@ -790,6 +791,18 @@ AppError.unavailableDeviceCommand = () => {
     error: 'Bad Request',
     errno: ERRNO.DEVICE_COMMAND_UNAVAILABLE,
     message: 'Unavailable device command.'
+  })
+}
+
+AppError.backendServiceFailure = (service, operation) => {
+  return new AppError({
+    code: 500,
+    error: 'Internal Server Error',
+    errno: ERRNO.BACKEND_SERVICE_FAILURE,
+    message: 'A backend service request failed.'
+  }, {
+    service,
+    operation
   })
 }
 

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -15,6 +15,7 @@ const log = {
 }
 const mocks = require('../mocks')
 const error = require(`${ROOT_DIR}/lib/error.js`)
+const P = require(`${ROOT_DIR}/lib/promise.js`)
 var nock = require('nock')
 
 const Customs = require(`${ROOT_DIR}/lib/customs.js`)(log, error)
@@ -223,7 +224,7 @@ describe('Customs', () => {
   )
 
   it(
-    'can create a customs object with non-existant customs service',
+    'failed closed when creating a customs object with non-existant customs service',
     () => {
       customsInvalidUrl = new Customs(CUSTOMS_URL_MISSING)
 
@@ -234,22 +235,22 @@ describe('Customs', () => {
       var email = newEmail()
       var action = newAction()
 
-      return customsInvalidUrl.check(request, email, action)
-        .then(function(result) {
-          assert.equal(result, undefined, 'Nothing is returned when /check succeeds even when service is non-existant')
+      return P.all([
+        customsInvalidUrl.check(request, email, action)
+        .then(assert.fail, err => {
+          assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE, 'an error is returned from /check')
+        }),
+
+        customsInvalidUrl.flag(ip, { email: email, uid: '12345' })
+        .then(assert.fail, err => {
+          assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE, 'an error is returned from /flag')
+        }),
+
+        customsInvalidUrl.reset(email)
+        .then(assert.fail, err => {
+          assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE, 'an error is returned from /passwordReset')
         })
-        .then(function() {
-          return customsInvalidUrl.flag(ip, { email: email, uid: '12345' })
-        })
-        .then(function(result) {
-          assert.equal(result, undefined, 'Nothing is returned when /failedLoginAttempt succeeds')
-        })
-        .then(function() {
-          return customsInvalidUrl.reset(email)
-        })
-        .then(function(result) {
-          assert.equal(result, undefined, 'Nothing is returned when /passwordReset succeeds')
-        })
+      ])
     }
   )
 


### PR DESCRIPTION
If we can an error response when talking to customs-server, the auth-server currently fails open.  This can lead to silent failures of our rate-limiting logic when customs is misconfigured or called incorrectly, as seen in [1].

ISTM that the risk of accidental failure of security measures should outweigh the convenience of handling misconfigured customs-server URLs, and we should fail closed on any error from customs server.  If you don't want a customs-server, explicitly disable it.

This PR changes the default config to have customs-server preffed off, and changes the behaviour to fail closed when it is preffed on.  I think those behaviours are the least likely to cause security footguns, but I'm worried about breakage in our various deployments:

* Do we now need to explicitly pref on a customs-server for fxa-dev boxes.  For production?
* Will self-hosters need to change any settings?
* Is it even a good idea to allow this thing to be preffed off at all?

@jrgm @mozilla/fxa-devs would love to hear your thoughts on the right setup here

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1470058