### PR TITLE
chore(email): force value to boolean in account deletion check

### DIFF
--- a/lib/email/bounces.js
+++ b/lib/email/bounces.js
@@ -144,7 +144,7 @@ module.exports = function (log, error) {
          * Code below will fetch the email record and if it is an unverified new account then it will delete
          * the account.
          */
-        const suggestAccountDeletion = !! bounce && bounce.bounceType
+        const suggestAccountDeletion = !! bounce.bounceType
         const work = []
 
         if (emailIsValid) {


### PR DESCRIPTION
This wasn't actually causing anything to be wrong and it's covered by tests so I almost didn't bother changing it. But the operator precedence is slightly different to what was (presumably) assumed by this code and it came up in https://github.com/mozilla/fxa-auth-server/pull/2602#issuecomment-416592053, so I figured it's worth honouring both the spirit and the letter of the law.

Anyway, `!` has [higher precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table) than `&&`, which means that this line:

```js
const suggestAccountDeletion = !! bounce && bounce.bounceType
```

...is the same as:

```js
const suggestAccountDeletion = (!! bounce) && bounce.bounceType
```

...so it ends up resolving to either the value of the `bounceType` property or `false` if `bounce` is falsey.

Logically that makes no difference to us because of coercion rules, but it still seems like the intention of the code was that `suggestAccountDeletion` should be boolean. Ergo, this PR forces it to be so.

@mozilla/fxa-devs r?