### PR TITLE
chore(tests): switch from insist to chai for assertions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -178,9 +178,9 @@
       }
     },
     "@tyriar/fibonacci-heap": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.7.tgz",
-      "integrity": "sha512-DANf9u0VN5oWrRk31B+xCy9mMNx1H9YhWUaTzCzU0uBruj/zg8u9JSw5qpArntvfJxaW/gWGWbQtzpAkYO6VBg=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.8.tgz",
+      "integrity": "sha512-yujW2S09dkH3uBUiTR5GtMni7LgQS2bSm1ezjugyUzuzM7JUkNvNRMwUL7/bee8gv812zhw1Yw/aIzL47UbTVQ=="
     },
     "JSONStream": {
       "version": "1.3.4",
@@ -568,9 +568,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.34",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.34.tgz",
-      "integrity": "sha512-+w6B0Uo0ZvTSzDkXjoBCTNK0oe+aVL+yPi7kwGZm8hd8+Nj1AFPoxoq1Bl/mEu/G/ivOkUc1LRqVR0XeWFUzuA=="
+      "version": "1.6.35",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.35.tgz",
+      "integrity": "sha512-jqLsX6dzmPHOhApAUyGwrpzqn3DXpdTqbOM6baPys7A423ys7IsTpcucDVGP0PmzxGsPYbW3xVOJ4SxAzI0vqQ=="
     },
     "big-time": {
       "version": "2.0.1",
@@ -861,19 +861,22 @@
       }
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
         "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -887,6 +890,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
       "integrity": "sha1-wN3kqxgnE7kZuXCVmhI+zBow/NY="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -987,18 +996,18 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -1662,7 +1671,7 @@
     },
     "css": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/css/-/css-1.0.8.tgz",
       "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
       "requires": {
         "css-parse": "1.0.4",
@@ -1753,20 +1762,12 @@
       }
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -2080,9 +2081,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+          "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
           "dev": true
         }
       }
@@ -2135,7 +2136,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -2837,7 +2838,7 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fxa-auth-db-mysql": {
-      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#a01e4aaf98d23d92a64f76ffa0fe7cc3aca4013a",
+      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#13ca41572f6e5af9a72f949dc6e0ad51e3afc1fa",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "dev": true,
       "requires": {
@@ -8407,7 +8408,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.9.15",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
           "integrity": "sha1-gLNxN8He5C76yGSGsK/F+Fg1SrA="
         }
       }
@@ -8429,10 +8430,13 @@
       }
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
@@ -8452,6 +8456,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-pkg-repo": {
       "version": "1.4.0",
@@ -9041,7 +9051,7 @@
     },
     "handlebars": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
       "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
       "requires": {
         "async": "^1.4.0",
@@ -9400,9 +9410,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9473,24 +9483,6 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.0",
         "through": "^2.3.6"
-      }
-    },
-    "insist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/insist/-/insist-1.0.1.tgz",
-      "integrity": "sha1-ITdKECnUoTpidEEV38LTMTQYldQ=",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.0",
-        "stack-trace": "^0.0.10"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "intel": {
@@ -10360,7 +10352,7 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -10413,7 +10405,7 @@
     },
     "mailparser": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/mailparser/-/mailparser-0.6.1.tgz",
       "integrity": "sha1-PeTbP0qQwWDAbYy4uCWn8cb2p8M=",
       "dev": true,
       "requires": {
@@ -10596,16 +10588,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimelib": {
@@ -10662,7 +10654,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -10677,7 +10669,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10685,7 +10677,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -10798,9 +10790,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "optional": true
     },
     "natural-compare": {
@@ -10873,6 +10865,17 @@
         "qs": "^6.0.2"
       },
       "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10881,6 +10884,29 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
         }
       }
     },
@@ -10889,7 +10915,7 @@
       "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
       "requires": {
         "array.prototype.find": "2.0.0",
-        "uap-core": "git://github.com/ua-parser/uap-core.git#fdee91274bbd6c36dd9f7d9b6673db80505d2c53",
+        "uap-core": "git://github.com/ua-parser/uap-core.git#f4d16a53e4771cf6deed18eb7273226606a4de21",
         "uap-ref-impl": "0.2.0",
         "yamlparser": "0.0.2"
       }
@@ -10971,7 +10997,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -12196,7 +12222,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
@@ -12231,7 +12257,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -12239,7 +12265,7 @@
     },
     "otplib": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/otplib/-/otplib-8.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/otplib/-/otplib-8.0.1.tgz",
       "integrity": "sha512-dtW+K211t2MR/8zNoLP0/l46vdhJ+Y7bv4qOaPEktXVjYCxTU6P4Y0/g8DZ49A20ILMHHORP6SzM+7a8wj+sYQ==",
       "requires": {
         "thirty-two": "1.0.2"
@@ -12324,6 +12350,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pem-jwk": {
       "version": "1.5.1",
@@ -13058,7 +13090,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scrypt-hash": {
@@ -13154,7 +13186,7 @@
     },
     "sinon": {
       "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.5.tgz",
+      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.5.tgz",
       "integrity": "sha1-EDjLqDDjcBLpmmSDfs07ZyAMBYw=",
       "dev": true,
       "requires": {
@@ -13424,7 +13456,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -13608,7 +13640,7 @@
         },
         "uglify-js": {
           "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
           "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
           "requires": {
             "optimist": "~0.3.5",
@@ -13659,9 +13691,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -13670,7 +13702,7 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uap-core": {
-      "version": "git://github.com/ua-parser/uap-core.git#fdee91274bbd6c36dd9f7d9b6673db80505d2c53",
+      "version": "git://github.com/ua-parser/uap-core.git#f4d16a53e4771cf6deed18eb7273226606a4de21",
       "from": "git://github.com/ua-parser/uap-core.git"
     },
     "uap-ref-impl": {
@@ -13723,7 +13755,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
             "camelcase": "^1.0.2",
@@ -13940,7 +13972,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -13954,9 +13986,9 @@
       "dev": true
     },
     "wreck": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
-      "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.0.tgz",
+      "integrity": "sha512-y/iwFhwdGoM8Hk1t1I4LbuLhM3curVD8STd5NcFI0c/4b4cQAMLcnCRxXX9sLQAggDC8dXYSaQNsT64hga6lvA==",
       "requires": {
         "boom": "7.x.x",
         "hoek": "5.x.x"
@@ -14046,7 +14078,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "acorn": "5.0.3",
+    "chai": "4.1.2",
     "commander": "2.9.0",
     "eslint-plugin-fxa": "git+https://github.com/mozilla/eslint-plugin-fxa#master",
     "fxa-auth-db-mysql": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
@@ -100,7 +101,6 @@
     "grunt-newer": "1.2.0",
     "hawk": "7.0.7",
     "husky": "0.14.3",
-    "insist": "1.0.1",
     "jsxgettext-recursive": "1.0.1",
     "jws": "3.1.5",
     "leftpad": "0.0.0",

--- a/test/e2e/push_tests.js
+++ b/test/e2e/push_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require('../../config').getProperties()
 const { mockDB, mockLog } = require('../mocks')
 const { PushManager } = require('../push_helper')

--- a/test/local/authMethods.js
+++ b/test/local/authMethods.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const sinon = require('sinon')
-const assert = Object.assign({}, sinon.assert, require('insist'))
+const assert = { ...sinon.assert, ...require('chai').assert }
 
 const mocks = require('../mocks')
 const P = require('../../lib/promise')

--- a/test/local/bounces.js
+++ b/test/local/bounces.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require(`${ROOT_DIR}/config`).getProperties()
 const createBounces = require(`${ROOT_DIR}/lib/bounces`)
 const error = require(`${ROOT_DIR}/lib/error`)

--- a/test/local/cache.js
+++ b/test/local/cache.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const Memcached = require('memcached')
 const mocks = require('../mocks')

--- a/test/local/crypto/hkdf.js
+++ b/test/local/crypto/hkdf.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const hkdf = require('../../../lib/crypto/hkdf')
 
 describe('hkdf', () => {

--- a/test/local/crypto/pbkdf2.js
+++ b/test/local/crypto/pbkdf2.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const pbkdf2 = require('../../../lib/crypto/pbkdf2')
 const ITERATIONS = 20000
 const LENGTH = 32

--- a/test/local/crypto/random.js
+++ b/test/local/crypto/random.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const random = require('../../../lib/crypto/random')
 const base10 = random.base10

--- a/test/local/crypto/scrypt.js
+++ b/test/local/crypto/scrypt.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var promise = require('../../../lib/promise')
 var config = { scrypt: { maxPending: 5 } }
 var log = {

--- a/test/local/customs.js
+++ b/test/local/customs.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const log = {
   trace: () => {},
   activityEvent: () => {},

--- a/test/local/db.js
+++ b/test/local/db.js
@@ -6,7 +6,7 @@
 
 const LIB_DIR = '../../lib'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../mocks')
 const P = require(`${LIB_DIR}/promise`)
 const proxyquire = require('proxyquire')
@@ -516,7 +516,7 @@ describe('redis enabled, token-pruning enabled:', () => {
           uaOS: 'Android',
           uaOSVersion: '8.1',
           uaDeviceType: 'mobile',
-          uaFormFactor: null,
+          uaFormFactor: undefined,
           location: {
             city: 'Mountain View',
             state: 'California',
@@ -582,8 +582,8 @@ describe('redis enabled, token-pruning enabled:', () => {
           uaBrowserVersion: '59',
           uaOS: 'Mac OS X',
           uaOSVersion: '10.11',
-          uaDeviceType: null,
-          uaFormFactor: null,
+          uaDeviceType: undefined,
+          uaFormFactor: undefined,
           location: {
             city: 'Bournemouth',
             state: 'England',

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const mocks = require('../mocks')
 const uuid = require('uuid')

--- a/test/local/email/bounce.js
+++ b/test/local/email/bounce.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const bounces = require(`${ROOT_DIR}/lib/email/bounces`)
 const error = require(`${ROOT_DIR}/lib/error`)
 const { EventEmitter } = require('events')

--- a/test/local/email/delivery.js
+++ b/test/local/email/delivery.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const EventEmitter = require('events').EventEmitter
 const { mockLog } = require('../../mocks')

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const P = require(`${ROOT_DIR}/lib/promise`)
 const { mockLog } = require('../../mocks')
 const proxyquire = require('proxyquire')

--- a/test/local/error.js
+++ b/test/local/error.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var messages = require('joi/lib/language')
 const AppError = require('../../lib/error')
 

--- a/test/local/features.js
+++ b/test/local/features.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 

--- a/test/local/geodb.js
+++ b/test/local/geodb.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const proxyquire = require('proxyquire')
 const mockLog = require('../mocks').mockLog
 const modulePath = '../../lib/geodb'

--- a/test/local/ip_profiling.js
+++ b/test/local/ip_profiling.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const getRoute = require('../routes_helpers').getRoute
 const mocks = require('../mocks')

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 

--- a/test/local/mailer_locales.js
+++ b/test/local/mailer_locales.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require(`${ROOT_DIR}/config/index`).getProperties()
 const error = require(`${ROOT_DIR}/lib/error`)
 const mocks = require('../mocks')

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const amplitudeModule = require('../../../lib/metrics/amplitude')
 const mocks = require('../../mocks')
 

--- a/test/local/metrics/context.js
+++ b/test/local/metrics/context.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 const log = {
   activityEvent: sinon.spy(),

--- a/test/local/mock-sns.js
+++ b/test/local/mock-sns.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 // noPreserveCache is needed to prevent the mock mailer from
 // being used for all future tests that include mock-nexmo.
 const proxyquire = require('proxyquire').noPreserveCache()

--- a/test/local/notifier.js
+++ b/test/local/notifier.js
@@ -7,7 +7,7 @@
 const ROOT_DIR = '../..'
 
 const proxyquire = require('proxyquire')
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 
 describe('notifier', () => {

--- a/test/local/password.js
+++ b/test/local/password.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const log = {}
 const config = {}
 const Password = require('../../lib/crypto/password')(log, config)

--- a/test/local/pool.js
+++ b/test/local/pool.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../mocks')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')

--- a/test/local/profile/updates.js
+++ b/test/local/profile/updates.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const EventEmitter = require('events').EventEmitter
 const sinon = require('sinon')

--- a/test/local/push.js
+++ b/test/local/push.js
@@ -8,7 +8,7 @@ const ROOT_DIR = '../..'
 
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const assert = Object.assign({}, sinon.assert, require('insist'))
+const assert = { ...sinon.assert, ...require('chai').assert }
 const ajv = require('ajv')()
 const fs = require('fs')
 const path = require('path')

--- a/test/local/pushbox.js
+++ b/test/local/pushbox.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const {mockLog} = require('../mocks')
@@ -52,13 +52,13 @@ describe('pushbox', () => {
           assert.equal(args.length, 3)
           assert.equal(args[0]._template.toString(), '/v1/store/:uid/:deviceId')
           assert.deepEqual(args[1], {uid: mockUid, deviceId: mockDeviceIds[0]})
-          assert.deepEqual(args[2], {query: {limit:50, index:10}, headers: {Authorization: `FxA-Server-Key ${mockConfig.pushbox.key}`}})
+          assert.deepEqual(args[2], {query: {limit:'50', index:'10'}, headers: {Authorization: `FxA-Server-Key ${mockConfig.pushbox.key}`}})
 
           assert.deepEqual(resp, {
             last: true,
-            index: '15',
+            index: 15,
             messages: [{
-              index: '15',
+              index: 15,
               data: { foo: 'bar', bar: 'bar' }
             }]
           })

--- a/test/local/redis/connection.js
+++ b/test/local/redis/connection.js
@@ -6,7 +6,7 @@
 
 const LIB_DIR = '../../../lib'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../../mocks')
 const P = require(`${LIB_DIR}/promise`)
 const redisConnection = require(`${LIB_DIR}/redis/connection`)

--- a/test/local/redis/index.js
+++ b/test/local/redis/index.js
@@ -6,7 +6,7 @@
 
 const LIB_DIR = '../../../lib'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../../mocks')
 const P = require(`${LIB_DIR}/promise`)
 const proxyquire = require('proxyquire')

--- a/test/local/redis/pool.js
+++ b/test/local/redis/pool.js
@@ -6,7 +6,7 @@
 
 const LIB_DIR = '../../../lib'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../../mocks')
 const P = require(`${LIB_DIR}/promise`)
 const proxyquire = require('proxyquire')

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -6,7 +6,7 @@
 
 var sinon = require('sinon')
 
-const assert = require('insist')
+const { assert } = require('chai')
 var mocks = require('../../mocks')
 var getRoute = require('../../routes_helpers').getRoute
 var proxyquire = require('proxyquire')

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const sinon = require('sinon')
-const assert = Object.assign({}, sinon.assert, require('insist'))
+const assert = { ...sinon.assert, ...require('chai').assert }
 const crypto = require('crypto')
 const error = require('../../../lib/error')
 const getRoute = require('../../routes_helpers').getRoute

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -6,7 +6,7 @@
 
 var sinon = require('sinon')
 
-const assert = require('insist')
+const { assert } = require('chai')
 var mocks = require('../../mocks')
 var getRoute = require('../../routes_helpers').getRoute
 var proxyquire = require('proxyquire')

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var mocks = require('../../mocks')
 var getRoute = require('../../routes_helpers').getRoute
 

--- a/test/local/routes/recovery-codes.js
+++ b/test/local/routes/recovery-codes.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const sinon = require('sinon')
-const assert = Object.assign({}, sinon.assert, require('insist'))
+const assert = { ...sinon.assert, ...require('chai').assert }
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 const error = require('../../../lib/error')

--- a/test/local/routes/recovery-keys.js
+++ b/test/local/routes/recovery-keys.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 const P = require('../../../lib/promise')

--- a/test/local/routes/request_helper.js
+++ b/test/local/routes/request_helper.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const requestHelper = require('../../../lib/routes/utils/request_helper')
 
 describe('requestHelper', () => {

--- a/test/local/routes/session.js
+++ b/test/local/routes/session.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')

--- a/test/local/routes/sign.js
+++ b/test/local/routes/sign.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const uuid = require('uuid')
 const getRoute = require('../../routes_helpers').getRoute

--- a/test/local/routes/signin-codes.js
+++ b/test/local/routes/signin-codes.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const AppError = require('../../../lib/error')
-const assert = require('insist')
+const { assert } = require('chai')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 const P = require('../../../lib/promise')

--- a/test/local/routes/token-codes.js
+++ b/test/local/routes/token-codes.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const errors = require('../../../lib/error')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')

--- a/test/local/routes/totp.js
+++ b/test/local/routes/totp.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 const otplib = require('otplib')

--- a/test/local/routes/unblock-codes.js
+++ b/test/local/routes/unblock-codes.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const getRoute = require('../../routes_helpers').getRoute
 const mocks = require('../../mocks')
 const P = require('../../../lib/promise')

--- a/test/local/routes/utils/signin.js
+++ b/test/local/routes/utils/signin.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const sinon = require('sinon')
-const assert = Object.assign({}, sinon.assert, require('insist'))
+const assert = { ...sinon.assert, ...require('chai').assert }
 
 const P = require('../../../../lib/promise')
 const mocks = require('../../../mocks')
@@ -140,12 +140,8 @@ describe('checkEmailAddress', () => {
   })
 
   it('should throw when email does not match primary after normalization', () => {
-    assert.throws(() => checkEmailAddress(accountRecord, 'secondary@test.net'), (err) => {
-      return err.errno === error.ERRNO.LOGIN_WITH_SECONDARY_EMAIL
-    }, 'threw the correct error')
-    assert.throws(() => checkEmailAddress(accountRecord, 'something@else.org'), (err) => {
-      return err.errno === error.ERRNO.LOGIN_WITH_SECONDARY_EMAIL
-    }, 'threw the correct error')
+    assert.throws(() => checkEmailAddress(accountRecord, 'secondary@test.net'), 'Sign in with this email type is not currently supported')
+    assert.throws(() => checkEmailAddress(accountRecord, 'something@else.org'), 'Sign in with this email type is not currently supported')
   })
 
   describe('with originalLoginEmail parameter', () => {
@@ -156,12 +152,8 @@ describe('checkEmailAddress', () => {
     })
 
     it('should throw when originalLoginEmail does not match primary after normalization', () => {
-      assert.throws(() => checkEmailAddress(accountRecord, 'other@email', 'secondary@test.net'), (err) => {
-        return err.errno === error.ERRNO.LOGIN_WITH_SECONDARY_EMAIL
-      }, 'threw the correct error')
-      assert.throws(() => checkEmailAddress(accountRecord, 'other@email', 'something@else.org'), (err) => {
-        return err.errno === error.ERRNO.LOGIN_WITH_SECONDARY_EMAIL
-      }, 'threw the correct error')
+      assert.throws(() => checkEmailAddress(accountRecord, 'other@email', 'secondary@test.net'), 'Sign in with this email type is not currently supported')
+      assert.throws(() => checkEmailAddress(accountRecord, 'other@email', 'something@else.org'), 'Sign in with this email type is not currently supported')
     })
   })
 })

--- a/test/local/routes/validators.js
+++ b/test/local/routes/validators.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const validators = require('../../../lib/routes/validators')
 

--- a/test/local/safe-url.js
+++ b/test/local/safe-url.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../mocks')
 
 const SOME_DISALLOWED_GRAPHEMES = [

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const cp = require('child_process')
 const mocks = require('../../mocks')
 const P = require('bluebird')
@@ -831,6 +831,12 @@ describe(
             assert.equal(mailerSend1.args[0].op, 'mailer.send.1', 'logs mailer.send.1')
             assert.equal(mailerSend1.args[0].to, message.email, 'logs sender to email address')
           })
+      })
+    })
+
+    describe('mock failing sendMail method:', () => {
+      beforeEach(() => {
+        sinon.stub(mailer.mailer, 'sendMail', (config, cb) => cb(new Error('Fail')))
       })
 
       it('rejects sendMail status', () => {

--- a/test/local/senders/email_service.js
+++ b/test/local/senders/email_service.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const proxyquire = require('proxyquire')
 
 const config = require(`${ROOT_DIR}/config`).getProperties()

--- a/test/local/senders/index.js
+++ b/test/local/senders/index.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require(`${ROOT_DIR}/config`).getProperties()
 const crypto = require('crypto')
 const error = require(`${ROOT_DIR}/lib/error`)

--- a/test/local/senders/legacy_log.js
+++ b/test/local/senders/legacy_log.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var sinon = require('sinon')
 const legacyLog = require('../../../lib/senders/legacy_log')
 

--- a/test/local/senders/oauth_client_info.js
+++ b/test/local/senders/oauth_client_info.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const mocks = require('../../mocks')
 const P = require('bluebird')
 const proxyquire = require('proxyquire')

--- a/test/local/senders/templates.js
+++ b/test/local/senders/templates.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 describe('lib/senders/templates/index:', () => {
   let templates

--- a/test/local/senders/translator.js
+++ b/test/local/senders/translator.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 require('../../../lib/senders/translator')(['en', 'pt_br', 'DE', 'ES_AR', 'ES_cl'], 'en')
 .then(translator => {

--- a/test/local/sentry.js
+++ b/test/local/sentry.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const Hapi = require('hapi')
 

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const EndpointError = require('poolee/lib/error')(require('util').inherits)
 const error = require(`${ROOT_DIR}/lib/error`)
 const hawk = require('hawk')

--- a/test/local/time.js
+++ b/test/local/time.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 describe('require:', () => {
   let time

--- a/test/local/tokens/account_reset_token.js
+++ b/test/local/tokens/account_reset_token.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const log = { trace() {} }
 const tokens = require('../../../lib/tokens/index')(log)

--- a/test/local/tokens/forgot_password_token.js
+++ b/test/local/tokens/forgot_password_token.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const log = { trace() {} }
 
 const timestamp = Date.now()

--- a/test/local/tokens/key_fetch_token.js
+++ b/test/local/tokens/key_fetch_token.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const log = { trace () {}, error () {} }
 

--- a/test/local/tokens/session_token.js
+++ b/test/local/tokens/session_token.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 const log = {
   trace () {},

--- a/test/local/tokens/token.js
+++ b/test/local/tokens/token.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require('../../../config').getProperties()
 var random = require('../../../lib/crypto/random')
 var hkdf = require('../../../lib/crypto/hkdf')

--- a/test/local/user_agent.js
+++ b/test/local/user_agent.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
 
@@ -559,12 +559,12 @@ describe('userAgent, real dependency', () => {
       os: 'iOS',
       osVersion: '1.0',
       deviceType: 'mobile',
-      formFactor: null
+      formFactor: undefined
     })
     assert.deepEqual(userAgent('<a>foo</a>-iPhone/2 CFNetwork'), {
       browser: null,
       browserVersion: '2',
-      os: null,
+      os: undefined,
       osVersion: null,
       deviceType: 'mobile',
       formFactor: 'iPhone'
@@ -572,10 +572,10 @@ describe('userAgent, real dependency', () => {
     assert.deepEqual(userAgent('wibble\t/7 CFNetwork'), {
       browser: null,
       browserVersion: '7',
-      os: null,
+      os: undefined,
       osVersion: null,
       deviceType: null,
-      formFactor: null
+      formFactor: undefined
     })
   })
 })

--- a/test/remote/account_create_tests.js
+++ b/test/remote/account_create_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 var crypto = require('crypto')
 const Client = require('../client')()

--- a/test/remote/account_destroy_tests.js
+++ b/test/remote/account_destroy_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/account_locale_tests.js
+++ b/test/remote/account_locale_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/account_reset_tests.js
+++ b/test/remote/account_reset_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var url = require('url')
 const Client = require('../client')()
 var TestServer = require('../test_server')

--- a/test/remote/account_signin_verification_tests.js
+++ b/test/remote/account_signin_verification_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var config = require('../../config').getProperties()

--- a/test/remote/account_status_tests.js
+++ b/test/remote/account_status_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/account_unlock_tests.js
+++ b/test/remote/account_unlock_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/base_path_tests.js
+++ b/test/remote/base_path_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const P = require('../../lib/promise')

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var jwtool = require('fxa-jwtool')

--- a/test/remote/concurrent_tests.js
+++ b/test/remote/concurrent_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var P = require('../../lib/promise')

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const base64url = require('base64url')
 const config = require('../../config').getProperties()
 const crypto = require('crypto')

--- a/test/remote/device_tests.js
+++ b/test/remote/device_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const config = require('../../config').getProperties()

--- a/test/remote/email_validity_tests.js
+++ b/test/remote/email_validity_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var P = require('../../lib/promise')

--- a/test/remote/flow_tests.js
+++ b/test/remote/flow_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const Client = require('../client')()
 var TestServer = require('../test_server')
 var jwtool = require('fxa-jwtool')

--- a/test/remote/hpkp_tests.js
+++ b/test/remote/hpkp_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 const P = require('../../lib/promise')
 const TestServer = require('../test_server')

--- a/test/remote/misc_tests.js
+++ b/test/remote/misc_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const P = require('../../lib/promise')

--- a/test/remote/password_change_tests.js
+++ b/test/remote/password_change_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const Client = require('../client')()
 var config = require('../../config').getProperties()
 var TestServer = require('../test_server')

--- a/test/remote/password_forgot_tests.js
+++ b/test/remote/password_forgot_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var url = require('url')
 const Client = require('../client')()
 var TestServer = require('../test_server')

--- a/test/remote/push_db_tests.js
+++ b/test/remote/push_db_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var P = require('../../lib/promise')
 var uuid = require('uuid')
 var crypto = require('crypto')

--- a/test/remote/recovery_code_tests.js
+++ b/test/remote/recovery_code_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require('../../config').getProperties()
 const TestServer = require('../test_server')
 const Client = require('../client')()

--- a/test/remote/recovery_email_change_email.js
+++ b/test/remote/recovery_email_change_email.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/recovery_email_emails.js
+++ b/test/remote/recovery_email_emails.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const ERRNO = require('../../lib/error').ERRNO

--- a/test/remote/recovery_email_resend_code_tests.js
+++ b/test/remote/recovery_email_resend_code_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const Client = require('../client')()
 var TestServer = require('../test_server')
 const P = require('../../lib/promise')

--- a/test/remote/recovery_email_verify_tests.js
+++ b/test/remote/recovery_email_verify_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var url = require('url')
 const Client = require('../client')()
 var TestServer = require('../test_server')

--- a/test/remote/recovery_key_tests.js
+++ b/test/remote/recovery_key_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require('../../config').getProperties()
 const crypto = require('crypto')
 const TestServer = require('../test_server')

--- a/test/remote/redis_tests.js
+++ b/test/remote/redis_tests.js
@@ -6,7 +6,7 @@
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require(`${ROOT_DIR}/config`).getProperties()
 const P = require(`${ROOT_DIR}/lib/promise`)
 

--- a/test/remote/session_tests.js
+++ b/test/remote/session_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const P = require('../../lib/promise')

--- a/test/remote/sign_key_tests.js
+++ b/test/remote/sign_key_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const P = require('../../lib/promise')
 const TestServer = require('../test_server')
 const request = P.promisify(require('request'), { multiArgs: true })

--- a/test/remote/signin_code_tests.js
+++ b/test/remote/signin_code_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const error = require('../../lib/error')

--- a/test/remote/sms_tests.js
+++ b/test/remote/sms_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const TestServer = require('../test_server')
 const Client = require('../client')()
 const config = require('../../config').getProperties()

--- a/test/remote/token_code_tests.js
+++ b/test/remote/token_code_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const config = require('../../config').getProperties()
 const TestServer = require('../test_server')
 const Client = require('../client')()

--- a/test/remote/token_expiry_tests.js
+++ b/test/remote/token_expiry_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 

--- a/test/remote/totp_tests.js
+++ b/test/remote/totp_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const config = require('../../config').getProperties()
 const TestServer = require('../test_server')

--- a/test/remote/verifier_upgrade_tests.js
+++ b/test/remote/verifier_upgrade_tests.js
@@ -4,7 +4,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 var TestServer = require('../test_server')
 const Client = require('../client')()
 var createDBServer = require('fxa-auth-db-mysql')

--- a/test/scripts/email-config.js
+++ b/test/scripts/email-config.js
@@ -7,7 +7,7 @@
 const ROOT_DIR = '../..'
 const LIB_DIR = `${ROOT_DIR}/lib`
 
-const assert = require('insist')
+const { assert } = require('chai')
 const cp = require('child_process')
 const mocks = require(`${ROOT_DIR}/test/mocks`)
 const P = require('bluebird')


### PR DESCRIPTION
This PR was mostly generated by the following script:

```sh
#!/bin/sh

FILES=`git grep "require('insist')" | cut -d ':' -f 1`
for FILE in $FILES
do
  sed -i '' "s/^const assert = require('insist')$/const { assert } = require('chai')/" "$FILE"
  sed -i '' "s/^const assert = Object.assign({}, sinon.assert, require('insist'))$/const assert = { ...sinon.assert, ...require('chai').assert }/" "$FILE"
done
```

That took care of the simple replacements but left us with 7 failing tests. 6 of those failures were due to a difference in the behaviour of `deepEqual`, where insist uses `==` but chai uses `===`. The other one was genuinely weird:

```
  6) lib/senders/email:
       mock sendMail method:
         rejects sendMail status:
     AssertionError: expected [ { resp: 'ok' } ] to be falsy
      at tryCatcher (node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (node_modules/bluebird/js/release/promise.js:512:31)
      at Promise._settlePromise (node_modules/bluebird/js/release/promise.js:569:18)
      at Promise._settlePromise0 (node_modules/bluebird/js/release/promise.js:614:10)
      at Promise._settlePromises (node_modules/bluebird/js/release/promise.js:693:18)
      at Async._drainQueue (node_modules/bluebird/js/release/async.js:133:16)
      at Async._drainQueues (node_modules/bluebird/js/release/async.js:143:10)
      at Immediate.Async.drainQueues (node_modules/bluebird/js/release/async.js:17:14)
```

Digging into the test, it looked to me like the setup was wrong and it should have been failing previously. I don't understand why it wasn't but will call the fix out in the inline comments so you can see for yourselves what I've changed.

@mozilla/fxa-devs r?