### PR TITLE
fix(metrics): emit login complete amplitude event after reset complete

### DIFF
--- a/lib/metrics/amplitude.js
+++ b/lib/metrics/amplitude.js
@@ -97,6 +97,9 @@ const FUZZY_EVENTS = new Map([
   } ]
 ])
 
+const ACCOUNT_RESET_COMPLETE = `${GROUPS.login} - forgot_complete`
+const LOGIN_COMPLETE = `${GROUPS.login} - complete`
+
 module.exports = (log, config) => {
   if (! log || ! config.oauth.clientIds) {
     throw new TypeError('Missing argument')
@@ -142,6 +145,15 @@ module.exports = (log, config) => {
 
         if (amplitudeEvent) {
           log.amplitudeEvent(amplitudeEvent)
+
+          // HACK: Account reset returns a session token so emit login complete too
+          if (amplitudeEvent.event_type === ACCOUNT_RESET_COMPLETE) {
+            log.amplitudeEvent({
+              ...amplitudeEvent,
+              event_type: LOGIN_COMPLETE,
+              time: amplitudeEvent.time + 1
+            })
+          }
         }
       })
   }

--- a/test/local/metrics/amplitude.js
+++ b/test/local/metrics/amplitude.js
@@ -308,9 +308,12 @@ describe('metrics/amplitude', () => {
       })
 
       it('called log.amplitudeEvent correctly', () => {
-        assert.equal(log.amplitudeEvent.callCount, 1)
-        const args = log.amplitudeEvent.args[0]
+        assert.equal(log.amplitudeEvent.callCount, 2)
+        let args = log.amplitudeEvent.args[0]
         assert.equal(args[0].event_type, 'fxa_login - forgot_complete')
+        args = log.amplitudeEvent.args[1]
+        assert.equal(args[0].event_type, 'fxa_login - complete')
+        assert.isAbove(args[0].time, log.amplitudeEvent.args[0][0].time)
       })
     })
 


### PR DESCRIPTION
Fixes mozilla/fxa-activity-metrics#110.

This is a hack to fix the login complete numbers in Amplitude for train 126. I did try a "proper" fix too, but [it backfired](https://github.com/mozilla/fxa-shared/pull/37) and I don't have time to implement the alternative suggestion for this train. We can replace this with something more appropriate when there is time.

@mozilla/fxa-devs r?