### PR TITLE
chore(package): disable security advisory 766 for sandbox dependency

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,7 @@
   "exceptions": [
     "https://npmjs.com/advisories/39",
     "https://npmjs.com/advisories/48",
-    "https://npmjs.com/advisories/658"
+    "https://npmjs.com/advisories/658",
+    "https://npmjs.com/advisories/766"
   ]
 }


### PR DESCRIPTION
[Advisory 766](https://www.npmjs.com/advisories/766) points out that it's possible for untrusted content to break out of the `sandbox` dependency. However that's not the case in our usage, where input is expanded inside JavaScript strings and has been validated previously anyway.

Our invocation of `sandbox` looks like this:

```js
sandbox.run(`new RegExp("${regex}").test("${emailAddress}")`
```

Here, `regex` is a string from our Redis instance, which can only be written to by our ops team. And `emailAddress` is a string from the front-end which has been validated by Joi at the API boundary.

But more importantly, both are wrapped as strings in the evaluated code and a preceeding check ensures that they do not terminate their enclosing string prematurely:

```js
if (regex.indexOf('"') !== -1 || emailAddress.indexOf('"') !== -1 || ! safeRegex(regex)) {
  resolve(false)
  return
}
```

So it's safe to add this advisory to the ignore file in our case. If we ever find ourselves using sandbox for another reason, we must ensure to take similar precautions there too.

@mozilla/fxa-devs r?