### PR TITLE
feat(totp): allow reliers to request totp on login

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -291,6 +291,8 @@ for `code` and `errno` are:
   Recovery key not found.
 * `code: 400, errno: 159`:
   Recovery key is not valid.
+* `code: 400, errno: 160`:
+  This request requires two step authentication enabled on your account.
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -707,6 +709,9 @@ by the following errors
 
 * `code: 400, errno: 149`:
   This email can not currently be used to login
+
+* `code: 400, errno: 160`:
+  This request requires two step authentication enabled on your account.
 
 
 #### GET /account/status
@@ -2620,6 +2625,9 @@ by the following errors
 
 * `code: 400, errno: 149`:
   This email can not currently be used to login
+
+* `code: 400, errno: 160`:
+  This request requires two step authentication enabled on your account.
 
 
 #### GET /session/status

--- a/lib/error.js
+++ b/lib/error.js
@@ -72,6 +72,7 @@ var ERRNO = {
 
   RECOVERY_KEY_NOT_FOUND: 158,
   RECOVERY_KEY_INVALID: 159,
+  TOTP_REQUIRED: 160,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -816,6 +817,15 @@ AppError.recoveryKeyInvalid = () => {
     error: 'Bad Request',
     errno: ERRNO.RECOVERY_KEY_INVALID,
     message: 'Recovery key is not valid.'
+  })
+}
+
+AppError.totpRequired = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.TOTP_REQUIRED,
+    message: 'This request requires two step authentication enabled on your account.'
   })
 }
 

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -518,7 +518,11 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
           return totpUtils.hasTotpToken(accountRecord)
             .then((result) => {
               if (result) {
+                // User has enabled TOTP, no way around it, they must verify TOTP token
                 verificationMethod = 'totp-2fa'
+              } else if (! result && verificationMethod === 'totp-2fa') {
+                // Error if requesting TOTP verification with TOTP not setup
+                throw error.totpRequired()
               }
             })
         }

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -140,7 +140,11 @@ module.exports = function (log, db, Password, config, signinUtils) {
           return totpUtils.hasTotpToken(accountRecord)
             .then((result) => {
               if (result) {
+                // User has enabled TOTP, no way around it, they must verify TOTP token
                 verificationMethod = 'totp-2fa'
+              } else if (! result && verificationMethod === 'totp-2fa') {
+                // Error if requesting TOTP verification with TOTP not setup
+                throw error.totpRequired()
               }
             })
         }

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -201,7 +201,7 @@ function isValidUrl(url, hostnameRegex) {
   return parsed.href
 }
 
-module.exports.verificationMethod = isA.string().valid(['email', 'email-2fa', 'email-captcha'])
+module.exports.verificationMethod = isA.string().valid(['email', 'email-2fa', 'email-captcha', 'totp-2fa'])
 
 module.exports.authPW = isA.string().length(64).regex(HEX_STRING).required()
 module.exports.wrapKb = isA.string().length(64).regex(HEX_STRING)

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -664,6 +664,7 @@ describe('/account/login', function () {
     mockDB.getSecondaryEmail = sinon.spy(() => P.reject(error.unknownSecondaryEmail()))
     mockDB.getSecondaryEmail.reset()
     mockRequest.payload.email = TEST_EMAIL
+    mockRequest.payload.verificationMethod = undefined
   })
 
   it('emits the correct series of calls and events', function () {
@@ -1292,6 +1293,20 @@ describe('/account/login', function () {
     return runTest(route, mockRequest).then(() => assert.ok(false), (err) => {
       assert.equal(mockDB.accountRecord.callCount, 1, 'db.accountRecord was called')
       assert.equal(err.errno, 142, 'correct errno called')
+    })
+  })
+
+  it('fails login when requesting TOTP verificationMethod and TOTP not setup', function () {
+    mockDB.totpToken = sinon.spy(function () {
+      return P.resolve({
+        verified: true,
+        enabled: false
+      })
+    })
+    mockRequest.payload.verificationMethod = 'totp-2fa'
+    return runTest(route, mockRequest).then(() => assert.ok(false), (err) => {
+      assert.equal(mockDB.totpToken.callCount, 1, 'db.totpToken was called')
+      assert.equal(err.errno, 160, 'correct errno called')
     })
   })
 })


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-oauth-server/issues/520

This PR allow's client to request their login be verified via TOTP. If a user does not have TOTP enabled, it throws an error.