### PR TITLE
chore(oauth): Remove unused `profileChangedAt` parameter in db call.

### DIFF
--- a/fxa-oauth-server/lib/db/mysql/index.js
+++ b/fxa-oauth-server/lib/db/mysql/index.js
@@ -436,6 +436,9 @@ MysqlStore.prototype = {
       token: unique.token(),
       type: 'bearer',
       expiresAt: vals.expiresAt || new Date(Date.now() + (vals.ttl  * 1000 || MAX_TTL)),
+      // We're not yet able to persist this value into the db
+      // for operational reasons, but it's here for consistency
+      // with the other token types.
       profileChangedAt: vals.profileChangedAt || 0
     };
     return this._write(QUERY_ACCESS_TOKEN_INSERT, [
@@ -446,7 +449,6 @@ MysqlStore.prototype = {
       t.type,
       t.expiresAt,
       encrypt.hash(t.token),
-      t.profileChangedAt,
     ]).then(function() {
       return t;
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2725