### PR TITLE
fix(metrics): prohibit overwriting stashed metrics context

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -11,6 +11,7 @@ P.promisifyAll(Memcached.prototype)
 
 const NOP = () => P.resolve()
 const NULL_CACHE = {
+  addAsync: NOP,
   delAsync: NOP,
   getAsync: NOP,
   setAsync: NOP
@@ -24,6 +25,21 @@ module.exports = (log, config, namespace) => {
   const CACHE_LIFETIME = config.memcached.lifetime
 
   return {
+    /**
+     * Add data to the cache, keyed by a string.
+     * If the key already exists,
+     * the call will fail.
+     *
+     * Fails silently if the cache is not enabled.
+     *
+     * @param {string} key
+     * @param data
+     */
+    add (key, data) {
+      return getCache()
+        .then(cache => cache.addAsync(key, data, CACHE_LIFETIME))
+    },
+
     /**
      * Delete data from the cache, keyed by a string.
      *
@@ -49,7 +65,7 @@ module.exports = (log, config, namespace) => {
     },
 
     /**
-     * Fetch data from the cache, keyed by a string.
+     * Set data in the cache, keyed by a string.
      *
      * Fails silently if the cache is not enabled.
      *

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -62,23 +62,14 @@ module.exports = function (log, config) {
 
     metadata.service = this.payload.service || this.query.service
 
-    let key
-
     return P.resolve()
       .then(() => {
-        key = getKey(token)
-        return cache.get(key)
-      })
-      .then(clash => {
-        if (clash) {
-          log.warn({ op: 'metricsContext.stash.clash' })
-        } else {
-          return cache.set(key, metadata)
-        }
+        return cache.add(getKey(token), metadata)
+          .catch(err => log.warn({ op: 'metricsContext.stash.add', err }))
       })
       .catch(err => log.error({
         op: 'metricsContext.stash',
-        err: err,
+        err,
         hasToken: !! token,
         hasId: !! (token && token.id),
         hasUid: !! (token && token.uid)

--- a/lib/metrics/context.js
+++ b/lib/metrics/context.js
@@ -44,6 +44,11 @@ module.exports = function (log, config) {
    * Stashes metrics context metadata using a key derived from a token.
    * Asynchronous, returns a promise.
    *
+   * A surprising aspect of this method's behaviour is that it silently
+   * fails if the key already is already stashed. This is so that UTM
+   * params can't be changed part-way through a flow, which is what
+   * inadvertently caused content server issue #6258.
+   *
    * @name stashMetricsContext
    * @this request
    * @param token    token to stash the metadata against
@@ -57,8 +62,20 @@ module.exports = function (log, config) {
 
     metadata.service = this.payload.service || this.query.service
 
+    let key
+
     return P.resolve()
-      .then(() => cache.set(getKey(token), metadata))
+      .then(() => {
+        key = getKey(token)
+        return cache.get(key)
+      })
+      .then(clash => {
+        if (clash) {
+          log.warn({ op: 'metricsContext.stash.clash' })
+        } else {
+          return cache.set(key, metadata)
+        }
+      })
       .catch(err => log.error({
         op: 'metricsContext.stash',
         err: err,

--- a/test/local/metrics/context.js
+++ b/test/local/metrics/context.js
@@ -34,6 +34,7 @@ describe('metricsContext', () => {
       set: P.resolve()
     }
     cache = {
+      add: sinon.spy(() => results.add),
       del: sinon.spy(() => results.del),
       get: sinon.spy(() => results.get),
       set: sinon.spy(() => results.set)
@@ -85,7 +86,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.stash',
     () => {
-      results.set = P.resolve('wibble')
+      results.add = P.resolve('wibble')
       const token = {
         uid: Array(64).fill('c').join(''),
         id: 'foo'
@@ -101,18 +102,17 @@ describe('metricsContext', () => {
       }, token).then(result => {
         assert.equal(result, 'wibble', 'result is correct')
 
-        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
-        assert.equal(cache.get.args[0].length, 1, 'cache.get was passed one argument')
-        assert.equal(cache.get.args[0][0], hashToken(token), 'argument was correct')
-
-        assert.equal(cache.set.callCount, 1, 'cache.set was called once')
-        assert.equal(cache.set.args[0].length, 2, 'cache.set was passed two arguments')
-        assert.equal(cache.set.args[0][0], hashToken(token), 'first argument was correct')
-        assert.deepEqual(cache.set.args[0][1], {
+        assert.equal(cache.add.callCount, 1, 'cache.add was called once')
+        assert.equal(cache.add.args[0].length, 2, 'cache.add was passed two arguments')
+        assert.equal(cache.add.args[0][0], hashToken(token), 'first argument was correct')
+        assert.deepEqual(cache.add.args[0][1], {
           foo: 'bar',
           service: 'baz'
         }, 'second argument was correct')
 
+        assert.equal(cache.get.callCount, 0, 'cache.get was not called')
+        assert.equal(cache.set.callCount, 0, 'cache.set was not called')
+        assert.equal(log.warn.callCount, 0, 'log.warn was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
     }
@@ -121,8 +121,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.stash with clashing data',
     () => {
-      results.get = P.resolve('wibble')
-      results.set = P.resolve('blee')
+      results.add = P.reject('wibble')
       const token = {
         uid: Array(64).fill('c').join(''),
         id: 'foo'
@@ -137,9 +136,8 @@ describe('metricsContext', () => {
         query: {}
       }, token).then(result => {
         assert.strictEqual(result, undefined, 'result is undefined')
-        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
+        assert.equal(cache.add.callCount, 1, 'cache.add was called once')
         assert.equal(log.warn.callCount, 1, 'log.warn was called once')
-        assert.equal(cache.set.callCount, 0, 'cache.set was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
     }
@@ -148,7 +146,7 @@ describe('metricsContext', () => {
   it(
     'metricsContext.stash with service query param',
     () => {
-      results.set = P.resolve('wibble')
+      results.add = P.resolve('wibble')
       const token = {
         uid: Array(64).fill('c').join(''),
         id: 'foo'
@@ -163,42 +161,10 @@ describe('metricsContext', () => {
           service: 'qux'
         }
       }, token).then(result => {
-        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
-        assert.equal(cache.set.callCount, 1, 'cache.set was called once')
-        assert.equal(cache.set.args[0][1].service, 'qux', 'service property was correct')
+        assert.equal(cache.add.callCount, 1, 'cache.add was called once')
+        assert.equal(cache.add.args[0][1].service, 'qux', 'service property was correct')
 
         assert.equal(log.error.callCount, 0, 'log.error was not called')
-      })
-    }
-  )
-
-  it(
-    'metricsContext.stash error',
-    () => {
-      results.set = P.reject('wibble')
-      return metricsContext.stash.call({
-        payload: {
-          metricsContext: {
-            foo: 'bar'
-          }
-        },
-        query: {}
-      }, {
-        uid: Array(64).fill('c').join(''),
-        id: 'foo'
-      }).then(result => {
-        assert.equal(result, undefined, 'result is undefined')
-
-        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
-        assert.equal(cache.set.callCount, 1, 'cache.set was called once')
-
-        assert.equal(log.error.callCount, 1, 'log.error was called once')
-        assert.equal(log.error.args[0].length, 1, 'log.error was passed one argument')
-        assert.equal(log.error.args[0][0].op, 'metricsContext.stash', 'argument op property was correct')
-        assert.equal(log.error.args[0][0].err, 'wibble', 'argument err property was correct')
-        assert.strictEqual(log.error.args[0][0].hasToken, true, 'hasToken property was correct')
-        assert.strictEqual(log.error.args[0][0].hasId, true, 'hasId property was correct')
-        assert.strictEqual(log.error.args[0][0].hasUid, true, 'hasUid property was correct')
       })
     }
   )
@@ -226,8 +192,7 @@ describe('metricsContext', () => {
         assert.strictEqual(log.error.args[0][0].hasId, true, 'hasId property was correct')
         assert.strictEqual(log.error.args[0][0].hasUid, false, 'hasUid property was correct')
 
-        assert.equal(cache.get.callCount, 0, 'cache.get was not called')
-        assert.equal(cache.set.callCount, 0, 'cache.set was not called')
+        assert.equal(cache.add.callCount, 0, 'cache.add was not called')
       })
     }
   )
@@ -244,8 +209,7 @@ describe('metricsContext', () => {
       }).then(result => {
         assert.equal(result, undefined, 'result is undefined')
 
-        assert.equal(cache.get.callCount, 0, 'cache.get was not called')
-        assert.equal(cache.set.callCount, 0, 'cache.set was not called')
+        assert.equal(cache.add.callCount, 0, 'cache.add was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
     }

--- a/test/local/metrics/context.js
+++ b/test/local/metrics/context.js
@@ -101,6 +101,10 @@ describe('metricsContext', () => {
       }, token).then(result => {
         assert.equal(result, 'wibble', 'result is correct')
 
+        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
+        assert.equal(cache.get.args[0].length, 1, 'cache.get was passed one argument')
+        assert.equal(cache.get.args[0][0], hashToken(token), 'argument was correct')
+
         assert.equal(cache.set.callCount, 1, 'cache.set was called once')
         assert.equal(cache.set.args[0].length, 2, 'cache.set was passed two arguments')
         assert.equal(cache.set.args[0][0], hashToken(token), 'first argument was correct')
@@ -109,6 +113,33 @@ describe('metricsContext', () => {
           service: 'baz'
         }, 'second argument was correct')
 
+        assert.equal(log.error.callCount, 0, 'log.error was not called')
+      })
+    }
+  )
+
+  it(
+    'metricsContext.stash with clashing data',
+    () => {
+      results.get = P.resolve('wibble')
+      results.set = P.resolve('blee')
+      const token = {
+        uid: Array(64).fill('c').join(''),
+        id: 'foo'
+      }
+      return metricsContext.stash.call({
+        payload: {
+          metricsContext: {
+            foo: 'bar'
+          },
+          service: 'baz'
+        },
+        query: {}
+      }, token).then(result => {
+        assert.strictEqual(result, undefined, 'result is undefined')
+        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
+        assert.equal(log.warn.callCount, 1, 'log.warn was called once')
+        assert.equal(cache.set.callCount, 0, 'cache.set was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
     }
@@ -132,6 +163,7 @@ describe('metricsContext', () => {
           service: 'qux'
         }
       }, token).then(result => {
+        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
         assert.equal(cache.set.callCount, 1, 'cache.set was called once')
         assert.equal(cache.set.args[0][1].service, 'qux', 'service property was correct')
 
@@ -157,6 +189,7 @@ describe('metricsContext', () => {
       }).then(result => {
         assert.equal(result, undefined, 'result is undefined')
 
+        assert.equal(cache.get.callCount, 1, 'cache.get was called once')
         assert.equal(cache.set.callCount, 1, 'cache.set was called once')
 
         assert.equal(log.error.callCount, 1, 'log.error was called once')
@@ -193,6 +226,7 @@ describe('metricsContext', () => {
         assert.strictEqual(log.error.args[0][0].hasId, true, 'hasId property was correct')
         assert.strictEqual(log.error.args[0][0].hasUid, false, 'hasUid property was correct')
 
+        assert.equal(cache.get.callCount, 0, 'cache.get was not called')
         assert.equal(cache.set.callCount, 0, 'cache.set was not called')
       })
     }
@@ -210,6 +244,7 @@ describe('metricsContext', () => {
       }).then(result => {
         assert.equal(result, undefined, 'result is undefined')
 
+        assert.equal(cache.get.callCount, 0, 'cache.get was not called')
         assert.equal(cache.set.callCount, 0, 'cache.set was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })


### PR DESCRIPTION
Related to #2496.

If we already have metrics context data in memcached, we shouldn't over-write it. Prohibiting it this way is the first step to fixing the linked issue. We also plan to deprecate the `metricsContext` param on some endpoints and reduce the amount of data it contains on others.

I'm not sure what an actual real-world test is for this change. The tests pass and I've added a test for the new behaviour, what else should I be doing?

@mozilla/fxa-devs r?