### PR TITLE
fix(metrics): use correct format for email service notifications

### DIFF
--- a/lib/email/notifications.js
+++ b/lib/email/notifications.js
@@ -22,10 +22,10 @@ module.exports = (log, error) => {
 
         let addresses = [], eventType = 'bounced', isDeletionCandidate = false
         if (message.bounce) {
-          addresses = mapBounceComplaintRecipients(message.bounce.bouncedRecipients)
+          addresses = message.bounce.bouncedRecipients
           isDeletionCandidate = true
         } else if (message.complaint) {
-          addresses = mapBounceComplaintRecipients(message.complaint.complainedRecipients)
+          addresses = message.complaint.complainedRecipients
           isDeletionCandidate = true
         } else if (message.delivery) {
           addresses = message.delivery.recipients
@@ -56,8 +56,4 @@ module.exports = (log, error) => {
       message.del()
     })
   }
-}
-
-function mapBounceComplaintRecipients (recipients) {
-  return recipients.map(recipient => recipient.emailAddress)
 }

--- a/test/local/email/notifications.js
+++ b/test/local/email/notifications.js
@@ -71,7 +71,7 @@ describe('lib/email/notifications:', () => {
           }
         },
         bounce: {
-          bouncedRecipients: [ { emailAddress: 'wibble@example.com' } ]
+          bouncedRecipients: [ 'wibble@example.com' ]
         }
       })
     })
@@ -136,10 +136,7 @@ describe('lib/email/notifications:', () => {
           }
         },
         complaint: {
-          complainedRecipients: [
-            { emailAddress: 'foo@example.com' },
-            { emailAddress: 'pmbooth@gmail.com' }
-          ]
+          complainedRecipients: [ 'foo@example.com', 'pmbooth@gmail.com' ]
         }
       })
     })
@@ -234,10 +231,7 @@ describe('lib/email/notifications:', () => {
           }
         },
         bounce: {
-          bouncedRecipients: [
-            { emailAddress: 'wibble@example.com' },
-            { emailAddress: 'blee@example.com' }
-          ]
+          bouncedRecipients: [ 'wibble@example.com', 'blee@example.com' ]
         }
       })
     })
@@ -309,9 +303,7 @@ describe('lib/email/notifications:', () => {
           }
         },
         complaint: {
-          complainedRecipients: [
-            { emailAddress: 'foo@example.com' }
-          ]
+          complainedRecipients: [ 'foo@example.com' ]
         }
       })
     })
@@ -351,9 +343,7 @@ describe('lib/email/notifications:', () => {
           }
         },
         bounce: {
-          bouncedRecipients: [
-            { emailAddress: 'wibble@example.com' }
-          ]
+          bouncedRecipients: [ 'wibble@example.com' ]
         }
       })
     })
@@ -444,7 +434,7 @@ describe('lib/email/notifications:', () => {
         del,
         mail: {},
         bounce: {
-          bouncedRecipients: [ { emailAddress: 'wibble@example.com' } ]
+          bouncedRecipients: [ 'wibble@example.com' ]
         }
       })
     })


### PR DESCRIPTION
The email service made a conscious break with the SQS notification structure, to make the recipients array more uniform. Rather than sometimes being an object with an `emailAddress` property and other times being a string, it makes the items plain strings on all notification types.

(for reference, see the `bounced_recipients`, `complained_recipients` and `recipients` properties in [src/queues/notification.rs](https://github.com/mozilla/fxa-email-service/blob/master/src/queues/notification.rs))

When I added code for the new notification queue to this repo in #2684, I forgot about that and just ported the SQS logic verbatim. This fixes it to always expect plain strings in the recipient arrays.

@mozilla/fxa-devs r?