### PR TITLE
fix(hapi): use the new server event error handler

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -236,7 +236,8 @@ async function create (log, error, config, routes, db, translator) {
   const sentryDsn = config.sentryDsn
   if (sentryDsn) {
     Raven.config(sentryDsn, {})
-    server.events.on('request-error', function (request, err) {
+    server.events.on({ name: 'request', channel: 'error' }, function (request, event) {
+      const err = event && event.error || null
       let exception = ''
       if (err && err.stack) {
         try {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2542


Per https://github.com/hapijs/hapi/issues/3658