### PR TITLE
Small improvements for the email-config script

### DIFF
--- a/scripts/email-config.js
+++ b/scripts/email-config.js
@@ -8,7 +8,7 @@ const ROOT_DIR = '..'
 const LIB_DIR = `${ROOT_DIR}/lib`
 
 const config = require(`${ROOT_DIR}/config`).getProperties()
-const log = require(`${LIB_DIR}/log`)(config.log.level, 'email-config')
+const log = require(`${ROOT_DIR}/test/mocks`).mockLog()
 const Promise = require(`${LIB_DIR}/promise`)
 const redis = require(`${LIB_DIR}/redis`)({ ...config.redis, ...config.redis.email }, log)
 

--- a/scripts/email-config.js
+++ b/scripts/email-config.js
@@ -11,6 +11,7 @@ const config = require(`${ROOT_DIR}/config`).getProperties()
 const log = require(`${ROOT_DIR}/test/mocks`).mockLog()
 const Promise = require(`${LIB_DIR}/promise`)
 const redis = require(`${LIB_DIR}/redis`)({ ...config.redis, ...config.redis.email }, log)
+const safeRegex = require('safe-regex')
 
 if (! redis) {
   console.error('Redis is disabled in config, aborting')
@@ -30,7 +31,9 @@ const KEYS = {
 const VALID_SERVICES = new Set([ 'sendgrid', 'ses', 'socketlabs' ])
 const VALID_PROPERTIES = new Map([
   [ 'percentage', value => value >= 0 && value <= 100 ],
-  [ 'regex', value => value && typeof value === 'string' ]
+  [ 'regex', value =>
+    value && typeof value === 'string' && value.indexOf('"') === -1 && safeRegex(value)
+  ]
 ])
 
 const { argv } = process

--- a/test/scripts/email-config.js
+++ b/test/scripts/email-config.js
@@ -67,7 +67,7 @@ describe('scripts/email-config:', () => {
   })
 
   it('write does not fail', () => {
-    return cp.execAsync('echo \'{"sendgrid":{"percentage":1,"regex":".*"}}\' | node scripts/email-config write', { cwd })
+    return cp.execAsync('echo \'{"sendgrid":{"percentage":100,"regex":".*"}}\' | node scripts/email-config write', { cwd })
   })
 
   it('write fails if stdin is not valid JSON', () => {
@@ -86,12 +86,27 @@ describe('scripts/email-config:', () => {
   })
 
   it('write fails if percentage is greater than 100', () => {
-    return cp.execAsync('echo \'{"sendgrid":{"percentage":101,"regex":".*"}}\' | node scripts/email-config write', { cwd })
+    return cp.execAsync('echo \'{"sendgrid":{"percentage":100.1,"regex":".*"}}\' | node scripts/email-config write', { cwd })
+      .then(() => assert(false, 'script should have failed'), () => {})
+  })
+
+  it('write fails if percentage is less than 0', () => {
+    return cp.execAsync('echo \'{"sendgrid":{"percentage":-0.1,"regex":".*"}}\' | node scripts/email-config write', { cwd })
       .then(() => assert(false, 'script should have failed'), () => {})
   })
 
   it('write fails if regex is not string', () => {
     return cp.execAsync('echo \'{"sendgrid":{"percentage":1,"regex":{}}}\' | node scripts/email-config write', { cwd })
+      .then(() => assert(false, 'script should have failed'), () => {})
+  })
+
+  it('write fails if regex contains quote character', () => {
+    return cp.execAsync('echo \'{"sendgrid":{"percentage":1,"regex":".*\\""}}\' | node scripts/email-config write', { cwd })
+      .then(() => assert(false, 'script should have failed'), () => {})
+  })
+
+  it('write fails if regex is unsafe', () => {
+    return cp.execAsync('echo \'{"sendgrid":{"percentage":1,"regex":"(.*)*"}}\' | node scripts/email-config write', { cwd })
       .then(() => assert(false, 'script should have failed'), () => {})
   })
 


### PR DESCRIPTION
While trying to reproduce issues @jrgm was having with the live email config in stage last night, I spotted a couple of improvements that could be made to the script:

1. Because it was instantiating a real logger to give to the `redis` module, auth server config was being logged to `stdout`. This breaks the script's aim of being pipe/cmdline-friendly, because only the intended output should end up on `stdout`. Fixed by instantiating a mock logger instead.

2. When we parse the live email config, we reject regexes that contain a terminating quote character or look like they might redos us (have a star height greater than 1). It makes sense to reject those when setting them too.

Unfortunately I didn't manage to reproduce the actual problem I'm looking for yet, but in the meantime this still seemed worth landing.

@mozilla/fxa-devs r?