### PR TITLE
feat(emails): get email service to work with mail helper

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -3,6 +3,9 @@
     "url": "http://127.0.0.1:3030"
   },
   "customsUrl": "none",
+  "emailService": {
+    "provider": "smtp"
+  },
   "lockoutEnabled": true,
   "log": {
     "fmt": "pretty",

--- a/config/index.js
+++ b/config/index.js
@@ -179,6 +179,11 @@ var conf = convict({
       default: 8001,
       env: 'EMAIL_SERVICE_PORT'
     },
+    provider: {
+      doc: 'email provider to use for fxa-email-service',
+      default: 'ses',
+      env: 'EMAIL_SERVICE_PROVIDER'
+    },
     forcedEmailAddresses: {
       doc: 'force usage of fxa-email-service when sending emails to addresses that match this pattern',
       format: RegExp,

--- a/lib/senders/email_service.js
+++ b/lib/senders/email_service.js
@@ -25,7 +25,8 @@ module.exports = (config) => {
         body: {
           text: emailConfig.text,
           html: emailConfig.html
-        }
+        },
+        provider: config.emailService.provider
       }
     }
 

--- a/test/mail_helper.js
+++ b/test/mail_helper.js
@@ -99,7 +99,15 @@ module.exports = (printLogs) => {
         req.accept()
       }
     )
-    smtp.listen(config.smtp.port, config.smtp.host)
+
+    smtp.listen(config.smtp.port, function(err) {
+      if (! err) {
+        console.log(`Local SMTP server listening on port ${config.smtp.port}`)
+      } else {
+        console.log('Error starting SMTP server...')
+        console.log(err.message)
+      }
+    })
 
     // HTTP half
 


### PR DESCRIPTION
These changes were made because of: https://github.com/mozilla/fxa-email-service/pull/122

The major changes are:

- If we are running locally it will not use SES by default, it will send emails to `mail_helper.js`.
- I added a log for `mail_helper.js` that says which port the SMTP server is listening to.
- I set the provider for local development to default to `smtp` and prod is `ses`. Also this makes it easier if ever we want to send some emails to sendgrid or any other provider, we can just add an optional argument to `emailService.sendMail` that overwrites whatever came from config.

This means that development workflow would be exactly the same if you are using Nodemailer or fxa-email-service. 

Finally, I was thinking. Should we add fxa-email-service to fxa-local-dev? Makes sense to me that we add it.

r? @mozilla/fxa-devs 