### PR TITLE
fix(purge): use GET_LOCK("purge_expired_tokens.lock", 3) to only allow one-at-a-time

### DIFF
--- a/fxa-oauth-server/lib/db/memory.js
+++ b/fxa-oauth-server/lib/db/memory.js
@@ -138,6 +138,9 @@ MemoryStore.prototype = {
   ping: function ping() {
     return P.resolve({});
   },
+  getLock: function getLock(/* lockName, timeout */) {
+    return P.resolve({ acquired: 1 });
+  },
   registerClient: function registerClient(client) {
     if (client.id) {
       client.id = buf(client.id);

--- a/fxa-oauth-server/lib/db/mysql/index.js
+++ b/fxa-oauth-server/lib/db/mysql/index.js
@@ -124,6 +124,7 @@ MysqlStore.connect = function mysqlConnect(options) {
   });
 };
 
+const QUERY_GET_LOCK = 'SELECT GET_LOCK(?, ?) AS acquired';
 const QUERY_CLIENT_REGISTER =
   'INSERT INTO clients ' +
   '(id, name, imageUri, hashedSecret, hashedSecretPrevious, redirectUri,' +
@@ -254,6 +255,12 @@ MysqlStore.prototype = {
         });
       });
     });
+  },
+
+  getLock: function getLock(lockName, timeout = 3) {
+    // returns `acquired: 1` on success
+    logger.debug('getLock');
+    return this._readOne(QUERY_GET_LOCK, [ lockName, timeout ]);
   },
 
   // createdAt is DEFAULT NOW() in the schema.sql

--- a/fxa-oauth-server/test/db/index.js
+++ b/fxa-oauth-server/test/db/index.js
@@ -594,4 +594,15 @@ describe('db', function() {
 
   });
 
+  describe('getLock', function () {
+    it('should return an acquired status', function() {
+      const lockName = randomString(10);
+      return db.getLock(lockName, 3)
+        .then(function(result) {
+          assert.ok(result);
+          assert.ok('acquired' in result);
+          assert.ok(result.acquired === 1);
+        });
+    });
+  });
 });


### PR DESCRIPTION
No hurry on this change. But while running `./bin/purge-expired-tokens.js` I thought this would be useful. Maybe this script is safe to run concurrently, but, at minimum, multiple runners would create redundant load on the database (and increased latency on api endpoints) for no real gain.

Feel free to criticize this as I've never had a good feel for how the oauth db code works.

