### PR TITLE
chore(install): Only clone the l10n repo if needed.

### DIFF
--- a/scripts/download_l10n.sh
+++ b/scripts/download_l10n.sh
@@ -9,13 +9,16 @@ if [ -z "$FXA_L10N_SHA" ]; then
     FXA_L10N_SHA="master"
 fi
 
-rm -rf fxa-content-server-l10n
-
 DOWNLOAD_PATH="https://github.com/mozilla/fxa-content-server-l10n.git"
 
-echo "Downloading L10N files from $DOWNLOAD_PATH..."
 # Download L10N using git
-git clone --depth=20 $DOWNLOAD_PATH
+if [ ! -d "fxa-content-server-l10n" ]; then
+	echo "Downloading L10N files from $DOWNLOAD_PATH..."
+	git clone --depth=20 $DOWNLOAD_PATH
+fi
 cd fxa-content-server-l10n
+echo "Updating L100N files"
+git checkout -- .
 git checkout $FXA_L10N_SHA
+git pull
 cd ..


### PR DESCRIPTION
While sitting on the train w/ a terrible 3G connection,
it took about 10 minutes to update the repo, mostly
downloading l10n.

I noticed we delete the l10n directory and re-clone
*every time* we do an `npm install`. This seems
heavy handed.

This change checks if the l10n directory exists,
if it does it reverts any local changes and pulls.

If the directory doens't exist, then clone the
l10n repo.

not attached to any issue.

@vladikoff - I don't remember why we delete the l10n directory every time we install. This approach seems like it should be safe, maybe I'm forgetting some context? r?