### PR TITLE
fix(email): add manage account button in new device login email template

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -72,7 +72,7 @@ module.exports = function (log, config) {
   // in template.
   const templateNameToContentMap = {
     'lowRecoveryCodesEmail': 'recovery-codes',
-    'newDeviceLoginEmail': 'password-change',
+    'newDeviceLoginEmail': 'manage-account',
     'passwordChangedEmail': 'password-change',
     'passwordResetEmail': 'password-reset',
     'passwordResetAccountRecoveryEmail': 'create-recovery-key',
@@ -911,7 +911,7 @@ module.exports = function (log, config) {
   Mailer.prototype.newDeviceLoginEmail = function (message) {
     log.trace({ op: 'mailer.newDeviceLoginEmail', email: message.email, uid: message.uid })
     var templateName = 'newDeviceLoginEmail'
-    var links = this._generateLinks(this.initiatePasswordChangeUrl, message.email, {}, templateName)
+    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
     var translator = this.translator(message.acceptLanguage)
 
     var headers = {
@@ -935,6 +935,7 @@ module.exports = function (log, config) {
           location: this._constructLocationString(message),
           passwordChangeLink: links.passwordChangeLink,
           passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+          link: links.link,
           privacyUrl: links.privacyUrl,
           supportLinkAttributes: links.supportLinkAttributes,
           supportUrl: links.supportUrl,

--- a/lib/senders/partials/new_device_login.html
+++ b/lib/senders/partials/new_device_login.html
@@ -3,4 +3,28 @@
 <% block heading %>{{t "New sign-in to %(clientName)s" }}<% endblock %>
 <% block text_primary %>
 <% include "./location/location.html" %>
+
+<!--Button Area-->
+<tr height="50">
+  <td align="center" valign="top">
+      <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0a84ff; border-radius: 4px; height: 50px; width: 310px !important;">
+          <tr style="page-break-before: always">
+              <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+                  <!--[if mso]>
+                  <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0a84ff">
+                      <w:anchorlock/>
+                      <center>
+                  <![endif]-->
+                  <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Manage account"}}</a>
+                  <!--[if mso]>
+                  </center>
+                  </v:roundrect>
+                  <![endif]-->
+              </td>
+          </tr>
+      </table>
+  </td>
+</tr>
+<!--Button Area-->
+
 <% endblock %>

--- a/lib/senders/templates/_versions.json
+++ b/lib/senders/templates/_versions.json
@@ -1,6 +1,6 @@
 {
   "lowRecoveryCodesEmail": 2,
-  "newDeviceLoginEmail": 1,
+  "newDeviceLoginEmail": 2,
   "passwordChangedEmail": 1,
   "passwordResetEmail": 1,
   "passwordResetRequiredEmail": 1,

--- a/lib/senders/templates/new_device_login.html
+++ b/lib/senders/templates/new_device_login.html
@@ -35,6 +35,30 @@
     {{#if timestamp }}{{ timestamp }}<br/>{{/if}}
 </p>
 
+
+<!--Button Area-->
+<tr height="50">
+  <td align="center" valign="top">
+      <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0a84ff; border-radius: 4px; height: 50px; width: 310px !important;">
+          <tr style="page-break-before: always">
+              <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+                  <!--[if mso]>
+                  <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0a84ff">
+                      <w:anchorlock/>
+                      <center>
+                  <![endif]-->
+                  <a href="{{{link}}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Manage account"}}</a>
+                  <!--[if mso]>
+                  </center>
+                  </v:roundrect>
+                  <![endif]-->
+              </td>
+          </tr>
+      </table>
+  </td>
+</tr>
+<!--Button Area-->
+
 </p>
   </td>
 </tr>

--- a/lib/senders/templates/new_device_login.txt
+++ b/lib/senders/templates/new_device_login.txt
@@ -5,6 +5,8 @@
 {{#if ip}}{{t "IP address: %(ip)s" }}{{/if}}
 {{#if timestamp}}{{ timestamp }}{{/if}}
 
+{{t "Manage account:"}} {{{ link }}}
+
 {{{t "This is an automated email; if you didn’t add a new device to your Firefox Account, you should change your password immediately at %(passwordChangeLink)s"}}}
 
 {{{t "For more information, please visit %(supportUrl)s"}}}

--- a/test/local/senders/email.js
+++ b/test/local/senders/email.js
@@ -139,6 +139,7 @@ const typesContainPasswordManagerInfoLinks = [
 ]
 
 const typesContainManageSettingsLinks = [
+  'newDeviceLoginEmail',
   'postVerifySecondaryEmail',
   'postChangePrimaryEmail',
   'postRemoveSecondaryEmail',


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2197

Adds manage account button in `New sign-in` email. Approved in https://github.com/mozilla/fxa-auth-server/pull/2747

<img width="393" alt="screen shot 2018-12-10 at 11 01 32 am" src="https://user-images.githubusercontent.com/1295288/49744536-fdd30c80-fc6a-11e8-806d-089d7961eb47.png">
