### PR TITLE
fix(email): handle the new error structure from fxa-email-service

### DIFF
--- a/lib/senders/email_service.js
+++ b/lib/senders/email_service.js
@@ -54,7 +54,9 @@ module.exports = (config) => {
 
   function marshallError (status, body) {
     if (status === 429) {
-      return marshallBounceError(body.errno, body.bouncedAt)
+      // Error structure is changing in mozilla/fxa-email-service#198,
+      // temporarily handle both formats
+      return marshallBounceError(body.errno, body.bouncedAt || body.time)
     }
 
     return error.unexpectedError()

--- a/test/local/senders/email_service.js
+++ b/test/local/senders/email_service.js
@@ -93,7 +93,7 @@ describe(
       })
     })
 
-    it('emailService handles 429 response', (done) => {
+    it('emailService handles old 429 response', (done) => {
       const mock = {
         'request': function (config, cb) {
           cb(null, {
@@ -103,7 +103,7 @@ describe(
             errno: 106,
             error: 'BounceComplaintError',
             message: 'FREAKOUT',
-            bounceAt: 1533641031755
+            bouncedAt: 1533641031755
           })
         }
       }
@@ -112,6 +112,34 @@ describe(
       emailService.sendMail(emailConfig, (err, body) => {
         assert.equal(err.errno, 133)
         assert.equal(err.output.statusCode, 400)
+        assert.equal(err.output.payload.bouncedAt, 1533641031755)
+        assert.equal(err.message, 'Email account sent complaint')
+        assert.equal(body.messageId, undefined)
+        assert.equal(body.message, 'FREAKOUT')
+        done()
+      })
+    })
+
+    it('emailService handles new 429 response', (done) => {
+      const mock = {
+        'request': function (config, cb) {
+          cb(null, {
+            statusCode: 429
+          }, {
+            code: '429',
+            errno: 106,
+            error: 'BounceComplaintError',
+            message: 'FREAKOUT',
+            time: 1533641031755
+          })
+        }
+      }
+
+      const emailService = proxyquire(`${ROOT_DIR}/lib/senders/email_service`, mock)(config)
+      emailService.sendMail(emailConfig, (err, body) => {
+        assert.equal(err.errno, 133)
+        assert.equal(err.output.statusCode, 400)
+        assert.equal(err.output.payload.bouncedAt, 1533641031755)
         assert.equal(err.message, 'Email account sent complaint')
         assert.equal(body.messageId, undefined)
         assert.equal(body.message, 'FREAKOUT')


### PR DESCRIPTION
Blocks mozilla/fxa-email-service#198.

The code review for mozilla/fxa-email-service#198 suggested fixing the property names on errors returned by the email service. Since they're already depended on by the auth server, we need to change them here first.

It's safe to just make the switch in both places on the same train but just in case that PR doesn't land in this train for some reason, I've opted to handle both error structures as a first step. When the other change has definitely merged, we can remove the old property name.

@mozilla/fxa-devs r?