### PR TITLE
fix(metrics): ensure email sent amplitude events include device id

### DIFF
--- a/lib/email/utils/helpers.js
+++ b/lib/email/utils/helpers.js
@@ -124,7 +124,6 @@ function logAmplitudeEvent (log, message, eventInfo) {
     query: {},
     payload: {}
   }, {
-    device_id: message.deviceId || getHeaderValue('X-Device-Id', message),
     email_domain: eventInfo.domain,
     email_sender: message.emailSender || getHeaderValue('X-Email-Sender', message),
     email_service: message.emailService || getHeaderValue('X-Email-Service', message),
@@ -132,6 +131,7 @@ function logAmplitudeEvent (log, message, eventInfo) {
     templateVersion: eventInfo.templateVersion,
     uid: message.uid || getHeaderValue('X-Uid', message)
   }, {
+    device_id: message.deviceId || getHeaderValue('X-Device-Id', message),
     flowBeginTime: message.flowBeginTime || getHeaderValue('X-Flow-Begin-Time', message),
     flow_id: eventInfo.flow_id,
     time: Date.now()

--- a/lib/routes/account.js
+++ b/lib/routes/account.js
@@ -76,7 +76,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
 
         request.validateMetricsContext()
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext
+        const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
         return customs.check(request, email, 'accountCreate')
           .then(deleteAccountIfUnverified)
@@ -272,6 +272,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
               redirectTo: form.redirectTo,
               resume: form.resume,
               acceptLanguage: request.app.acceptLanguage,
+              deviceId,
               flowId,
               flowBeginTime,
               ip,
@@ -677,7 +678,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
                 const geoData = request.app.geo
                 const service = request.payload.service || request.query.service
                 const ip = request.app.clientAddress
-                const { flowId, flowBeginTime } = await request.app.metricsContext
+                const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
                 try {
                   await mailer.sendNewDeviceLoginNotification(
@@ -685,6 +686,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push)
                     accountRecord,
                     {
                       acceptLanguage: request.app.acceptLanguage,
+                      deviceId,
                       flowId,
                       flowBeginTime,
                       ip,

--- a/lib/routes/password.js
+++ b/lib/routes/password.js
@@ -441,7 +441,7 @@ module.exports = function (
         }
         request.setMetricsFlowCompleteSignal(flowCompleteSignal)
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext
+        const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
         let passwordForgotToken
 
@@ -483,6 +483,7 @@ module.exports = function (
               redirectTo: request.payload.redirectTo,
               resume: request.payload.resume,
               acceptLanguage: request.app.acceptLanguage,
+              deviceId,
               flowId,
               flowBeginTime,
               ip,
@@ -538,7 +539,7 @@ module.exports = function (
         var service = request.payload.service || request.query.service
         const ip = request.app.clientAddress
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext
+        const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
         return P.all([
           request.emitMetricsEvent('password.forgot.resend_code.start'),
@@ -564,6 +565,7 @@ module.exports = function (
                     redirectTo: request.payload.redirectTo,
                     resume: request.payload.resume,
                     acceptLanguage: request.app.acceptLanguage,
+                    deviceId,
                     flowId,
                     flowBeginTime,
                     ip,
@@ -621,7 +623,7 @@ module.exports = function (
         var code = request.payload.code
         const accountResetWithRecoveryKey = request.payload.accountResetWithRecoveryKey
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext
+        const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
         let accountResetToken
 
@@ -663,6 +665,7 @@ module.exports = function (
               {
                 code,
                 acceptLanguage: request.app.acceptLanguage,
+                deviceId,
                 flowId,
                 flowBeginTime,
                 uid: passwordForgotToken.uid

--- a/lib/routes/utils/signin.js
+++ b/lib/routes/utils/signin.js
@@ -182,7 +182,7 @@ module.exports = (log, config, customs, db, mailer)  => {
 
       let sessions
 
-      const { flowId, flowBeginTime } = await request.app.metricsContext
+      const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext
 
       const mustVerifySession = sessionToken.mustVerify && ! sessionToken.tokenVerified
 
@@ -278,6 +278,7 @@ module.exports = (log, config, customs, db, mailer)  => {
           redirectTo,
           resume,
           acceptLanguage: request.app.acceptLanguage,
+          deviceId,
           flowId,
           flowBeginTime,
           ip,
@@ -330,6 +331,7 @@ module.exports = (log, config, customs, db, mailer)  => {
           {
             acceptLanguage: request.app.acceptLanguage,
             code: sessionToken.tokenVerificationId,
+            deviceId,
             flowId,
             flowBeginTime,
             ip,
@@ -367,6 +369,7 @@ module.exports = (log, config, customs, db, mailer)  => {
           {
             acceptLanguage: request.app.acceptLanguage,
             code: sessionToken.tokenVerificationCode,
+            deviceId,
             flowId,
             flowBeginTime,
             ip,

--- a/test/local/email/utils.js
+++ b/test/local/email/utils.js
@@ -116,7 +116,6 @@ describe('email utils helpers', () => {
       payload: {}
     })
     assert.deepEqual(args[2], {
-      device_id: 'bbb',
       email_domain: 'other',
       email_service: 'fxa-email-service',
       email_sender: 'ses',
@@ -124,6 +123,7 @@ describe('email utils helpers', () => {
       templateVersion: 'eee',
       uid: 'fff'
     })
+    assert.equal(args[3].device_id, 'bbb')
     assert.equal(args[3].flow_id, 'ccc')
     assert.equal(args[3].flowBeginTime, 42)
     assert.ok(args[3].time > Date.now() - 1000)
@@ -164,7 +164,6 @@ describe('email utils helpers', () => {
       payload: {}
     })
     assert.deepEqual(args[2], {
-      device_id: 'b',
       email_domain: 'gmail',
       email_sender: 'wibble',
       email_service: 'fxa-auth-server',
@@ -172,6 +171,7 @@ describe('email utils helpers', () => {
       templateVersion: 42,
       uid: 'e'
     })
+    assert.equal(args[3].device_id, 'b')
     assert.equal(args[3].flow_id, 'c')
     assert.equal(args[3].flowBeginTime, 1)
   })

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -299,6 +299,7 @@ describe('/account/create', () => {
         authPW: hexString(32),
         service: 'sync',
         metricsContext: {
+          deviceId: 'wibble',
           flowBeginTime: Date.now(),
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           utmCampaign: 'utm campaign',
@@ -505,6 +506,7 @@ describe('/account/create', () => {
       assert.equal(args[2].uaOS, 'iOS')
       assert.equal(args[2].uaOSVersion, '11')
       assert.strictEqual(args[2].uaDeviceType, 'tablet')
+      assert.equal(args[2].deviceId, mockRequest.payload.metricsContext.deviceId)
       assert.equal(args[2].flowId, mockRequest.payload.metricsContext.flowId)
       assert.equal(args[2].flowBeginTime, mockRequest.payload.metricsContext.flowBeginTime)
       assert.equal(args[2].service, 'sync')
@@ -584,6 +586,7 @@ describe('/account/login', function () {
       service: 'sync',
       reason: 'signin',
       metricsContext: {
+        deviceId: 'blee',
         flowBeginTime: Date.now(),
         flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         utmCampaign: 'utm campaign',
@@ -611,6 +614,7 @@ describe('/account/login', function () {
       service: 'dcdb5ae7add825d2',
       reason: 'signin',
       metricsContext: {
+        deviceId: 'blee',
         flowBeginTime: Date.now(),
         flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         service: 'dcdb5ae7add825d2'
@@ -627,6 +631,7 @@ describe('/account/login', function () {
       service: 'dcdb5ae7add825d2',
       reason: 'signin',
       metricsContext: {
+        deviceId: 'blee',
         flowBeginTime: Date.now(),
         flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103'
       }
@@ -800,6 +805,7 @@ describe('/account/login', function () {
       assert.equal(args[2].uaOS, 'Android')
       assert.equal(args[2].uaOSVersion, '6')
       assert.equal(args[2].uaDeviceType, 'mobile')
+      assert.equal(args[2].deviceId, mockRequest.payload.metricsContext.deviceId)
       assert.equal(args[2].flowId, mockRequest.payload.metricsContext.flowId)
       assert.equal(args[2].flowBeginTime, mockRequest.payload.metricsContext.flowBeginTime)
       assert.equal(args[2].service, 'sync')
@@ -1058,6 +1064,7 @@ describe('/account/login', function () {
           assert.equal(tokenData.tokenVerificationId, null, 'sessionToken was created verified')
           assert.equal(mockMailer.sendVerifyCode.callCount, 0, 'mailer.sendVerifyLoginEmail was not called')
           assert.equal(mockMailer.sendNewDeviceLoginNotification.callCount, 1, 'mailer.sendNewDeviceLoginNotification was called')
+          assert.equal(mockMailer.sendNewDeviceLoginNotification.args[0][2].deviceId, mockRequest.payload.metricsContext.deviceId)
           assert.equal(mockMailer.sendNewDeviceLoginNotification.args[0][2].flowId, mockRequest.payload.metricsContext.flowId)
           assert.equal(mockMailer.sendNewDeviceLoginNotification.args[0][2].flowBeginTime, mockRequest.payload.metricsContext.flowBeginTime)
           assert.equal(mockMailer.sendNewDeviceLoginNotification.args[0][2].service, 'sync')

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -87,6 +87,7 @@ describe('/password', () => {
       payload: {
         email: TEST_EMAIL,
         metricsContext: {
+          deviceId: 'wibble',
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           flowBeginTime: Date.now() - 1
         }
@@ -127,6 +128,7 @@ describe('/password', () => {
         assert.equal(args[2].location.country, 'United States')
         assert.equal(args[2].timeZone, 'America/Los_Angeles')
         assert.equal(args[2].uid, uid)
+        assert.equal(args[2].deviceId, 'wibble')
       })
   })
 
@@ -172,6 +174,7 @@ describe('/password', () => {
         payload: {
           email: TEST_EMAIL,
           metricsContext: {
+            deviceId: 'wibble',
             flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
             flowBeginTime: Date.now() - 1
           }
@@ -182,6 +185,7 @@ describe('/password', () => {
         .then(function(response) {
           assert.equal(mockMailer.sendRecoveryCode.callCount, 1, 'mailer.sendRecoveryCode was called once')
           assert.equal(mockMailer.sendRecoveryCode.args[0][2].uid, uid)
+          assert.equal(mockMailer.sendRecoveryCode.args[0][2].deviceId, 'wibble')
 
           assert.equal(mockRequest.validateMetricsContext.callCount, 0)
           assert.equal(mockLog.flowEvent.callCount, 2, 'log.flowEvent was called twice')
@@ -242,6 +246,7 @@ describe('/password', () => {
       payload: {
         code: 'abcdef',
         metricsContext: {
+          deviceId: 'wibble',
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           flowBeginTime: Date.now() - 1
         }
@@ -275,6 +280,7 @@ describe('/password', () => {
 
         assert.equal(mockMailer.sendPasswordResetNotification.callCount, 1, 'mailer.sendPasswordResetNotification was called once')
         assert.equal(mockMailer.sendPasswordResetNotification.args[0][2].uid, uid, 'mailer.sendPasswordResetNotification was passed uid')
+        assert.equal(mockMailer.sendPasswordResetNotification.args[0][2].deviceId, 'wibble')
       })
     }
   )

--- a/test/local/routes/utils/signin.js
+++ b/test/local/routes/utils/signin.js
@@ -451,6 +451,7 @@ describe('sendSigninNotifications', () => {
       payload: {
         service: 'testservice',
         metricsContext: {
+          deviceId: 'wibble',
           flowBeginTime: Date.now(),
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           utmCampaign: 'utm campaign',
@@ -543,6 +544,7 @@ describe('sendSigninNotifications', () => {
         assert.calledWithExactly(mailer.sendVerifyCode, [], accountRecord, {
           acceptLanguage: 'en-US',
           code: 'emailVerifyCode',
+          deviceId: request.payload.metricsContext.deviceId,
           flowBeginTime: request.payload.metricsContext.flowBeginTime,
           flowId: request.payload.metricsContext.flowId,
           ip: CLIENT_ADDRESS,
@@ -590,6 +592,7 @@ describe('sendSigninNotifications', () => {
         assert.calledWithExactly(mailer.sendVerifyCode, [], accountRecord, {
           acceptLanguage: 'en-US',
           code: 'tokenVerifyCode',  // the token verification code is used if available
+          deviceId: request.payload.metricsContext.deviceId,
           flowBeginTime: request.payload.metricsContext.flowBeginTime,
           flowId: request.payload.metricsContext.flowId,
           ip: CLIENT_ADDRESS,
@@ -673,6 +676,7 @@ describe('sendSigninNotifications', () => {
         assert.calledWithExactly(mailer.sendVerifyLoginEmail, accountRecord.emails, accountRecord, {
           acceptLanguage: 'en-US',
           code: 'tokenVerifyCode',
+          deviceId: request.payload.metricsContext.deviceId,
           flowBeginTime: request.payload.metricsContext.flowBeginTime,
           flowId: request.payload.metricsContext.flowId,
           ip: CLIENT_ADDRESS,
@@ -721,6 +725,7 @@ describe('sendSigninNotifications', () => {
         assert.calledWithExactly(mailer.sendVerifyLoginCodeEmail, accountRecord.emails, accountRecord, {
           acceptLanguage: 'en-US',
           code: 'tokenVerifyShortCode',
+          deviceId: request.payload.metricsContext.deviceId,
           flowBeginTime: request.payload.metricsContext.flowBeginTime,
           flowId: request.payload.metricsContext.flowId,
           ip: CLIENT_ADDRESS,


### PR DESCRIPTION
Related to mozilla/fxa-activity-metrics#109.

Currently our `fxa_email - sent` amplitude events do not include the device id, which may be causing problems with the funnels with Amplitude. This change fixes it by passing the device id to the mailer in our sign-in, sign-up and reset flows, and also by setting the property on the correct object when calling the amplitude module.

Here is an example event from before these changes (without `device_id`):

```
{"op":"amplitudeEvent","event_type":"fxa_email - sent","time":1543488875186,"user_id":"92edc9c2522745d29c96d99daab0f759","session_id":1543488852908,"app_version":"126","language":"en","event_properties":{"email_type":"reset_password","email_provider":"other","email_sender":"ses","email_service":"fxa-auth-server","email_template":"recoveryEmail","email_version":1},"user_properties":{"flow_id":"ddb4d3455676fc74125b0e90f744b9563c9f855a1501f270028a01d6721e30c7","sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
```

And here is an example event after these changes (with `device_id`):

```
{"op":"amplitudeEvent","event_type":"fxa_email - sent","time":1543495408243,"user_id":"0bc26f36d7044a6a94e115eced630b2e","device_id":"593cb512c5284c298bb1c8a9b3c03dd9","session_id":1543495397648,"app_version":"126","language":"en","event_properties":{"email_type":"reset_password","email_provider":"other","email_sender":"ses","email_service":"fxa-auth-server","email_template":"recoveryEmail","email_version":1},"user_properties":{"flow_id":"b03ec6df0e4318eb789038d2d1fa6781b913575168bece58039067e6dfe8f728","sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
```

Opened against `train-126` for a patch release as it's affecting metrics.

@mozilla/fxa-devs r?