### PR TITLE
fix(circle): can never have enough version.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
             "$CIRCLE_PROJECT_USERNAME"
             "fxa-oauth-server"
             "$CIRCLE_BUILD_URL"
-            | tee fxa-oauth-server/config/version.json fxa-oauth-server/version.json
+            | tee version.json fxa-oauth-server/version.json fxa-oauth-server/config/version.json
       - store_artifacts:
           path: version.json
 


### PR DESCRIPTION
Our build pipeline wants to find this file in version.json, so put it in all the places.

r? - @vladikoff 

(p.s., this will need to go into a v1.128.1 release)