### PR TITLE
fix(email): gracefully handle errors from fxa-email-service

### DIFF
--- a/lib/senders/email_service.js
+++ b/lib/senders/email_service.js
@@ -31,7 +31,7 @@ module.exports = (config) => {
 
     request(options, function(err, res, body) {
       cb(err, {
-        messageId: body.messageId,
+        messageId: body && body.messageId,
         message: err ? err.message : body.message
       })
     })


### PR DESCRIPTION
If, say, `fxa-email-service` isn't running and you try to send email using it, requests fail and no `body` is passed to the response handler. This causes the auth server to fail messily with a 500 error:

```
{"op":"request.summary","code":500,"errno":999,"rid":"1531159435204:Phils-MacBook-Pro.local:56504:jjekohf0:10034","path":"/v1/account/create","lang":"en-US,en;q=0.7,fr;q=0.3","agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","remoteAddressChain":["127.0.0.1"],"accountRecreated":true,"t":205,"uid":"00","service":"sync","keys":true,"email":"emailservice42@restmail.net","stack":"TypeError: Uncaught error: Cannot read property 'messageId' of undefined\n    at Request._callback (/Users/pb/code/fxa-auth-server/lib/senders/email_service.js:34:25)\n    at self.callback (/Users/pb/code/fxa-auth-server/node_modules/request/request.js:186:22)\n    at emitOne (events.js:116:13)\n    at Request.emit (events.js:211:7)\n    at Request.onRequestError (/Users/pb/code/fxa-auth-server/node_modules/request/request.js:878:8)\n    at emitOne (events.js:116:13)\n    at ClientRequest.emit (events.js:211:7)\n    at Socket.socketErrorListener (_http_client.js:387:9)\n    at emitOne (events.js:116:13)\n    at Socket.emit (events.js:211:7)\n    at emitErrorNT (internal/streams/destroy.js:64:8)\n    at _combinedTickCallback (internal/process/next_tick.js:138:11)\n    at process._tickDomainCallback (internal/process/next_tick.js:218:9)"}
```

Better test coverage would have picked this up, so I've opened #2509 to address that. In the meantime, this PR is a quick hack in case we want to patch it in train 116.

@mozilla/fxa-devs r?