### PR TITLE
fix(metrics): stash metrics context during the account reset flow

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -263,6 +263,7 @@ async function create (log, error, config, routes, db, translator) {
   const metricsContext = require('./metrics/context')(log, config)
   server.decorate('request', 'stashMetricsContext', metricsContext.stash)
   server.decorate('request', 'gatherMetricsContext', metricsContext.gather)
+  server.decorate('request', 'propagateMetricsContext', metricsContext.propagate)
   server.decorate('request', 'clearMetricsContext', metricsContext.clear)
   server.decorate('request', 'validateMetricsContext', metricsContext.validate)
   server.decorate('request', 'setMetricsFlowCompleteSignal', metricsContext.setFlowCompleteSignal)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -121,6 +121,7 @@ const MAILER_METHOD_NAMES = [
 const METRICS_CONTEXT_METHOD_NAMES = [
   'clear',
   'gather',
+  'propagate',
   'setFlowCompleteSignal',
   'stash',
   'validate'
@@ -566,10 +567,11 @@ function mockRequest (data, errors) {
     info: {
       received: data.received || Date.now() - 1
     },
-    path: data.path,
-    params: data.params || {},
     method: data.method || undefined,
+    params: data.params || {},
+    path: data.path,
     payload: data.payload || {},
+    propagateMetricsContext: metricsContext.propagate,
     query: data.query || {},
     setMetricsFlowCompleteSignal: metricsContext.setFlowCompleteSignal,
     stashMetricsContext: metricsContext.stash,


### PR DESCRIPTION
Related to #2496.

We are planning to deprecate metrics context payloads on endpoints where it is not strictly required. This means only endpoints that start a flow or endpoints that occur outside of any flow will accept metrics context payloads in the future. The motivation for making this change is to reduce the likelihood of metrics weirdness arising from conflicting metrics context data being set mid-flow.

The account reset flow includes three different token types. By stashing metrics context as each new token is created, we can stop sending it to the subsequent endpoints in some future content server change without interrupting metrics.

There is no observable effect from making this change. Stashed metrics context is ignored when an endpoint receives metrics context data in the payload.

You'll want to review with `?w=1` btw. I had a minor explosion at the archaic code that was getting all in my grill and decided to bust out some `const` and some fat arrows and flatten some promise chains while working on this.

@mozilla/fxa-devs r?