### PR TITLE
fix(profile_server_messaging): fix db constructor signature

### DIFF
--- a/bin/profile_server_messaging.js
+++ b/bin/profile_server_messaging.js
@@ -11,7 +11,6 @@ require('../lib/newrelic')()
 
 var config = require('../config').getProperties()
 var log = require('../lib/log')(config.log.level, 'profile-server-messaging')
-var error = require('../lib/error')
 var Token = require('../lib/tokens')(log, config)
 var SQSReceiver = require('../lib/sqs')(log)
 var profileUpdates = require('../lib/profile/updates')(log)
@@ -20,12 +19,7 @@ var push = require('../lib/push')
 var DB = require('../lib/db')(
   config,
   log,
-  error,
-  Token.SessionToken,
-  Token.KeyFetchToken,
-  Token.AccountResetToken,
-  Token.PasswordForgotToken,
-  Token.PasswordChangeToken
+  Token
 )
 
 var profileUpdatesQueue = new SQSReceiver(config.profileServerMessaging.region, [

--- a/lib/db.js
+++ b/lib/db.js
@@ -32,7 +32,7 @@ module.exports = (
   config,
   log,
   Token,
-  UnblockCode
+  UnblockCode=null
   ) => {
 
   const features = require('./features')(config)
@@ -1056,6 +1056,9 @@ module.exports = (
 
   SAFE_URLS.createUnblockCode = new SafeUrl('/account/:uid/unblock/:unblock', 'db.createUnblockCode')
   DB.prototype.createUnblockCode = function (uid) {
+    if (! UnblockCode) {
+      return Promise.reject(new Error('Unblock has not been configured'));
+    }
     log.trace('DB.createUnblockCode', { uid })
     return UnblockCode()
       .then(

--- a/scripts/must-reset.js
+++ b/scripts/must-reset.js
@@ -21,7 +21,6 @@ var butil = require('../lib/crypto/butil')
 var commandLineOptions = require('commander')
 var config = require('../config').getProperties()
 var crypto = require('crypto')
-var error = require('../lib/error')
 var log = require('../lib/log')(config.log.level)
 var P = require('../lib/promise')
 var path = require('path')
@@ -41,12 +40,7 @@ requiredOptions.forEach(checkRequiredOption)
 var DB = require('../lib/db')(
   config,
   log,
-  error,
-  Token.SessionToken,
-  Token.KeyFetchToken,
-  Token.AccountResetToken,
-  Token.PasswordForgotToken,
-  Token.PasswordChangeToken
+  Token
 )
 
 DB.connect(config[config.db.backend])


### PR DESCRIPTION
Fixes #2916. The signature didn't cause any bugs, since the DB object is only used for very specific things in the profile_server_messaging and must-reset scripts, but this corrects the invocation.

Also makes the UnblockCode parameter explicitly optional.

I wasn't sure if a test was necessary here. The bad signature doesn't represent any outward bug. `profileUpdates` (which does all the work in this script) is tested elsewhere.