### PR TITLE
feat(basket): Updates to `login` and `verified` events for Basket

### DIFF
--- a/docs/service_notifications.md
+++ b/docs/service_notifications.md
@@ -58,6 +58,7 @@ that may have been received out-of-order.
 Message Properties:
 
 * `event`: The string "verified".
+* `service`: The name of the service that was logged in to.
 * `uid`: The userid of the account being that was created.
 * `email`: The primary email address that was verified for the account.
 * `locale`: The accept-language header supplies by the user at account creation.
@@ -77,7 +78,7 @@ when seeing a user for the first time.
 Message Properties:
 
 * `event`: The string "login".
-* `service`: The name of the service that was logged in to.  Currently always "sync".
+* `service`: The name of the service that was logged in to.
 * `uid`: The userid of the account being that was used to log in.
 * `email`: The primary email address of the account.
 * `deviceCount`: The number of active sessions on the user's account.

--- a/lib/log.js
+++ b/lib/log.js
@@ -10,6 +10,7 @@ const mozlog = require('mozlog')
 const config = require('../config')
 const logConfig = config.get('log')
 
+const CLIENT_ID_TO_SERVICE_NAMES = config.get('oauth.clientIds') || {}
 
 function Lug(options) {
   EventEmitter.call(this)
@@ -132,11 +133,19 @@ Lug.prototype.notifyAttachedServices = function (name, request, data) {
         // Add a timestamp that this event occurred to help attached services resolve any
         // potential timing issues
         data.ts = data.ts || Date.now() / 1000 // Convert to float seconds
+
+        // convert an oauth client-id to a human readable format, if a name is available.
+        // If no name is available, continue to use the client_id.
+        if (data.service && data.service !== 'sync') {
+          data.service = CLIENT_ID_TO_SERVICE_NAMES[data.service] || data.service
+        }
+
         const e = {
           event: name,
           data: data
         }
         e.data.metricsContext = metricsContextData
+        this.info('notify.attached', e)
         this.notifier.send(e)
       }
     )

--- a/lib/routes/emails.js
+++ b/lib/routes/emails.js
@@ -451,9 +451,10 @@ module.exports = (log, db, mailer, config, customs, push) => {
                     return P.all([
                       log.notifyAttachedServices('verified', request, {
                         email: account.email,
-                        uid: account.uid,
                         locale: account.locale,
-                        marketingOptIn: marketingOptIn ? true : undefined
+                        marketingOptIn: marketingOptIn ? true : undefined,
+                        service,
+                        uid: account.uid,
                       }),
                       request.emitMetricsEvent('account.verified', {
                         // The content server omits marketingOptIn in the false case.

--- a/lib/routes/utils/signin.js
+++ b/lib/routes/utils/signin.js
@@ -237,20 +237,20 @@ module.exports = (log, config, customs, db, mailer)  => {
           })
       }
 
-      function emitLoginEvent () {
-        return request.emitMetricsEvent('account.login', {
+      async function emitLoginEvent () {
+        await request.emitMetricsEvent('account.login', {
           uid: accountRecord.uid
-        }).then(() => {
-          if (service === 'sync' && request.payload.reason === 'signin') {
-            return log.notifyAttachedServices('login', request, {
-              service: 'sync',
-              uid: accountRecord.uid,
-              email: accountRecord.primaryEmail.email,
-              deviceCount: sessions.length,
-              userAgent: request.headers['user-agent']
-            })
-          }
         })
+
+        if (request.payload.reason === 'signin') {
+          await log.notifyAttachedServices('login', request, {
+            deviceCount: sessions.length,
+            email: accountRecord.primaryEmail.email,
+            service,
+            uid: accountRecord.uid,
+            userAgent: request.headers['user-agent']
+          })
+        }
       }
 
       function sendEmail() {

--- a/test/local/routes/emails.js
+++ b/test/local/routes/emails.js
@@ -478,6 +478,7 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(args[0], 'verified')
         assert.equal(args[2].uid, uid)
         assert.equal(args[2].marketingOptIn, undefined)
+        assert.equal(args[2].service, 'sync')
 
         assert.equal(mockMailer.sendPostVerifyEmail.callCount, 1, 'sendPostVerifyEmail was called once')
         assert.equal(mockMailer.sendPostVerifyEmail.args[0][2].service, mockRequest.payload.service)
@@ -533,6 +534,7 @@ describe('/recovery_email/verify_code', function () {
         assert.equal(args[0], 'verified')
         assert.equal(args[2].uid, uid)
         assert.equal(args[2].marketingOptIn, true)
+        assert.equal(args[2].service, 'sync')
 
         assert.equal(mockLog.amplitudeEvent.callCount, 2, 'amplitudeEvent was called twice')
         args = mockLog.amplitudeEvent.args[1]


### PR DESCRIPTION
The Mozmeao team would like to create custom onboarding journeys
for different services, but we don't provide sufficient information
for them to do so.

Send along a `service` when emitting the `verified` event.
Send `login` for all services, not just Sync.

fixes #2915