### PR TITLE
fix(push): send FxA commands push messages to iOS devices

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -118,6 +118,9 @@ module.exports = function (log, db, config) {
     const command = (payload && payload.command) || null
     let canSendToIOSVersion/* ({Number} version) => bool */
     switch (command) {
+    case 'fxaccounts:command_received':
+      canSendToIOSVersion = () => true
+      break
     case 'sync:collection_changed':
       canSendToIOSVersion = () => payload.data.reason !== 'firstsync'
       break

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -199,6 +199,35 @@ describe('push', () => {
   )
 
   it(
+    'sendPush pushes to all ios devices if it is triggered with a "commands received" command',
+    () => {
+      const data = {
+        command: 'fxaccounts:command_received',
+        data: { foo: 'bar' }
+      }
+      const endPoints = []
+      const mocks = {
+        'web-push': {
+          sendNotification: function (sub, payload, options) {
+            endPoints.push(sub.endpoint)
+            return P.resolve()
+          }
+        }
+      }
+
+      const push = proxyquire(pushModulePath, mocks)(mockLog(), mockDb, mockConfig)
+      const options = { data: data }
+      return push.sendPush(mockUid, mockDevices, 'devicesNotify', options)
+        .then(() => {
+          assert.equal(endPoints.length, 3)
+          assert.equal(endPoints[0], mockDevices[0].pushCallback)
+          assert.equal(endPoints[1], mockDevices[1].pushCallback)
+          assert.equal(endPoints[2], mockDevices[2].pushCallback)
+        })
+    }
+  )
+
+  it(
     'sendPush pushes to all ios devices if it is triggered with a "collection changed" command',
     () => {
       const data = {


### PR DESCRIPTION
This ihttps://github.com/mozilla/fxa-auth-server/pull/2515 re-opened as a cherry-pick onto master.