### PR TITLE
fix(metrics): ensure metrics context is propagated from /account/reset

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -1105,7 +1105,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
               .then(
                 function (result) {
                   sessionToken = result
-                  return request.stashMetricsContext(sessionToken)
+                  return request.propagateMetricsContext(accountResetToken, sessionToken)
                 }
               )
           }
@@ -1127,7 +1127,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
               .then(
                 function (result) {
                   keyFetchToken = result
-                  return request.stashMetricsContext(keyFetchToken)
+                  return request.propagateMetricsContext(accountResetToken, keyFetchToken)
                 }
               )
           }

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -207,7 +207,7 @@ describe('/account/reset', function () {
       args = mockMetricsContext.setFlowCompleteSignal.args[0]
       assert.equal(args.length, 1, 'metricsContext.setFlowCompleteSignal was passed one argument')
       assert.equal(args[0], 'account.signed', 'argument was event name')
-      assert.equal(mockMetricsContext.stash.callCount, 2, 'metricsContext.stash was called twice')
+      assert.equal(mockMetricsContext.propagate.callCount, 2)
     })
 
     it('should have created session', () => {
@@ -258,19 +258,19 @@ describe('/account/reset', function () {
       assert.equal(args.length, 1, 'metricsContext.setFlowCompleteSignal was passed one argument')
       assert.equal(args[0], 'account.signed', 'argument was event name')
 
-      assert.equal(mockMetricsContext.stash.callCount, 2, 'metricsContext.stash was called twice')
+      assert.equal(mockMetricsContext.propagate.callCount, 2)
 
-      args = mockMetricsContext.stash.args[0]
-      assert.equal(args.length, 1, 'metricsContext.stash was passed one argument first time')
-      assert.deepEqual(args[0].id, sessionTokenId, 'argument was session token')
-      assert.deepEqual(args[0].uid, uid, 'sessionToken.uid was correct')
-      assert.equal(mockMetricsContext.stash.thisValues[0], mockRequest, 'this was request')
+      args = mockMetricsContext.propagate.args[0]
+      assert.lengthOf(args, 2)
+      assert.equal(args[0].uid, uid)
+      assert.equal(args[1].uid, uid)
+      assert.equal(args[1].id, sessionTokenId)
 
-      args = mockMetricsContext.stash.args[1]
-      assert.equal(args.length, 1, 'metricsContext.stash was passed one argument second time')
-      assert.deepEqual(args[0].id, keyFetchTokenId, 'argument was key fetch token')
-      assert.deepEqual(args[0].uid, uid, 'keyFetchToken.uid was correct')
-      assert.equal(mockMetricsContext.stash.thisValues[1], mockRequest, 'this was request')
+      args = mockMetricsContext.propagate.args[1]
+      assert.lengthOf(args, 2)
+      assert.equal(args[0].uid, uid)
+      assert.equal(args[1].uid, uid)
+      assert.equal(args[1].id, keyFetchTokenId)
 
       assert.equal(mockDB.createSessionToken.callCount, 1, 'db.createSessionToken was called once')
       args = mockDB.createSessionToken.args[0]


### PR DESCRIPTION
Sorry, another late metrics fix for train 123.

In #2642, a new `request.propagateMetricsContext` method was added to support propagation of metrics context data through each stage of the account reset flow. What's here is something that should have been part of that change: two calls to `request.stashMetricsContext` in the `/account/reset` endpoint.

Those calls will not do anything now that the content server stopped sending metrics context data to `/account/reset` in train 123. This means that the flow completion events will not be emitted. By changing those two calls to `request.propagateMetricsContext` instead, it fixes the issue.

@mozilla/fxa-devs r?