### PR TITLE
fix(db): Improve query performance when deleting tokens for public clients

### DIFF
--- a/fxa-oauth-server/lib/db/mysql/index.js
+++ b/fxa-oauth-server/lib/db/mysql/index.js
@@ -154,7 +154,6 @@ const QUERY_CLIENT_LIST = 'SELECT id, name, redirectUri, imageUri, ' +
   'WHERE clients.id = clientDevelopers.clientId AND ' +
   'developers.developerId = clientDevelopers.developerId AND ' +
   'developers.email =?;';
-const QUERY_PUBLIC_CLIENTS_LIST = 'SELECT * FROM clients WHERE publicClient = 1 OR canGrant = 1;';
 const QUERY_CLIENT_UPDATE = 'UPDATE clients SET ' +
   'name=COALESCE(?, name), imageUri=COALESCE(?, imageUri), ' +
   'hashedSecret=COALESCE(?, hashedSecret), ' +
@@ -163,7 +162,7 @@ const QUERY_CLIENT_UPDATE = 'UPDATE clients SET ' +
   'trusted=COALESCE(?, trusted), allowedScopes=COALESCE(?, allowedScopes), ' +
   'canGrant=COALESCE(?, canGrant) ' +
   'WHERE id=?';
-// This query deletes everythin related to the client, and is thus quite expensive!
+// This query deletes everything related to the client, and is thus quite expensive!
 // Don't worry, it's not exposed to any production-facing routes.
 const QUERY_CLIENT_DELETE = 'DELETE clients, codes, tokens, refreshTokens, clientDevelopers ' +
   'FROM clients ' +
@@ -189,9 +188,17 @@ const QUERY_CODE_DELETE = 'DELETE FROM codes WHERE code=?';
 const QUERY_ACCESS_TOKEN_DELETE = 'DELETE FROM tokens WHERE token=?';
 const QUERY_REFRESH_TOKEN_DELETE = 'DELETE FROM refreshTokens WHERE token=?';
 const QUERY_ACCESS_TOKEN_DELETE_USER = 'DELETE FROM tokens WHERE userId=?';
-
-const QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS = 'DELETE FROM tokens WHERE userId=? AND clientId IN (?);';
-const QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS = 'DELETE FROM refreshTokens WHERE userId=? AND clientId IN (?);';
+// These next two queries can be very expensive if MySQL
+// tries to filter by clientId before userId, so we add
+// an explicit index hint to help ensure this doesn't happen.
+const QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS = 'DELETE tokens ' +
+   'FROM tokens FORCE INDEX (tokens_user_id)' +
+   'INNER JOIN clients ON tokens.clientId = clients.id ' +
+   'WHERE tokens.userId=? AND (clients.publicClient = 1 OR clients.canGrant = 1)';
+const QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS = 'DELETE refreshTokens ' +
+   'FROM refreshTokens FORCE INDEX (tokens_user_id)' +
+   'INNER JOIN clients ON refreshTokens.clientId = clients.id ' +
+   'WHERE refreshTokens.userId=? AND (clients.publicClient = 1 OR clients.canGrant = 1)';
 const QUERY_REFRESH_TOKEN_DELETE_USER =
   'DELETE FROM refreshTokens WHERE userId=?';
 const QUERY_CODE_DELETE_USER = 'DELETE FROM codes WHERE userId=?';
@@ -806,12 +813,8 @@ MysqlStore.prototype = {
   removePublicAndCanGrantTokens: function removePublicAndCanGrantTokens(userId) {
     const uid = buf(userId);
 
-    return this._read(QUERY_PUBLIC_CLIENTS_LIST).then((_clients) => {
-      const clientIds = _clients.map((client) => client.id);
-
-      return this._write(QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS, [uid, clientIds])
-        .then(() => this._write(QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS, [uid, clientIds]));
-    });
+    return this._write(QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS, [uid])
+      .then(() => this._write(QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS, [uid]));
   },
 
   getScope: function getScope (scope) {

--- a/fxa-oauth-server/lib/db/mysql/patch.js
+++ b/fxa-oauth-server/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 25;
+module.exports.level = 26;

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-025-026.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-025-026.sql
@@ -1,0 +1,18 @@
+-- Drop foreign key constraints.  They make DB migrations harder
+-- and aren't really providing us much value in practice.
+--
+-- We previously attempted this in migration #23, but had to roll
+-- it back because it caused MySQL's query planner to make some poor
+-- choices.  We've re-worked the queries to help it make better
+-- choices and are now ready to try again.
+
+ALTER TABLE refreshTokens DROP FOREIGN KEY refreshTokens_ibfk_1,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE codes DROP FOREIGN KEY codes_ibfk_1,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE tokens DROP FOREIGN KEY tokens_ibfk_1,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+UPDATE dbMetadata SET value = '26' WHERE name = 'schema-patch-level';

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-026-025.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-026-025.sql
@@ -1,0 +1,11 @@
+
+-- ALTER TABLE refreshTokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE codes ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE tokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '25' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2695

As noted in https://github.com/mozilla/fxa-auth-server/issues/2695, the performance of this query was causing problems in production:

```
DELETE FROM tokens WHERE userId=? AND clientId IN (?);
```

It's fast if MySQL decides to use the `tokens_user_id` index, and it's very slow of if MySQL decides to use the `tokens_client_id` index.  Unfortunately MySQL's choice here doesn't seem very scrutable - in my testing it will choose `tokens_client_id` if the list of clients has only a single element, while in production it appears to choose `tokens_client_id` unless there's a foreign key constraint on the `clientId` column.

Double unfortunately, we can't use index hints to influence MySQL's choice, because they're not supported on raw delete statements.

What we *can* do is switch to MySQL's multi-table delete syntax, which appears to allow index hints in the join, and which has the added advantage of saving us a query to read the list of public clients.

Here's the `EXPLAIN` output on my test db, which has no foreign-key constraints on the `tokens` table.  First for the original query which doesn't consistently use the right index:

```
mysql> EXPLAIN DELETE FROM tokens WHERE userId=UNHEX('08C263A41CDC39C90F609F2A9FA12EF3') AND clientId IN (UNHEX('00A8F8482522BE5B'));
+----+-------------+--------+------------+-------+---------------------------------+------------------+---------+-------+------+----------+-------------+
| id | select_type | table  | partitions | type  | possible_keys                   | key              | key_len | ref   | rows | filtered | Extra       |
+----+-------------+--------+------------+-------+---------------------------------+------------------+---------+-------+------+----------+-------------+
|  1 | DELETE      | tokens | NULL       | range | tokens_client_id,tokens_user_id | tokens_client_id | 8       | const |    1 |   100.00 | Using where |
+----+-------------+--------+------------+-------+---------------------------------+------------------+---------+-------+------+----------+-------------+
1 row in set (0.00 sec)

mysql> EXPLAIN DELETE FROM tokens WHERE userId=UNHEX('08C263A41CDC39C90F609F2A9FA12EF3') AND clientId IN (UNHEX('00A8F8482522BE5B'), UNHEX('FB88B057B5C0AED8'));
+----+-------------+--------+------------+-------+---------------------------------+----------------+---------+-------+------+----------+-------------+
| id | select_type | table  | partitions | type  | possible_keys                   | key            | key_len | ref   | rows | filtered | Extra       |
+----+-------------+--------+------------+-------+---------------------------------+----------------+---------+-------+------+----------+-------------+
|  1 | DELETE      | tokens | NULL       | range | tokens_client_id,tokens_user_id | tokens_user_id | 16      | const |    1 |   100.00 | Using where |
+----+-------------+--------+------------+-------+---------------------------------+----------------+---------+-------+------+----------+-------------+
1 row in set (0.00 sec)
```

And for the modified query:

```
mysql> EXPLAIN DELETE tokens FROM tokens FORCE INDEX (tokens_user_id) INNER JOIN clients ON tokens.clientId = clients.id WHERE tokens.userId=UNHEX('08C263A41CDC39C90F609F2A9FA12EF3') AND (clients.publicClient = 1 OR clients.canGrant = 1);
+----+-------------+---------+------------+--------+----------------+----------------+---------+---------------------------+------+----------+-------------+
| id | select_type | table   | partitions | type   | possible_keys  | key            | key_len | ref                       | rows | filtered | Extra       |
+----+-------------+---------+------------+--------+----------------+----------------+---------+---------------------------+------+----------+-------------+
|  1 | DELETE      | tokens  | NULL       | ref    | tokens_user_id | tokens_user_id | 16      | const                     |    1 |   100.00 | Using where |
|  1 | SIMPLE      | clients | NULL       | eq_ref | PRIMARY        | PRIMARY        | 8       | fxa_oauth.tokens.clientId |    1 |    19.00 | Using where |
+----+-------------+---------+------------+--------+----------------+----------------+---------+---------------------------+------+----------+-------------+
2 rows in set (0.00 sec)
```

The `FORCE INDEX (tokens_user_id) ` doesn't appear to be necessary here, as I get the same result without it:

```
mysql> EXPLAIN DELETE tokens FROM tokens INNER JOIN clients ON tokens.clientId = clients.id WHERE tokens.userId=UNHEX('08C263A41CDC39C90F609F2A9FA12EF3') AND (clients.publicClient = 1 OR clients.canGrant = 1);
+----+-------------+---------+------------+--------+---------------------------------+----------------+---------+---------------------------+------+----------+-------------+
| id | select_type | table   | partitions | type   | possible_keys                   | key            | key_len | ref                       | rows | filtered | Extra       |
+----+-------------+---------+------------+--------+---------------------------------+----------------+---------+---------------------------+------+----------+-------------+
|  1 | DELETE      | tokens  | NULL       | ref    | tokens_client_id,tokens_user_id | tokens_user_id | 16      | const                     |    1 |   100.00 | Using where |
|  1 | SIMPLE      | clients | NULL       | eq_ref | PRIMARY                         | PRIMARY        | 8       | fxa_oauth.tokens.clientId |    1 |    19.00 | Using where |
+----+-------------+---------+------------+--------+---------------------------------+----------------+---------+---------------------------+------+----------+-------------+
2 rows in set (0.00 sec)
```

But I don't think it can hurt, so it seemed prudent to include it.

@jrgm, when you get a chance, could we please try an `EXPLAIN` of these modified queries in stage or prod to check the query plan there?

If we like this solution, I'll add a migration that re-drops the foreign key constraints that we re-introuces in https://github.com/mozilla/fxa-oauth-server/pull/623.  I havent added it yet because we need to get that merged and ported over to this repo.