### PR TITLE
feat(signin): add ability to skip signin confirmation for specific emails

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -654,6 +654,12 @@ var conf = convict({
       default: /.+@mozilla\.com$/,
       env: 'SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX'
     },
+    skipForEmailAddresses: {
+      doc: 'Comma separated list of email addresses that will always skip any non TOTP sign-in confirmation',
+      format: Array,
+      default: [],
+      env: 'SIGNIN_CONFIRMATION_SKIP_FOR_EMAIL_ADDRESS'
+    },
     skipForNewAccounts: {
       enabled: {
         doc: 'Skip sign-in confirmation for newly-created accounts.',


### PR DESCRIPTION
Fixes #2685

This PR exposes an environment config that can contain email addresses that will always skip any sign-in confirmation emails. We opt to use an explicit list here to avoid any accidental regex foot-guns.