### PR TITLE
fix(logging): log the reason for account deletions

### DIFF
--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -100,6 +100,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
                 }
                 request.app.accountRecreated = true
                 return db.deleteAccount(secondaryEmailRecord)
+                  .then(() => log.info({ op: 'accountDeleted.unverifiedSecondaryEmail', ...secondaryEmailRecord }))
               } else {
                 if (secondaryEmailRecord.isVerified) {
                   throw error.verifiedSecondaryEmailAlreadyExists()
@@ -1215,6 +1216,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
               .then((devices) => {
                 devicesToNotify = devices
                 return db.deleteAccount(emailRecord)
+                  .then(() => log.info({ op: 'accountDeleted.byRequest', ...emailRecord }))
               })
               .then(() => {
                 push.notifyAccountDestroyed(uid, devicesToNotify)

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -76,6 +76,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
             if (! validators.isValidEmailAddress(sessionToken.email)) {
               return db.deleteAccount(sessionToken)
                 .then(() => {
+                  log.info({ op: 'accountDeleted.invalidEmailAddress', ...sessionToken })
                   // Act as though we deleted the account asynchronously
                   // and caused the sessionToken to become invalid.
                   throw error.invalidToken('This account was invalid and has been deleted')
@@ -590,6 +591,7 @@ module.exports = (log, db, mailer, config, customs, push) => {
                 const minUnverifiedAccountTime = config.secondaryEmail.minUnverifiedAccountTime
                 if (msSinceCreated >= minUnverifiedAccountTime) {
                   return db.deleteAccount(secondaryEmailRecord)
+                    .then(() => log.info({ op: 'accountDeleted.unverifiedSecondaryEmail', ...secondaryEmailRecord }))
                 } else {
                   throw error.unverifiedPrimaryEmailNewlyCreated()
                 }

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -1432,6 +1432,13 @@ describe('/account/destroy', function () {
       assert.equal(args[0].email, email, 'db.deleteAccount was passed email record')
       assert.deepEqual(args[0].uid, uid, 'email record had correct uid')
 
+      assert.equal(mockLog.info.callCount, 1)
+      args = mockLog.info.args[0]
+      assert.lengthOf(args, 1)
+      assert.equal(args[0].op, 'accountDeleted.byRequest')
+      assert.equal(args[0].email, email)
+      assert.equal(args[0].uid, uid)
+
       assert.equal(mockPush.notifyAccountDestroyed.callCount, 1)
       assert.equal(mockPush.notifyAccountDestroyed.firstCall.args[0], uid)
 


### PR DESCRIPTION
It came up in [bug 1502164](https://bugzilla.mozilla.org/show_bug.cgi?id=1502164) that we don't always write a log line when deleting an account. This change does so and tries to include a deletion reason in the `op`, to make it easier to understand what's happened based on a single log line.

@mozilla/fxa-devs r?