### PR TITLE
feat(metrics): amplitude events from the OAuth server for MAU

### DIFF
--- a/fxa-oauth-server/config/dev.json
+++ b/fxa-oauth-server/config/dev.json
@@ -7,6 +7,10 @@
   "clientManagement": {
     "enabled": true
   },
+  "clientIdToServiceNames": {
+    "dcdb5ae7add825d2": "123done",
+    "98e6508e88680e1a": "fxa-settings"
+  },
   "clients": [
     {
       "id": "dcdb5ae7add825d2",

--- a/fxa-oauth-server/lib/config.js
+++ b/fxa-oauth-server/lib/config.js
@@ -66,6 +66,12 @@ const conf = convict({
       env: 'CLIENT_MANAGEMENT_ENABLED'
     }
   },
+  clientIdToServiceNames: {
+    doc: 'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
+    format: Object,
+    default: {},
+    env: 'OAUTH_CLIENT_IDS'
+  },
   scopes: {
     doc: 'Some pre-defined list of scopes that will be inserted into the DB',
     env: 'OAUTH_SCOPES',

--- a/fxa-oauth-server/lib/grant.js
+++ b/fxa-oauth-server/lib/grant.js
@@ -11,6 +11,8 @@ const db = require('./db');
 const util = require('./util');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const JwTool = require('fxa-jwtool');
+const logger = require('./logging')('grant');
+const amplitude = require('./metrics/amplitude')(logger, config.getProperties());
 
 const ACR_VALUE_AAL2 = 'AAL2';
 const ACCESS_TYPE_OFFLINE = 'offline';
@@ -138,6 +140,12 @@ module.exports.generateTokens = async function generateTokens(grant) {
   if (grant.scope && grant.scope.contains(SCOPE_OPENID)) {
     result.id_token = await generateIdToken(grant, access);
   }
+
+  amplitude('token.created', {
+    service: hex(grant.clientId),
+    uid: hex(grant.userId)
+  });
+
   return result;
 };
 

--- a/fxa-oauth-server/lib/metrics/amplitude.js
+++ b/fxa-oauth-server/lib/metrics/amplitude.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module contains mappings from event names to amplitude event definitions.
+// A module in fxa-shared is responsible for performing the actual transformations.
+//
+// You can see the event taxonomy here:
+//
+// https://docs.google.com/spreadsheets/d/1G_8OJGOxeWXdGJ1Ugmykk33Zsl-qAQL05CONSeD4Uz4
+
+'use strict';
+
+const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
+
+const EVENTS = {
+  'token.created': {
+    group: GROUPS.activity,
+    event: 'access_token_created'
+  },
+  'verify.success': {
+    group: GROUPS.activity,
+    event: 'access_token_checked'
+  },
+};
+
+const FUZZY_EVENTS = new Map([]);
+
+module.exports = (log, config) => {
+  if (! log || ! config.clientIdToServiceNames) {
+    throw new TypeError('Missing argument');
+  }
+
+  const transformEvent = initialize(config.clientIdToServiceNames, EVENTS, FUZZY_EVENTS);
+
+  return function receiveEvent (event, data) {
+    if (! event || ! data) {
+      log.error('amplitude.badArgument', { err: 'Bad argument', event });
+      return;
+    }
+
+    const eventData = Object.assign({}, {
+      uid: data.uid,
+      service: data.service
+    });
+
+    const amplitudeEvent = transformEvent({
+      type: event,
+      time: data.time || Date.now()
+    }, eventData);
+
+    if (amplitudeEvent) {
+      log.info('amplitudeEvent', amplitudeEvent);
+    }
+  };
+};

--- a/fxa-oauth-server/test/metrics/amplitude.js
+++ b/fxa-oauth-server/test/metrics/amplitude.js
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const amplitudeModule = require('../../lib/metrics/amplitude');
+const sinon = require('sinon');
+
+describe('metrics/amplitude', () => {
+
+  it('interface is correct', () => {
+    assert.strictEqual(typeof amplitudeModule, 'function');
+    assert.strictEqual(amplitudeModule.length, 2);
+  });
+
+  it('throws if log argument is missing', () => {
+    assert.throws(() => amplitudeModule(null, { clientIdToServiceNames: {} }));
+  });
+
+  it('throws if config argument is missing', () => {
+    assert.throws(() => amplitudeModule({}, { clientIdToServiceNames: null }));
+  });
+
+  describe('instantiate', () => {
+    let amplitude, log;
+
+    beforeEach(() => {
+      log = {
+        error: sinon.spy(),
+        info: sinon.spy()
+      };
+
+      amplitude = amplitudeModule(log, {
+        clientIdToServiceNames: {
+          0: 'amo',
+          1: 'pocket'
+        },
+      });
+    });
+
+    it('interface is correct', () => {
+      assert.isFunction(amplitude);
+      assert.lengthOf(amplitude, 2);
+    });
+
+    describe('empty event argument', () => {
+      beforeEach(() => {
+        return amplitude('', {});
+      });
+
+      it('called log.error correctly', () => {
+        assert.strictEqual(log.error.callCount, 1);
+        assert.lengthOf(log.error.args[0], 2);
+        assert.strictEqual(log.error.args[0][0], 'amplitude.badArgument');
+        assert.deepEqual(log.error.args[0][1], {
+          err: 'Bad argument',
+          event: ''
+        });
+      });
+
+      it('did not call log.info', () => {
+        assert.strictEqual(log.info.callCount, 0);
+      });
+    });
+
+    describe('missing data argument', () => {
+      beforeEach(() => {
+        return amplitude('foo');
+      });
+
+      it('called log.error correctly', () => {
+        assert.strictEqual(log.error.callCount, 1);
+        assert.lengthOf(log.error.args[0], 2);
+        assert.strictEqual(log.error.args[0][0], 'amplitude.badArgument');
+        assert.deepEqual(log.error.args[0][1], {
+          err: 'Bad argument',
+          event: 'foo'
+        });
+      });
+
+      it('did not call log.info', () => {
+        assert.strictEqual(log.info.callCount, 0);
+      });
+    });
+
+    describe('token.created', () => {
+      beforeEach(() => {
+        return amplitude('token.created', {
+          service: '0',
+          uid: 'blee',
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.strictEqual(log.error.callCount, 0);
+      });
+
+      it('called log.info correctly', () => {
+        assert.strictEqual(log.info.callCount, 1);
+
+        const args = log.info.args[0];
+        assert.strictEqual(args.length, 2);
+        assert.strictEqual(args[0], 'amplitudeEvent');
+        assert.strictEqual(args[1].user_id, 'blee');
+        assert.strictEqual(args[1].event_type, 'fxa_activity - access_token_created');
+        assert.deepEqual(args[1].event_properties, {
+          service: 'amo',
+          oauth_client_id: '0'
+        });
+        assert.deepEqual(args[1].user_properties, {
+          '$append': {
+            fxa_services_used: 'amo'
+          }
+        });
+        assert.isAbove(args[1].time, Date.now() - 1000);
+      });
+    });
+
+    describe('verify.success', () => {
+      beforeEach(() => {
+        const now = Date.now();
+        return amplitude('verify.success', {
+          service: '1',
+          time: now,
+          uid: 'biz',
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.strictEqual(log.error.callCount, 0);
+      });
+
+      it('called log.info correctly', () => {
+        assert.strictEqual(log.info.callCount, 1);
+
+        const args = log.info.args[0];
+        assert.strictEqual(args.length, 2);
+        assert.strictEqual(args[0], 'amplitudeEvent');
+        assert.strictEqual(args[1].user_id, 'biz');
+        assert.strictEqual(args[1].event_type, 'fxa_activity - access_token_checked');
+        assert.deepEqual(args[1].event_properties, {
+          service: 'pocket',
+          oauth_client_id: '1'
+        });
+        assert.deepEqual(args[1].user_properties, {
+          '$append': {
+            fxa_services_used: 'pocket'
+          }
+        });
+        assert.isAbove(args[1].time, Date.now() - 1000);
+      });
+    });
+  });
+});

--- a/fxa-oauth-server/test/routes/verify.js
+++ b/fxa-oauth-server/test/routes/verify.js
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const Joi = require('joi');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+
+
+const TOKEN = 'df6dcfe7bf6b54a65db5742cbcdce5c0a84a5da81a0bb6bdf5fc793eef041fc6';
+
+function joiRequired(err, param) {
+  assert.ok(err.isJoi);
+  assert.ok(err.name, 'ValidationError');
+  assert.strictEqual(err.details[0].message, `"${param}" is required`);
+}
+
+describe('/verify POST', () => {
+  let dependencies;
+  let mocks;
+  let route;
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+
+    mocks = {
+      amplitude: sandbox.spy(),
+      config: {
+        getProperties: sinon.spy(() => ({ key: 'value'}))
+      },
+      log: {
+        info: sandbox.spy(),
+        warn: sandbox.spy(),
+      },
+      token: {
+        verify: sandbox.spy(() => Promise.resolve({
+          client_id: 'foo',
+          scope: ScopeSet.fromArray(['bar:foo', 'clients:write']),
+          user: 'bar'
+        }))
+      }
+    };
+
+    dependencies = {
+      '../config': mocks.config,
+      '../metrics/amplitude': sandbox.spy(() => mocks.amplitude),
+      '../logging': () => mocks.log,
+      '../token': mocks.token
+    };
+
+    route = proxyquire('../../lib/routes/verify', dependencies);
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  describe('setup', () => {
+    it('initializes amplitude correctly', () => {
+      assert.isTrue(dependencies['../metrics/amplitude'].calledOnce);
+      const args = dependencies['../metrics/amplitude'].args[0];
+      assert.strictEqual(args[0], mocks.log);
+      assert.isTrue(mocks.config.getProperties.calledOnce);
+      assert.deepEqual(args[1], { key: 'value'});
+    });
+  });
+
+  describe('validation', () => {
+    function validate(req, context={}) {
+      const result = Joi.validate(req, route.validate.payload, {context});
+      return result.error;
+    }
+
+    it('fails with no token', () => {
+      const err = validate({
+        token: undefined,
+        email: true
+      });
+      joiRequired(err, 'token');
+    });
+
+    it('no validation errors', () => {
+      const err = validate({
+        token: TOKEN,
+        email: true
+      });
+      assert.strictEqual(err, null);
+    });
+  });
+
+
+  describe('handler', () => {
+    let resp;
+
+    beforeEach(async () => {
+      resp = await route.handler({
+        payload: {
+          token: TOKEN
+        }
+      });
+    });
+
+    it('returns the expected response', () => {
+      assert.strictEqual(resp.client_id, 'foo');
+      assert.strictEqual(resp.user, 'bar');
+      assert.deepEqual(resp.scope, ['bar:foo','clients:write']);
+    });
+
+    it('verifies the token', () => {
+      assert.isTrue(mocks.token.verify.calledOnceWith(TOKEN));
+    });
+
+    it('logs as expected', () => {
+      assert.isTrue(mocks.log.info.calledOnceWith('verify.success', {
+        client_id: 'foo',
+        scope: ['bar:foo','clients:write']
+      }));
+    });
+
+    it('logs an amplitude event', () => {
+      assert.isTrue(mocks.amplitude.calledOnceWith('verify.success', {
+        service: 'foo',
+        uid: 'bar'
+      }));
+    });
+  });
+});


### PR DESCRIPTION
* `fxa_activity - access_token_created` whenever an access token is created.
* `fxa_activity - access_token_checked` whenever an access token is checked.

issue #2957

After adding config for 123done, here's what a checked event looks like:

```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1553867227015,"user_id":"572a021237bf486fbf4951c07008f3f4","app_version":"133","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"123done"}}}
```

@philbooth - r?