### PR TITLE
fix(db): Stop using deprecated 'sessionWithDevice' db route.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -534,7 +534,7 @@ module.exports = (
       })
   }
 
-  SAFE_URLS.sessionToken = new SafeUrl('/sessionToken/:id/device', 'db.sessionToken')
+  SAFE_URLS.sessionToken = new SafeUrl('/sessionToken/:id', 'db.sessionToken')
   DB.prototype.sessionToken = function (id) {
     log.trace({ op: 'DB.sessionToken', id })
     return this.pool.get(SAFE_URLS.sessionToken, { id })


### PR DESCRIPTION
The database now always returns device information when getting a sessionToken, so we don't need to use a special route for it. I think this code was just left over from our cleanup of the old "sessionWithDevice" route.