### PR TITLE
fix(oauth-sentry): arg to server.events.on is "channels" (plural)

### DIFF
--- a/fxa-oauth-server/lib/server/index.js
+++ b/fxa-oauth-server/lib/server/index.js
@@ -98,7 +98,7 @@ exports.create = async function createServer() {
   const sentryDsn = config.sentryDsn;
   if (sentryDsn) {
     Raven.config(sentryDsn, {});
-    server.events.on({ name: 'request', channel: 'error' }, function (req, ev) {
+    server.events.on({ name: 'request', channels: 'error' }, function (req, ev) {
       const err = ev && ev.error || null;
       let exception = '';
       if (err && err.stack) {


### PR DESCRIPTION
Same deal as https://github.com/mozilla/fxa-auth-server/pull/2555/files.

Sentry is not configured for oauth in stage. But when I built production:

```
 {"Timestamp":1541442915235000000,"Logger":"fxa-oauth-server","Type":"server.prod","Severity":6,"Pid":6,"EnvVersion":"2.0","Fields":{"msg":"Disabling response schema validation"}}
 (node:6) UnhandledPromiseRejectionWarning: ValidationError: Invalid event listener options {
 "name": "request",
 "listener": function (req, ev) {\n      const err = ev && ev.error || null;\n      let exception = '';\n      if (err && err.stack) {\n        try {\n          exception = err.stack.split('\\n')[0];\n        } catch (e) {\n          // ignore bad stack frames\n        }\n      }\n\n      Raven.captureException(err, {\n        extra: {\n          exception: exception\n        }\n      });\n    },
 "channel" [1]: "error"
 }

 [1] "channel" is not allowed
 at Object.exports.process (/app/node_modules/podium/node_modules/joi/lib/errors.js:196:19)
 at internals.Object._validateWithOptions (/app/node_modules/podium/node_modules/joi/lib/types/any/index.js:675:31)
 at module.exports.internals.Any.root.validate (/app/node_modules/podium/node_modules/joi/lib/index.js:146:23)
 at module.exports.internals.Any.root.attempt (/app/node_modules/podium/node_modules/joi/lib/index.js:175:29)
 at module.exports.internals.Podium.internals.Podium.on.internals.Podium.addListener (/app/node_modules/podium/lib/index.js:255:20)
 at Object.createServer [as create] (/app/lib/server/index.js:101:19)
 at <anonymous>
```

I should add a test similar to https://github.com/mozilla/fxa-auth-server/pull/2556, but for the immediate task at hand, I can add that later on master.

r? - @vladikoff 

Blocks train-124