### PR TITLE
chore(tests): make geolocation assertions more robust

### DIFF
--- a/test/known-ip-location.js
+++ b/test/known-ip-location.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = {
+  // This is a known IP address and its expected location.
+  //
+  // For `city`, results have fluctuated sufficiently that
+  // we decided not to do direct assertions in the tests.
+  // Instead we assert that the result matches one of the
+  // expected locations.
+  //
+  // If you are from the future and the cities listed here
+  // do not include what's being reported in your time, feel
+  // free to add it to the set. :)
+  ip: '63.245.221.32',
+  location: {
+    city: new Set([ 'Mountain View', 'Oakland', 'San Francisco', 'San Jose' ]),
+    country: 'United States',
+    countryCode: 'US',
+    state: 'California',
+    stateCode: 'CA',
+    tz: 'America/Los_Angeles'
+  }
+}

--- a/test/local/geodb.js
+++ b/test/local/geodb.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const { assert } = require('chai')
+const knownIpLocation = require('../known-ip-location')
 const proxyquire = require('proxyquire')
 const mockLog = require('../mocks').mockLog
 const modulePath = '../../lib/geodb'
@@ -27,13 +28,13 @@ describe('geodb', () => {
       const thisMockLog = mockLog({})
 
       const getGeoData = proxyquire(modulePath, moduleMocks)(thisMockLog)
-      const geoData = getGeoData('63.245.221.32') // San Jose
-      assert.equal(geoData.location.city, 'San Jose')
-      assert.equal(geoData.location.country, 'United States')
-      assert.equal(geoData.location.countryCode, 'US')
-      assert.equal(geoData.timeZone, 'America/Los_Angeles')
-      assert.equal(geoData.location.state, 'California')
-      assert.equal(geoData.location.stateCode, 'CA')
+      const geoData = getGeoData(knownIpLocation.ip)
+      assert.ok(knownIpLocation.location.city.has(geoData.location.city))
+      assert.equal(geoData.location.country, knownIpLocation.location.country)
+      assert.equal(geoData.location.countryCode, knownIpLocation.location.countryCode)
+      assert.equal(geoData.timeZone, knownIpLocation.location.tz)
+      assert.equal(geoData.location.state, knownIpLocation.location.state)
+      assert.equal(geoData.location.stateCode, knownIpLocation.location.stateCode)
     }
   )
 

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -4,21 +4,21 @@
 
 'use strict'
 
-var sinon = require('sinon')
+const sinon = require('sinon')
 
 const { assert } = require('chai')
-var mocks = require('../../mocks')
-var getRoute = require('../../routes_helpers').getRoute
-var proxyquire = require('proxyquire')
+const crypto = require('crypto')
+const error = require('../../../lib/error')
+const getRoute = require('../../routes_helpers').getRoute
+const knownIpLocation = require('../../known-ip-location')
+const mocks = require('../../mocks')
+const P = require('../../../lib/promise')
+const proxyquire = require('proxyquire')
+const uuid = require('uuid')
 
-var P = require('../../../lib/promise')
-var uuid = require('uuid')
-var crypto = require('crypto')
-var error = require('../../../lib/error')
-
-var TEST_EMAIL = 'foo@gmail.com'
-var TEST_EMAIL_ADDITIONAL = 'foo2@gmail.com'
-var TEST_EMAIL_INVALID = 'example@dotless-domain'
+const TEST_EMAIL = 'foo@gmail.com'
+const TEST_EMAIL_ADDITIONAL = 'foo2@gmail.com'
+const TEST_EMAIL_INVALID = 'example@dotless-domain'
 const MS_IN_DAY = 1000 * 60 * 60 * 24
 // This is slightly less than 2 months ago, regardless of which
 // months are in question (I'm looking at you, February...)
@@ -308,10 +308,10 @@ describe('/recovery_email/resend_code', () => {
       assert.equal(args[2].uaBrowserVersion, '52')
       assert.equal(args[2].uaOS, 'Mac OS X')
       assert.equal(args[2].uaOSVersion, '10.10')
-      assert.equal(args[2].location.city, 'Mountain View')
-      assert.equal(args[2].location.country, 'United States')
-      assert.equal(args[2].ip, '63.245.221.32')
-      assert.equal(args[2].timeZone, 'America/Los_Angeles')
+      assert.ok(knownIpLocation.location.city.has(args[2].location.city))
+      assert.equal(args[2].location.country, knownIpLocation.location.country)
+      assert.equal(args[2].ip, knownIpLocation.ip)
+      assert.equal(args[2].timeZone, knownIpLocation.location.tz)
       assert.strictEqual(args[2].uaDeviceType, undefined)
       assert.equal(args[2].deviceId, mockRequest.auth.credentials.deviceId)
       assert.equal(args[2].flowId, mockRequest.payload.metricsContext.flowId)

--- a/test/local/routes/session.js
+++ b/test/local/routes/session.js
@@ -7,6 +7,7 @@
 const { assert } = require('chai')
 const crypto = require('crypto')
 const getRoute = require('../../routes_helpers').getRoute
+const knownIpLocation = require('../../known-ip-location')
 const mocks = require('../../mocks')
 const P = require('../../../lib/promise')
 const error = require('../../../lib/error')
@@ -151,7 +152,7 @@ describe('/session/reauth', () => {
       assert.equal(args.length, 3, 'checkPassword was called with correct number of arguments')
       assert.equal(args[0].uid, TEST_UID, 'checkPassword was called with account record as first argument')
       assert.equal(args[1].authPW.toString('hex'), TEST_AUTHPW, 'checkPassword was called with Password object as second argument')
-      assert.equal(args[2], '63.245.221.32', 'checkPassword was called with mock ip address as third argument')
+      assert.equal(args[2], knownIpLocation.ip, 'checkPassword was called with mock ip address as third argument')
 
       assert.equal(db.updateSessionToken.callCount, 1, 'db.updateSessionToken was called')
       args = db.updateSessionToken.args[0]

--- a/test/local/server.js
+++ b/test/local/server.js
@@ -10,6 +10,7 @@ const { assert } = require('chai')
 const EndpointError = require('poolee/lib/error')(require('util').inherits)
 const error = require(`${ROOT_DIR}/lib/error`)
 const hawk = require('hawk')
+const knownIpLocation = require('../known-ip-location')
 const mocks = require('../mocks')
 const server = require(`${ROOT_DIR}/lib/server`)
 const sinon = require('sinon')
@@ -114,14 +115,14 @@ describe('lib/server', () => {
               headers: {
                 'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
                 'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:57.0) Gecko/20100101 Firefox/57.0',
-                'x-forwarded-for': '63.245.221.32 , moo , 1.2.3.4'
+                'x-forwarded-for': `${knownIpLocation.ip} , moo , 1.2.3.4`
               },
               method: 'POST',
               url: '/account/create',
               payload: {
                 features: [ 'signinCodes' ]
               },
-              remoteAddress: '63.245.221.32'
+              remoteAddress: knownIpLocation.ip
             }).then(response => request = response.request)
           })
 
@@ -160,13 +161,13 @@ describe('lib/server', () => {
           it('parsed remote address chain correctly', () => {
             assert.ok(Array.isArray(request.app.remoteAddressChain))
             assert.equal(request.app.remoteAddressChain.length, 3)
-            assert.equal(request.app.remoteAddressChain[0], '63.245.221.32')
+            assert.equal(request.app.remoteAddressChain[0], knownIpLocation.ip)
             assert.equal(request.app.remoteAddressChain[1], '1.2.3.4')
             assert.equal(request.app.remoteAddressChain[2], request.app.remoteAddressChain[0])
           })
 
           it('parsed client address correctly', () => {
-            assert.equal(request.app.clientAddress, '63.245.221.32')
+            assert.equal(request.app.clientAddress, knownIpLocation.ip)
           })
 
           it('parsed accept-language correctly', () => {
@@ -192,12 +193,12 @@ describe('lib/server', () => {
           it('parsed location correctly', () => {
             const geo = request.app.geo
             assert.ok(geo)
-            assert.equal(geo.location.city, 'San Jose')
-            assert.equal(geo.location.country, 'United States')
-            assert.equal(geo.location.countryCode, 'US')
-            assert.equal(geo.location.state, 'California')
-            assert.equal(geo.location.stateCode, 'CA')
-            assert.equal(geo.timeZone, 'America/Los_Angeles')
+            assert.ok(knownIpLocation.location.city.has(geo.location.city))
+            assert.equal(geo.location.country, knownIpLocation.location.country)
+            assert.equal(geo.location.countryCode, knownIpLocation.location.countryCode)
+            assert.equal(geo.location.state, knownIpLocation.location.state)
+            assert.equal(geo.location.stateCode, knownIpLocation.location.stateCode)
+            assert.equal(geo.timeZone, knownIpLocation.location.tz)
           })
 
           it('fetched devices correctly', () => {
@@ -229,7 +230,7 @@ describe('lib/server', () => {
                   features: [ 'signinCodes' ],
                   uid: 'another fake uid'
                 },
-                remoteAddress: '63.245.221.32'
+                remoteAddress: knownIpLocation.ip
               }).then(response => secondRequest = response.request)
             })
 
@@ -239,11 +240,11 @@ describe('lib/server', () => {
               assert.equal(secondRequest.app.remoteAddressChain.length, 3)
               assert.equal(secondRequest.app.remoteAddressChain[0], '194.12.187.0')
               assert.equal(secondRequest.app.remoteAddressChain[1], '194.12.187.1')
-              assert.equal(secondRequest.app.remoteAddressChain[2], '63.245.221.32')
+              assert.equal(secondRequest.app.remoteAddressChain[2], knownIpLocation.ip)
             })
 
-            it('second request has its own client address', () => {
-              assert.equal(secondRequest.app.clientAddress, '63.245.221.32')
+            it('second request has correct client address', () => {
+              assert.equal(secondRequest.app.clientAddress, knownIpLocation.ip)
             })
 
             it('second request has its own accept-language', () => {
@@ -269,12 +270,12 @@ describe('lib/server', () => {
             it('second request has its own location info', () => {
               const geo = secondRequest.app.geo
               assert.notEqual(request.app.geo, secondRequest.app.geo)
-              assert.equal(geo.location.city, 'San Jose')
-              assert.equal(geo.location.country, 'United States')
-              assert.equal(geo.location.countryCode, 'US')
-              assert.equal(geo.location.state, 'California')
-              assert.equal(geo.location.stateCode, 'CA')
-              assert.equal(geo.timeZone, 'America/Los_Angeles')
+              assert.ok(knownIpLocation.location.city.has(geo.location.city))
+              assert.equal(geo.location.country, knownIpLocation.location.country)
+              assert.equal(geo.location.countryCode, knownIpLocation.location.countryCode)
+              assert.equal(geo.location.state, knownIpLocation.location.state)
+              assert.equal(geo.location.stateCode, knownIpLocation.location.stateCode)
+              assert.equal(geo.timeZone, knownIpLocation.location.tz)
             })
 
             it('second request fetched devices correctly', () => {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -9,11 +9,12 @@
 'use strict'
 
 const assert = require('assert')
-const sinon = require('sinon')
-const P = require('../lib/promise')
-const crypto = require('crypto')
 const config = require('../config').getProperties()
+const crypto = require('crypto')
 const error = require('../lib/error')
+const knownIpLocation = require('./known-ip-location')
+const P = require('../lib/promise')
+const sinon = require('sinon')
 
 const CUSTOMS_METHOD_NAMES = [
   'check',
@@ -520,13 +521,13 @@ function mockRequest (data, errors) {
   const metricsContext = data.metricsContext || module.exports.mockMetricsContext()
 
   const geo = data.geo || {
-    timeZone: 'America/Los_Angeles',
+    timeZone: knownIpLocation.location.tz,
     location: {
-      city: 'Mountain View',
-      country: 'United States',
-      countryCode: 'US',
-      state: 'California',
-      stateCode: 'CA'
+      city: knownIpLocation.location.city.values().next().value,
+      country: knownIpLocation.location.country,
+      countryCode: knownIpLocation.location.countryCode,
+      state: knownIpLocation.location.state,
+      stateCode: knownIpLocation.location.stateCode
     }
   }
 
@@ -545,7 +546,7 @@ function mockRequest (data, errors) {
   return {
     app: {
       acceptLanguage: data.acceptLanguage || 'en-US',
-      clientAddress: data.clientAddress || '63.245.221.32',
+      clientAddress: data.clientAddress || knownIpLocation.ip,
       devices,
       features: new Set(data.features),
       geo,


### PR DESCRIPTION
As suggested by @shane-tomlinson in https://github.com/mozilla/fxa-auth-server/pull/2727#issuecomment-436976181, let's stop asserting a single specific city for the location tests and instead use a `Set` of the previous values returned by fxa-geodb. IIRC, that's Mountain View, Oakland, San Francisco and San Jose.

@mozilla/fxa-devs r?