### PR TITLE
fix(sentry): server.events.on takes channels, not channel

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -236,7 +236,7 @@ async function create (log, error, config, routes, db, translator) {
   const sentryDsn = config.sentryDsn
   if (sentryDsn) {
     Raven.config(sentryDsn, {})
-    server.events.on({ name: 'request', channel: 'error' }, function (request, event) {
+    server.events.on({ name: 'request', channels: 'error' }, function (request, event) {
       const err = event && event.error || null
       let exception = ''
       if (err && err.stack) {


### PR DESCRIPTION
Uplift https://github.com/mozilla/fxa-auth-server/pull/2555 from master to train-117.