### PR TITLE
chore(sms): log JSON-serialised result if we fail to parse max spend

### DIFF
--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -107,7 +107,14 @@ module.exports = (log, translator, templates, config) => {
         }).promise()
       })
       .then(result => {
-        const current = parseFloat(result.Datapoints[0].Maximum)
+        let current
+
+        try {
+          current = parseFloat(result.Datapoints[0].Maximum)
+        } catch (err) {
+          err.result = JSON.stringify(result)
+          throw err
+        }
 
         if (isNaN(current)) {
           throw new Error(`Invalid getMetricStatistics result "${result.Datapoints[0].Maximum}"`)
@@ -117,7 +124,7 @@ module.exports = (log, translator, templates, config) => {
         log.info({ op: 'sms.budget.ok', isBudgetOk, current, limit, threshold: CREDIT_THRESHOLD })
       })
       .catch(err => {
-        log.error({ op: 'sms.budget.error', err: err.message })
+        log.error({ op: 'sms.budget.error', err: err.message, result: err.result })
 
         // If we failed to query the data, assume current spend is fine
         isBudgetOk = true

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -184,7 +184,33 @@ describe('lib/senders/sms:', () => {
           assert.equal(args.length, 1)
           assert.deepEqual(args[0], {
             op: 'sms.budget.error',
-            err: 'Invalid getMetricStatistics result "wibble"'
+            err: 'Invalid getMetricStatistics result "wibble"',
+            result: undefined
+          })
+        })
+      })
+    })
+
+    describe('unexpected response:', () => {
+      beforeEach(() => {
+        results.getMetricStatistics.Datapoints = []
+      })
+
+      describe('wait a tick:', () => {
+        beforeEach(done => setImmediate(done))
+
+        it('isBudgetOk returns true', () => {
+          assert.strictEqual(sms.isBudgetOk(), true)
+        })
+
+        it('called log.error correctly', () => {
+          assert.equal(log.error.callCount, 1)
+          const args = log.error.args[0]
+          assert.equal(args.length, 1)
+          assert.deepEqual(args[0], {
+            op: 'sms.budget.error',
+            err: 'Cannot read property \'Maximum\' of undefined',
+            result: JSON.stringify(results.getMetricStatistics)
           })
         })
       })


### PR DESCRIPTION
Related to #2647.

Sometimes the attempt to dereference the result from `GetMetricStatistics` fails. Maybe it will help if we can see what the entire serialised result looks like, so this change logs that in the error message.

@mozilla/fxa-devs r?