### PR TITLE
fix(config): use local redirect for the reference browser

### DIFF
--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -143,7 +143,7 @@
       "name": "Android Components Reference Browser",
       "hashedSecret": "a7ee3482fab1782f5d3945cde06bb911605a8dfc1a45e4b77bc76615d5671e51",
       "imageUri": "",
-      "redirectUri": "https://accounts.firefox.com/oauth/success/3c49430b43dfba77",
+      "redirectUri": "http://127.0.0.1:3030/oauth/success/3c49430b43dfba77",
       "canGrant": false,
       "trusted": true,
       "allowedScopes": "https://identity.mozilla.com/apps/oldsync",


### PR DESCRIPTION
Each environment maps this endpoint to its content server