### PR TITLE
refactor(config): cache repetitive calls to conf.get

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -893,18 +893,19 @@ conf.validate({ allowed: 'strict' });
 conf.set('domain', url.parse(conf.get('publicUrl')).host);
 
 // derive fxa-auth-mailer configuration from our content-server url
-conf.set('smtp.accountSettingsUrl', `${conf.get('contentServer.url')  }/settings`);
-conf.set('smtp.accountRecoveryCodesUrl', `${conf.get('contentServer.url')  }/settings/two_step_authentication/recovery_codes`);
-conf.set('smtp.verificationUrl', `${conf.get('contentServer.url')  }/verify_email`);
-conf.set('smtp.passwordResetUrl', `${conf.get('contentServer.url')  }/complete_reset_password`);
-conf.set('smtp.initiatePasswordResetUrl', `${conf.get('contentServer.url')  }/reset_password`);
-conf.set('smtp.initiatePasswordChangeUrl', `${conf.get('contentServer.url')  }/settings/change_password`);
-conf.set('smtp.verifyLoginUrl', `${conf.get('contentServer.url')  }/complete_signin`);
-conf.set('smtp.reportSignInUrl', `${conf.get('contentServer.url')  }/report_signin`);
-conf.set('smtp.revokeAccountRecoveryUrl', `${conf.get('contentServer.url')  }/settings/account_recovery/confirm_revoke`);
-conf.set('smtp.createAccountRecoveryUrl', `${conf.get('contentServer.url')  }/settings/account_recovery/confirm_password`);
-conf.set('smtp.verifyPrimaryEmailUrl', `${conf.get('contentServer.url')  }/verify_primary_email`);
-conf.set('smtp.verifySecondaryEmailUrl', `${conf.get('contentServer.url')  }/verify_secondary_email`);
+const baseUri = conf.get('contentServer.url');
+conf.set('smtp.accountSettingsUrl', `${baseUri}/settings`);
+conf.set('smtp.accountRecoveryCodesUrl', `${baseUri}/settings/two_step_authentication/recovery_codes`);
+conf.set('smtp.verificationUrl', `${baseUri}/verify_email`);
+conf.set('smtp.passwordResetUrl', `${baseUri}/complete_reset_password`);
+conf.set('smtp.initiatePasswordResetUrl', `${baseUri}/reset_password`);
+conf.set('smtp.initiatePasswordChangeUrl', `${baseUri}/settings/change_password`);
+conf.set('smtp.verifyLoginUrl', `${baseUri}/complete_signin`);
+conf.set('smtp.reportSignInUrl', `${baseUri}/report_signin`);
+conf.set('smtp.revokeAccountRecoveryUrl', `${baseUri}/settings/account_recovery/confirm_revoke`);
+conf.set('smtp.createAccountRecoveryUrl', `${baseUri}/settings/account_recovery/confirm_password`);
+conf.set('smtp.verifyPrimaryEmailUrl', `${baseUri}/verify_primary_email`);
+conf.set('smtp.verifySecondaryEmailUrl', `${baseUri}/verify_secondary_email`);
 
 conf.set('isProduction', conf.get('env') === 'prod');
 


### PR DESCRIPTION
This is just a tiny little improvement I noticed we could make while reviewing #2986. Instead of calling `conf.get('contentServer.url')` inline 12 times inside these template literals, it reads a bit nicer if we assign the result to a variable name instead.

@mozilla/fxa-devs r?