### PR TITLE
fix(email): include data from headers in email sent events

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -360,7 +360,7 @@ module.exports = function (log, config) {
               emailService
             })
 
-            emailUtils.logEmailEventSent(log, message)
+            emailUtils.logEmailEventSent(log, Object.assign({}, message,  { headers }))
 
             return d.resolve(status)
           })

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -844,6 +844,7 @@ describe(
             assert.equal(emailEventLog.args[0].flow_id, 'wibble', 'logs flow id')
             assert.equal(emailEventLog.args[0].template, 'verifyLoginEmail', 'logs correct template')
             assert.equal(emailEventLog.args[0].type, 'sent', 'logs correct type')
+            assert.equal(emailEventLog.args[0].locale, 'en')
             const mailerSend1 = mockLog.info.getCalls()[1]
             assert.equal(mailerSend1.args[0].op, 'mailer.send.1', 'logs mailer.send.1')
             assert.equal(mailerSend1.args[0].to, message.email, 'logs sender to email address')


### PR DESCRIPTION
Fixes #2665.

`logEmailEventSent` expects a bunch of header data that is set on an object that is not passed to it. This change just ensures those headers are copied to the argument.

@mozilla/fxa-devs r?