### PR TITLE
feat(email): Update verification email for OAuth reliers.

### DIFF
--- a/lib/senders/partials/verify.html
+++ b/lib/senders/partials/verify.html
@@ -4,8 +4,22 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
-    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;"><% block verify_title %>{{t "Welcome!"}}<% endblock %></h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;"><% block verify_content %>{{{t "Please activate your account by confirming this email address." }}}<% endblock %></p>
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;"><% block verify_title %>
+      {{#if serviceName}}
+        {{{t "Welcome to %(serviceName)s!"}}}
+      {{/if}}
+      {{^if serviceName}}
+        {{t "Welcome!"}}
+      {{/if}}
+    <% endblock %></h1>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;"><% block verify_content %>
+      {{#if serviceName}}
+        {{{t "Confirm this email address to activate your Firefox Account and continue to %(serviceName)s." }}}
+      {{/if}}
+      {{^if serviceName}}
+        {{t "Confirm this email address to activate your Firefox Account." }}
+      {{/if}}
+    <% endblock %></p>
   </td>
 </tr>
 

--- a/lib/senders/templates/_versions.json
+++ b/lib/senders/templates/_versions.json
@@ -11,7 +11,7 @@
   "recoveryEmail": 1,
   "sms.installFirefox": 1,
   "unblockCodeEmail": 1,
-  "verifyEmail": 1,
+  "verifyEmail": 2,
   "verifyPrimaryEmail": 3,
   "verifyLoginEmail": 1,
   "verifyLoginCodeEmail": 2,

--- a/lib/senders/templates/verify.html
+++ b/lib/senders/templates/verify.html
@@ -25,8 +25,22 @@
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
-    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Welcome!"}}</h1>
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{{t "Please activate your account by confirming this email address." }}}</p>
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">
+      {{#if serviceName}}
+        {{{t "Welcome to %(serviceName)s!"}}}
+      {{/if}}
+      {{^if serviceName}}
+        {{t "Welcome!"}}
+      {{/if}}
+    </h1>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{#if serviceName}}
+        {{{t "Confirm this email address to activate your Firefox Account and continue to %(serviceName)s." }}}
+      {{/if}}
+      {{^if serviceName}}
+        {{t "Confirm this email address to activate your Firefox Account." }}
+      {{/if}}
+    </p>
   </td>
 </tr>
 

--- a/lib/senders/templates/verify.txt
+++ b/lib/senders/templates/verify.txt
@@ -1,6 +1,14 @@
+
+{{#if serviceName}}
+{{{t "Welcome to %(serviceName)s!"}}}
+
+{{{t "Confirm this email address to activate your Firefox Account and continue to %(serviceName)s." }}}
+{{/if}}
+{{^if serviceName}}
 {{t "Welcome!"}}
 
-{{{t "Please activate your account by confirming this email address." }}}
+{{t "Confirm this email address to activate your Firefox Account." }}
+{{/if}}
 {{t "Activate now:"}} {{{link}}}
 
 {{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit %(supportUrl)s"}}}


### PR DESCRIPTION
Show the relier name in the email in the header and in
the main text.

fixes #2859 

<img width="415" alt="screenshot 2019-02-08 at 12 02 59" src="https://user-images.githubusercontent.com/848085/52477558-35423480-2b9a-11e9-9f69-c0a921c560af.png">
