### PR TITLE
Scoped keys data fixes

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -599,7 +599,7 @@ var conf = convict({
     url: {
       format: 'url',
       doc: 'URL at which to verify OAuth tokens',
-      default: 'http://localhost:9010',
+      default: 'http://127.0.0.1:9010',
       env: 'OAUTH_URL'
     },
     keepAlive: {

--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -161,6 +161,7 @@
     "key": {}
   },
   "allowHttpRedirects": true,
+  "authServerSecrets": ["megaz0rd"],
   "scopes": [
     {
       "scope": "https://identity.mozilla.com/apps/notes",

--- a/lib/oauthdb.js
+++ b/lib/oauthdb.js
@@ -106,7 +106,7 @@ module.exports = (log, config) => {
       issuer: config.domain
     }
     const claims = {
-      uid: credentials.uid,
+      'sub': credentials.uid,
       'fxa-generation': credentials.verifierSetAt,
       'fxa-verifiedEmail': credentials.email,
       'fxa-lastAuthAt': credentials.lastAuthAt(),

--- a/test/local/oauthdb.js
+++ b/test/local/oauthdb.js
@@ -180,7 +180,7 @@ describe('oauthdb', () => {
         'fxa-tokenVerified': true,
         'fxa-verifiedEmail': MOCK_CREDENTIALS.email,
         iss: 'accounts.example.com',
-        uid: MOCK_UID
+        sub: MOCK_UID
       })
       assert.deepEqual(keyData, {
         'mock-scope': {


### PR DESCRIPTION
- The `sub` change is because of
https://github.com/mozilla/fxa-auth-server/blob/fa4baba5b468c8a0e4f071c965a55af4b5e6d0a4/fxa-oauth-server/lib/assertion.js#L117.
- `megaz0rd` is the default `oauth.secretKey` in `fxa-auth-server`.