### PR TITLE
fix(devices): check token.deviceAvailableCommands before dereferencing

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -65,10 +65,10 @@ module.exports = (log, db, push) => {
 
     if (payload.availableCommands) {
       if (token.deviceAvailableCommands) {
-        spurious = spurious && Object.keys(payload.availableCommands).some(key => {
+        spurious = spurious && ! Object.keys(payload.availableCommands).some(key => {
           return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
         })
-        spurious = spurious && Object.keys(token.deviceAvailableCommands).some(key => {
+        spurious = spurious && ! Object.keys(token.deviceAvailableCommands).some(key => {
           return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
         })
       } else {

--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -178,7 +178,7 @@ module.exports = (log, db, config, customs, push, pushbox, devices) => {
 
         if (payload.id) {
           // Don't write out the update if nothing has actually changed.
-          if (isSpuriousUpdate(payload, sessionToken)) {
+          if (devices.isSpuriousUpdate(payload, sessionToken)) {
             return payload
           }
 
@@ -223,48 +223,6 @@ module.exports = (log, db, config, customs, push, pushbox, devices) => {
               type: device.type || sessionToken.deviceType || 'desktop',
             })
           })
-
-        // Clients have been known to send spurious device updates,
-        // which generates lots of unnecessary database load.
-        // Check if anything has actually changed, and log lots metrics on what.
-        function isSpuriousUpdate (payload, token) {
-          let spurious = true
-
-          if (! token.deviceId || payload.id !== token.deviceId) {
-            spurious = false
-          }
-
-          if (payload.name && payload.name !== token.deviceName) {
-            spurious = false
-          }
-
-          if (payload.type && payload.type !== token.deviceType) {
-            spurious = false
-          }
-
-          if (payload.pushCallback && payload.pushCallback !== token.deviceCallbackURL) {
-            spurious = false
-          }
-
-          if (payload.pushPublicKey && payload.pushPublicKey !== token.deviceCallbackPublicKey) {
-            spurious = false
-          }
-
-          if (payload.availableCommands) {
-            if (token.deviceAvailableCommands) {
-              spurious = spurious && Object.keys(payload.availableCommands).some(key => {
-                return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
-              })
-              spurious = spurious && Object.keys(token.deviceAvailableCommands).some(key => {
-                return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
-              })
-            } else {
-              spurious = false
-            }
-          }
-
-          return spurious
-        }
       }
     },
     {

--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -251,12 +251,16 @@ module.exports = (log, db, config, customs, push, pushbox, devices) => {
           }
 
           if (payload.availableCommands) {
-            spurious = spurious && Object.keys(payload.availableCommands).some(key => {
-              return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
-            })
-            spurious = spurious && Object.keys(token.deviceAvailableCommands).some(key => {
-              return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
-            })
+            if (token.deviceAvailableCommands) {
+              spurious = spurious && Object.keys(payload.availableCommands).some(key => {
+                return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
+              })
+              spurious = spurious && Object.keys(token.deviceAvailableCommands).some(key => {
+                return payload.availableCommands[key] !== token.deviceAvailableCommands[key]
+              })
+            } else {
+              spurious = false
+            }
           }
 
           return spurious

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -1051,7 +1051,7 @@ describe('/account/sessions', () => {
     {
       id: tokenIds[3], uid: 'blee', createdAt: times[7], lastAccessTime: 1,
       uaBrowser: null, uaBrowserVersion: '50', uaOS: null, uaOSVersion: '10',
-      uaDeviceType: 'tablet', deviceId: 'deviceId', deviceCreatedAt: times[8], deviceAvailableCommands: {},
+      uaDeviceType: 'tablet', deviceId: 'deviceId', deviceCreatedAt: times[8],
       deviceCallbackURL: 'callback', deviceCallbackPublicKey: 'publicKey', deviceCallbackAuthKey: 'authKey',
       deviceCallbackIsExpired: false,
       location: null
@@ -1151,7 +1151,7 @@ describe('/account/sessions', () => {
           deviceId: 'deviceId',
           deviceName: '',
           deviceType: 'tablet',
-          deviceAvailableCommands: {},
+          deviceAvailableCommands: null,
           deviceCallbackURL: 'callback',
           deviceCallbackPublicKey: 'publicKey',
           deviceCallbackAuthKey: 'authKey',

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -83,7 +83,8 @@ describe('/account/device', function () {
       name: mockDeviceName
     }
   })
-  var mockDevices = mocks.mockDevices()
+  const devicesData = {}
+  var mockDevices = mocks.mockDevices(devicesData)
   var mockLog = mocks.mockLog()
   var accountRoutes = makeRoutes({
     config: config,
@@ -93,16 +94,25 @@ describe('/account/device', function () {
   var route = getRoute(accountRoutes, '/account/device')
 
   it('identical data', function () {
+    devicesData.spurious = true
     return runTest(route, mockRequest, function (response) {
-      assert.equal(mockDevices.upsert.callCount, 0, 'the device was not updated')
+      assert.equal(mockDevices.isSpuriousUpdate.callCount, 1)
+      const args = mockDevices.isSpuriousUpdate.args[0]
+      assert.equal(args.length, 2)
+      assert.equal(args[0], mockRequest.payload)
+      assert.equal(args[1], mockRequest.auth.credentials)
+
+      assert.equal(mockDevices.upsert.callCount, 0)
       assert.deepEqual(response, mockRequest.payload)
     })
       .then(function () {
+        mockDevices.isSpuriousUpdate.reset()
         mockDevices.upsert.reset()
       })
   })
 
   it('different data', function () {
+    devicesData.spurious = false
     mockRequest.auth.credentials.deviceId = crypto.randomBytes(16).toString('hex')
     var payload = mockRequest.payload
     payload.name = 'my even awesomer device'
@@ -111,6 +121,7 @@ describe('/account/device', function () {
     payload.pushPublicKey = mocks.MOCK_PUSH_KEY
 
     return runTest(route, mockRequest, function (response) {
+      assert.equal(mockDevices.isSpuriousUpdate.callCount, 1)
       assert.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
       var args = mockDevices.upsert.args[0]
       assert.equal(args.length, 3, 'devices.upsert was passed three arguments')
@@ -120,11 +131,13 @@ describe('/account/device', function () {
       assert.deepEqual(args[2], mockRequest.payload, 'third argument was payload')
     })
       .then(function () {
+        mockDevices.isSpuriousUpdate.reset()
         mockDevices.upsert.reset()
       })
   })
 
   it('with no id in payload', function () {
+    devicesData.spurious = false
     mockRequest.payload.id = undefined
 
     return runTest(route, mockRequest, function (response) {
@@ -133,6 +146,7 @@ describe('/account/device', function () {
       assert.equal(args[2].id, mockRequest.auth.credentials.deviceId.toString('hex'), 'payload.id defaulted to credentials.deviceId')
     })
       .then(function () {
+        mockDevices.isSpuriousUpdate.reset()
         mockDevices.upsert.reset()
       })
   })

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -429,6 +429,7 @@ function mockDevices (data, errors) {
   errors = errors || {}
 
   return {
+    isSpuriousUpdate: sinon.spy(() => data.spurious || false),
     upsert: sinon.spy(() => {
       if (errors.upsert) {
         return P.reject(errors.upsert)


### PR DESCRIPTION
Fixes #2533.

This is the obvious fix but it might not be the right one. In the linked issue, @rfk mentions concern that a patch like this might be masking some deeper problem. But given there are actual 500 errors in prod that will go away with this fix applied, I still think it's worth doing (and it seems like we may have caused more of these ourselves anyway when we truncated `deviceCommands`).

@mozilla/fxa-devs r?