### PR TITLE
feat(metrics): add country and region to activity and flow events

### DIFF
--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -156,8 +156,11 @@ module.exports = (log, config) => {
   }
 
   function emitActivityEvent (event, request, data) {
+    const { location } = request.app.geo
     data = Object.assign({
+      country: location && location.country,
       event,
+      region: location && location.state,
       userAgent: request.headers['user-agent']
     }, data)
 
@@ -172,9 +175,12 @@ module.exports = (log, config) => {
       return P.resolve()
     }
 
+    const { location } = request.app.geo
     return request.gatherMetricsContext({
+      country: location && location.country,
       event: event,
       locale: request.app && request.app.locale,
+      region: location && location.state,
       userAgent: request.headers['user-agent']
     }).then(data => {
       if (data.flow_id) {

--- a/test/local/devices.js
+++ b/test/local/devices.js
@@ -261,7 +261,9 @@ describe('lib/devices:', () => {
             args = log.activityEvent.args[0]
             assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
             assert.deepEqual(args[0], {
+              country: 'United States',
               event: 'device.created',
+              region: 'California',
               service: undefined,
               userAgent: 'test user-agent',
               uid: sessionToken.uid,
@@ -358,7 +360,9 @@ describe('lib/devices:', () => {
             args = log.activityEvent.args[0]
             assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
             assert.deepEqual(args[0], {
+              country: 'United States',
               event: 'device.updated',
+              region: 'California',
               service: undefined,
               userAgent: 'test user-agent',
               uid: sessionToken.uid,

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -84,7 +84,9 @@ describe('metrics/events', () => {
         let args = log.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'device.created',
+          region: 'California',
           userAgent: 'foo',
           service: 'bar',
           uid: 'baz'
@@ -116,7 +118,9 @@ describe('metrics/events', () => {
         const args = log.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'device.created',
+          region: 'California',
           userAgent: 'test user-agent',
           service: 'bar'
         }, 'argument was event data')
@@ -139,7 +143,9 @@ describe('metrics/events', () => {
         const args = log.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'device.created',
+          region: 'California',
           service: undefined,
           userAgent: 'test user-agent'
         }, 'argument was event data')
@@ -189,6 +195,7 @@ describe('metrics/events', () => {
         args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 1000,
@@ -196,6 +203,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'account.signed',
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           uid: 'deadbeef',
           userAgent: 'test user-agent',
@@ -222,7 +230,12 @@ describe('metrics/events', () => {
     const request = {
       app: {
         devices: P.resolve(),
-        geo: {},
+        geo: {
+          location: {
+            country: 'United Kingdom',
+            state: 'Dorset'
+          }
+        },
         locale: 'en',
         ua: {}
       },
@@ -249,6 +262,7 @@ describe('metrics/events', () => {
         const args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United Kingdom',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 1000,
@@ -256,6 +270,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'account.signed',
           flowType: undefined,
           locale: 'en',
+          region: 'Dorset',
           time,
           userAgent: 'foo'
         }, 'argument was event data')
@@ -295,6 +310,7 @@ describe('metrics/events', () => {
         const args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 1000,
@@ -302,6 +318,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'account.signed',
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           uid: 'deadbeef',
           userAgent: 'test user-agent'
@@ -342,6 +359,7 @@ describe('metrics/events', () => {
         const args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 1000,
@@ -349,6 +367,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'account.signed',
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           uid: 'deadbeef',
           userAgent: 'test user-agent'
@@ -389,6 +408,7 @@ describe('metrics/events', () => {
         const args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 1000,
@@ -396,6 +416,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'account.signed',
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was event data')
@@ -435,6 +456,7 @@ describe('metrics/events', () => {
 
         assert.equal(log.flowEvent.callCount, 2, 'log.flowEvent was called twice')
         assert.deepEqual(log.flowEvent.args[0][0], {
+          country: 'United States',
           event: 'email.verification.sent',
           flow_id: 'bar',
           flow_time: 2000,
@@ -442,11 +464,13 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'email.verification.sent',
           flowType: 'registration',
           locale: 'fr',
+          region: 'California',
           time,
           uid: 'qux',
           userAgent: 'test user-agent'
         }, 'argument was event data first time')
         assert.deepEqual(log.flowEvent.args[1][0], {
+          country: 'United States',
           event: 'flow.complete',
           flow_id: 'bar',
           flow_time: 2000,
@@ -454,6 +478,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: 'email.verification.sent',
           flowType: 'registration',
           locale: 'fr',
+          region: 'California',
           time,
           uid: 'qux',
           userAgent: 'test user-agent'
@@ -562,7 +587,9 @@ describe('metrics/events', () => {
       .then(() => {
         assert.equal(log.activityEvent.callCount, 1, 'log.activityEvent was called once')
         assert.deepEqual(log.activityEvent.args[0][0], {
+          country: 'United States',
           event: 'account.keyfetch',
+          region: 'California',
           userAgent: 'test user-agent',
           service: undefined,
           uid: 'baz'
@@ -572,6 +599,7 @@ describe('metrics/events', () => {
 
         assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
         assert.deepEqual(log.flowEvent.args[0][0], {
+          country: 'United States',
           time,
           event: 'account.keyfetch',
           flow_id: 'bar',
@@ -580,6 +608,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           uid: 'baz',
           userAgent: 'test user-agent'
         }, 'flow event data was correct')
@@ -721,6 +750,7 @@ describe('metrics/events', () => {
         let args = log.flowEvent.args[0]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument first time')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'route./account/create.200',
           flow_id: 'bar',
           flow_time: 1000,
@@ -728,6 +758,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was route summary event data')
@@ -735,6 +766,7 @@ describe('metrics/events', () => {
         args = log.flowEvent.args[1]
         assert.equal(args.length, 1, 'log.flowEvent was passed one argument second time')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'route.performance./account/create',
           flow_id: 'bar',
           flow_time: 42,
@@ -742,6 +774,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was performance event data')
@@ -778,6 +811,7 @@ describe('metrics/events', () => {
 
         assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
         assert.deepEqual(log.flowEvent.args[0][0], {
+          country: 'United States',
           event: 'route./account/login.399',
           flow_id: 'bar',
           flow_time: 1000,
@@ -785,6 +819,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was event data')
@@ -821,6 +856,7 @@ describe('metrics/events', () => {
 
         assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
         assert.deepEqual(log.flowEvent.args[0][0], {
+          country: 'United States',
           event: 'route./recovery_email/resend_code.400.999',
           flow_id: 'bar',
           flow_time: 1000,
@@ -828,6 +864,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was event data')
@@ -894,6 +931,7 @@ describe('metrics/events', () => {
 
         assert.equal(log.flowEvent.callCount, 1, 'log.flowEvent was called once')
         assert.deepEqual(log.flowEvent.args[0][0], {
+          country: 'United States',
           event: 'route./account/destroy.400.42',
           flow_id: 'bar',
           flow_time: 1000,
@@ -901,6 +939,7 @@ describe('metrics/events', () => {
           flowCompleteSignal: undefined,
           flowType: undefined,
           locale: 'en-US',
+          region: 'California',
           time,
           userAgent: 'test user-agent'
         }, 'argument was event data')

--- a/test/local/routes/account.js
+++ b/test/local/routes/account.js
@@ -195,7 +195,9 @@ describe('/account/reset', function () {
       const args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.reset',
+        region: 'California',
         service: undefined,
         userAgent: 'test user-agent',
         uid: uid
@@ -234,7 +236,9 @@ describe('/account/reset', function () {
       var args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.reset',
+        region: 'California',
         service: undefined,
         userAgent: 'test user-agent',
         uid: uid
@@ -434,7 +438,9 @@ describe('/account/create', () => {
       args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.created',
+        region: 'California',
         service: 'sync',
         userAgent: 'test user-agent',
         uid: uid
@@ -444,6 +450,7 @@ describe('/account/create', () => {
       args = mockLog.flowEvent.args[0]
       assert.equal(args.length, 1, 'log.flowEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.created',
         flowBeginTime: mockRequest.payload.metricsContext.flowBeginTime,
         flowCompleteSignal: 'account.signed',
@@ -451,6 +458,7 @@ describe('/account/create', () => {
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
         flow_id: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         locale: 'en-GB',
+        region: 'California',
         time: now,
         uid: uid,
         userAgent: 'test user-agent',
@@ -731,7 +739,9 @@ describe('/account/login', function () {
       args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.login',
+        region: 'California',
         service: 'sync',
         userAgent: 'test user-agent',
         uid: uid
@@ -741,6 +751,7 @@ describe('/account/login', function () {
       args = mockLog.flowEvent.args[0]
       assert.equal(args.length, 1, 'log.flowEvent was passed one argument first time')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.login',
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
         flow_id: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
@@ -748,6 +759,7 @@ describe('/account/login', function () {
         flowCompleteSignal: 'account.signed',
         flowType: undefined,
         locale: 'en-US',
+        region: 'California',
         time: now,
         uid: uid,
         userAgent: 'test user-agent'
@@ -755,6 +767,7 @@ describe('/account/login', function () {
       args = mockLog.flowEvent.args[1]
       assert.equal(args.length, 1, 'log.flowEvent was passed one argument second time')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'email.confirmation.sent',
         flow_time: now - mockRequest.payload.metricsContext.flowBeginTime,
         flow_id: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
@@ -762,6 +775,7 @@ describe('/account/login', function () {
         flowCompleteSignal: 'account.signed',
         flowType: undefined,
         locale: 'en-US',
+        region: 'California',
         time: now,
         userAgent: 'test user-agent'
       }, 'second flow event was correct')
@@ -1449,7 +1463,9 @@ describe('/account/keys', function () {
       args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.keyfetch',
+        region: 'California',
         service: undefined,
         userAgent: 'test user-agent',
         uid: uid
@@ -1539,7 +1555,9 @@ describe('/account/destroy', function () {
       args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'account.deleted',
+        region: 'California',
         service: undefined,
         userAgent: 'test user-agent',
         uid: uid

--- a/test/local/routes/devices-and-sessions.js
+++ b/test/local/routes/devices-and-sessions.js
@@ -381,7 +381,9 @@ describe('/account/devices/notify', function () {
         args = mockLog.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'sync.sentTabToDevice',
+          region: 'California',
           service: 'sync',
           userAgent: 'test user-agent',
           uid: uid.toString('hex'),
@@ -870,7 +872,9 @@ describe('/account/device/destroy', function () {
       var args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         event: 'device.deleted',
+        region: 'California',
         service: undefined,
         userAgent: 'test user-agent',
         uid: uid.toString('hex'),

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -487,8 +487,10 @@ describe('/recovery_email/verify_code', function () {
         args = mockLog.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'account.verified',
           marketingOptIn: false,
+          region: 'California',
           service: 'sync',
           uid: uid.toString('hex'),
           userAgent: 'test user-agent'
@@ -632,7 +634,9 @@ describe('/recovery_email/verify_code', function () {
         var args = mockLog.activityEvent.args[0]
         assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
         assert.deepEqual(args[0], {
+          country: 'United States',
           event: 'account.confirmed',
+          region: 'California',
           service: 'sync',
           userAgent: 'test user-agent',
           uid: uid.toString('hex')

--- a/test/local/routes/password.js
+++ b/test/local/routes/password.js
@@ -349,7 +349,9 @@ describe('/password', () => {
           var args = mockLog.activityEvent.args[0]
           assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
           assert.deepEqual(args[0], {
+            country: 'United States',
             event: 'account.changedPassword',
+            region: 'California',
             service: undefined,
             uid: uid.toString('hex'),
             userAgent: 'test user-agent'
@@ -430,7 +432,9 @@ describe('/password', () => {
           var args = mockLog.activityEvent.args[0]
           assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
           assert.deepEqual(args[0], {
+            country: 'United States',
             event: 'account.changedPassword',
+            region: 'California',
             service: undefined,
             uid: uid.toString('hex'),
             userAgent: 'test user-agent'

--- a/test/local/routes/sign.js
+++ b/test/local/routes/sign.js
@@ -105,8 +105,10 @@ describe('/certificate/sign', () => {
       args = mockLog.activityEvent.args[0]
       assert.equal(args.length, 1, 'log.activityEvent was passed one argument')
       assert.deepEqual(args[0], {
+        country: 'United States',
         device_id: deviceId.toString('hex'),
         event: 'account.signed',
+        region: 'California',
         service: undefined,
         uid: mockRequest.auth.credentials.uid.toString('hex'),
         userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:55.0) Gecko/20100101 Firefox/55.0'

--- a/test/local/routes/utils/signin.js
+++ b/test/local/routes/utils/signin.js
@@ -500,7 +500,9 @@ describe('sendSigninNotifications', () => {
 
       assert.calledOnce(log.activityEvent)
       assert.calledWithExactly(log.activityEvent, {
+        country: 'United States',
         event: 'account.login',
+        region: 'California',
         service: 'testservice',
         userAgent: 'test user-agent',
         uid: TEST_UID


### PR DESCRIPTION
Related to mozilla/fxa-activity-metrics#108.

We'll also need to update the import scripts and the Heka filter.

@mozilla/fxa-devs r?