### PR TITLE
Add option to disable requirement of config.events to be set in production

### DIFF
--- a/fxa-oauth-server/lib/config.js
+++ b/fxa-oauth-server/lib/config.js
@@ -110,6 +110,12 @@ const conf = convict({
     default: 'prod'
   },
   events: {
+    enabled: {
+      doc: 'Whether or not config.events has to be properly set in production',
+      format: Boolean,
+      default: true,
+      env: 'EVENTS_ENABLED'
+    },
     region: {
       doc: 'AWS Region of fxa account events',
       format: String,

--- a/fxa-oauth-server/lib/events.js
+++ b/fxa-oauth-server/lib/events.js
@@ -15,7 +15,7 @@ let fxaEvents;
 if (! config.events.region || ! config.events.queueUrl) {
   fxaEvents = {
     start: function start() {
-      if (env.isProdLike()) {
+      if (env.isProdLike() && config.events.enabled) {
         throw new Error('config.events must be included in prod');
       } else {
         logger.warn('accountEvent.unconfigured');


### PR DESCRIPTION
Folks,

First of all, quite new to all this collaboration bits and bobs. I'm trying to run my own Mozilla Services. For my simple setup I don't see the need to have config.events to be set. When I change the NODE_ENV variable to production it requires me though. 

According to the friendly folks in #fxa it's made deliberately hard to disable the events system to guard against accidentally deploying this into production without it being properly set. It was reasonable to create a configuration flag to disable this requirement which is by default set to true. 

So hereby.

Best regards,

Jurgen Brunink