### PR TITLE
feat(oauth): Use an assertion to directly grant tokens at /token.

### DIFF
--- a/fxa-oauth-server/lib/db/memory.js
+++ b/fxa-oauth-server/lib/db/memory.js
@@ -388,7 +388,7 @@ MemoryStore.prototype = {
     return P.resolve();
   },
   getScope: function getScope (scope) {
-    return P.resolve(this.scopes[scope]);
+    return P.resolve(this.scopes[scope] || null);
   },
   registerScope: function registerScope (scope) {
     this.scopes[scope.scope] = scope;

--- a/fxa-oauth-server/lib/db/mysql/index.js
+++ b/fxa-oauth-server/lib/db/mysql/index.js
@@ -824,8 +824,13 @@ MysqlStore.prototype = {
       .then(() => this._write(QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS, [uid]));
   },
 
-  getScope: function getScope (scope) {
-    return this._readOne(QUERY_SCOPE_FIND, [scope]);
+  getScope: async function getScope (scope) {
+    // We currently only have database entries for URL-format scopes,
+    // so don't bother hitting the db for common scopes like 'profile'.
+    if (! scope.startsWith('https://')) {
+      return null;
+    }
+    return await this._readOne(QUERY_SCOPE_FIND, [scope]) || null;
   },
 
   registerScope: function registerScope (scope) {

--- a/fxa-oauth-server/lib/error.js
+++ b/fxa-oauth-server/lib/error.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const util = require('util');
+const hex = require('buf').to.hex;
 
 const DEFAULTS = {
   code: 500,
@@ -82,7 +83,7 @@ AppError.unknownClient = function unknownClient(clientId) {
     errno: 101,
     message: 'Unknown client'
   }, {
-    clientId: clientId
+    clientId: hex(clientId)
   });
 };
 
@@ -93,7 +94,7 @@ AppError.incorrectSecret = function incorrectSecret(clientId) {
     errno: 102,
     message: 'Incorrect secret'
   }, {
-    clientId: clientId
+    clientId: hex(clientId)
   });
 };
 
@@ -135,8 +136,8 @@ AppError.mismatchCode = function mismatchCode(code, clientId) {
     errno: 106,
     message: 'Incorrect code'
   }, {
-    requestCode: code,
-    client: clientId
+    requestCode: hex(code),
+    client: hex(clientId)
   });
 };
 
@@ -147,7 +148,7 @@ AppError.expiredCode = function expiredCode(code, expiredAt) {
     errno: 107,
     message: 'Expired code'
   }, {
-    requestCode: code,
+    requestCode: hex(code),
     expiredAt: expiredAt
   });
 };
@@ -233,14 +234,14 @@ AppError.expiredToken = function expiredToken(expiredAt) {
   });
 };
 
-AppError.notPublicClient = function unknownClient(clientId) {
+AppError.notPublicClient = function notPublicClient(clientId) {
   return new AppError({
     code: 400,
     error: 'Bad Request',
     errno: 116,
     message: 'Not a public client'
   }, {
-    clientId: clientId
+    clientId: hex(clientId)
   });
 };
 
@@ -283,6 +284,15 @@ AppError.mismatchAcr = function mismatchAcr(foundValue) {
     errno: 120,
     message: 'Mismatch acr value'
   }, {foundValue});
+};
+
+AppError.invalidGrantType = function invalidGrantType() {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: 121,
+    message: 'Invalid grant_type'
+  });
 };
 
 module.exports = AppError;

--- a/fxa-oauth-server/lib/grant.js
+++ b/fxa-oauth-server/lib/grant.js
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const buf = require('buf').hex;
+const hex = require('buf').to.hex;
+
+const config = require('./config');
+const AppError = require('./error');
+const db = require('./db');
+const util = require('./util');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const JwTool = require('fxa-jwtool');
+
+const ACR_VALUE_AAL2 = 'AAL2';
+const ACCESS_TYPE_OFFLINE = 'offline';
+
+const SCOPE_OPENID = ScopeSet.fromArray(['openid']);
+
+const ID_TOKEN_EXPIRATION = Math.floor(config.get('openid.ttl') / 1000);
+const ID_TOKEN_ISSUER = config.get('openid.issuer');
+const ID_TOKEN_KEY = JwTool.JWK.fromObject(config.get('openid.key'), {
+  iss: ID_TOKEN_ISSUER
+});
+
+const UNTRUSTED_CLIENT_ALLOWED_SCOPES = ScopeSet.fromArray([
+  'openid',
+  'profile:uid',
+  'profile:email',
+  'profile:display_name'
+]);
+
+// Given a set of verified user identity claims, can the given client
+// be granted the specified access to the user's data?
+//
+// This is a shared helper function responsible for checking:
+//   * whether the identity claims are sufficient to authorize the requested access
+//   * whether config allows that particular client to request such access at all
+//
+// It does *not* perform any user or client authentication, assuming that the
+// authenticity of the passed-in details has been sufficiently verified by
+// calling code.
+module.exports.validateRequestedGrant = async function validateRequestedGrant(verifiedClaims, client, requestedGrant) {
+  requestedGrant.scope = requestedGrant.scope || ScopeSet.fromArray([]);
+
+  // If the grant request is for specific ACR values, do the identity claims support them?
+  if (requestedGrant.acr_values) {
+    const acrTokens = requestedGrant.acr_values.trim().split(/\s+/g);
+    if (acrTokens.includes(ACR_VALUE_AAL2) && ! (verifiedClaims['fxa-aal'] >= 2)) {
+      throw AppError.mismatchAcr(verifiedClaims['fxa-aal']);
+    }
+  }
+
+  // Is an untrusted client requesting scopes that it's not allowed?
+  if (! client.trusted) {
+    const invalidScopes = requestedGrant.scope.difference(UNTRUSTED_CLIENT_ALLOWED_SCOPES);
+    if (! invalidScopes.isEmpty()) {
+      throw AppError.invalidScopes(invalidScopes.getScopeValues());
+    }
+  }
+
+  // For key-bearing scopes, is the client allowed to request them?
+  // We probably want to clean this logic up in the future, but for now,
+  // all trusted clients are allowed to request all non-key-bearing scopes.
+  const scopeConfig = {};
+  const keyBearingScopes = ScopeSet.fromArray([]);
+  for (const scope of requestedGrant.scope.getScopeValues()) {
+    const s = scopeConfig[scope] = await db.getScope(scope);
+    if (s && s.hasScopedKeys) {
+      keyBearingScopes.add(scope);
+    }
+  }
+  if (! keyBearingScopes.isEmpty()) {
+    const invalidScopes = keyBearingScopes.difference(ScopeSet.fromString(client.allowedScopes || ''));
+    if (! invalidScopes.isEmpty()) {
+      throw AppError.invalidScopes(invalidScopes.getScopeValues());
+    }
+    // Any request for a key-bearing scope should be using a verified token,
+    // so we can also double-check that here as a defense-in-depth measure.
+    //
+    // Note that this directly reflects the `verified` property of the sessionToken
+    // used to create the assertion, so it can be true for e.g. sessions that were
+    // verified by email before 2FA was enabled on the account. Such sessions must
+    // be able to access sync even after 2FA is enabled, hence checking `verified`
+    // rather than the `aal`-related properties here.
+    if (! verifiedClaims['fxa-tokenVerified']) {
+      throw AppError.invalidAssertion();
+    }
+  }
+
+  // If we grow our per-client config, there are more things we could check here:
+  //   * Is this client allowed to request ACCESS_TYPE_OFFLINE?
+  //   * Is this client allowed to request all the non-key-bearing scopes?
+  //   * Do we expect this client to be using OIDC?
+
+  return {
+    clientId: client.id,
+    userId: buf(verifiedClaims.uid),
+    email: verifiedClaims['fxa-verifiedEmail'],
+    scope: requestedGrant.scope,
+    scopeConfig,
+    offline: (requestedGrant.access_type === ACCESS_TYPE_OFFLINE),
+    authAt: verifiedClaims['fxa-lastAuthAt'],
+    amr: verifiedClaims['fxa-amr'],
+    aal: verifiedClaims['fxa-aal'],
+    profileChangedAt: verifiedClaims['fxa-profileChangedAt'],
+    keysJwe: requestedGrant.keys_jwe
+  };
+};
+
+// Generate tokens that will give the holder all the access in the specified grant.
+// This always include an access_token, but may also include a refresh_token and/or
+// id_token if implied by the grant.
+//
+// This function does *not* perform any authentication or validation, assuming that
+// the specified grant has been sufficiently vetted by calling code.
+module.exports.generateTokens = async function generateTokens(grant) {
+  // We always generate an access_token.
+  const access = await db.generateAccessToken(grant);
+  const result = {
+    access_token: access.token.toString('hex'),
+    token_type: access.type,
+    scope: access.scope.toString()
+  };
+  result.expires_in = grant.ttl || Math.floor((access.expiresAt - Date.now()) / 1000);
+  if (grant.authAt) {
+    result.auth_at = grant.authAt;
+  }
+  if (grant.keysJwe) {
+    result.keys_jwe = grant.keysJwe;
+  }
+  // Maybe also generate a refreshToken?
+  if (grant.offline) {
+    const refresh = await db.generateRefreshToken(grant);
+    result.refresh_token = refresh.token.toString('hex');
+  }
+  // Maybe also generate an idToken?
+  if (grant.scope && grant.scope.contains(SCOPE_OPENID)) {
+    result.id_token = await generateIdToken(grant, access);
+  }
+  return result;
+};
+
+function generateIdToken(grant, access) {
+  var now = Math.floor(Date.now() / 1000);
+  var claims = {
+    sub: hex(grant.userId),
+    aud: hex(grant.clientId),
+    iss: ID_TOKEN_ISSUER,
+    iat: now,
+    exp: now + ID_TOKEN_EXPIRATION,
+    at_hash: util.generateTokenHash(access.token)
+  };
+  if (grant.amr) {
+    claims.amr = grant.amr;
+  }
+  if (grant.aal) {
+    claims['fxa-aal'] = grant.aal;
+    claims.acr = 'AAL' + grant.aal;
+  }
+
+  return ID_TOKEN_KEY.sign(claims);
+}

--- a/fxa-oauth-server/lib/routes/authorization.js
+++ b/fxa-oauth-server/lib/routes/authorization.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const buf = require('buf').hex;
 const hex = require('buf').to.hex;
 const Joi = require('joi');
 const URI = require('urijs');
@@ -11,30 +10,20 @@ const AppError = require('../error');
 const config = require('../config');
 const db = require('../db');
 const logger = require('../logging')('routes.authorization');
-const P = require('../promise');
-const ScopeSet = require('fxa-shared').oauth.scopes;
 const validators = require('../validators');
+const { validateRequestedGrant, generateTokens } = require('../grant');
 const verifyAssertion = require('../assertion');
 
-const CODE = 'code';
-const TOKEN = 'token';
+const RESPONSE_TYPE_CODE = 'code';
+const RESPONSE_TYPE_TOKEN = 'token';
 
 const ACCESS_TYPE_ONLINE = 'online';
 const ACCESS_TYPE_OFFLINE = 'offline';
-
-const ACR_VALUE_AAL2 = 'AAL2';
 
 const PKCE_SHA256_CHALLENGE_METHOD = 'S256'; // This server only supports S256 PKCE, no 'plain'
 const PKCE_CODE_CHALLENGE_LENGTH = 43;
 
 const MAX_TTL_S = config.get('expiration.accessToken') / 1000;
-
-const UNTRUSTED_CLIENT_ALLOWED_SCOPES = ScopeSet.fromArray([
-  'openid',
-  'profile:uid',
-  'profile:email',
-  'profile:display_name'
-]);
 
 const allowHttpRedirects = config.get('allowHttpRedirects');
 
@@ -52,92 +41,9 @@ function isLocalHost(url) {
   return host === 'localhost' || host === '127.0.0.1';
 }
 
-function generateCode(claims, client, scope, req) {
-  return db.generateCode({
-    clientId: client.id,
-    userId: buf(claims.uid),
-    email: claims['fxa-verifiedEmail'],
-    scope: scope,
-    authAt: claims['fxa-lastAuthAt'],
-    amr: claims['fxa-amr'],
-    aal: claims['fxa-aal'],
-    offline: req.payload.access_type === ACCESS_TYPE_OFFLINE,
-    codeChallengeMethod: req.payload.code_challenge_method,
-    codeChallenge: req.payload.code_challenge,
-    keysJwe: req.payload.keys_jwe,
-    profileChangedAt: claims['fxa-profileChangedAt']
-  }).then(function(code) {
-    logger.debug('redirecting', { uri: req.payload.redirect_uri });
-
-    code = hex(code);
-    const redirect = URI(req.payload.redirect_uri)
-      .addQuery({ state: req.payload.state, code });
-
-    const out = {
-      code,
-      state: req.payload.state,
-      redirect: String(redirect)
-    };
-    logger.info('generateCode', {
-      request: {
-        client_id: req.payload.client_id,
-        redirect_uri: req.payload.redirect_uri,
-        scope: req.payload.scope,
-        state: req.payload.state,
-        response_type: req.payload.response_type
-      },
-      response: out
-    });
-    return out;
-  });
-}
-
-function generateGrant(claims, client, scope, req) {
-  return db.generateAccessToken({
-    clientId: client.id,
-    userId: buf(claims.uid),
-    email: claims['fxa-verifiedEmail'],
-    scope: scope,
-    ttl: req.payload.ttl,
-    profileChangedAt: claims['fxa-profileChangedAt']
-  }).then(function(token) {
-    return {
-      access_token: hex(token.token),
-      token_type: 'bearer',
-      expires_in: Math.floor((token.expiresAt - Date.now()) / 1000),
-      scope: scope.toString(),
-      auth_at: claims['fxa-lastAuthAt']
-    };
-  });
-}
-
-// Check that PKCE is provided if and only if appropriate.
-function checkPKCEParams(req, client) {
-  if (req.payload.response_type === TOKEN) {
-    // Direct token grant can't use PKCE.
-    if (req.payload.code_challenge_method) {
-      throw new AppError.invalidRequestParameter('code_challenge_method');
-    }
-    if (req.payload.code_challenge) {
-      throw new AppError.invalidRequestParameter('code_challenge');
-    }
-  } else if (client.publicClient) {
-    // Public clients *must* use PKCE.
-    if (! req.payload.code_challenge_method || ! req.payload.code_challenge) {
-      logger.info('client.missingPkceParameters');
-      throw AppError.missingPkceParameters();
-    }
-  } else {
-    // non-Public Clients can't use PKCE.
-    if (req.payload.code_challenge_method || req.payload.code_challenge) {
-      logger.info('client.notPublicClient');
-      throw AppError.notPublicClient({ id: req.payload.client_id });
-    }
-  }
-}
-
 module.exports = {
   validate: {
+
     payload: {
       client_id: validators.clientId,
       assertion: validators.assertion
@@ -150,12 +56,12 @@ module.exports = {
         }),
       scope: validators.scope,
       response_type: Joi.string()
-        .valid(CODE, TOKEN)
-        .default(CODE),
+        .valid(RESPONSE_TYPE_CODE, RESPONSE_TYPE_TOKEN)
+        .default(RESPONSE_TYPE_CODE),
       state: Joi.string()
         .max(256)
         .when('response_type', {
-          is: TOKEN,
+          is: RESPONSE_TYPE_TOKEN,
           then: Joi.optional(),
           otherwise: Joi.required()
         }),
@@ -164,7 +70,7 @@ module.exports = {
         .max(MAX_TTL_S)
         .default(MAX_TTL_S)
         .when('response_type', {
-          is: TOKEN,
+          is: RESPONSE_TYPE_TOKEN,
           then: Joi.optional(),
           otherwise: Joi.forbidden()
         }),
@@ -175,20 +81,24 @@ module.exports = {
       code_challenge_method: Joi.string()
         .valid(PKCE_SHA256_CHALLENGE_METHOD)
         .when('response_type', {
-          is: CODE,
+          is: RESPONSE_TYPE_CODE,
           then: Joi.optional(),
           otherwise: Joi.forbidden()
+        })
+        .when('code_challenge', {
+          is: Joi.string().required(),
+          then: Joi.required()
         }),
       code_challenge: Joi.string()
         .length(PKCE_CODE_CHALLENGE_LENGTH)
         .when('response_type', {
-          is: CODE,
+          is: RESPONSE_TYPE_CODE,
           then: Joi.optional(),
           otherwise: Joi.forbidden()
         }),
       keys_jwe: validators.jwe
         .when('response_type', {
-          is: CODE,
+          is: RESPONSE_TYPE_CODE,
           then: Joi.optional(),
           otherwise: Joi.forbidden()
         }),
@@ -218,104 +128,102 @@ module.exports = {
     ])
   },
   handler: async function authorizationEndpoint(req) {
-    /*eslint complexity: [2, 13] */
-    logger.debug('response_type', req.payload.response_type);
-    var start = Date.now();
-    var wantsGrant = req.payload.response_type === TOKEN;
-    var exitEarly = false;
-    var scope = req.payload.scope;
-    return P.all([
-      verifyAssertion(req.payload.assertion).then(function(claims) {
-        logger.info('time.verify_assertion', { ms: Date.now() - start });
-        if (! claims) {
-          exitEarly = true;
-          throw AppError.invalidAssertion();
-        }
+    const claims = await verifyAssertion(req.payload.assertion);
 
-        // Check to see if the acr value requested by oauth matches what is expected
-        const acrValues = req.payload.acr_values;
-        if (acrValues) {
-          const acrTokens = acrValues.split('\s+');
-          if (acrTokens.includes(ACR_VALUE_AAL2) && ! (claims['fxa-aal'] >= 2)) {
-            throw AppError.mismatchAcr(claims['fxa-aal']);
-          }
-        }
+    const client = await db.getClient(Buffer.from(req.payload.client_id, 'hex'));
+    if (! client) {
+      logger.debug('notFound', { id: req.payload.client_id });
+      throw AppError.unknownClient(req.payload.client_id);
+    }
+    validateClientDetails(client, req.payload);
 
-        // Any request for a key-bearing scope should be using a verified token.
-        // Double-check that here as a defense-in-depth measure.
-        if (! claims['fxa-tokenVerified']) {
-          return P.each(scope.getScopeValues(), scope => {
-            // Don't bother hitting the DB if other checks have failed.
-            if (exitEarly) {
-              return;
-            }
-            // We know only URL-format scopes can have keys,
-            // so avoid trips to the DB for common scopes like 'profile'.
-            if (scope.startsWith('https://')) {
-              return db.getScope(scope).then(s => {
-                if (s && s.hasScopedKeys) {
-                  exitEarly = true;
-                  throw AppError.invalidAssertion();
-                }
-              });
-            }
-          }).then(() => {
-            return claims;
-          });
-        }
-        return claims;
-      }),
-      db.getClient(Buffer.from(req.payload.client_id, 'hex')).then(function(client) {
-        logger.info('time.db_get_client', { ms: Date.now() - start });
-        if (exitEarly) {
-          // assertion was invalid, we can just stop here
-          return;
-        }
-        if (! client) {
-          logger.debug('notFound', { id: req.payload.client_id });
-          throw AppError.unknownClient(req.payload.client_id);
-        } else if (! client.trusted) {
-          var invalidScopes = scope.difference(UNTRUSTED_CLIENT_ALLOWED_SCOPES);
-          if (! invalidScopes.isEmpty()) {
-            throw AppError.invalidScopes(invalidScopes.getScopeValues());
-          }
-        }
-
-        var uri = req.payload.redirect_uri || client.redirectUri;
-
-        if (uri !== client.redirectUri) {
-          logger.debug('redirect.mismatch', {
-            param: uri,
-            registered: client.redirectUri
-          });
-
-          if (config.get('localRedirects') && isLocalHost(uri)) {
-            logger.debug('redirect.local', { uri: uri });
-          } else {
-            throw AppError.incorrectRedirect(uri);
-          }
-
-        }
-
-        if (wantsGrant && ! client.canGrant) {
-          logger.warn('implicitGrant.notAllowed', {
-            id: req.payload.client_id
-          });
-          throw AppError.invalidResponseType();
-        }
-
-        req.payload.redirect_uri = uri;
-
-        checkPKCEParams(req, client);
-
-        return client;
-      }).catch(err => {
-        exitEarly = true;
-        throw err;
-      }),
-      scope,
-      req
-    ])
-    .spread(wantsGrant ? generateGrant : generateCode);
+    const grant = await validateRequestedGrant(claims, client, req.payload);
+    switch (req.payload.response_type) {
+    case RESPONSE_TYPE_CODE:
+      return await generateAuthorizationCode(client, req.payload, grant);
+    case RESPONSE_TYPE_TOKEN:
+      return await generateImplicitGrant(client, req.payload, grant);
+    default:
+      // Joi validation means this should never happen.
+      logger.critical('joi.response_type', { response_type: req.payload.response_type });
+      throw AppError.invalidResponseType();
+    }
   }
 };
+
+
+async function generateAuthorizationCode(client, payload, grant) {
+  // Clients must use PKCE if and only if they are a pubic client.
+  if (client.publicClient) {
+    if (! payload.code_challenge_method || ! payload.code_challenge) {
+      logger.info('client.missingPkceParameters');
+      throw AppError.missingPkceParameters();
+    }
+  } else {
+    if (payload.code_challenge_method || payload.code_challenge) {
+      logger.info('client.notPublicClient');
+      throw AppError.notPublicClient({ id: payload.client_id });
+    }
+  }
+
+  const state = payload.state;
+
+  let code = await db.generateCode(Object.assign(grant, {
+    codeChallengeMethod: payload.code_challenge_method,
+    codeChallenge: payload.code_challenge,
+  }));
+  code = hex(code);
+
+  const redirect = URI(payload.redirect_uri).addQuery({ code, state });
+
+  return {
+    code,
+    state,
+    redirect: String(redirect)
+  };
+}
+
+// N.B. We do not correctly implement the "implicit grant" flow from
+// RFC6749 which defines `response_type=token`. Instead we have a
+// privileged set of clients that use `response_type=token` for something
+// approximating the "resource owner password grant" flow, using an identity
+// assertion to just directly grant tokens for their own use. Known current
+// users of this functinality include:
+//
+//  * Firefox Desktop, for getting "profile"-scoped tokens to access profile data
+//  * Firefox for Android, for getting "profile"-scoped tokens to access profile data
+//  * Firefox for iOS, for getting "profile"-scoped tokens to access profile data
+//
+// New clients should not do this, and should instead of `grant_type=fxa-credentials`
+// on the /token endpoint.
+//
+// This route is kept for backwards-compatibility only.
+async function generateImplicitGrant(client, payload, grant) {
+  if (! client.canGrant) {
+    logger.warn('grantType.notAllowed', {
+      id: hex(client.id),
+      grant_type: 'fxa-credentials'
+    });
+    throw AppError.invalidResponseType();
+  }
+  return generateTokens(Object.assign(grant, {
+    ttl: payload.ttl,
+  }));
+}
+
+function validateClientDetails(client, payload) {
+  // Clients must use a single specific redirect_uri,
+  // but they're allowed to not provide one and have us fill it in automatically.
+  payload.redirect_uri = payload.redirect_uri || client.redirectUri;
+  if (payload.redirect_uri !== client.redirectUri) {
+    logger.debug('redirect.mismatch', {
+      param: payload.redirect_uri,
+      registered: client.redirectUri
+    });
+    if (config.get('localRedirects') && isLocalHost(payload.redirect_uri)) {
+      logger.debug('redirect.local', { uri: payload.redirect_uri });
+    } else {
+      throw AppError.incorrectRedirect(payload.redirect_uri);
+    }
+  }
+}

--- a/fxa-oauth-server/test/grant.js
+++ b/fxa-oauth-server/test/grant.js
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const AppError = require('../lib/error');
+
+async function assertThrowsAsync(fn, errorLike, errMsgMatcher, message) {
+  let threw = null;
+  return fn().catch(err => {
+    threw = err;
+  }).then(() => {
+    // Use synchronous `assert.throws` to get all the nice matching logic.
+    assert.throws(() => {
+      if (threw) {
+        throw threw;
+      }
+    }, errorLike, errMsgMatcher, message);
+  });
+}
+
+const CLAIMS = {
+  'uid': 'ABCDEF123456',
+  'fxa-generation': 12345,
+  'fxa-verifiedEmail': 'test@example.com',
+  'fxa-lastAuthAt': Date.now(),
+  'fxa-tokenVerified': true,
+  'fxa-amr': ['pwd'],
+  'fxa-aal': 1,
+  'fxa-profileChangedAt': Date.now()
+};
+
+const CLIENT = {
+  id: Buffer.from('0123456789', 'hex'),
+  trusted: true,
+};
+
+describe('validateRequestedGrant', () => {
+
+  let mockDB, validateRequestedGrant;
+
+  beforeEach(() => {
+    mockDB = {};
+    validateRequestedGrant = proxyquire('../lib/grant', { './db': mockDB }).validateRequestedGrant;
+  });
+
+  it('should return validated grant data', async () => {
+    const scope = ScopeSet.fromArray(['profile']);
+    const grant = await validateRequestedGrant(CLAIMS, CLIENT, { scope });
+    assert.deepEqual(grant, {
+      clientId: CLIENT.id,
+      userId: Buffer.from(CLAIMS.uid, 'hex'),
+      email: CLAIMS['fxa-verifiedEmail'],
+      scope,
+      scopeConfig: { profile: null },
+      offline: false,
+      authAt: CLAIMS['fxa-lastAuthAt'],
+      amr: CLAIMS['fxa-amr'],
+      aal: CLAIMS['fxa-aal'],
+      profileChangedAt: CLAIMS['fxa-profileChangedAt'],
+      keysJwe: undefined,
+    });
+  });
+
+  it('should allow unchecked AAL if not requested in acr_values', async () => {
+    let grant = await validateRequestedGrant(CLAIMS, CLIENT, {});
+    assert.equal(grant.aal, 1);
+    grant = await validateRequestedGrant(CLAIMS, CLIENT, { acr_values: 'AAL1' });
+    assert.equal(grant.aal, 1);
+  });
+
+  it('should require AAL2 or higher if requested in acr_values', async () => {
+    const requestedGrant = {
+      acr_values: 'AAL2'
+    };
+    await assertThrowsAsync(async () => {
+      await validateRequestedGrant(CLAIMS, CLIENT, requestedGrant);
+    }, AppError, 'Mismatch acr value');
+    let grant = await validateRequestedGrant({...CLAIMS, 'fxa-aal': 2}, CLIENT, requestedGrant);
+    assert.equal(grant.aal, 2);
+    grant = await validateRequestedGrant({ ...CLAIMS, 'fxa-aal': 17 }, CLIENT, requestedGrant);
+    assert.equal(grant.aal, 17);
+  });
+
+  it('should correctly split acr_values on whitespace', async () => {
+    const requestedGrant = {
+      acr_values: 'AAL4 AAL2 AAL3'
+    };
+    await assertThrowsAsync(async () => {
+      await validateRequestedGrant(CLAIMS, CLIENT, requestedGrant);
+    }, AppError, 'Mismatch acr value');
+    const grant = await validateRequestedGrant({ ...CLAIMS, 'fxa-aal': 2 }, CLIENT, requestedGrant);
+    assert.equal(grant.aal, 2);
+  });
+
+  it('should reject disallowed scopes for untrusted clients', async () => {
+    const requestedGrant = {
+      scope: ScopeSet.fromArray(['profile'])
+    };
+    const grant = await validateRequestedGrant(CLAIMS, { ...CLIENT, trusted: true }, requestedGrant);
+    assert.equal(grant.scope.toString(), 'profile');
+    await assertThrowsAsync(async () => {
+      await validateRequestedGrant(CLAIMS, { ...CLIENT, trusted: false }, requestedGrant);
+    }, AppError, 'Requested scopes are not allowed');
+  });
+
+  it('should allow restricted set of scopes for untrusted clients', async () => {
+    const requestedGrant = {
+      scope: ScopeSet.fromArray(['profile:uid', 'profile:email'])
+    };
+    let grant = await validateRequestedGrant(CLAIMS, { ...CLIENT, trusted: true }, requestedGrant);
+    assert.equal(grant.scope.toString(), 'profile:uid profile:email');
+    grant = await validateRequestedGrant(CLAIMS, { ...CLIENT, trusted: false }, requestedGrant);
+    assert.equal(grant.scope.toString(), 'profile:uid profile:email');
+  });
+
+  it('should check key-bearing scopes in the database, and reject if not allowed for that client', async () => {
+    sinon.stub(mockDB, 'getScope').callsFake(async () => {
+      return { hasScopedKeys: true };
+    });
+    const requestedGrant = {
+      scope: ScopeSet.fromArray(['https://identity.mozilla.com/apps/oldsync'])
+    };
+    await assertThrowsAsync(async () => {
+      await validateRequestedGrant(CLAIMS, CLIENT, requestedGrant);
+    }, AppError, 'Requested scopes are not allowed');
+    assert.equal(mockDB.getScope.callCount, 1);
+
+    const allowedClient = { ...CLIENT, allowedScopes: 'https://identity.mozilla.com/apps/oldsync' };
+    const grant = await validateRequestedGrant(CLAIMS, allowedClient, requestedGrant);
+    assert.equal(mockDB.getScope.callCount, 2);
+    assert.equal(grant.scope.toString(), 'https://identity.mozilla.com/apps/oldsync');
+  });
+
+  it('should reject key-bearing scopes requested with claims from an unverified session', async () => {
+    sinon.stub(mockDB, 'getScope').callsFake(async () => {
+      return { hasScopedKeys: true };
+    });
+    const requestedGrant = {
+      scope: ScopeSet.fromArray(['https://identity.mozilla.com/apps/oldsync'])
+    };
+    await assertThrowsAsync(async () => {
+      await validateRequestedGrant({ ...CLAIMS, 'fxa-tokenVerified': false }, CLIENT, requestedGrant);
+    }, AppError, 'Requested scopes are not allowed');
+  });
+});

--- a/fxa-oauth-server/test/routes/authorization.js
+++ b/fxa-oauth-server/test/routes/authorization.js
@@ -112,7 +112,7 @@ describe('/authorization POST', function () {
         code_challenge: PKCE_CODE_CHALLENGE,
         code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
         response_type: 'token'
-      }, 'code_challenge_method', 'is not allowed');
+      }, 'code_challenge', 'is not allowed');
     });
 
   });

--- a/fxa-oauth-server/test/routes/token.js
+++ b/fxa-oauth-server/test/routes/token.js
@@ -79,7 +79,8 @@ describe('/token POST', function () {
 
   it('forbids client_secret when authz header provided', (done) => {
     v({
-      client_secret: CLIENT_SECRET
+      client_secret: CLIENT_SECRET,
+      code: CODE // If we don't send `code`, then the missing `code` will fail validation first.
     }, {
       headers: {
         authorization: 'Basic ABCDEF'


### PR DESCRIPTION
Fixes #2962. Requires #2946 as it's based off that commit.

Clients could previously use an FxA assertion to grant themselves OAuth access tokens via the /authorization endpoint in a style modelled after OAuth's "implicit grant" flow. But it's not really
the implicit grant flow, the way we use it in practice much more closely resembles the "resource owner password credentials" flow. In particular, existing clients use it to directly create tokens for their own use, rather than to authorize tokens for another client.

This commit makes that functionality available on the /token endpoint instead, using `grant_type=fxa-assertion`. This is better aligned with the way that the rest of OAuth works, closely mirroring
the `grant_type=password` flow and keeping a clear distinction between obtaining tokens for ones own use (always use the /token endpoint) versus authorizing them for someone else (always use the
/authorization endpoint).

It will hopefully help us avoid future footguns if we want to allow assertion-bearing clients to create things for their own use (such as refresh tokens) that are forbidden in the "implicit grant" flow proper.