### PR TITLE
fix(config): update correct recoveryCodes config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -884,11 +884,6 @@ var conf = convict({
       env: 'TOTP_WINDOW'
     },
     recoveryCodes: {
-      length: {
-        doc: 'The length of a recovery code',
-        default: 10,
-        env: 'RECOVERY_CODE_LENGTH'
-      },
       count: {
         doc: 'Number of recovery codes to create',
         default: 8,

--- a/lib/routes/totp.js
+++ b/lib/routes/totp.js
@@ -29,7 +29,7 @@ module.exports = (log, db, mailer, customs, config) => {
   // Ref: https://github.com/soldair/node-qrcode#error-correction-level
   const qrCodeOptions = {errorCorrectionLevel: 'H'}
 
-  const RECOVERY_CODE_COUNT = config.recoveryCodes && config.recoveryCodes.codeCount || 8
+  const RECOVERY_CODE_COUNT = config.recoveryCodes && config.recoveryCodes.count || 8
 
   P.promisify(qrcode.toDataURL)
 


### PR DESCRIPTION
Not associated with an issue, just some config cleanup found while working on https://github.com/mozilla/fxa-content-server/pull/6482. 

This removes the `recoveryCodes.length` config since it is not configurable via the auth-server but rather the auth-db-server. This also uses the correct recovery code count value.