### PR TITLE
fix(emails): expose config to prepend domain to verification emails

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -231,6 +231,19 @@ var conf = convict({
       default: 'Firefox Accounts <no-reply@lcip.org>',
       env: 'SMTP_SENDER'
     },
+    prependVerificationSubdomain: {
+      enabled: {
+        doc: 'Flag to prepend a verification subdomain to verification emails',
+        default: false,
+        env: 'PREPEND_VERIFICATION_SUBDOMAIN_ENABLED'
+      },
+      subdomain: {
+        doc: 'Prepend this subdomain',
+        format: String,
+        default: 'confirm',
+        env: 'PREPEND_VERIFICATION_SUBDOMAIN_SUBDOMAIN'
+      },
+    },
     verificationUrl: {
       doc: 'Deprecated. uses contentServer.url',
       format: String,

--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -174,6 +174,7 @@ module.exports = function (log, config) {
     this.verifyLoginUrl = mailerConfig.verifyLoginUrl
     this.verifySecondaryEmailUrl = mailerConfig.verifySecondaryEmailUrl
     this.verifyPrimaryEmailUrl = mailerConfig.verifyPrimaryEmailUrl
+    this.prependVerificationSubdomain = mailerConfig.prependVerificationSubdomain
   }
 
   Mailer.prototype.stop = function () {
@@ -1327,7 +1328,14 @@ module.exports = function (log, config) {
       parsedQuery['utm_content'] = UTM_PREFIX + content
     }
 
-    return parsedLink.protocol + '//' + parsedLink.host + parsedLink.pathname + '?' + qs.stringify(parsedQuery)
+    parsedLink.query = parsedQuery
+
+    const isAccountOrEmailVerification = link === this.verificationUrl || link === this.verifyLoginUrl
+    if (this.prependVerificationSubdomain.enabled && isAccountOrEmailVerification) {
+      parsedLink.host = `${this.prependVerificationSubdomain.subdomain}.${parsedLink.host}`
+    }
+
+    return url.format(parsedLink)
   }
 
   Mailer.prototype._generateLinks = function (primaryLink, email, query, templateName) {

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -154,6 +154,11 @@ const typesContainRecoveryCodeLinks = [
   'lowRecoveryCodesEmail'
 ]
 
+const typesPrependVerificationSubdomain = [
+  'verifyEmail',
+  'verifyLoginEmail'
+]
+
 function includes(haystack, needle) {
   return (haystack.indexOf(needle) > -1)
 }
@@ -373,6 +378,18 @@ describe(
               mailer[type](message)
             }
           )
+        }
+
+        if (includes(typesPrependVerificationSubdomain, type)) {
+          it(`can prepend verification subdomain for ${type}`, () => {
+            mailer.prependVerificationSubdomain.enabled = true
+            const subdomain = mailer.prependVerificationSubdomain.subdomain
+            mailer.mailer.sendMail = (emailConfig) => {
+              const link = emailConfig.headers['X-Link'];
+              assert.equal(link.indexOf(`http://${subdomain}.`), 0, 'link prepend with domain')
+            }
+            mailer[type](message)
+          })
         }
 
         if (includes(typesContainTokenCode, type)) {


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-content-server/issues/6599

This PR creates a new config option that will prepend a subdomain (`confirm`) to our `/verify_email` and `/complete_signin` email links.

I was able to test this in our stage environment since it has been setup to use to the redirect. Here is a video of it in action using a custom build of https://github.com/mozilla-mobile/firefox-ios/pull/4284.

https://drive.google.com/file/d/1ukcSZZ8MnwBH_NVPoKjs9LrIBvzyryf6/view?usp=sharing