### PR TITLE
fix(server): do not return customs.flag in the destroy route

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1235,7 +1235,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
               })
           }, (err) => {
             if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
-              return customs.flag(request.app.clientAddress, {
+              customs.flag(request.app.clientAddress, {
                 email: form.email,
                 errno: err.errno
               })


### PR DESCRIPTION
Fixes #2563

I believe this was regression from https://github.com/mozilla/fxa-auth-server/commit/63738c85b5443c7e15bc03610deec9f1223e03eb#diff-ab87c506e682e952973178a41792df12L1241