### PR TITLE
fix(email): add missing query params to link in new device email

### DIFF
--- a/lib/senders/email.js
+++ b/lib/senders/email.js
@@ -911,7 +911,7 @@ module.exports = function (log, config, oauthdb) {
   Mailer.prototype.newDeviceLoginEmail = function (message) {
     log.trace({ op: 'mailer.newDeviceLoginEmail', email: message.email, uid: message.uid })
     var templateName = 'newDeviceLoginEmail'
-    var links = this._generateLinks(this.accountSettingsUrl, message.email, {}, templateName)
+    var links = this._generateSettingLinks(message, templateName)
     var translator = this.translator(message.acceptLanguage)
 
     var headers = {


### PR DESCRIPTION
Fixes #2882.

In 3b2e946, I fix the local email tests so that they actually fail if one of the assertions throws an error. You can verify this if you run them against that commit, because you'll see this failure which has been lurking in tree since last month:

```
  1) lib/senders/email:
       account settings info link is in email template output for newDeviceLoginEmail:
     AssertionError: expected false to be truthy
      at mailer.mailer.sendMail.emailConfig (test/local/senders/email.js:525:22)
      at Nodemailer.sendMail (test/local/senders/email.js:184:7)
      at P.all.services.map.service (lib/senders/email.js:338:18)
      at Array.map (<anonymous>)
      at selectEmailServices.then.services (lib/senders/email.js:282:31)
      at tryCatcher (node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (node_modules/bluebird/js/release/promise.js:512:31)
      at Promise._settlePromise (node_modules/bluebird/js/release/promise.js:569:18)
      at Promise._settlePromise0 (node_modules/bluebird/js/release/promise.js:614:10)
      at Promise._settlePromises (node_modules/bluebird/js/release/promise.js:694:18)
      at _drainQueueStep (node_modules/bluebird/js/release/async.js:138:12)
      at _drainQueue (node_modules/bluebird/js/release/async.js:131:9)
      at Async._drainQueues (node_modules/bluebird/js/release/async.js:147:5)
      at Immediate.Async.drainQueues (node_modules/bluebird/js/release/async.js:17:14)
```

In f13de2f, I fix the aforementioned failure by using the existing method `_generateSettingLinks`, which adds the appropriate query params that the test was expecting.

@mozilla/fxa-devs r?