### PR TITLE
fix(keys): return proper error when failing to create duplicate recovery key

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -293,6 +293,8 @@ for `code` and `errno` are:
   Recovery key is not valid.
 * `code: 400, errno: 160`:
   This request requires two step authentication enabled on your account.
+* `code: 400, errno: 161`:
+  Recovery key already exists.
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:

--- a/lib/db.js
+++ b/lib/db.js
@@ -1299,6 +1299,13 @@ module.exports = (
     log.trace({op: 'DB.createRecoveryKey', uid})
 
     return this.pool.post(SAFE_URLS.createRecoveryKey, { uid }, { recoveryKeyId, recoveryData })
+      .catch((err) => {
+        if (isRecordAlreadyExistsError(err)) {
+          throw error.recoveryKeyExists()
+        }
+
+        throw err
+      })
   }
 
   SAFE_URLS.getRecoveryKey = new SafeUrl(

--- a/lib/error.js
+++ b/lib/error.js
@@ -73,6 +73,7 @@ var ERRNO = {
   RECOVERY_KEY_NOT_FOUND: 158,
   RECOVERY_KEY_INVALID: 159,
   TOTP_REQUIRED: 160,
+  RECOVERY_KEY_EXISTS: 161,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -826,6 +827,15 @@ AppError.totpRequired = () => {
     error: 'Bad Request',
     errno: ERRNO.TOTP_REQUIRED,
     message: 'This request requires two step authentication enabled on your account.'
+  })
+}
+
+AppError.recoveryKeyExists = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.RECOVERY_KEY_EXISTS,
+    message: 'Recovery key already exists.'
   })
 }
 

--- a/test/remote/recovery_key_tests.js
+++ b/test/remote/recovery_key_tests.js
@@ -153,6 +153,18 @@ describe('remote recovery keys', function () {
       })
   })
 
+  it('should fail to create recovery key when one already exists', () => {
+    return createMockRecoveryKey(client.uid, keys.kB)
+      .then((result) => {
+        recoveryKeyId = result.recoveryKeyId
+        recoveryData = result.recoveryData
+        return client.createRecoveryKey(result.recoveryKeyId, result.recoveryData)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 161, 'correct errno')
+          });
+      })
+  })
+
   describe('check recovery key status', () => {
     describe('with sessionToken', () => {
       it('should return true if recovery key exists', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/6498

This was previously returning a 500 `unexpected error` when a user attempted to create a recovery but already had one. This PR gives them a shiny custom error in that scenario.

<img width="429" alt="screen shot 2018-09-12 at 12 22 01 pm" src="https://user-images.githubusercontent.com/1295288/45439140-05444300-b687-11e8-8980-d241c81ad186.png">
