### PR TITLE
fix(metrics): ensure email events use stashed flow data where applicable

### DIFF
--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -150,8 +150,6 @@ module.exports = (log, db, mailer, config, customs, push) => {
         let verifyFunction
         let event
         let emails = []
-        let flowId
-        let flowBeginTime
         let sendEmail = true
 
         // Return immediately if this session or token is already verified. Only exception
@@ -161,10 +159,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
           return {}
         }
 
-        if (request.payload.metricsContext) {
-          flowId = request.payload.metricsContext.flowId
-          flowBeginTime = request.payload.metricsContext.flowBeginTime
-        }
+        const { flowId, flowBeginTime } = await request.app.metricsContext
 
         return customs.check(request, sessionToken.email, 'recoveryEmailResendCode')
           .then(setVerifyCode)

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -441,12 +441,7 @@ module.exports = function (
         }
         request.setMetricsFlowCompleteSignal(flowCompleteSignal)
 
-        // Store flowId and flowBeginTime to send in email
-        let flowId, flowBeginTime
-        if (request.payload.metricsContext) {
-          flowId = request.payload.metricsContext.flowId
-          flowBeginTime = request.payload.metricsContext.flowBeginTime
-        }
+        const { flowId, flowBeginTime } = await request.app.metricsContext
 
         let passwordForgotToken
 
@@ -488,9 +483,9 @@ module.exports = function (
               redirectTo: request.payload.redirectTo,
               resume: request.payload.resume,
               acceptLanguage: request.app.acceptLanguage,
-              flowId: flowId,
-              flowBeginTime: flowBeginTime,
-              ip: ip,
+              flowId,
+              flowBeginTime,
+              ip,
               location: geoData.location,
               timeZone: geoData.timeZone,
               uaBrowser,
@@ -546,12 +541,7 @@ module.exports = function (
 
         request.validateMetricsContext()
 
-        // Store flowId and flowBeginTime to send in email
-        let flowId, flowBeginTime
-        if (request.payload.metricsContext) {
-          flowId = request.payload.metricsContext.flowId
-          flowBeginTime = request.payload.metricsContext.flowBeginTime
-        }
+        const { flowId, flowBeginTime } = await request.app.metricsContext
 
         return P.all([
           request.emitMetricsEvent('password.forgot.resend_code.start'),
@@ -637,12 +627,7 @@ module.exports = function (
 
         request.validateMetricsContext()
 
-        // Store flowId and flowBeginTime to send in email
-        let flowId, flowBeginTime
-        if (request.payload.metricsContext) {
-          flowId = request.payload.metricsContext.flowId
-          flowBeginTime = request.payload.metricsContext.flowBeginTime
-        }
+        const { flowId, flowBeginTime } = await request.app.metricsContext
 
         let accountResetToken
 

--- a/lib/routes/unblock-codes.js
+++ b/lib/routes/unblock-codes.js
@@ -33,12 +33,7 @@ module.exports = (log, db, mailer, config, customs) => {
 
         request.validateMetricsContext()
 
-        // Store flowId and flowBeginTime to send in email
-        let flowId, flowBeginTime
-        if (request.payload.metricsContext) {
-          flowId = request.payload.metricsContext.flowId
-          flowBeginTime = request.payload.metricsContext.flowBeginTime
-        }
+        const { flowId, flowBeginTime } = await request.app.metricsContext
 
         return customs.check(request, email, 'sendUnblockCode')
           .then(lookupAccount)
@@ -74,8 +69,8 @@ module.exports = (log, db, mailer, config, customs) => {
               return mailer.sendUnblockCode(emails, emailRecord, {
                 acceptLanguage: request.app.acceptLanguage,
                 unblockCode: code,
-                flowId: flowId,
-                flowBeginTime: flowBeginTime,
+                flowId,
+                flowBeginTime,
                 ip: request.app.clientAddress,
                 location: geoData.location,
                 timeZone: geoData.timeZone,

--- a/lib/routes/utils/signin.js
+++ b/lib/routes/utils/signin.js
@@ -172,7 +172,7 @@ module.exports = (log, config, customs, db, mailer)  => {
      * This includes emailing the user, logging metrics events, and
      * notifying attached services.
      */
-    sendSigninNotifications(request, accountRecord, sessionToken, verificationMethod) {
+    async sendSigninNotifications (request, accountRecord, sessionToken, verificationMethod) {
       const service = request.payload.service || request.query.service
       const redirectTo = request.payload.redirectTo
       const resume = request.payload.resume
@@ -180,12 +180,7 @@ module.exports = (log, config, customs, db, mailer)  => {
 
       let sessions
 
-      // Store flowId and flowBeginTime to send in email
-      let flowId, flowBeginTime
-      if (request.payload.metricsContext) {
-        flowId = request.payload.metricsContext.flowId
-        flowBeginTime = request.payload.metricsContext.flowBeginTime
-      }
+      const { flowId, flowBeginTime } = await request.app.metricsContext
 
       const mustVerifySession = sessionToken.mustVerify && ! sessionToken.tokenVerified
 
@@ -333,9 +328,9 @@ module.exports = (log, config, customs, db, mailer)  => {
           {
             acceptLanguage: request.app.acceptLanguage,
             code: sessionToken.tokenVerificationId,
-            flowId: flowId,
-            flowBeginTime: flowBeginTime,
-            ip: ip,
+            flowId,
+            flowBeginTime,
+            ip,
             location: geoData.location,
             redirectTo: redirectTo,
             resume: resume,
@@ -370,9 +365,9 @@ module.exports = (log, config, customs, db, mailer)  => {
           {
             acceptLanguage: request.app.acceptLanguage,
             code: sessionToken.tokenVerificationCode,
-            flowId: flowId,
-            flowBeginTime: flowBeginTime,
-            ip: ip,
+            flowId,
+            flowBeginTime,
+            ip,
             location: geoData.location,
             redirectTo: redirectTo,
             resume: resume,

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -537,6 +537,11 @@ function mockRequest (data, errors) {
     devices = P.resolve(data.devices || [])
   }
 
+  let metricsContextData = data.payload && data.payload.metricsContext
+  if (! metricsContextData) {
+    metricsContextData = {}
+  }
+
   return {
     app: {
       acceptLanguage: data.acceptLanguage || 'en-US',
@@ -545,6 +550,7 @@ function mockRequest (data, errors) {
       features: new Set(data.features),
       geo,
       locale: data.locale || 'en-US',
+      metricsContext: P.resolve(metricsContextData),
       ua: {
         browser: data.uaBrowser || 'Firefox',
         browserVersion: data.uaBrowserVersion || '57.0',


### PR DESCRIPTION
Fixes #2675.

A number of places that were sending emails assumed they had access to flowId and flowBeginTime on the request payload. However, we're in the process of changing some of those endpoints so that they don't receive metrics context data in the payload.

To fix this, all endpoints are changed here to read metrics context data via a lazy getter that falls back to loading from memcached if there's no flow data in the payload. This happened to be a nice refactor anyway, fitting in with our broader adoption of lazy getters. It makes the code more resilient to change and reduces the frequency that we hit the cache with.

Note this is the same commit as #2676, but opened against the correct train branch because I am a short-sighted fool.

@vbudhram r?