### PR TITLE
feat(validation): Have `validators.scope` automatically parse the value to a `ScopeSet`.

### DIFF
--- a/fxa-oauth-server/lib/routes/authorization.js
+++ b/fxa-oauth-server/lib/routes/authorization.js
@@ -223,7 +223,7 @@ module.exports = {
     var start = Date.now();
     var wantsGrant = req.payload.response_type === TOKEN;
     var exitEarly = false;
-    var scope = ScopeSet.fromString(req.payload.scope || '');
+    var scope = req.payload.scope;
     return P.all([
       verifyAssertion(req.payload.assertion).then(function(claims) {
         logger.info('time.verify_assertion', { ms: Date.now() - start });

--- a/fxa-oauth-server/lib/routes/key_data.js
+++ b/fxa-oauth-server/lib/routes/key_data.js
@@ -46,7 +46,7 @@ module.exports = {
       payload: req.payload
     });
 
-    const requestedScopes = ScopeSet.fromString(req.payload.scope);
+    const requestedScopes = req.payload.scope;
     const requestedClientId = req.payload.client_id;
 
     const [claims, scopes] = await P.all([

--- a/fxa-oauth-server/lib/routes/token.js
+++ b/fxa-oauth-server/lib/routes/token.js
@@ -72,11 +72,11 @@ const PAYLOAD_SCHEMA = Joi.object({
     .default(MAX_TTL_S)
     .optional(),
 
-  scope: Joi.alternatives().when('grant_type', {
-    is: GRANT_REFRESH_TOKEN,
-    then: validators.scope,
-    otherwise: Joi.optional()
-  }),
+  scope: validators.scope
+    .when('grant_type', {
+      is: GRANT_REFRESH_TOKEN,
+      otherwise: Joi.forbidden()
+    }),
 
   code: Joi.string()
     .length(config.get('unique.code') * 2)
@@ -130,7 +130,7 @@ module.exports = {
       access_token: validators.token.required(),
       refresh_token: validators.token,
       id_token: validators.assertion,
-      scope: validators.scope.required().allow(''),
+      scope: validators.scope.required(),
       token_type: Joi.string().valid('bearer').required(),
       expires_in: Joi.number().max(MAX_TTL_S).required(),
       auth_at: Joi.number(),
@@ -139,7 +139,6 @@ module.exports = {
   },
   handler: async function tokenEndpoint(req) {
     var params = req.payload;
-    params.scope = ScopeSet.fromString(params.scope || '');
     return P.try(function() {
 
       // Clients are allowed to provide credentials in either

--- a/fxa-oauth-server/test/api.js
+++ b/fxa-oauth-server/test/api.js
@@ -1456,6 +1456,34 @@ describe('/v1', function() {
             assertSecurityHeaders(res);
           });
         });
+
+        it('does not accept a `scope` parameter', function() {
+          mockAssertion().reply(200, VERIFY_GOOD);
+          return Server.api.post({
+            url: '/authorization',
+            payload: authParams()
+          }).then(function(res) {
+            return res.result.code;
+          }).then(function(code) {
+            return Server.api.post({
+              url: '/token',
+              payload: {
+                client_id: clientId,
+                client_secret: secret,
+                code: code,
+                scope: 'a'
+              }
+            });
+          }).then(function(res) {
+            assert.equal(res.result.code, 400);
+            assert.equal(res.result.errno, 109);
+            assert.deepEqual(res.result.validation, {
+              source: 'payload',
+              keys: ['scope']
+            });
+            assertSecurityHeaders(res);
+          });
+        });
       });
 
       describe('response', function() {


### PR DESCRIPTION
We had another instance of #2687, which finally encouraged me to dig in and fix it.  The `validators.scope` validator will now automatically parse and return a `ScopeSet` object, and any errors thrown during the parse will be handled cleanly as validation failures.

Unlike the way we do custom validators [in the auth-server codebase](https://github.com/mozilla/fxa-auth-server/blob/master/lib/routes/validators.js), this implementation uses Joi's public extension API to add a new data type.  If we like it, we should consider refactoring the auth-server validators to this this as well.

Fixes #2687.