### PR TITLE
fix(email): ensure email-service errors fail the call to sendMail

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -337,10 +337,11 @@ module.exports = function (log, config) {
           mailer.sendMail(emailConfig, (err, status) => {
             if (err) {
               log.error({
-                op: 'mailer.send.1',
-                err: err && err.message,
-                status: status && status.message,
-                id: status && status.messageId,
+                op: 'mailer.send.error',
+                err: err.message,
+                code: err.code,
+                errno: err.errno,
+                message: status && status.message,
                 to: emailConfig && emailConfig.to,
                 emailSender,
                 emailService


### PR DESCRIPTION
Related to #2565.

The response handler for the email service was not creating error objects for error responses, so the call to `sendMail` was succeeding in those cases. I've changed it here so that `sendMail` fails and also tweaked the logging a little bit to give us better error info.

Although this addresses the auth server end of things for #2565, I notice that even with this fix applied the user is still told to go and check their email. I need to do some more digging to see whether that needs some content server code to change too (or whatever).

@mozilla/fxa-devs r?