### PR TITLE
fix(config): Add imageUri for reference browser client-id

### DIFF
--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -139,6 +139,7 @@
       "id": "3c49430b43dfba77",
       "name": "Android Components Reference Browser",
       "hashedSecret": "a7ee3482fab1782f5d3945cde06bb911605a8dfc1a45e4b77bc76615d5671e51",
+      "imageUri": "",
       "redirectUri": "https://accounts.firefox.com/oauth/success/3c49430b43dfba77",
       "canGrant": false,
       "trusted": true,

--- a/test/local/geodb.js
+++ b/test/local/geodb.js
@@ -27,8 +27,8 @@ describe('geodb', () => {
       const thisMockLog = mockLog({})
 
       const getGeoData = proxyquire(modulePath, moduleMocks)(thisMockLog)
-      const geoData = getGeoData('63.245.221.32') // San Francisco
-      assert.equal(geoData.location.city, 'San Francisco')
+      const geoData = getGeoData('63.245.221.32') // San Jose
+      assert.equal(geoData.location.city, 'San Jose')
       assert.equal(geoData.location.country, 'United States')
       assert.equal(geoData.location.countryCode, 'US')
       assert.equal(geoData.timeZone, 'America/Los_Angeles')

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -192,7 +192,7 @@ describe('lib/server', () => {
           it('parsed location correctly', () => {
             const geo = request.app.geo
             assert.ok(geo)
-            assert.equal(geo.location.city, 'San Francisco')
+            assert.equal(geo.location.city, 'San Jose')
             assert.equal(geo.location.country, 'United States')
             assert.equal(geo.location.countryCode, 'US')
             assert.equal(geo.location.state, 'California')
@@ -269,7 +269,7 @@ describe('lib/server', () => {
             it('second request has its own location info', () => {
               const geo = secondRequest.app.geo
               assert.notEqual(request.app.geo, secondRequest.app.geo)
-              assert.equal(geo.location.city, 'San Francisco')
+              assert.equal(geo.location.city, 'San Jose')
               assert.equal(geo.location.country, 'United States')
               assert.equal(geo.location.countryCode, 'US')
               assert.equal(geo.location.state, 'California')


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2726; @jrgm r?