### PR TITLE
fix(logging): log errors when reading/parsing live email config

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -430,10 +430,14 @@ module.exports = function (log, config) {
     }
 
     return redis.get('config')
-      .catch(() => {})
+      .catch(err => log.error({ op: 'emailConfig.read.error', err: err.message }))
       .then(liveConfig => {
         if (liveConfig) {
-          liveConfig = JSON.parse(liveConfig)
+          try {
+            liveConfig = JSON.parse(liveConfig)
+          } catch (err) {
+            log.error({ op: 'emailConfig.parse.error', err: err.message })
+          }
         }
 
         return emailAddresses.reduce((promise, emailAddress) => {


### PR DESCRIPTION
Related to #2577.

Speaking to @jrgm just now he noticed that this problem is only intermittent in stage too. That made me wonder if the call to `redis.get` is failing and, foolishly, like a fool, I didn't put any logging inside that `catch`.

This adds logging both there and around the associated `JSON.parse`, even though we know the latter is not a problem here because the call to `sendMail` itself is succeeding. But anyway, they could both do with some logging.

@mozilla/fxa-devs r?