### PR TITLE
fix(sms): catch errors thrown from phoneNumberUtil.parse

### DIFF
--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -61,8 +61,12 @@ module.exports = (log, db, config, customs, sms) => {
           .then(createResponse)
 
         function parsePhoneNumber () {
-          phoneNumberUtil = PhoneNumberUtil.getInstance()
-          parsedPhoneNumber = phoneNumberUtil.parse(phoneNumber)
+          try {
+            phoneNumberUtil = PhoneNumberUtil.getInstance()
+            parsedPhoneNumber = phoneNumberUtil.parse(phoneNumber)
+          } catch (err) {
+            throw error.invalidPhoneNumber()
+          }
         }
 
         function validatePhoneNumber () {

--- a/test/local/routes/sms.js
+++ b/test/local/routes/sms.js
@@ -313,6 +313,44 @@ describe('/sms with the signinCodes feature included in the payload', () => {
         assert.equal(err.output.payload.region, 'TW')
       })
     })
+
+    describe('too-short phone number', () => {
+      let err
+
+      beforeEach(() => {
+        request.payload.phoneNumber = '+18'
+        return runTest(route, request)
+          .catch(e => {
+            err = e
+          })
+      })
+
+      it('called log.begin once', () => {
+        assert.equal(log.begin.callCount, 1)
+      })
+
+      it('called request.validateMetricsContext once', () => {
+        assert.equal(request.validateMetricsContext.callCount, 1)
+      })
+
+      it('did not call db.createSigninCode', () => {
+        assert.equal(db.createSigninCode.callCount, 0)
+      })
+
+      it('did not call sms.send', () => {
+        assert.equal(sms.send.callCount, 0)
+      })
+
+      it('did not call log.flowEvent', () => {
+        assert.equal(log.flowEvent.callCount, 0)
+      })
+
+      it('threw the correct error data', () => {
+        assert.instanceOf(err, AppError)
+        assert.equal(err.errno, AppError.ERRNO.INVALID_PHONE_NUMBER)
+        assert.equal(err.message, 'Invalid phone number')
+      })
+    })
   })
 
   describe('sms.send fails', () => {


### PR DESCRIPTION
Ref: https://sentry.prod.mozaws.net/operations/auth-prod/issues/5170677/?environment=prod

It turns out, sometimes `phoneNumberUtil.parse` throws instead of signalling state via `phoneNumberUtil.isValidNumber`, which I didn't realise when I wrote the code. This just ensures we catch those errors and return the appropriate 400 error instead of a 500.

@mozilla/fxa-devs r?