### PR TITLE
feat(totp): remove other existing sessions when TOTP is enabled

### DIFF
--- a/lib/routes/totp.js
+++ b/lib/routes/totp.js
@@ -260,6 +260,7 @@ module.exports = (log, db, mailer, customs, config) => {
           .then(verifyTotpToken)
           .then(replaceRecoveryCodes)
           .then(verifySession)
+          .then(removePreviousSessions)
           .then(emitMetrics)
           .then(sendEmailNotification)
           .then(() => {
@@ -315,6 +316,26 @@ module.exports = (log, db, mailer, customs, config) => {
         function verifySession() {
           if (isValidCode && sessionToken.authenticatorAssuranceLevel <= 1) {
             return db.verifyTokensWithMethod(sessionToken.id, 'totp-2fa')
+          }
+        }
+
+        // To ensure that some clients are not in a quirky state, lets delete their
+        // other sessions if this request is enabling TOTP. Other sessions won't be
+        // TOTP verified at this point. When the session gets removed, the client
+        // will be able to detect this and log the user out. At that point, the client
+        // can prompt them to re-login and verify session with TOTP.
+        function removePreviousSessions() {
+          if (isValidCode && ! tokenVerified) {
+            return db.sessions(uid)
+              .then((sessions) => {
+                const sessionsToRevoke = sessions.filter((session) => {
+                  if (session.id === sessionToken.id) {
+                    return false
+                  }
+                  return true
+                })
+                return P.each(sessionsToRevoke, (session) => db.deleteSessionToken(session));
+              })
           }
         }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/6525

Putting this PR up for consideration as a fix for https://github.com/mozilla/fxa-content-server/issues/6525. With this, when a TOTP token is verified, it will remove all other sessions from a user's account (maybe it should just remove sync?). By doing this, clients will have to re-login to get access to the account. 

I am not 100% sure of the side-effects with this approach, however, clients have native code that handles when a session expires and perform the proper cleanup needed to let them login again. They also surface these errors so users know they need to login again.

@mozilla/fxa-devs thoughts?