### PR TITLE
Fixes for email address validation

### DIFF
--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -104,7 +104,7 @@ module.exports.isValidEmailAddress = function(value) {
   domain = punycode.toASCII(domain)
   // The username portion must contain only allowed characters.
   for (var i = 0; i < username.length; i++) {
-    if (! username[i].match(/[a-zA-Z0-9.!#$%&'*+-\/=?^_`{|}~]/)) {
+    if (! username[i].match(/[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]/)) {
       return false
     }
   }

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -78,63 +78,37 @@ module.exports.service = isA.string().max(16).regex(/^[a-zA-Z0-9\-]*$/g)
 
 
 // Function to validate an email address.
-// This is a transliteration of the HTML5 email-validation logic
-// inside Firefox.  It splits the username and domain portions,
-// translates tham into IDN punycode syntax, then does some very
-// basic sanity-checking.
+//
+// Uses regexes based on the ones in fxa-email-service, tweaked slightly
+// because Node's support for unicode regexes is hidden behind a harmony
+// flag. As soon as we have default support for unicode regexes, we should
+// be able to just use the regex from there directly (and ditch the punycode
+// transformation).
+//
+// https://github.com/mozilla/fxa-email-service/blob/6fc6c31043598b246102cd1fdd27fc325f4514fb/src/validate/mod.rs#L28-L30
+
+const EMAIL_USER = /^[A-Z0-9.!#$%&'*+\/=?^_`{|}~-]{1,64}$/i
+const EMAIL_DOMAIN = /^[A-Z0-9](?:[A-Z0-9-]{0,253}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,253}[A-Z0-9])?)+$/i
 
 module.exports.isValidEmailAddress = function(value) {
-  // It cant be empty or end with strange chars.
   if (! value) {
     return false
   }
-  if (value[value.length - 1] === '.' || value[value.length - 1] === '-') {
+
+  const parts = value.split('@')
+  if (parts.length !== 2 || parts[1].length > 255) {
     return false
   }
-  const atPos = value.indexOf('@')
-  // User part must be between 1 and 64 characters, domain part must be between
-  // 1 and 255 characters
-  if (atPos < 1 || atPos > 64 || atPos === value.length || atPos < value.length - 256) {
+
+  if (! EMAIL_USER.test(punycode.toASCII(parts[0]))) {
     return false
   }
-  var username = value.substring(0, atPos)
-  var domain = value.substring(atPos + 1)
-  // Unicode is hard, let's work with ascii only.
-  username = punycode.toASCII(username)
-  domain = punycode.toASCII(domain)
-  // The username portion must contain only allowed characters.
-  for (var i = 0; i < username.length; i++) {
-    if (! username[i].match(/[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]/)) {
-      return false
-    }
-  }
-  // The domain portion can't begin with a dot or a dash.
-  if (domain[0] === '.' || domain[0] === '-') {
+
+  if (! EMAIL_DOMAIN.test(punycode.toASCII(parts[1]))) {
     return false
   }
-  var hasDot = false
-  // The domain portion must be a valid punycode domain.
-  for (i = 0; i < domain.length; i++) {
-    if (domain[i] === '.') {
-      hasDot = true
-      // A dot can't follow a dot or a dash.
-      if (domain[i - 1] === '.' || domain[i - 1] === '-') {
-        return false
-      }
-    }
-    else if (domain[i] === '-') {
-      // A dash can't follow a dot.
-      if (domain[i - 1] === '.') {
-        return false
-      }
-    } else if (! domain[i].match(/[a-zA-Z0-9-]/)) {
-      // The domain characters must be alphanumeric.
-      return false
-    }
-  }
-  // Even though the RFC doesn't require it, we need a dot. See:
-  // https://github.com/mozilla/fxa-auth-server/issues/1193
-  return hasDot
+
+  return true
 }
 
 module.exports.redirectTo = function redirectTo(base) {

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -91,9 +91,10 @@ module.exports.isValidEmailAddress = function(value) {
   if (value[value.length - 1] === '.' || value[value.length - 1] === '-') {
     return false
   }
-  // It must contain an '@' somewhere in the middle.
-  var atPos = value.indexOf('@')
-  if (atPos === -1 || atPos === 0 || atPos === value.length) {
+  const atPos = value.indexOf('@')
+  // User part must be between 1 and 64 characters, domain part must be between
+  // 1 and 255 characters
+  if (atPos < 1 || atPos > 64 || atPos === value.length || atPos < value.length - 256) {
     return false
   }
   var username = value.substring(0, atPos)

--- a/test/local/routes/validators.js
+++ b/test/local/routes/validators.js
@@ -62,6 +62,7 @@ describe('lib/routes/validators:', () => {
   })
 
   it('isValidEmailAddress returns false if the user part contains other disallowed characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo,@example.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo;@example.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo:@example.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo"@example.com'), false)

--- a/test/local/routes/validators.js
+++ b/test/local/routes/validators.js
@@ -16,11 +16,13 @@ describe('lib/routes/validators:', () => {
     assert.strictEqual(validators.isValidEmailAddress('.+#$!%&|*/+-=?^_{}~`@example.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('Δ٢@example.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('🦀🧙@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress(`${new Array(64).fill('a').join('')}@example.com`), true)
     assert.strictEqual(validators.isValidEmailAddress('foo@EXAMPLE.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('foo@42.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('foo@ex-ample.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('foo@Δ٢.com'), true)
     assert.strictEqual(validators.isValidEmailAddress('foo@ex🦀ample.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress(`foo@${new Array(251).fill('a').join('')}.com`), true)
   })
 
   it('isValidEmailAddress returns false for undefined', () => {
@@ -63,6 +65,10 @@ describe('lib/routes/validators:', () => {
     assert.strictEqual(validators.isValidEmailAddress('foo;@example.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo:@example.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo"@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the user part exceeds 64 characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress(`${new Array(65).fill('a').join('')}@example.com`), false)
   })
 
   it('isValidEmailAddress returns false if the domain part does not have a period', () => {
@@ -113,6 +119,10 @@ describe('lib/routes/validators:', () => {
     assert.strictEqual(validators.isValidEmailAddress('foo@ex:ample.com'), false)
     assert.strictEqual(validators.isValidEmailAddress('foo@ex\'ample.com'), false)
   })
+
+  it('isValidEmailAddress returns false if the domain part exceeds 255 characters', () => {
+     assert.strictEqual(validators.isValidEmailAddress(`foo@${new Array(252).fill('a').join('')}.com`), false)
+   })
 
   describe('validators.redirectTo without base hostname:', () => {
     const v = validators.redirectTo()

--- a/test/local/routes/validators.js
+++ b/test/local/routes/validators.js
@@ -8,8 +8,113 @@ const assert = require('insist')
 
 const validators = require('../../../lib/routes/validators')
 
-describe('redirectTo() validator', () => {
-  describe('with no base hostname', () => {
+describe('lib/routes/validators:', () => {
+  it('isValidEmailAddress returns true for valid email addresses', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('FOO@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('42@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('.+#$!%&|*/+-=?^_{}~`@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('Δ٢@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('🦀🧙@example.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('foo@EXAMPLE.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('foo@42.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex-ample.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('foo@Δ٢.com'), true)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex🦀ample.com'), true)
+  })
+
+  it('isValidEmailAddress returns false for undefined', () => {
+    assert.strictEqual(validators.isValidEmailAddress(), false)
+  })
+
+  it('isValidEmailAddress returns false if the string has no @', () => {
+    assert.strictEqual(validators.isValidEmailAddress('fooexample.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the string begins with @', () => {
+    assert.strictEqual(validators.isValidEmailAddress('@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the string ends with @', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@'), false)
+  })
+
+  it('isValidEmailAddress returns false if the string contains multiple @', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@foo@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the user part contains whitespace', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo @example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\x160@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\t@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\v@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\r@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\n@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\f@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the user part contains other control characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo\0@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\b@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo\x128@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the user part contains other disallowed characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo;@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo:@example.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo"@example.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part does not have a period', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part ends with a period', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example.com.'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part ends with a hyphen', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example.com-'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part follows a period with a hyphen', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example.-com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part follows a hyphen with a period', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@example-.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part contains whitespace', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\x160ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\tample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\vample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\rample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\nample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\fample.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part contains other control characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\0ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@e\bxample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\x128ample.com'), false)
+  })
+
+  it('isValidEmailAddress returns false if the domain part contains other disallowed characters', () => {
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex+ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex_ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex#ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex$ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex!ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex~ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex,ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex;ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex:ample.com'), false)
+    assert.strictEqual(validators.isValidEmailAddress('foo@ex\'ample.com'), false)
+  })
+
+  describe('validators.redirectTo without base hostname:', () => {
     const v = validators.redirectTo()
 
     it('accepts a well-formed https:// URL', function () {
@@ -43,7 +148,7 @@ describe('redirectTo() validator', () => {
     })
   })
 
-  describe('with a base hostname', () => {
+  describe('validators.redirectTo with a base hostname:', () => {
     const v = validators.redirectTo('mozilla.com')
 
     it('accepts a well-formed https:// URL at the base hostname', function () {


### PR DESCRIPTION
Fixes #2568.

The user part of an email address is limited to 64 characters, but our validation wasn't enforcing that. Before trying to fix that problem, I wrote some unit tests for the validation code because there weren't any. They uncovered a separate problem, where a regex was mistakenly using `+-\/` as a character range, so I've fixed that here too.

After that, feeling confident with the extra test support, I opted to simplify the whole function and boil it down to just two regexes and a call to `String.split`. Mostly that was for readability, but there's also a micro-optimisation in there because the old code was rather curiously testing regexes on individual characters, iterating through the string.

@mozilla/fxa-devs r?