### PR TITLE
fix(tests): split running remote and local tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2951,7 +2951,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4747,8 +4746,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "optional": true
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -4977,7 +4975,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5242,8 +5239,7 @@
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "optional": true
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "loud-rejection": {
           "version": "1.6.0",
@@ -7409,8 +7405,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "optional": true
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
           "version": "2.0.1",
@@ -12590,9 +12585,9 @@
       "dev": true
     },
     "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.0.tgz",
+      "integrity": "sha512-TO9TAIz0mpa+SKddXsgCFatoe/KmHvoNVj2jDMC1kXE6kKn7/4CRpxvQ+0wAK9sbMT2FVO89qItlvnZMcFbJ2Q==",
       "dev": true,
       "requires": {
         "fill-keys": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "nock": "8.0.0",
     "npmshrink": "1.0.1",
     "nyc": "13.0.0",
-    "proxyquire": "1.8.0",
+    "proxyquire": "2.0.0",
     "simplesmtp": "0.3.35",
     "sinon": "1.17.5",
     "sjcl": "1.0.6",

--- a/scripts/mocha-coverage.js
+++ b/scripts/mocha-coverage.js
@@ -13,7 +13,7 @@ const MOCHA_BIN = path.join(path.dirname(__dirname), 'node_modules', '.bin', 'mo
 const NYC_BIN = path.join(path.dirname(__dirname), 'node_modules', '.bin', 'nyc')
 
 let bin = NYC_BIN
-let argv = ['--cache', MOCHA_BIN]
+let argv = ['--cache', '--no-clean', MOCHA_BIN]
 
 if (process.env.NO_COVERAGE) {
   bin = MOCHA_BIN

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -7,14 +7,20 @@ if [ -z "$CORS_ORIGIN" ]; then export CORS_ORIGIN="http://foo,http://bar"; fi;
 
 set -u
 
-GLOB=$*
-if [ -z "$GLOB" ]; then
-  GLOB="test/local test/remote"
-fi
-
 DEFAULT_ARGS="-R dot --recursive --timeout 5000 --exit"
 
 ./scripts/gen_keys.js
 ./scripts/gen_vapid_keys.js
-./scripts/mocha-coverage.js $DEFAULT_ARGS $GLOB
+
+GLOB=$*
+if [ -z "$GLOB" ]; then
+  echo "Local tests"
+  ./scripts/mocha-coverage.js $DEFAULT_ARGS test/local
+
+  echo "Remote tests"
+  ./scripts/mocha-coverage.js $DEFAULT_ARGS test/remote
+else
+  ./scripts/mocha-coverage.js $DEFAULT_ARGS $GLOB
+fi
+
 grunt eslint copyright

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -683,15 +683,13 @@ describe('remote db', function() {
         .then(function(passwordForgotToken) {
           return db.forgotPasswordVerified(passwordForgotToken)
             .then(accountResetToken => {
-              assert.ok(accountResetToken.createdAt > passwordForgotToken.createdAt, 'account reset token should be newer than password forgot token')
+              assert.ok(accountResetToken.createdAt >= passwordForgotToken.createdAt, 'account reset token should be equal or newer than password forgot token')
               return accountResetToken
             })
         })
         .then(function(accountResetToken) {
           assert.deepEqual(accountResetToken.uid, account.uid, 'account reset token uid should be the same as the account.uid')
           tokenId = accountResetToken.id
-        })
-        .then(function() {
           return db.accountResetToken(tokenId)
         })
         .then(function(accountResetToken) {
@@ -702,15 +700,13 @@ describe('remote db', function() {
         .then(function(accountResetToken) {
           return db.deleteAccountResetToken(accountResetToken)
         })
-        .then(function() {
+        .then(function () {
           return db.accountResetToken(tokenId)
-        })
-        .then(function(accountResetToken) {
-          assert(false, 'The above accountResetToken() call should fail, since the accountResetToken has been deleted')
-        }, function(err) {
-          assert.equal(err.errno, 110, 'accountResetToken() fails with the correct error code')
-          var msg = 'Error: The authentication token could not be found'
-          assert.equal(msg, '' + err, 'accountResetToken() fails with the correct message')
+            .then(assert.fail, function (err) {
+              assert.equal(err.errno, 110, 'accountResetToken() fails with the correct error code')
+              var msg = 'Error: The authentication token could not be found'
+              assert.equal(msg, '' + err, 'accountResetToken() fails with the correct message')
+            })
         })
     }
   )


### PR DESCRIPTION
Another potential fix for https://github.com/mozilla/fxa-auth-server/issues/2534. This PR has successfully ran tests 5 and 10 times in a row, ref https://circleci.com/gh/mozilla/fxa-auth-server/3368.

I think part of the flaky test failures might involve `proxyrequire` and caching modules. When running the local and remote test suites individually I could not get the majority of errors in https://github.com/mozilla/fxa-auth-server/issues/2534. I thought using proxyrequire with `noPreserveCache()` and `noCallThru()` would fix the issue but I could not determine the exact modules that needed them (it is probably very time consuming as well).

To that end, this solution just splits remote and local tests and updates coverage tool to combine from both runs.