### PR TITLE
fix(sessionTokens): actually prune expired session tokens

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -114,7 +114,7 @@ async function create (log, error, config, routes, db, translator) {
           if (token.expired(Date.now())) {
             const err = error.invalidToken('The authentication token has expired')
 
-            if (token.tokenTypeID === 'sessionToken') {
+            if (token.constructor.tokenTypeID === 'sessionToken') {
               return db.pruneSessionTokens(token.uid, [ token ])
                 .catch(() => {})
                 .then(() => { throw err })

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -373,9 +373,10 @@ function mockDB (data, errors) {
         uaOS: data.uaOS,
         uaOSVersion: data.uaOSVersion,
         uaDeviceType: data.uaDeviceType,
-        tokenTypeID: 'sessionToken',
         expired: () => data.expired || false
       }
+      // SessionToken is a class, and tokenTypeID is a class attribute. Fake that.
+      res.constructor.tokenTypeID = 'sessionToken'
       if (data.devices && data.devices.length > 0) {
         Object.keys(data.devices[0]).forEach(key => {
           var keyOnSession = 'device' + key.charAt(0).toUpperCase() + key.substr(1)


### PR DESCRIPTION
I found this while working on the OAuth devices api:

https://github.com/mozilla/fxa-auth-server/blob/5caedf31c36108becb3768804813c8893ccc1af2/lib/tokens/session_token.js#L118
As you can see above `tokenTypeID` is a class variable, which means the following condition will never be true.
https://github.com/mozilla/fxa-auth-server/blob/5caedf31c36108becb3768804813c8893ccc1af2/lib/server.js#L117