### PR TITLE
chore(docs): Expand docs for recovery key usage.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2217,9 +2217,13 @@ Verify a session using a recovery code.
 
 :lock: HAWK-authenticated with session token
 <!--begin-route-post-recoverykeys-->
-Creates a new recovery key for a user. These are one time use
-keys. More details on registering a recovery key can be
-found in /doc/recovery_keys.md
+Creates a new recovery key for a user.
+
+Recovery keys are one-time-use tokens
+that can be used to recover the user's kB
+if they forget their password.
+For more details, see the
+[recovery keys](recovery_keys.md) docs.
 <!--end-route-post-recoverykeys-->
 
 ##### Request body
@@ -2227,13 +2231,13 @@ found in /doc/recovery_keys.md
 * `recoveryKeyId`: *validators.recoveryKeyId*
 
   <!--begin-request-body-post-recoverykeys-recoveryKeyId-->
-  Recovery Key Id is a hash of the recovery key.
+  A unique identifier for this recovery key, derived from the key via HKDF.
   <!--end-request-body-post-recoverykeys-recoveryKeyId-->
 
 * `recoveryData`: *validators.recoveryData*
 
   <!--begin-request-body-post-recoverykeys-recoveryData-->
-  Recovery Data is an encrypted bundle containing the user's kB.
+  An encrypted bundle containing the user's kB.
   <!--end-request-body-post-recoverykeys-recoveryData-->
 
 
@@ -2241,7 +2245,7 @@ found in /doc/recovery_keys.md
 
 :lock: HAWK-authenticated with account reset token
 <!--begin-route-get-recoverykeysrecoverykeyid-->
-Retrieve the user's recovery data using their recovery key.
+Retrieve the account recovery data associated with the given recovery key.
 <!--end-route-get-recoverykeysrecoverykeyid-->
 
 

--- a/docs/recovery_keys.md
+++ b/docs/recovery_keys.md
@@ -1,36 +1,56 @@
 # Firefox Accounts Recovery Keys
 
 To help reduce the risk of a user losing their encrypted data
-(ex. passwords, history, bookmarks) during a password reset,
-Firefox Account users can create an account recovery key. This
-recovery key stores an encrypted version of the
-original `kB` and is used to re-bundle the new password during a
-password reset.
+(such as synced passwords or bookmarks) during a password reset,
+Firefox Account users can create an "account recovery key".
+This recovery key is used to store an encrypted version
+of the user's encryption key `kB`,
+which can be re-wrapped with their new password
+during the password reset process.
 
-## Registering Recovery Key
+## Registering a Recovery Key
 
-* FxA web-content prompts for the user's password and retrieves kB
-* FxA web-content generates a random binary recovery code
-  * Recovery code is between 16 and 32 in length
-* FxA web-content uses the recovery code to derive the fingerprint and
-encryption key (recovery-kid and recovery-key, respectively)
-* FxA web-content encrypts kB using recover key
-  * Recovery data = JWE(recover-key, {“alg”: “dir”, “enc”: “A256GCM”, “kid”:  recover-kid}, kB)
-* FxA web-content submits recovery data to FxA server for
-storage associated with the fingerprint (recover-kid)
+Creating a new recovery key involves the following steps:
 
-## Recovering kB
+* FxA web-content prompts for the user's password and retrieves kB.
+* FxA web-content generates a "recovery key", consisting of between 16 and 32 random bytes.
+* FxA web-content uses HKDF to derive two values from the recovery key:
+  * A key fingerprint: recover-kid = HKDF(recover-key, uid, "fxa recovery fingerprint", len=16)
+  * An encryption key: recover-enc = HKDF(recover-key, uid, "fxa recovery encrypt key", len=32)
+* FxA web-content encrypts kB into a JWE to produce the "recovery data":
+  * recover-data = JWE(recover-enc, {"alg": "dir", "enc": "A256GCM", "kid": recover-kid}, kB)
+* FxA web-content submits recovery data to FxA server for storage,
+  associating it with the fingerprint (recover-kid)
+  * `POST /recoveryKeys`, providing `recoveryKeyId` and `recoveryData` in the request body.
 
-* User completes an email confirmation loop to confirm password reset
-  * Results in temporary session credential/token for subsequent requests
-* User retrieves recovery code from print out or downloaded file
+This scheme ensures someone in posession of the recovery key,
+can request the encrypted recovery data
+from the FxA server,
+and use it to recover the user's kB.
+
+## Using a Recovery Key during password reset
+
+During the password reset process,
+a user who has a recovery key
+can use it to maintain their existing kB
+as follows:
+
+* User completes an email confirmation loop to confirm password reset.
+  * This produces an `accountResetToken`, a credential for subsequent requests.
+* User retrieves recovery code from print out or downloaded file,
+  and provides it to FxA web-content in the password reset flow.
 * FxA web-content uses the recovery code to derive the fingerprint
-and encryption key (recover-kid and recover-key, respectively)
-* FxA web-content requests recover-data from FxA server, providing recover-kid
-  * FxA auth-server checks email-validated user (something they have) provided
-  the recover-kid (something they know) is assigned/bound to the recover-data
-* FxA web-content decrypts recover-data with recover-key to recover kB
-* User enters a new password into web-content
-  * FxA web-content wraps kB with new password, submit wrapKb
-  to server with account reset request
-* Upon successful password reset, the recovery key and recovery data are deleted
+  and encryption key (recover-kid and recover-enc as defined above).
+* FxA web-content requests recover-data from FxA server, providing recover-kid.
+  * `GET /recoveryKeys/:recoveryKeyId`, authenticated with `accountResetToken`.
+  * Providing the `:recoveryKeyId` here proves that the user posesses the recovery key,
+    while the `accountResetToken` proves that they control the email address
+    of the account.
+* FxA web-content decrypts recover-data with recover-enc to obtain the user's kB.
+* User enters a new password into web-content.
+* FxA web-content wraps kB with the new password,
+  and submits `wrapKb` and `recoveryKeyId` with the account reset request.
+  * `POST /account/reset`, authenticated with `accountResetToken`,
+    providing `recoveryKeyId` and `wrapKb` in the request body.
+* Upon successful password reset, the FxA auth-server deletes the
+  recovery key and its associated recovery data.


### PR DESCRIPTION
@vbudhram I gave your recovery-key docs a light edit, r?

Of note, I tried to clean up the terminology a bit, and it differs from what's in the google doc.  I think we need to call the top-level token the "recovery key" rather than "recovery code" as it is in the google doc, to avoid confusion with the other thing called recovery codes in this repo.  Thoughts?