### PR TITLE
feat(codes): expose verificationMethod as optional

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2843,7 +2843,7 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fxa-auth-db-mysql": {
-      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#27277a4f7efc810df41b5cf17cbb3237f1fe3bb8",
+      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#29b9b4bc65784659ff103d77a390dc043e41992c",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "dev": true,
       "requires": {
@@ -10949,7 +10949,7 @@
       "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
       "requires": {
         "array.prototype.find": "2.0.0",
-        "uap-core": "git://github.com/ua-parser/uap-core.git#f4d16a53e4771cf6deed18eb7273226606a4de21",
+        "uap-core": "git://github.com/ua-parser/uap-core.git#590f66f40b00644efa6045d06e3c2a605eb22ea1",
         "uap-ref-impl": "0.2.0",
         "yamlparser": "0.0.2"
       }
@@ -13730,7 +13730,7 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uap-core": {
-      "version": "git://github.com/ua-parser/uap-core.git#f4d16a53e4771cf6deed18eb7273226606a4de21",
+      "version": "git://github.com/ua-parser/uap-core.git#590f66f40b00644efa6045d06e3c2a605eb22ea1",
       "from": "git://github.com/ua-parser/uap-core.git"
     },
     "uap-ref-impl": {

--- a/test/remote/account_login_tests.js
+++ b/test/remote/account_login_tests.js
@@ -261,6 +261,23 @@ describe('remote account login', () => {
           assert.ok(code, 'code is sent')
         })
     })
+
+    it('should ignore verificationMethod if not requesting keys', () => {
+      return Client.login(config.publicUrl, email, password, {
+        verificationMethod: 'email',
+        keys: false
+      })
+        .then((res) => {
+          client = res
+          assert.equal(res.verificationMethod, undefined, 'sets correct verification method')
+          return client.emailStatus()
+        })
+        .then((status) => {
+          assert.equal(status.verified, true, 'account is verified')
+          assert.equal(status.emailVerified, true, 'email is verified')
+          assert.equal(status.sessionVerified, false, 'session is not verified')
+        })
+    })
   })
 
   after(() => {

--- a/test/remote/account_login_tests.js
+++ b/test/remote/account_login_tests.js
@@ -186,17 +186,18 @@ describe('remote account login', () => {
     }
   )
 
-  describe('can force verificationMethod', () => {
+  describe('can use verificationMethod', () => {
     let client, email
     const password = 'foo'
     before(() => {
-      email = server.uniqueEmail()
+      email = server.uniqueEmail('@mozilla.com')
       return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
     })
 
     it('fails with invalid verification method', () => {
       return Client.login(config.publicUrl, email, password, {
-        verificationMethod: 'notvalid'
+        verificationMethod: 'notvalid',
+        keys: true
       })
         .then(() => {
           assert.fail('should not have succeed')
@@ -205,9 +206,10 @@ describe('remote account login', () => {
         })
     })
 
-    it('can force `email` verification', () => {
+    it('can use `email` verification', () => {
       return Client.login(config.publicUrl, email, password, {
-        verificationMethod: 'email'
+        verificationMethod: 'email',
+        keys: true
       })
         .then((res) => {
           client = res
@@ -237,9 +239,10 @@ describe('remote account login', () => {
         })
     })
 
-    it('can force `email-2fa` verification', () => {
+    it('can use `email-2fa` verification', () => {
       return Client.login(config.publicUrl, email, password, {
-        verificationMethod: 'email-2fa'
+        verificationMethod: 'email-2fa',
+        keys: true
       })
         .then((res) => {
           client = res

--- a/test/remote/token_code_tests.js
+++ b/test/remote/token_code_tests.js
@@ -24,7 +24,7 @@ describe('remote tokenCodes', function () {
   })
 
   beforeEach(() => {
-    email = server.uniqueEmail()
+    email = server.uniqueEmail('@mozilla.com')
     return Client.createAndVerify(config.publicUrl, email, password, server.mailbox)
       .then(function (x) {
         client = x
@@ -34,7 +34,8 @@ describe('remote tokenCodes', function () {
 
   it('should error with invalid code', () => {
     return Client.login(config.publicUrl, email, password, {
-      verificationMethod: 'email-2fa'
+      verificationMethod: 'email-2fa',
+      keys: true
     })
     .then((res) => {
       client = res
@@ -56,7 +57,8 @@ describe('remote tokenCodes', function () {
 
   it('should error with invalid request param when using wrong code format', () => {
     return Client.login(config.publicUrl, email, password, {
-      verificationMethod: 'email-2fa'
+      verificationMethod: 'email-2fa',
+      keys: true
     })
       .then((res) => {
         client = res
@@ -78,7 +80,8 @@ describe('remote tokenCodes', function () {
 
   it('should consume valid code', () => {
     return Client.login(config.publicUrl, email, password, {
-      verificationMethod: 'email-2fa'
+      verificationMethod: 'email-2fa',
+      keys: true
     })
     .then((res) => {
       client = res
@@ -110,7 +113,8 @@ describe('remote tokenCodes', function () {
 
   it('should accept optional uid parameter in request body', () => {
     return Client.login(config.publicUrl, email, password, {
-      verificationMethod: 'email-2fa'
+      verificationMethod: 'email-2fa',
+      keys: true
     })
     .then((res) => {
       client = res
@@ -135,11 +139,12 @@ describe('remote tokenCodes', function () {
 
   it('should reject mismatched uid parameter in request body', () => {
     const uid1 = client.uid
-    const email2 = server.uniqueEmail()
+    const email2 = server.uniqueEmail('@mozilla.com')
     return Client.createAndVerify(config.publicUrl, email2, password, server.mailbox)
     .then(() => {
       return Client.login(config.publicUrl, email2, password, {
-        verificationMethod: 'email-2fa'
+        verificationMethod: 'email-2fa',
+        keys: true
       })
     })
     .then((res) => {


### PR DESCRIPTION
This PR changes how the `verificationMethod` param behaves.

Previously, if the `verificationMethod` param was specified in a login requrest, the auth-server would force the client to verify using that method. This was regardless whether or not a verification was required (aka skip if account is new, or skip if they recently logged in). This behavior was put in place so that we could reduce any outliers in the `tokenCode` experiment. 

This change makes the `verificationMethod` optional. If a client specifies this param *and* it has to perform a verification, then this method will be used, otherwise it is not used.

These changes are safe to make because the `verificationMethod` is only specified in our tokenCode experiment, which is currently turned off.

Fixes #2466 