### PR TITLE
chore(config): Allow desktop client to request "oldsync" scope.

### DIFF
--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -106,6 +106,7 @@
       "imageUri": "",
       "redirectUri": "urn:ietf:wg:oauth:2.0:oob",
       "trusted": true,
+      "allowedScopes": "https://identity.mozilla.com/apps/oldsync",
       "canGrant": true
     },
     {


### PR DESCRIPTION
Ref https://bugzilla.mozilla.org/show_bug.cgi?id=1502229