### PR TITLE
fix(oauth): Allow keys_jwk through GET /authorization

### DIFF
--- a/fxa-oauth-server/lib/routes/redirect.js
+++ b/fxa-oauth-server/lib/routes/redirect.js
@@ -5,17 +5,9 @@
 const url = require('url');
 
 const contentUrl = require('../config').get('contentUrl');
-const AppError = require('../error');
 
 module.exports = {
   handler: async function redirectAuthorization(req, h) {
-    // keys_jwk is barred from transiting the OAuth server
-    // to prevent a malicious OAuth server from stealing
-    // a user's Scoped Keys. See bz1456351
-    if (req.query.keys_jwk) {
-      throw AppError.invalidRequestParameter('keys_jwk');
-    }
-
     const redirect = url.parse(contentUrl, true);
     redirect.pathname = '/authorization';
     redirect.query = req.query;

--- a/fxa-oauth-server/test/api.js
+++ b/fxa-oauth-server/test/api.js
@@ -243,17 +243,6 @@ describe('/v1', function() {
           assert.equal(redirect.host, target.host);
         });
       });
-
-      it('should fail if keys_jwk specified', () => {
-        return Server.api
-        .get('/authorization?keys_jwk=xyz&client_id=123&state=321&scope=1')
-        .then(function(res) {
-          assert.equal(res.statusCode, 400);
-          assert.equal(res.result.errno, 109);
-          assert.equal(res.result.validation, 'keys_jwk');
-          assertSecurityHeaders(res);
-        });
-      });
     });
 
     describe('content-type', function() {


### PR DESCRIPTION
Barring keys_jwk from GET /authorization broke Notes. We can't break Notes.

fixes mozilla/notes#1440

@vladikoff - r?