### PR TITLE
feat(oauth): Add /oauth/token route, optionally authed via sessionToken

### DIFF
--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -155,7 +155,7 @@
       "hashedSecret": "4a892c55feaceb4ef2dbfffaaaa3d8eea94b5c205c815dddfc90170741cd4c19",
       "imageUri": "",
       "redirectUri": "http://127.0.0.1:3030/oauth/success/a2270f727f45f648",
-      "canGrant": false,
+      "canGrant": true,
       "trusted": true,
       "allowedScopes": "https://identity.mozilla.com/apps/oldsync",
       "publicClient": true

--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -144,7 +144,7 @@
       "hashedSecret": "a7ee3482fab1782f5d3945cde06bb911605a8dfc1a45e4b77bc76615d5671e51",
       "imageUri": "",
       "redirectUri": "http://127.0.0.1:3030/oauth/success/3c49430b43dfba77",
-      "canGrant": false,
+      "canGrant": true,
       "trusted": true,
       "allowedScopes": "https://identity.mozilla.com/apps/oldsync",
       "publicClient": true

--- a/lib/error.js
+++ b/lib/error.js
@@ -80,6 +80,11 @@ const ERRNO = {
   INVALID_RESPONSE_TYPE: 168,
   MISSING_PKCE_PARAMETERS: 169,
   INSUFFICIENT_ACR_VALUES: 170,
+  INCORRECT_CLIENT_SECRET: 171,
+  UNKNOWN_AUTHORIZATION_CODE: 172,
+  MISMATCH_AUTHORIZATION_CODE: 173,
+  EXPIRED_AUTHORIZATION_CODE: 174,
+  INVALID_PKCE_CHALLENGE: 175,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -902,6 +907,17 @@ AppError.unknownClientId = (clientId) => {
   });
 };
 
+AppError.incorrectClientSecret = (clientId) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.INCORRECT_CLIENT_SECRET,
+    message: 'Incorrect client_secret'
+  }, {
+      clientId
+    });
+};
+
 AppError.staleAuthAt = (authAt) => {
   return new AppError({
     code: 400,
@@ -942,6 +958,41 @@ AppError.incorrectRedirectURI = (redirectUri) => {
   });
 };
 
+AppError.unknownAuthorizationCode = (code) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.UNKNOWN_AUTHORIZATION_CODE,
+    message: 'Unknown authorization code'
+  }, {
+      code
+    });
+};
+
+AppError.mismatchAuthorizationCode = (code, clientId) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.MISMATCH_AUTHORIZATION_CODE,
+    message: 'Mismatched authorization code'
+  }, {
+      code,
+      clientId
+    });
+};
+
+AppError.expiredAuthorizationCode = (code, expiredAt) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.EXPIRED_AUTHORIZATION_CODE,
+    message: 'Expired authorization code'
+  }, {
+      code,
+      expiredAt
+    });
+};
+
 AppError.invalidResponseType = () => {
   return new AppError({
     code: 400,
@@ -968,6 +1019,17 @@ AppError.missingPkceParameters = () => {
     error: 'Bad Request',
     errno: ERRNO.MISSING_PKCE_PARAMETERS,
     message: 'Public clients require PKCE OAuth parameters'
+  });
+};
+
+AppError.invalidPkceChallenge = (pkceHashValue) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.INVALID_PKCE_CHALLENGE,
+    message: 'Public clients require PKCE OAuth parameters'
+  }, {
+    pkceHashValue
   });
 };
 

--- a/lib/oauthdb/grant-tokens-from-authorization-code.js
+++ b/lib/oauthdb/grant-tokens-from-authorization-code.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Joi = require('joi');
+const validators = require('../routes/validators');
+
+module.exports = (config) => {
+  return {
+    path: '/v1/token',
+    method: 'POST',
+    validate: {
+      payload: Joi.object({
+        grant_type: Joi.string().valid('authorization_code').default('authorization_code'),
+        client_id: validators.clientId.required(),
+        client_secret: validators.clientSecret.optional(),
+        code: validators.authorizationCode.required(),
+        code_verifier: validators.pkceCodeVerifier.optional(),
+        redirect_uri: validators.url().optional(),
+        // Note: the max allowed TTL is currently configured in oauth-server config,
+        // making it hard to know what limit to set here.
+        ttl: Joi.number().positive().optional(),
+      }).xor('client_secret', 'code_verifier'),
+      response: Joi.object({
+        access_token: validators.accessToken.required(),
+        refresh_token: validators.refreshToken.optional(),
+        id_token: validators.assertion.optional(),
+        scope: validators.scope.required(),
+        token_type: Joi.string().valid('bearer').required(),
+        expires_in: Joi.number().required(),
+        auth_at: Joi.number().required(),
+        keys_jwe: validators.jwe.optional()
+      })
+    }
+  };
+};

--- a/lib/oauthdb/grant-tokens-from-credentials.js
+++ b/lib/oauthdb/grant-tokens-from-credentials.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Joi = require('joi');
+const validators = require('../routes/validators');
+
+module.exports = (config) => {
+  return {
+    path: '/v1/token',
+    method: 'POST',
+    validate: {
+      payload: Joi.object({
+        grant_type: Joi.string().valid('fxa-credentials').default('fxa-credentials'),
+        client_id: validators.clientId.required(),
+        assertion: validators.assertion.required(),
+        scope: validators.scope.optional(),
+        access_type: Joi.string().valid('online', 'offline').default('online'),
+        // Note: the max allowed TTL is currently configured in oauth-server config,
+        // making it hard to know what limit to set here.
+        ttl: Joi.number().positive().optional(),
+      }),
+      response: Joi.object({
+        access_token: validators.accessToken.required(),
+        refresh_token: validators.refreshToken.optional(),
+        id_token: validators.assertion.optional(),
+        scope: validators.scope.required(),
+        auth_at: Joi.number().required(),
+        token_type: Joi.string().valid('bearer').required(),
+        expires_in: Joi.number().required()
+      })
+    }
+  };
+};

--- a/lib/oauthdb/grant-tokens-from-refresh-token.js
+++ b/lib/oauthdb/grant-tokens-from-refresh-token.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Joi = require('joi');
+const validators = require('../routes/validators');
+
+module.exports = (config) => {
+  return {
+    path: '/v1/token',
+    method: 'POST',
+    validate: {
+      payload: Joi.object({
+        grant_type: Joi.string().valid('refresh_token').required(),
+        client_id: validators.clientId.required(),
+        client_secret: validators.clientSecret.optional(),
+        refresh_token: validators.refreshToken.required(),
+        scope: validators.scope.optional(),
+        // Note: the max allowed TTL is currently configured in oauth-server config,
+        // making it hard to know what limit to set here.
+        ttl: Joi.number().positive().optional(),
+      }),
+      response: Joi.object({
+        access_token: validators.accessToken.required(),
+        scope: validators.scope.required(),
+        token_type: Joi.string().valid('bearer').required(),
+        expires_in: Joi.number().required()
+      })
+    }
+  };
+};

--- a/lib/oauthdb/index.js
+++ b/lib/oauthdb/index.js
@@ -29,6 +29,9 @@ module.exports = (log, config) => {
     getClientInfo: require('./client-info')(config),
     getScopedKeyData: require('./scoped-key-data')(config),
     createAuthorizationCode: require('./create-authorization-code')(config),
+    grantTokensFromAuthorizationCode: require('./grant-tokens-from-authorization-code')(config),
+    grantTokensFromRefreshToken: require('./grant-tokens-from-refresh-token')(config),
+    grantTokensFromCredentials: require('./grant-tokens-from-credentials')(config),
   });
 
   const api = new OAuthAPI(config.oauth.url, config.oauth.poolee);
@@ -82,6 +85,31 @@ module.exports = (log, config) => {
       oauthParams.assertion = await makeAssertionJWT(config, sessionToken);
       try {
         return await api.createAuthorizationCode(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
+
+    async grantTokensFromAuthorizationCode(oauthParams) {
+      try {
+        return await api.grantTokensFromAuthorizationCode(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
+
+    async grantTokensFromRefreshToken(oauthParams) {
+      try {
+        return await api.grantTokensFromRefreshToken(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
+
+    async grantTokensFromSessionToken(sessionToken, oauthParams) {
+      oauthParams.assertion = await makeAssertionJWT(config, sessionToken);
+      try {
+        return await api.grantTokensFromCredentials(oauthParams);
       } catch (err) {
         throw mapOAuthError(log, err);
       }

--- a/lib/oauthdb/utils.js
+++ b/lib/oauthdb/utils.js
@@ -28,10 +28,18 @@ module.exports = {
     switch (err.errno) {
     case 101:
       return error.unknownClientId(err.clientId);
+    case 102:
+      return error.incorrectClientSecret(err.clientId);
     case 103:
       return error.incorrectRedirectURI(err.redirectUri);
     case 104:
       return error.invalidToken();
+    case 105:
+      return error.unknownAuthorizationCode(err.code);
+    case 106:
+      return error.mismatchAuthorizationCode(err.code, err.clientId);
+    case 107:
+      return error.expiredAuthorizationCode(err.code, err.expiredAt);
     case 108:
       return error.invalidToken();
     case 109:
@@ -42,6 +50,8 @@ module.exports = {
       return error.invalidScopes(err.invalidScopes);
     case 116:
       return error.notPublicClient();
+    case 117:
+      return error.invalidPkceChallenge(err.pkceHashValue);
     case 118:
       return error.missingPkceParameters();
     case 119:

--- a/lib/routes/validators.js
+++ b/lib/routes/validators.js
@@ -17,6 +17,9 @@ module.exports.BASE_36 = /^[a-zA-Z0-9]*$/;
 // RFC 4648, section 5
 module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]+$/;
 
+// RFC 7636, section 4.1
+module.exports.PKCE_CODE_VERIFIER = /^[A-Za-z0-9-\._~]{43,128}$/;
+
 // Crude phone number validation. The handler code does it more thoroughly.
 exports.E164_NUMBER = /^\+[1-9]\d{1,14}$/;
 
@@ -80,13 +83,16 @@ module.exports.email = function() {
 module.exports.service = isA.string().max(16).regex(/^[a-zA-Z0-9\-]*$/);
 module.exports.hexString = isA.string().regex(HEX_STRING);
 module.exports.clientId = module.exports.hexString.length(16);
+module.exports.clientSecret = module.exports.hexString;
 module.exports.accessToken = module.exports.hexString.length(64);
 module.exports.refreshToken = module.exports.hexString.length(64);
 module.exports.authorizationCode = module.exports.hexString.length(64);
-module.exports.scope = isA.string().max(256).regex(/^[a-zA-Z0-9 _\/.:-]+$/);
+// Note that the empty string is a valid scope value (meaning "no permissions").
+module.exports.scope = isA.string().max(256).regex(/^[a-zA-Z0-9 _\/.:-]*$/).allow('');
 module.exports.assertion = isA.string().min(50).max(10240).regex(/^[a-zA-Z0-9_\-\.~=]+$/);
 module.exports.pkceCodeChallengeMethod = isA.string().valid('S256');
 module.exports.pkceCodeChallenge = isA.string().length(43).regex(module.exports.URL_SAFE_BASE_64);
+module.exports.pkceCodeVerifier = isA.string().min(43).max(128).regex(module.exports.PKCE_CODE_VERIFIER);
 module.exports.jwe = isA.string().max(1024)
   // JWE token format: 'protectedheader.encryptedkey.iv.cyphertext.authenticationtag'
   .regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/);

--- a/test/client/api.js
+++ b/test/client/api.js
@@ -1000,6 +1000,27 @@ module.exports = config => {
       });
   };
 
+  ClientApi.prototype.grantOAuthTokensFromSessionToken = function (sessionTokenHex, oauthParams) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then((token) => {
+        return this.doRequest(
+          'POST',
+          `${this.baseURL}/oauth/token`,
+          token,
+          oauthParams
+        );
+      });
+  };
+
+  ClientApi.prototype.grantOAuthTokens = function (oauthParams) {
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/oauth/token`,
+      null,
+      oauthParams
+    );
+  };
+
   ClientApi.heartbeat = function (origin) {
     return (new ClientApi(origin)).doRequest('GET', `${origin  }/__heartbeat__`);
   };

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -684,5 +684,13 @@ module.exports = config => {
     return this.api.createAuthorizationCode(this.sessionToken, oauthParams);
   };
 
+  Client.prototype.grantOAuthTokensFromSessionToken = function (oauthParams) {
+    return this.api.grantOAuthTokensFromSessionToken(this.sessionToken, oauthParams);
+  };
+
+  Client.prototype.grantOAuthTokens = function (oauthParams) {
+    return this.api.grantOAuthTokens(oauthParams);
+  };
+
   return Client;
 };

--- a/test/local/oauthdb/grant-tokens-from-authorization-code.js
+++ b/test/local/oauthdb/grant-tokens-from-authorization-code.js
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const oauthdbModule = require('../../../lib/oauthdb');
+const error = require('../../../lib/error');
+const { mockLog } = require('../../mocks');
+
+const MOCK_CLIENT_ID = '0123456789ABCDEF';
+const MOCK_AUTHORIZATION_CODE = '1111112222223333334444445555556611111122222233333344444455555566';
+const MOCK_ACCESS_TOKEN = 'aaaaaa2222223333334444445555556611111122222233333344444455555566';
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  oauth: {
+    url: 'https://oauth.server.com',
+    secretKey: 'secret-key-oh-secret-key',
+  },
+  domain: 'accounts.example.com'
+};
+const mockOAuthServer = nock(mockConfig.oauth.url).defaultReplyHeaders({
+  'Content-Type': 'application/json'
+});
+
+describe('oauthdb/grantTokensFromAuthorizationCode', () => {
+  let oauthdb;
+
+  afterEach(async () => {
+    assert.ok(nock.isDone(), 'there should be no pending request mocks at the end of a test');
+    if (oauthdb) {
+      await oauthdb.close();
+    }
+  });
+
+  it('can exchange a code for some tokens', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(200, {
+        access_token: MOCK_ACCESS_TOKEN,
+        scope: '',
+        token_type: 'bearer',
+        expires_in: 123,
+        auth_at: 123456,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    const res = await oauthdb.grantTokensFromAuthorizationCode({
+      client_id: MOCK_CLIENT_ID,
+      client_secret: MOCK_CLIENT_ID,
+      code: MOCK_AUTHORIZATION_CODE,
+    });
+    assert.deepEqual(res, {
+      access_token: MOCK_ACCESS_TOKEN,
+      scope: '',
+      token_type: 'bearer',
+      expires_in: 123,
+      auth_at: 123456,
+    });
+  });
+
+  it('correctly maps errno 102 to "incorrect client secret"', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(400, {
+        errno: 102,
+        clientId: MOCK_CLIENT_ID,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromAuthorizationCode({
+        client_id: MOCK_CLIENT_ID,
+        client_secret: 'abcdef',
+        code: MOCK_AUTHORIZATION_CODE,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INCORRECT_CLIENT_SECRET);
+      assert.equal(err.output.payload.clientId, MOCK_CLIENT_ID);
+    }
+  });
+
+  it('correctly maps errno 105 to "unknown authorization code"', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(400, {
+        errno: 105,
+        code: 'mock-code',
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromAuthorizationCode({
+        client_id: MOCK_CLIENT_ID,
+        client_secret: 'abcdef',
+        code: MOCK_AUTHORIZATION_CODE,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.UNKNOWN_AUTHORIZATION_CODE);
+      assert.equal(err.output.payload.code, 'mock-code');
+    }
+  });
+
+  it('correctly maps errno 106 to "mismatched authorization code"', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(400, {
+        errno: 106,
+        code: 'mock-code',
+        clientId: MOCK_CLIENT_ID,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromAuthorizationCode({
+        client_id: MOCK_CLIENT_ID,
+        client_secret: 'abcdef',
+        code: MOCK_AUTHORIZATION_CODE,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.MISMATCH_AUTHORIZATION_CODE);
+      assert.equal(err.output.payload.clientId, MOCK_CLIENT_ID);
+      assert.equal(err.output.payload.code, 'mock-code');
+    }
+  });
+
+  it('correctly maps errno 107 to "expired authorization code"', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(400, {
+        errno: 107,
+        code: 'mock-code',
+        expiredAt: 123456,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromAuthorizationCode({
+        client_id: MOCK_CLIENT_ID,
+        client_secret: 'abcdef',
+        code: MOCK_AUTHORIZATION_CODE,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.EXPIRED_AUTHORIZATION_CODE);
+      assert.equal(err.output.payload.code, 'mock-code');
+      assert.equal(err.output.payload.expiredAt, 123456);
+    }
+  });
+
+  it('correctly maps errno 117 to "incorrect pkce challenge"', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(400, {
+        errno: 117,
+        pkceHashValue: 'mock-pkce-hash',
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromAuthorizationCode({
+        client_id: MOCK_CLIENT_ID,
+        code_verifier: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb',
+        code: MOCK_AUTHORIZATION_CODE,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PKCE_CHALLENGE);
+      assert.equal(err.output.payload.pkceHashValue, 'mock-pkce-hash');
+    }
+  });
+});

--- a/test/local/oauthdb/grant-tokens-from-refresh-token.js
+++ b/test/local/oauthdb/grant-tokens-from-refresh-token.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const oauthdbModule = require('../../../lib/oauthdb');
+const error = require('../../../lib/error');
+const { mockLog } = require('../../mocks');
+
+const MOCK_CLIENT_ID = '0123456789ABCDEF';
+const MOCK_ACCESS_TOKEN = 'aaaaaa2222223333334444445555556611111122222233333344444455555566';
+const MOCK_REFRESH_TOKEN = 'bbbbbb2222223333334444445555556611111122222233333344444455555566';
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  oauth: {
+    url: 'https://oauth.server.com',
+    secretKey: 'secret-key-oh-secret-key',
+  },
+  domain: 'accounts.example.com'
+};
+const mockOAuthServer = nock(mockConfig.oauth.url).defaultReplyHeaders({
+  'Content-Type': 'application/json'
+});
+
+describe('oauthdb/grantTokensFromRefreshToken', () => {
+  let oauthdb;
+
+  afterEach(async () => {
+    assert.ok(nock.isDone(), 'there should be no pending request mocks at the end of a test');
+    if (oauthdb) {
+      await oauthdb.close();
+    }
+  });
+
+  it('can get new tokens from a refresh token', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(200, {
+        access_token: MOCK_ACCESS_TOKEN,
+        scope: '',
+        token_type: 'bearer',
+        expires_in: 123,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    const res = await oauthdb.grantTokensFromRefreshToken({
+      client_id: MOCK_CLIENT_ID,
+      client_secret: MOCK_CLIENT_ID,
+      refresh_token: MOCK_REFRESH_TOKEN,
+      grant_type: 'refresh_token',
+    });
+    assert.deepEqual(res, {
+      access_token: MOCK_ACCESS_TOKEN,
+      scope: '',
+      token_type: 'bearer',
+      expires_in: 123,
+    });
+  });
+
+  it('accepts optional parameters', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(200, {
+        access_token: MOCK_ACCESS_TOKEN,
+        scope: '',
+        token_type: 'bearer',
+        expires_in: 123,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    const res = await oauthdb.grantTokensFromRefreshToken({
+      client_id: MOCK_CLIENT_ID,
+      refresh_token: MOCK_REFRESH_TOKEN,
+      grant_type: 'refresh_token',
+      scope: 'profile oldsync',
+      ttl: 234,
+    });
+    assert.deepEqual(res, {
+      access_token: MOCK_ACCESS_TOKEN,
+      scope: '',
+      token_type: 'bearer',
+      expires_in: 123,
+    });
+  });
+
+  it('requires explicit grant_type parameter', async () => {
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.grantTokensFromRefreshToken({
+        client_id: MOCK_CLIENT_ID,
+        refresh_token: MOCK_REFRESH_TOKEN,
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INTERNAL_VALIDATION_ERROR);
+    }
+  });
+});

--- a/test/local/oauthdb/grant-tokens-from-session-token.js
+++ b/test/local/oauthdb/grant-tokens-from-session-token.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const oauthdbModule = require('../../../lib/oauthdb');
+const { mockLog } = require('../../mocks');
+
+const MOCK_CLIENT_ID = '0123456789ABCDEF';
+const MOCK_ACCESS_TOKEN = 'aaaaaa2222223333334444445555556611111122222233333344444455555566';
+const MOCK_REFRESH_TOKEN = 'bbbbbb2222223333334444445555556611111122222233333344444455555566';
+const MOCK_ID_TOKEN = 'ABABABABABABABABABABABABABABABABABABABABABABABABAB';
+const mockSessionToken = {
+  emailVerified: true,
+  tokenVerified: true,
+  uid: 'ABCDEF123456',
+  lastAuthAt: () => Date.now(),
+  authenticationMethods: ['pwd', 'email'],
+};
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  oauth: {
+    url: 'https://oauth.server.com',
+    secretKey: 'secret-key-oh-secret-key',
+  },
+  domain: 'accounts.example.com'
+};
+const mockOAuthServer = nock(mockConfig.oauth.url).defaultReplyHeaders({
+  'Content-Type': 'application/json'
+});
+
+describe('oauthdb/grantTokensFromSessionToken', () => {
+  let oauthdb;
+
+  afterEach(async () => {
+    assert.ok(nock.isDone(), 'there should be no pending request mocks at the end of a test');
+    if (oauthdb) {
+      await oauthdb.close();
+    }
+  });
+
+  it('can grant oauth tokens directly from a sessionToken', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(200, {
+        access_token: MOCK_ACCESS_TOKEN,
+        scope: 'test1',
+        token_type: 'bearer',
+        expires_in: 123,
+        auth_at: 123456,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    const res = await oauthdb.grantTokensFromSessionToken(mockSessionToken, {
+      client_id: MOCK_CLIENT_ID,
+      scope: 'test1',
+    });
+    assert.deepEqual(res, {
+      access_token: MOCK_ACCESS_TOKEN,
+      scope: 'test1',
+      token_type: 'bearer',
+      expires_in: 123,
+      auth_at: 123456,
+    });
+  });
+
+  it('accepts optional parameters', async () => {
+    mockOAuthServer.post('/v1/token', body => true)
+      .reply(200, {
+        access_token: MOCK_ACCESS_TOKEN,
+        refresh_token: MOCK_REFRESH_TOKEN,
+        id_token: MOCK_ID_TOKEN,
+        scope: 'test1 openid',
+        token_type: 'bearer',
+        expires_in: 123,
+        auth_at: 123456,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    const res = await oauthdb.grantTokensFromSessionToken(mockSessionToken, {
+      client_id: MOCK_CLIENT_ID,
+      scope: 'test1 openid',
+      ttl: 123,
+      grant_type: 'fxa-credentials',
+      access_type: 'offline',
+    });
+    assert.deepEqual(res, {
+      access_token: MOCK_ACCESS_TOKEN,
+      refresh_token: MOCK_REFRESH_TOKEN,
+      id_token: MOCK_ID_TOKEN,
+      scope: 'test1 openid',
+      token_type: 'bearer',
+      expires_in: 123,
+      auth_at: 123456,
+    });
+  });
+});

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -92,6 +92,9 @@ const OAUTHDB_METHOD_NAMES = [
   'getClientInfo',
   'getScopedKeyData',
   'createAuthorizationCode',
+  'grantTokensFromAuthorizationCode',
+  'grantTokensFromRefreshToken',
+  'grantTokensFromSessionToken',
 ];
 
 const LOG_METHOD_NAMES = [


### PR DESCRIPTION
Fixes #2954; Requires #2969.

Here's my draft of how we'd use the new `fxa-assertion` grant type from #2969 to implenent a `/oauth/token` endpoint on the auth-server.  Needs tests etc, but hopefully gives you a bit of the idea.  You can imagine us proceeding to add additional auth-server things to this endpoint, like sending emails and creating/updating device records.

/cc @vladikoff 