### PR TITLE
fix(tests): remove assertions of profileChangedAt property

### DIFF
--- a/test/remote/db_tests.js
+++ b/test/remote/db_tests.js
@@ -773,7 +773,6 @@ describe('remote db', function() {
         })
         .then(function(account) {
           assert.ok(account.emailVerified, 'account should now be emailVerified')
-          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     }
   )
@@ -832,10 +831,6 @@ describe('remote db', function() {
         })
         .then(function(exists) {
           assert.equal(exists, true, 'account should still exist')
-          return db.accountRecord(account.email)
-        })
-        .then((account) => {
-          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     }
   )
@@ -1051,7 +1046,6 @@ describe('remote db', function() {
         })
         .then(function (account) {
           assert.equal(account.primaryEmail.email, secondEmail, 'primary email set')
-          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated since account created')
         })
     })
   })


### PR DESCRIPTION
In https://github.com/mozilla/fxa-auth-db-mysql/pull/421, the `accountRecord_4` stored procedure got rolled back. That means code depending on the `profileChangedAt` property will no longer work.

This commit removes the assertions of that property that were added to the remote db tests in #2638, but it doesn't revert anything else from that changeset. The property is also returned from `GET /account/profile` and `POST /certificate/sign` endpoints, so the ultimate consumers of those may need to be on their toes.

I'm mostly opening this to unblock CI for train 124.

@mozilla/fxa-devs r?