### PR TITLE
Uplift oauth-server train-123 point releases

### DIFF
--- a/fxa-oauth-server/CHANGELOG.md
+++ b/fxa-oauth-server/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="1.123.2"></a>
+## [1.123.2](https://github.com/mozilla/fxa-oauth-server/compare/v1.123.1...v1.123.2) (2018-10-30)
+
+
+### Bug Fixes
+
+* **db:** Restore foreign key constraints on core tables. ([2bd0845](https://github.com/mozilla/fxa-oauth-server/commit/2bd0845))
+
+
+
+<a name="1.123.1"></a>
+## [1.123.1](https://github.com/mozilla/fxa-oauth-server/compare/v1.123.0...v1.123.1) (2018-10-26)
+
+
+### Bug Fixes
+
+* **profile:** remove the `profileChangedAt` column on tokens table ([5e87bce](https://github.com/mozilla/fxa-oauth-server/commit/5e87bce))
+
+
+
 <a name="1.123.0"></a>
 # [1.123.0](https://github.com/mozilla/fxa-oauth-server/compare/v1.122.0...v1.123.0) (2018-10-16)
 

--- a/fxa-oauth-server/lib/db/memory.js
+++ b/fxa-oauth-server/lib/db/memory.js
@@ -244,8 +244,7 @@ MemoryStore.prototype = {
       createdAt: now,
       // ttl is in seconds
       expiresAt: new Date(+now + (vals.ttl * 1000 || MAX_TTL)),
-      token: encrypt.hash(token),
-      profileChangedAt: vals.profileChangedAt || 0
+      token: encrypt.hash(token)
     };
     var ret = clone(t);
     this.tokens[unbuf(t.token)] = t;

--- a/fxa-oauth-server/lib/db/mysql/index.js
+++ b/fxa-oauth-server/lib/db/mysql/index.js
@@ -177,7 +177,7 @@ const QUERY_CODE_INSERT =
   'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_ACCESS_TOKEN_INSERT =
   'INSERT INTO tokens (clientId, userId, email, scope, type, expiresAt, ' +
-  'token, profileChangedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+  'token) VALUES (?, ?, ?, ?, ?, ?, ?)';
 const QUERY_REFRESH_TOKEN_INSERT =
   'INSERT INTO refreshTokens (clientId, userId, email, scope, token, profileChangedAt) VALUES ' +
   '(?, ?, ?, ?, ?, ?)';

--- a/fxa-oauth-server/lib/db/mysql/patch.js
+++ b/fxa-oauth-server/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 23;
+module.exports.level = 25;

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-023-024.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-023-024.sql
@@ -1,0 +1,8 @@
+-- This removes the `profileChangedAt` column on the tokens table.
+-- Since the tokens table is so large, this migration causes some issues.
+-- When the tokens get purged and the table is a bit smaller we can attempt to
+-- add this column.
+ALTER TABLE tokens DROP COLUMN profileChangedAt,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-024-023.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-024-023.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE tokens ADD COLUMN profileChangedAt BIGINT DEFAULT NULL,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '23`' WHERE name = 'schema-patch-level';

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-024-025.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-024-025.sql
@@ -1,0 +1,26 @@
+-- This restores some of the FOREIGN KEY constraints that were
+-- dropped in migration #23.  They unexpectedly caused MySQL to
+-- change its query plan and start scanning large chunks of the
+-- `tokens` table.  More context here:
+--
+--     https://github.com/mozilla/fxa-auth-server/issues/2695
+--
+-- We'll remove them again in a follow-up migration, and adjust
+-- the queries to ensure they use the right indexes.  For now
+-- we're just putting them back so that the alleged state of
+-- the db matches what's in production.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+ALTER TABLE refreshTokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE codes ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE tokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+SET FOREIGN_KEY_CHECKS=1;
+
+UPDATE dbMetadata SET value = '25' WHERE name = 'schema-patch-level';

--- a/fxa-oauth-server/lib/db/mysql/patches/patch-025-024.sql
+++ b/fxa-oauth-server/lib/db/mysql/patches/patch-025-024.sql
@@ -1,0 +1,11 @@
+
+-- ALTER TABLE refreshTokens DROP FOREIGN KEY refreshTokens_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE codes DROP FOREIGN KEY codes_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE tokens DROP FOREIGN KEY tokens_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';

--- a/fxa-oauth-server/lib/db/mysql/schema.sql
+++ b/fxa-oauth-server/lib/db/mysql/schema.sql
@@ -45,7 +45,6 @@ CREATE TABLE IF NOT EXISTS tokens (
   scope VARCHAR(256) NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   expiresAt TIMESTAMP NOT NULL,
-  profileChangedAt BIGINT DEFAULT NULL,
   INDEX idx_expiresAt(expiresAt)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 

--- a/fxa-oauth-server/npm-shrinkwrap.json
+++ b/fxa-oauth-server/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-server",
-  "version": "1.123.0",
+  "version": "1.123.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fxa-oauth-server/package.json
+++ b/fxa-oauth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-server",
-  "version": "1.123.0",
+  "version": "1.123.2",
   "private": true,
   "description": "Firefox Accounts OAuth2 server.",
   "scripts": {

--- a/fxa-oauth-server/test/api.js
+++ b/fxa-oauth-server/test/api.js
@@ -2931,7 +2931,11 @@ describe('/v1', function() {
           assert.equal(res.result.client_id, clientId);
           assert.equal(res.result.scope[0], 'profile');
           assert.equal(res.result.email, undefined);
-          assert.equal(res.result.profile_changed_at, PROFILE_CHANGED_AT_LATER_TIME, 'profile changed at is correct');
+
+          // profileChangedAt (profile_changed_at) was introduced on the tokens table to
+          // help detect stale profile data, but we couldn't complete the migration at the time.
+          // If/when migration gets sorted out, we can check for actual value.
+          assert.equal(res.result.profile_changed_at, undefined, 'profile changed at is not set');
         });
       });
     });


### PR DESCRIPTION
Fixes #2696.  Merge steps recorded below for completeness.

First, merge with the previously uplifted commit (8453f6ec94085f6b1bbb9759d98bc469a8038ff5) in the fxa-oauth-server repo, manually moving new files into the fxa-oauth-server subdirectory:

* `cd fxa-oauth-server`
* `git checkout 8453f6ec94085f6b1bbb9759d98bc469a8038ff5`
* `git checkout -b monorepo-uplift-train-123`
* `git merge train-123`
* `git mv lib/db/mysql/patches/patch-* ./fxa-oauth-server/lib/db/mysql/patches/`
* `git commit -a --amend`
* `git push -u origin monorepo-uplift-train-123`

Then, merge that merged commit into the auth-server repo:

* `cd ../fxa-auth-server; git checkout master; git pull`
* `git fetch oauth monorepo-uplift-train-123`
* `git checkout -b monorepo-oauth-uplift-train-123`
* `git merge oauth/monorepo-uplift-train-123`
* `git push -u origin monorepo-oauth-uplift-train-123`

And here we are.  @mozilla/fxa-devs r?