### PR TITLE
fix(email): make config.sesConfigurationSet default the empty string and assert key is always there

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -298,7 +298,7 @@ var conf = convict({
             'X-SES-MESSAGE-TAGS headers will be added to emails. Only ' +
             'intended for Production/Stage use.'),
       format: String,
-      default: undefined,
+      default: '',
       env: 'SES_CONFIGURATION_SET'
     },
     bounces: {

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -254,6 +254,7 @@ describe(
         it(
           'If sesConfigurationSet is not defined, then outgoing email does not contain X-SES* headers, for type ' + type,
           function () {
+            assert.ok('sesConfigurationSet' in mailer, 'configuration key exists')
             mailer.mailer.sendMail = function (emailConfig) {
               var sesConfigurationSetHeader = emailConfig.headers['X-SES-CONFIGURATION-SET']
               assert.ok(! sesConfigurationSetHeader)
@@ -268,6 +269,7 @@ describe(
         it(
           'If sesConfigurationSet is defined, then outgoing email will contain X-SES* headers, for type ' + type,
           function () {
+            assert.ok('sesConfigurationSet' in mailer, 'configuration key exists')
             var savedSesConfigurationSet = mailer.sesConfigurationSet
             mailer.sesConfigurationSet = 'some-defined-value'
 


### PR DESCRIPTION
In the current master, if sesConfigurationSet is not explicitly in config/<env>.json or in the environment, then config.sesConfigurationSet does not exist as a key. It seems to me the default should be an empty string anyways.

r? - @philbooth 