### PR TITLE
fix(scripts): sanely handle refreshTokens in the docs script

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -792,7 +792,7 @@ by [fxa-customs-server](https://github.com/mozilla/fxa-customs-server).
 
 #### GET /account/profile
 
-:lock: authenticated with OAuth bearer token, or HAWK-authenticated with session token
+:lock: authenticated with OAuth bearer token or HAWK-authenticated with session token
 <!--begin-route-get-accountprofile-->
 Get the email and locale of a user.
 

--- a/scripts/write-api-docs.js
+++ b/scripts/write-api-docs.js
@@ -728,12 +728,7 @@ function marshallAuthentication (authentication) {
       }
       return 0
     }).reduce((summary, token, index) => {
-      if (token === 'oauthToken') {
-        summary += 'authenticated with OAuth bearer token'
-      } else {
-        summary += `${index === 0 ? '' : ', or '}HAWK-authenticated with ${uncamel(token)}`
-      }
-      return summary
+      return `${summary}${index === 0 ? '' : ' or '}${authenticatedWith(token)}`
     }, authentication.optional ? 'Optionally ' : '')
   }
 }
@@ -749,6 +744,17 @@ function marshallToken (token) {
 
   // HACK: Assumes other tokens don't have extra authentication strategies
   return token
+}
+
+function authenticatedWith (token) {
+  switch (token) {
+    case 'oauthToken':
+      return 'authenticated with OAuth bearer token'
+    case 'refreshToken':
+      return 'authenticated with OAuth refresh token'
+    default:
+      return `HAWK-authenticated with ${uncamel(token)}`
+  }
 }
 
 function uncamel (string) {


### PR DESCRIPTION
Saw this mentioned in https://github.com/mozilla/fxa-auth-server/pull/2896#discussion_r253717840.

Fixes the docs script so that it doesn't say refresh tokens are HAWK-authenticated. I also removed a comma in the generated output.

@mozilla/fxa-devs r?