### PR TITLE
fix(metrics): don't force utm_source=email on links in emails

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -265,12 +265,12 @@ var conf = convict({
     androidUrl: {
       doc: 'url to Android product page',
       format: String,
-      default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=android&creative=button'
+      default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=android&creative=button&utm_source=email'
     },
     iosUrl: {
       doc: 'url to IOS product page',
       format: String,
-      default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8'
+      default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8&utm_source=email'
     },
     supportUrl: {
       doc: 'url to Mozilla Support product page',

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -1092,7 +1092,6 @@ module.exports = function (log, config) {
       parsedQuery[key] = query[key]
     })
 
-    parsedQuery['utm_source'] = 'email'
     parsedQuery['utm_medium'] = 'email'
 
     var campaign = templateNameToCampaignMap[templateName]

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -228,6 +228,8 @@ describe(
             mailer.mailer.sendMail = function (emailConfig) {
               assert.ok(includes(emailConfig.html, privacyLink))
               assert.ok(includes(emailConfig.text, privacyLink))
+              assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+              assert.ok(! includes(emailConfig.text, 'utm_source=email'))
             }
             mailer[type](message)
           }
@@ -241,6 +243,9 @@ describe(
                 assert.ok(includes(emailConfig.headers['X-Link'], 'type=secondary'))
                 assert.ok(includes(emailConfig.html, 'type=secondary'))
                 assert.ok(includes(emailConfig.text, 'type=secondary'))
+                assert.ok(! includes(emailConfig.headers['X-Link'], 'utm_source=email'))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -291,6 +296,8 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, supportTextLink))
                 assert.ok(includes(emailConfig.text, supportTextLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -306,6 +313,8 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, resetPasswordLink))
                 assert.ok(includes(emailConfig.text, resetPasswordLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -321,6 +330,8 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, passwordChangeLink))
                 assert.ok(includes(emailConfig.text, passwordChangeLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -362,6 +373,8 @@ describe(
                   mailer.createReportSignInLink(type, message)
                 assert.ok(includes(emailConfig.html, reportSignInLink))
                 assert.ok(includes(emailConfig.text, reportSignInLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -376,6 +389,7 @@ describe(
 
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, androidStoreLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
                 // only the html email contains links to the store
               }
               mailer[type](message)
@@ -391,6 +405,7 @@ describe(
 
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, iosStoreLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
                 // only the html email contains links to the store
               }
               mailer[type](message)
@@ -407,6 +422,8 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, passwordManagerInfoUrl))
                 assert.ok(includes(emailConfig.text, passwordManagerInfoUrl))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -420,6 +437,8 @@ describe(
             mailer.mailer.sendMail = function (emailConfig) {
               assert.ok(includes(emailConfig.html, accountSettingsUrl))
               assert.ok(includes(emailConfig.text, accountSettingsUrl))
+              assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+              assert.ok(! includes(emailConfig.text, 'utm_source=email'))
             }
             mailer[type](message)
           })
@@ -432,6 +451,8 @@ describe(
             mailer.mailer.sendMail = function (emailConfig) {
               assert.ok(includes(emailConfig.html, url))
               assert.ok(includes(emailConfig.text, url))
+              assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+              assert.ok(! includes(emailConfig.text, 'utm_source=email'))
             }
             mailer[type](message)
           })
@@ -629,6 +650,7 @@ describe(
                 assert.ok(includes(emailConfig.html, syncLink))
                 assert.ok(includes(emailConfig.html, androidLink))
                 assert.ok(includes(emailConfig.html, iosLink))
+                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -639,6 +661,8 @@ describe(
               const verifyPrimaryEmailUrl = config.get('smtp').verifyPrimaryEmailUrl
               assert.ok(emailConfig.html.indexOf(verifyPrimaryEmailUrl) > 0)
               assert.ok(emailConfig.text.indexOf(verifyPrimaryEmailUrl) > 0)
+              assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+              assert.ok(! includes(emailConfig.text, 'utm_source=email'))
             }
             mailer[type](message)
           })

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -228,8 +228,6 @@ describe(
             mailer.mailer.sendMail = function (emailConfig) {
               assert.ok(includes(emailConfig.html, privacyLink))
               assert.ok(includes(emailConfig.text, privacyLink))
-              assert.ok(! includes(emailConfig.html, 'utm_source=email'))
-              assert.ok(! includes(emailConfig.text, 'utm_source=email'))
             }
             mailer[type](message)
           }
@@ -296,8 +294,6 @@ describe(
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, supportTextLink))
                 assert.ok(includes(emailConfig.text, supportTextLink))
-                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
-                assert.ok(! includes(emailConfig.text, 'utm_source=email'))
               }
               mailer[type](message)
             }
@@ -389,7 +385,7 @@ describe(
 
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, androidStoreLink))
-                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(includes(emailConfig.html, 'utm_source=email'))
                 // only the html email contains links to the store
               }
               mailer[type](message)
@@ -405,7 +401,7 @@ describe(
 
               mailer.mailer.sendMail = function (emailConfig) {
                 assert.ok(includes(emailConfig.html, iosStoreLink))
-                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(includes(emailConfig.html, 'utm_source=email'))
                 // only the html email contains links to the store
               }
               mailer[type](message)
@@ -650,7 +646,7 @@ describe(
                 assert.ok(includes(emailConfig.html, syncLink))
                 assert.ok(includes(emailConfig.html, androidLink))
                 assert.ok(includes(emailConfig.html, iosLink))
-                assert.ok(! includes(emailConfig.html, 'utm_source=email'))
+                assert.ok(includes(emailConfig.html, 'utm_source=email'))
               }
               mailer[type](message)
             }


### PR DESCRIPTION
I'm putting this forward as a blunt-instrument proposal to fix mozilla/fxa-content-server#6258. It completely removes `utm_source=email` from the links we send out, which has the obvious knock-on effect of not overwriting `utm_source` in Amplitude:

```
{"op":"amplitudeEvent","event_type":"fxa_email - click","time":1530797664542,"user_id":"1f705b2692bc4565bf6a3f25d610d841","device_id":"81a9e7d7aa8c4de0a1cbcb3d3b64068c","session_id":1530797640628,"app_version":"115","language":"en","os_name":"Mac OS X","os_version":"10.11","event_properties":{"service":"sync","email_type":"registration"},"user_properties":{"entrypoint":"menupanel","flow_id":"c4bd39952cae9955fd90b3e892f5a4941a9ccea993e1b70aee76a4fa1a83dcb0","ua_browser":"Firefox","ua_version":"63.0","utm_campaign":"fx-welcome","utm_content":"fx-activate","utm_medium":"email","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1530797664760,"user_id":"1f705b2692bc4565bf6a3f25d610d841","device_id":"81a9e7d7aa8c4de0a1cbcb3d3b64068c","session_id":1530797640628,"app_version":"115","language":"en","os_name":"Mac OS X","os_version":"10.11","event_properties":{"service":"sync","connect_device_flow":"signin"},"user_properties":{"entrypoint":"menupanel","flow_id":"c4bd39952cae9955fd90b3e892f5a4941a9ccea993e1b70aee76a4fa1a83dcb0","ua_browser":"Firefox","ua_version":"63.0","utm_campaign":"fx-welcome","utm_content":"fx-activate","utm_medium":"email","$append":{"fxa_services_used":"sync"}}}
```

Compare those events, generated with this change, to the ones logged in https://github.com/mozilla/fxa-auth-server/issues/2496#issuecomment-402712407.

Is this too blunt an instrument to fix the problem with? Are we relying on `utm_source=email` for some other reason? Forgive me if that got discussed in the meeting on Tuesday, I wasn't paying attention properly at the time.

If we need something more fine-grained, I can make some kind of change in the content server that specifically disables `utm_source` just for those events, but that approach feels more hackish to me.

@mozilla/fxa-devs r?