### PR TITLE
feat(email): use fxa-email-server for specific email addresses

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -166,6 +166,26 @@ var conf = convict({
       env: 'CONTENT_SERVER_URL'
     }
   },
+  emailService: {
+    host: {
+      doc: 'host for fxa-email-service',
+      format: 'ipaddress',
+      default: '127.0.0.1',
+      env: 'EMAIL_SERVICE_HOST'
+    },
+    port: {
+      doc: 'port for fxa-email-service',
+      format: 'port',
+      default: 8001,
+      env: 'EMAIL_SERVICE_PORT'
+    },
+    forcedEmailAddresses: {
+      doc: 'force usage of fxa-email-service when sending emails to addresses that match this pattern',
+      format: RegExp,
+      default: /emailservice.[A-Za-z0-9._%+-]+@restmail.net$/,
+      env: 'EMAIL_SERVICE_FORCE_EMAIL_REGEX'
+    },
+  },
   smtp: {
     api: {
       host: {

--- a/lib/senders/email_service.js
+++ b/lib/senders/email_service.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const request = require('request')
+
+module.exports = (config) => {
+  function sendMail(emailConfig, cb) {
+    // Email service requires that all headers are strings.
+    const headers = {}
+    for (const header in emailConfig.headers) {
+      headers[header] = emailConfig.headers[header].toString()
+    }
+    const options = {
+      url: `http://${config.emailService.host}:${config.emailService.port}/send`,
+      method: 'POST',
+      json: true,
+      body: {
+        cc: emailConfig.cc,
+        to: emailConfig.to,
+        subject: emailConfig.subject,
+        headers,
+        body: {
+          text: emailConfig.text,
+          html: emailConfig.html
+        }
+      }
+    }
+
+    request(options, function(err, res, body) {
+      cb(err, {
+        messageId: body.messageId,
+        message: err ? err.message : body.message
+      })
+    })
+  }
+
+  function close() {
+
+  }
+
+  return {
+    sendMail,
+    close
+  }
+}


### PR DESCRIPTION
Fixes #2411 

This is using fxa-email-service to send emails when the email matches the ` /emailservice.[A-Za-z0-9._%+-]+@restmail.net$/` pattern.

r? @vladikoff @philbooth 