### PR TITLE
feat(scripts): force registry links in shrinkwrap to use tls

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7099,7 +7099,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "optimist": {
@@ -12207,7 +12207,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "update-api-docs": "grunt newer:doc && git add docs/api.md",
     "precommit": "npm run bump-template-versions && npm run update-api-docs",
     "postinstall": "scripts/download_l10n.sh",
-    "shrink": "npmshrink && npm run postinstall",
+    "shrink": "npmshrink && npm run postinstall && scripts/tls-shrink.sh",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
     "test": "VERIFIER_VERSION=0 MEMCACHE_METRICS_CONTEXT_ADDRESS=none NO_COVERAGE=1 scripts/test-local.sh",

--- a/scripts/tls-shrink.sh
+++ b/scripts/tls-shrink.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -i '' 's/"resolved": "http:\/\/registry\.npmjs\.org\//"resolved": "https:\/\/registry.npmjs.org\//' npm-shrinkwrap.json


### PR DESCRIPTION
Continuing from the discussion in the meeting just now, this change adds a script that forces shrinkwrap to use TLS URLs.

Not sure where the best place for it to live is because we may want to use this in multiple repos. But anyway, if this lands I can use it to unblock myself in #2640.

@mozilla/fxa-devs r?