### PR TITLE
fix(profile): add profileChangedAt to cert sign and profile

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -812,6 +812,12 @@ The `profile` scope includes all the above sub-scopes.
   
   <!--end-response-body-get-accountprofile-authenticatorAssuranceLevel-->
 
+* `profileChangedAt`: *number, min(0)*
+
+  <!--begin-response-body-get-accountprofile-profileChangedAt-->
+  
+  <!--end-response-body-get-accountprofile-profileChangedAt-->
+
 
 #### GET /account/keys
 

--- a/lib/routes/sign.js
+++ b/lib/routes/sign.js
@@ -170,7 +170,8 @@ module.exports = (log, signer, db, domain, devices) => {
                   deviceId: deviceId,
                   tokenVerified: sessionToken.tokenVerified,
                   authenticationMethods: Array.from(sessionToken.authenticationMethods),
-                  authenticatorAssuranceLevel: sessionToken.authenticatorAssuranceLevel
+                  authenticatorAssuranceLevel: sessionToken.authenticatorAssuranceLevel,
+                  profileChangedAt: sessionToken.profileChangedAt
                 }
               )
             }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -27,7 +27,8 @@ module.exports = function (secretKeyFile, domain) {
           'fxa-deviceId': data.deviceId,
           'fxa-tokenVerified': data.tokenVerified,
           'fxa-amr': data.authenticationMethods,
-          'fxa-aal': data.authenticatorAssuranceLevel
+          'fxa-aal': data.authenticatorAssuranceLevel,
+          'fxa-profileChangedAt': data.profileChangedAt
         }
       )
       .then(

--- a/lib/tokens/session_token.js
+++ b/lib/tokens/session_token.js
@@ -35,6 +35,7 @@ module.exports = (log, Token, config) => {
       this.emailCode = details.emailCode || null
       this.emailVerified = !! details.emailVerified
       this.verifierSetAt = details.verifierSetAt
+      this.profileChangedAt = details.profileChangedAt
       this.authAt = details.authAt || 0
       this.locale = details.locale || null
       this.mustVerify = !! details.mustVerify || false

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2838,7 +2838,7 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fxa-auth-db-mysql": {
-      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#022768734985cbd47cee4d6adbda19204fd0ff68",
+      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#0404b8258a465e636d5ce4381f4e9f5c0e773275",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "dev": true,
       "requires": {
@@ -7099,7 +7099,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "optimist": {
@@ -10915,7 +10915,7 @@
       "from": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
       "requires": {
         "array.prototype.find": "2.0.0",
-        "uap-core": "git://github.com/ua-parser/uap-core.git#590f66f40b00644efa6045d06e3c2a605eb22ea1",
+        "uap-core": "git://github.com/ua-parser/uap-core.git#23bfabe34b86f29f4840c9dd1ef6129e685581e3",
         "uap-ref-impl": "0.2.0",
         "yamlparser": "0.0.2"
       }
@@ -12207,7 +12207,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13702,7 +13702,7 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uap-core": {
-      "version": "git://github.com/ua-parser/uap-core.git#590f66f40b00644efa6045d06e3c2a605eb22ea1",
+      "version": "git://github.com/ua-parser/uap-core.git#23bfabe34b86f29f4840c9dd1ef6129e685581e3",
       "from": "git://github.com/ua-parser/uap-core.git"
     },
     "uap-ref-impl": {

--- a/test/remote/account_profile_tests.js
+++ b/test/remote/account_profile_tests.js
@@ -39,6 +39,7 @@ describe('remote account profile', function() {
           assert.equal(response.locale, 'en-US', 'locale is returned')
           assert.deepEqual(response.authenticationMethods, ['pwd', 'email'], 'authentication methods are returned')
           assert.equal(response.authenticatorAssuranceLevel, 1, 'assurance level is returned')
+          assert.ok(response.profileChangedAt, 'profileChangedAt is returned')
         })
     }
   )
@@ -60,6 +61,7 @@ describe('remote account profile', function() {
           assert.equal(response.locale, 'en-US', 'locale is returned')
           assert.deepEqual(response.authenticationMethods, ['pwd', 'email'], 'authentication methods are returned')
           assert.equal(response.authenticatorAssuranceLevel, 1, 'assurance level is returned')
+          assert.ok(response.profileChangedAt, 'profileChangedAt is returned')
         })
     }
   )
@@ -163,6 +165,7 @@ describe('remote account profile', function() {
         .then(response => {
           assert.ok(response.email, 'email address is returned')
           assert.ok(! response.locale, 'locale should not be returned')
+          assert.ok(response.profileChangedAt, 'profileChangedAt is returned')
         })
         .then(() => {
           return client.api.accountProfile(null, {
@@ -175,6 +178,7 @@ describe('remote account profile', function() {
         .then(response => {
           assert.ok(! response.email, 'email address should not be returned')
           assert.equal(response.locale, 'en-US', 'locale is returned')
+          assert.ok(response.profileChangedAt, 'profileChangedAt is returned')
         })
     }
   )
@@ -198,6 +202,7 @@ describe('remote account profile', function() {
           assert.ok(response.locale, 'locale is returned')
           assert.ok(response.authenticationMethods, 'authenticationMethods is returned')
           assert.ok(response.authenticatorAssuranceLevel, 'authenticatorAssuranceLevel is returned')
+          assert.ok(response.profileChangedAt, 'profileChangedAt is returned')
         })
         .then(() => {
           return client.api.accountProfile(null, {

--- a/test/remote/certificate_sign_tests.js
+++ b/test/remote/certificate_sign_tests.js
@@ -52,6 +52,7 @@ describe('remote certificate sign', function() {
           assert.equal(payload['fxa-tokenVerified'], true, 'tokenVerified is correct')
           assert.deepEqual(payload['fxa-amr'].sort(), ['email', 'pwd'], 'amr values are correct')
           assert.equal(payload['fxa-aal'], 1, 'aal value is correct')
+          assert.ok(new Date() - new Date(payload['fxa-profileChangedAt'] * 1000) < 1000 * 60 * 60, 'profileChangedAt is plausible')
         })
     }
   )
@@ -79,6 +80,7 @@ describe('remote certificate sign', function() {
           assert.equal(payload['fxa-tokenVerified'], true, 'tokenVerified is correct')
           assert.deepEqual(payload['fxa-amr'].sort(), ['otp', 'pwd'], 'amr values are correct')
           assert.equal(payload['fxa-aal'], 2, 'aal value is correct')
+          assert.ok(new Date() - new Date(payload['fxa-profileChangedAt'] * 1000) < 1000 * 60 * 60, 'profileChangedAt is plausible')
         })
     }
   )

--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -773,6 +773,7 @@ describe('remote db', function() {
         })
         .then(function(account) {
           assert.ok(account.emailVerified, 'account should now be emailVerified')
+          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     }
   )
@@ -831,6 +832,10 @@ describe('remote db', function() {
         })
         .then(function(exists) {
           assert.equal(exists, true, 'account should still exist')
+          return db.accountRecord(account.email)
+        })
+        .then((account) => {
+          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     }
   )
@@ -1044,8 +1049,9 @@ describe('remote db', function() {
           assert.ok(res, 'ok response')
           return db.accountRecord(secondEmail)
         })
-        .then(function (accountRecord) {
-          assert.equal(accountRecord.primaryEmail.email, secondEmail, 'primary email set')
+        .then(function (account) {
+          assert.equal(account.primaryEmail.email, secondEmail, 'primary email set')
+          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     })
   })


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2490

This PR adds `fxa-profileChangedAt` to the `/cert/sign` endpoint. This will be used by the oauth-server to add this property in the id token. This also adds `profileChangedAt` to the `/account/profile` endpoint. This will be used by the profile server to compare profile change times and invalidate cache added as needed.