### PR TITLE
fix(circle): version.json "source" should be code repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             "$CIRCLE_SHA1"
             "$CIRCLE_TAG"
             "$CIRCLE_PROJECT_USERNAME"
-            "fxa-oauth-server"
+            "$CIRCLE_PROJECT_REPONAME"
             "$CIRCLE_BUILD_URL"
             | tee version.json fxa-oauth-server/version.json fxa-oauth-server/config/version.json
       - store_artifacts:


### PR DESCRIPTION
Minor point, and I realize @vladikoff chose to set this to `fxa-oauth-server`, but, if I remember correctly, the intent was that `/__version__` could be used to located the source code of an image.

This (https://mana.mozilla.org/wiki/display/SVCOPS/New+Service+Guide#NewServiceGuide-/__version__) is a little imprecise on that point though.