### PR TITLE
fix(test): set default test timeout to 5000

### DIFF
--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -12,13 +12,7 @@ if [ -z "$GLOB" ]; then
   GLOB="test/local test/remote"
 fi
 
-DEFAULT_ARGS="-R dot --recursive"
-
-# When running under Windows Subsystem for Linux,
-# some tests take unusually long to complete.
-if uname -a | grep -q 'Microsoft'; then
-  DEFAULT_ARGS="$DEFAULT_ARGS --timeout 5000"
-fi
+DEFAULT_ARGS="-R dot --recursive --timeout 5000"
 
 ./scripts/gen_keys.js
 ./scripts/gen_vapid_keys.js


### PR DESCRIPTION
I have noticed that a few of our intermittent tests failures (in circle) are because the test timeouts. We currently have a default of 2 seconds for remote and local tests. The timeout almost always occur with the remote tests.

@mozilla/fxa-devs Putting this PR up for consideration, since we currently have it set to 5s in linux subsystem.

Connects to https://github.com/mozilla/fxa-auth-server/issues/2534