### PR TITLE
fix(release): on `grunt version(:patch?), bump both ./package.json and fxa-oauth-server/package.json

### DIFF
--- a/fxa-oauth-server/npm-shrinkwrap.json
+++ b/fxa-oauth-server/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-server",
-  "version": "1.124.0",
+  "version": "1.124.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fxa-oauth-server/package.json
+++ b/fxa-oauth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-server",
-  "version": "1.124.0",
+  "version": "1.124.3",
   "private": true,
   "description": "Firefox Accounts OAuth2 server.",
   "scripts": {

--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -9,11 +9,23 @@
 module.exports = function (grunt) {
   grunt.config('bump', {
     options: {
-      files: ['package.json', 'npm-shrinkwrap.json'],
+      files: [
+        'package.json',
+        'fxa-oauth-server/package.json',
+        'npm-shrinkwrap.json',
+        'fxa-oauth-server/npm-shrinkwrap.json'
+      ],
       bumpVersion: true,
       commit: true,
       commitMessage: 'Release v%VERSION%',
-      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG.md', 'AUTHORS'],
+      commitFiles: [
+        'package.json',
+        'fxa-oauth-server/package.json',
+        'npm-shrinkwrap.json',
+        'fxa-oauth-server/npm-shrinkwrap.json',
+        'CHANGELOG.md',
+        'AUTHORS'
+      ],
       createTag: true,
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',


### PR DESCRIPTION
Fixes #2720 

r? - @mozilla/fxa-devs 