### PR TITLE
fix(server): make sure to log errors on server start crash

### DIFF
--- a/bin/key_server.js
+++ b/bin/key_server.js
@@ -181,7 +181,10 @@ function main() {
       })
     }
   })
-  .catch(process.exit.bind(null, 8))
+  .catch((err) => {
+    console.error(err) // eslint-disable-line no-console
+    process.exit(8)
+  })
 }
 
 if (require.main === module) {


### PR DESCRIPTION
It can be really confusing this, some server errors would make the server crash, but not output anything.