### PR TITLE
chore(emails): log smtp port in mail_helper.js

### DIFF
--- a/test/mail_helper.js
+++ b/test/mail_helper.js
@@ -99,7 +99,15 @@ module.exports = (printLogs) => {
         req.accept()
       }
     )
-    smtp.listen(config.smtp.port, config.smtp.host)
+
+    smtp.listen(config.smtp.port, function(err) {
+      if (! err) {
+        console.log(`Local SMTP server listening on port ${config.smtp.port}`)
+      } else {
+        console.log('Error starting SMTP server...')
+        console.log(err.message)
+      }
+    })
 
     // HTTP half
 


### PR DESCRIPTION
Extracted from https://github.com/mozilla/fxa-auth-server/pull/2511

Added this logs for debugging purposes while working on https://github.com/mozilla/fxa-email-service/pull/122 , but they are very useful so I thought it would be good to send this in.

r? @vladikoff 