### PR TITLE
fix(metrics): stop emitting route flow events for status endpoints

### DIFF
--- a/lib/metrics/events.js
+++ b/lib/metrics/events.js
@@ -53,8 +53,12 @@ const IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS = new Set([
   '/account/devices',
   '/account/profile',
   '/account/sessions',
-  '/certificate/sign'
+  '/certificate/sign',
+  '/password/forgot/status',
+  '/recovery_email/status'
 ])
+
+const IGNORE_ROUTE_FLOW_EVENTS_REGEX = /^\/recoveryKey\/[0-9A-Fa-f]+$/
 
 const PATH_PREFIX = /^\/v1/
 
@@ -130,7 +134,7 @@ module.exports = (log, config) => {
       const path = request.path.replace(PATH_PREFIX, '')
       let status = response.statusCode || response.output.statusCode
 
-      if (status === 404 || IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS.has(path)) {
+      if (status === 404 || IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS.has(path) || IGNORE_ROUTE_FLOW_EVENTS_REGEX.test(path)) {
         return P.resolve()
       }
 

--- a/test/local/metrics/events.js
+++ b/test/local/metrics/events.js
@@ -952,11 +952,19 @@ describe('metrics/events', () => {
       })
   })
 
-  it('.emitRouteFlowEvent with non-matching route', () => {
+  ;[
+    '/account/devices',
+    '/account/profile',
+    '/account/sessions',
+    '/certificate/sign',
+    '/password/forgot/status',
+    '/recovery_email/status',
+    '/recoveryKey/0123456789abcdef0123456789ABCDEF'
+  ].forEach(route => it(`.emitRouteFlowEvent with ${route}`, () => {
     const metricsContext = mocks.mockMetricsContext()
     const request = mocks.mockRequest({
       metricsContext,
-      path: '/v1/account/devices',
+      path: `/v1${route}`,
       payload: {
         metricsContext: {
           flowId: 'bar',
@@ -972,7 +980,7 @@ describe('metrics/events', () => {
         assert.equal(metricsContext.clear.callCount, 0, 'metricsContext.clear was not called')
         assert.equal(log.error.callCount, 0, 'log.error was not called')
       })
-  })
+  }))
 
   it('.emitRouteFlowEvent with matching route and invalid metrics context', () => {
     const metricsContext = mocks.mockMetricsContext({ validate: sinon.spy(() => false) })


### PR DESCRIPTION
Fixes #2850.

`/password/forgot/status` and `/recovery_email/status` are hit frequently, generating lots of events which aren't very useful. If we skip them we can appreciably reduce the amount of data that passes through our logs, our metrics pipeline and into Redshift.

Additionally, there are a number of specific `/recoveryKey/...` endpoints that also generate useless event data (although nowhere near as many events as the other two). I've stopped emitting those too.

@mozilla/fxa-devs r?