### PR TITLE
fix(logs): rename `code` to `status` on request.summary log lines

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -86,7 +86,7 @@ Lug.prototype.summary = function (request, response) {
   var query = request.query || {}
   var line = {
     op: 'request.summary',
-    code: (response.isBoom) ? response.output.statusCode : response.statusCode,
+    status: (response.isBoom) ? response.output.statusCode : response.statusCode,
     errno: response.errno || 0,
     rid: request.id,
     path: request.path,
@@ -106,7 +106,7 @@ Lug.prototype.summary = function (request, response) {
   line.keys = query.keys
   line.email = payload.email || query.email
 
-  if (line.code >= 500) {
+  if (line.status >= 500) {
     line.trace = request.app.traced
     line.stack = response.stack
     this.error(line, response.message)

--- a/test/local/log.js
+++ b/test/local/log.js
@@ -471,14 +471,17 @@ describe('log', () => {
       path: '/v1/frobnicate',
       payload: {}
     }, {
-      code: 200
+      code: 200,
+      statusCode: 201
     })
 
     assert.equal(logger.info.callCount, 1)
     assert.equal(logger.info.args[0][1].op, 'request.summary')
+    assert.equal(logger.info.args[0][1].status, 201)
+    assert.equal(logger.info.args[0][1].code, undefined)
     assert.equal(emitRouteFlowEvent.callCount, 1)
     assert.equal(emitRouteFlowEvent.args[0].length, 1)
-    assert.deepEqual(emitRouteFlowEvent.args[0][0], { code: 200 })
+    assert.deepEqual(emitRouteFlowEvent.args[0][0], { code: 200, statusCode: 201 })
     assert.equal(logger.error.callCount, 0)
   })
 


### PR DESCRIPTION
Fixes #2885.

Stackdriver doesn't like it when properties change their type across log lines, and there is a clash between the type of the `code` property for the `account.signin.confirm.success` and `request.summary` log lines.

This change renames it to `status` on `request.summary`, because that seems like a more appropriate name and the other log message appears to have greater legitimacy to its claim to use the `code` property name (that is literally the name of the corresponding property in the request payload).

However, I also know that `request.summary` is going to be parsed by the fraud detection pipeline, so maybe this is a breaking change for them. If that is the case I can change the other log line instead, no probs. @shane-tomlinson, maybe you know for certain whether that is the case (or can point me towards the right person to ask to find out)?

@mozilla/fxa-devs r?