### PR TITLE
fix(devices): Add feature-flag for the "device commands" functionality.

### DIFF
--- a/lib/routes/devices-and-sessions.js
+++ b/lib/routes/devices-and-sessions.js
@@ -205,6 +205,13 @@ module.exports = (log, db, config, customs, push, pushbox, devices) => {
           }
         }
 
+        // We're doing a gradual rollout of the 'device commands' feature
+        // in support of pushbox, so accept an 'availableCommands' field
+        // if pushbox is enabled.
+        if (payload.availableCommands && ! config.pushbox.enabled) {
+            payload.availableCommands = {}
+        }
+
         return devices.upsert(request, sessionToken, payload)
           .then(function (device) {
             // We must respond with the full device record,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2837,7 +2837,7 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fxa-auth-db-mysql": {
-      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0a28801306b1e0d9f7e37a263f84c6e1cbca6fbd",
+      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#9e0e6305df28c5c6d0223ba07a52dc970322785e",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "dev": true,
       "requires": {

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -160,6 +160,25 @@ describe('/account/device', function () {
       .then(() => assert.ok(false), function (err) {
         assert.equal(err.output.statusCode, 503, 'correct status code is returned')
         assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED, 'correct errno is returned')
+        delete config.deviceUpdatesEnabled
+      })
+  })
+
+  it('pushbox feature disabled', function () {
+    config.pushbox = { enabled: false }
+    mockRequest.payload.availableCommands = {
+      'test': 'command'
+    }
+
+    return runTest(route, mockRequest, function () {
+      assert.equal(mockDevices.upsert.callCount, 1, 'devices.upsert was called once')
+      var args = mockDevices.upsert.args[0]
+      assert.deepEqual(args[2].availableCommands, {}, 'availableCommands are ignored when pushbox is disabled')
+    })
+      .then(function () {
+        mockDevices.isSpuriousUpdate.reset()
+        mockDevices.upsert.reset()
+        delete config.pushbox
       })
   })
 

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -496,7 +496,7 @@ describe('remote db', function() {
           assert.ok(device.lastAccessTime > 0, 'device.lastAccessTime is set')
           assert.equal(device.name, deviceInfo.name, 'device.name is correct')
           assert.equal(device.type, deviceInfo.type, 'device.type is correct')
-          //assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
+          assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'device.availableCommands is correct')
           assert.equal(device.pushCallback, deviceInfo.pushCallback, 'device.pushCallback is correct')
           assert.equal(device.pushPublicKey, deviceInfo.pushPublicKey, 'device.pushPublicKey is correct')
           assert.equal(device.pushAuthKey, deviceInfo.pushAuthKey, 'device.pushAuthKey is correct')

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -75,8 +75,7 @@ describe('remote device', function () {
                   assert.equal(devices.length, 1, 'devices returned one item')
                   assert.equal(devices[0].name, deviceInfo.name, 'devices returned correct name')
                   assert.equal(devices[0].type, deviceInfo.type, 'devices returned correct type')
-                  // HACK: disabled until deviceCommands insertion is re-endabled in the db
-                  //assert.deepEqual(devices[0].availableCommands, deviceInfo.availableCommands, 'devices returned correct availableCommands')
+                  assert.deepEqual(devices[0].availableCommands, deviceInfo.availableCommands, 'devices returned correct availableCommands')
                   assert.equal(devices[0].pushCallback, '', 'devices returned empty pushCallback')
                   assert.equal(devices[0].pushPublicKey, '', 'devices returned correct pushPublicKey')
                   assert.equal(devices[0].pushAuthKey, '', 'devices returned correct pushAuthKey')


### PR DESCRIPTION
This goes along with https://github.com/mozilla/fxa-auth-db-mysql/pull/389 to reinstate the "device commands" functionality, this time behind the pushbox feature-flag for easy turning-it-off-if-things-go-pear-shaped-in-production.