### PR TITLE
fix(error): remove `A` from totpTokenNotFound and totpTokenAlreadyExists errors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -285,9 +285,9 @@ for `code` and `errno` are:
 * `code: 400, errno: 153`:
   Expired token verification code
 * `code: 400, errno: 154`:
-  A TOTP token already exists for this account.
+  TOTP token already exists for this account.
 * `code: 400, errno: 155`:
-  A TOTP token not found.
+  TOTP token not found.
 * `code: 400, errno: 156`:
   Recovery code not found.
 * `code: 400, errno: 157`:

--- a/lib/error.js
+++ b/lib/error.js
@@ -785,7 +785,7 @@ AppError.totpTokenAlreadyExists = () => {
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.TOTP_TOKEN_EXISTS,
-    message: 'A TOTP token already exists for this account.'
+    message: 'TOTP token already exists for this account.'
   })
 }
 
@@ -794,7 +794,7 @@ AppError.totpTokenNotFound = () => {
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.TOTP_TOKEN_NOT_FOUND,
-    message: 'A TOTP token not found.'
+    message: 'TOTP token not found.'
   })
 }
 


### PR DESCRIPTION
Fixes #2888 

Remove `A` from totpTokenAlreadyExists as well because it seemed to be a little clearer without it.