### PR TITLE
fix(sms): use a five minute period on polling

### DIFF
--- a/lib/senders/sms.js
+++ b/lib/senders/sms.js
@@ -14,6 +14,7 @@ const time = require('../time')
 const SECONDS_PER_MINUTE = 60
 const MILLISECONDS_PER_MINUTE = SECONDS_PER_MINUTE * 1000
 const MILLISECONDS_PER_HOUR = MILLISECONDS_PER_MINUTE * 60
+const PERIOD_IN_MINUTES = 5
 
 class MockCloudwatch {
   getMetricStatistics () {
@@ -95,14 +96,14 @@ module.exports = (log, translator, templates, config) => {
           throw new Error(`Invalid getSMSAttributes result "${result.attributes.MonthlySpendLimit}"`)
         }
 
-        const now = new Date()
-        const minuteAgo = new Date(now.getTime() - MILLISECONDS_PER_MINUTE)
+        const endTime = new Date()
+        const startTime = new Date(endTime.getTime() - PERIOD_IN_MINUTES * MILLISECONDS_PER_MINUTE)
         return cloudwatch.getMetricStatistics({
           Namespace: 'AWS/SNS',
           MetricName: 'SMSMonthToDateSpentUSD',
-          StartTime: time.startOfMinute(minuteAgo),
-          EndTime: time.startOfMinute(now),
-          Period: SECONDS_PER_MINUTE,
+          StartTime: time.startOfMinute(startTime),
+          EndTime: time.startOfMinute(endTime),
+          Period: PERIOD_IN_MINUTES * SECONDS_PER_MINUTE,
           Statistics: [ 'Maximum' ]
         }).promise()
       })

--- a/test/local/senders/sms.js
+++ b/test/local/senders/sms.js
@@ -105,6 +105,7 @@ describe('lib/senders/sms:', () => {
       })
 
       it('called cloudwatch.getMetricStatistics correctly', () => {
+        const PERIOD_IN_MINUTES = 5 // matches setting in ../../../lib/senders/sms.js
         assert.equal(cloudwatch.getMetricStatistics.callCount, 1)
         const args = cloudwatch.getMetricStatistics.args[0]
         assert.equal(args.length, 1)
@@ -112,9 +113,9 @@ describe('lib/senders/sms:', () => {
         assert.equal(args[0].MetricName, 'SMSMonthToDateSpentUSD')
         assert(ISO_8601_FORMAT.test(args[0].StartTime))
         assert(ISO_8601_FORMAT.test(args[0].EndTime))
-        assert(new Date(args[0].StartTime).getTime() === new Date(args[0].EndTime).getTime() - 60000)
-        assert(new Date(args[0].EndTime).getTime() > Date.now() - 60000)
-        assert.equal(args[0].Period, 60)
+        assert(new Date(args[0].StartTime).getTime() === new Date(args[0].EndTime).getTime() - PERIOD_IN_MINUTES * 60000)
+        assert(new Date(args[0].EndTime).getTime() > Date.now() - PERIOD_IN_MINUTES * 60000)
+        assert.equal(args[0].Period, PERIOD_IN_MINUTES * 60)
         assert.deepEqual(args[0].Statistics, [ 'Maximum' ])
       })
 


### PR DESCRIPTION
I factored out the polling and ran it live. The granularity of data for this metric is 5 minutes, so using a 5 minute period and a starttime at least 5 minutes in the past always produces a result.

fixes #2647

r? - @philbooth 