### PR TITLE
fix(key-data): Fail cleanly when the client has no allowedScopes.

### DIFF
--- a/fxa-oauth-server/config/test.json
+++ b/fxa-oauth-server/config/test.json
@@ -59,6 +59,16 @@
       "publicClient": true
     },
     {
+      "id": "38a6b9b3a65a1872",
+      "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
+      "name": "Public Client PKCE with no allowedScoeps",
+      "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
+      "redirectUri": "https://example.domain/return?foo=bar",
+      "trusted": true,
+      "canGrant": false,
+      "publicClient": true
+    },
+    {
       "id": "aaa6b9b3a65a1871",
       "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
       "name": "Scoped Key Client",

--- a/fxa-oauth-server/lib/routes/key_data.js
+++ b/fxa-oauth-server/lib/routes/key_data.js
@@ -52,7 +52,7 @@ module.exports = {
       db.getClient(Buffer.from(requestedClientId, 'hex')).then((client) => {
         if (client) {
           // find all requested scopes that are allowed for this client.
-          const allowedScopes = ScopeSet.fromString(client.allowedScopes);
+          const allowedScopes = ScopeSet.fromString(client.allowedScopes || '');
           const scopeLookups = requestedScopes.filtered(allowedScopes).getScopeValues().map(s => db.getScope(s));
           return P.all(scopeLookups).then((result) => {
             return result.filter((s) => !! (s && s.hasScopedKeys));

--- a/fxa-oauth-server/test/api.js
+++ b/fxa-oauth-server/test/api.js
@@ -62,6 +62,7 @@ JWT_PUB_KEY.alg = 'RS';
 
 const SCOPED_CLIENT_ID = 'aaa6b9b3a65a1871';
 const NO_KEY_SCOPES_CLIENT_ID = '38a6b9b3a65a1871';
+const NO_ALLOWED_SCOPES_CLIENT_ID = '38a6b9b3a65a1872';
 const BAD_CLIENT_ID = '0006b9b3a65a1871';
 const SCOPE_CAN_SCOPE_KEY = 'https://identity.mozilla.com/apps/sample-scope-can-scope-key';
 
@@ -2736,8 +2737,20 @@ describe('/v1', function() {
           });
       });
 
-      it('fails for clients that do not have the scope', () => {
+      it('succeeds for clients that do not have the scope, returning an empty object', () => {
         genericRequest.payload.client_id = NO_KEY_SCOPES_CLIENT_ID;
+
+        mockAssertion().reply(200, VERIFY_GOOD);
+        return Server.api.post(genericRequest)
+          .then((res) => {
+            assert.equal(res.statusCode, 200);
+            assertSecurityHeaders(res);
+            assert.equal(Object.keys(res.result).length, 0, 'no scoped keys');
+          });
+      });
+
+      it('succeeds for clients that have no allowedScopes, returning an empty object', () => {
+        genericRequest.payload.client_id = NO_ALLOWED_SCOPES_CLIENT_ID;
 
         mockAssertion().reply(200, VERIFY_GOOD);
         return Server.api.post(genericRequest)


### PR DESCRIPTION
This fixes the following 500 error, which @eoger helpfully triggered in production:

  https://sentry.prod.mozaws.net/operations/oauth-prod/issues/4883316/

@mozilla/fxa-devs r?